### PR TITLE
Set correct html lang

### DIFF
--- a/apps/onboarding/src/pages/_document.tsx
+++ b/apps/onboarding/src/pages/_document.tsx
@@ -1,11 +1,14 @@
 import { fonts } from '@hedviginsurance/brand'
 import Document, { Head, Html, Main, NextScript } from 'next/document'
+import { LocaleLabel, locales } from '@/lib/l10n/locales'
 import { gtmDevScript, gtmProdScript } from '@/services/analytics/gtm'
 
 export default class MyDocument extends Document {
   render() {
+    const currentLocale = this.props.__NEXT_DATA__.locale
+    const htmlLang = locales[currentLocale as LocaleLabel].htmlLang
     return (
-      <Html>
+      <Html lang={htmlLang}>
         <Head>
           {Object.values(fonts).map((fontName) => (
             <link


### PR DESCRIPTION
## Describe your changes
Set correct `<html>` `lang` value. This will make sure the cookie banner is in the correct language.

## Justify why they are needed
I thought this would be a simple fix but it wasn't so straight forward working with the `_document` it seems.

Next sets the `<html>` `lang` value based on our i18n config: 
```js
locales: ['default', 'se', 'se-en', 'no', 'no-en', 'dk', 'dk-en'],
```

These are not valid html lang values (it should be `en, se, da, no`). So we need to set them manually by getting the value from the `locales` object. This solution works on initial load, but won't update if you change language client-side (since _document is rendered server-side). 

So if you have any idea how we could solve this in another fashion, please chip in :) 

https://user-images.githubusercontent.com/6661511/172651388-8671fe9c-c2c3-420d-9f41-57574b13cf2d.mov


