### PR TITLE
GRW-1239 / Fix / 404 links in language switcher

### DIFF
--- a/apps/onboarding/src/components/language-switcher.tsx
+++ b/apps/onboarding/src/components/language-switcher.tsx
@@ -4,6 +4,8 @@ import { useRouter } from 'next/router'
 import { Separate } from 'ui'
 import { useCurrentMarket } from '@/lib/l10n'
 
+const FALLBACK_PATH = '/'
+
 const Wrapper = styled(Separate)({
   display: 'flex',
   height: '1.5rem',
@@ -32,7 +34,13 @@ export const LanguageSwitcher = () => {
   return (
     <Wrapper Separator={<Separator />}>
       {languages.map((language) => (
-        <Link key={language.urlParam} href={router.asPath} locale={language.urlParam} passHref>
+        <Link
+          key={language.urlParam}
+          // avoid using `asPath` until `isReady` field is `true` (https://nextjs.org/docs/api-reference/next/router)
+          href={router.isReady ? router.asPath : FALLBACK_PATH}
+          locale={language.urlParam}
+          passHref
+        >
           <Anchor active={router.locale === language.urlParam}>{language.displayName}</Anchor>
         </Link>
       ))}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix 404 links in language switcher.
Avoid rendering link until router is ready.

## Justify why they are needed

The next docs recommend not using `asPath` until router is ready:
https://nextjs.org/docs/api-reference/next/router#router-object

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
