### PR TITLE
refact(CartList): removes component level integration between product and cms prodcut

### DIFF
--- a/apps/store/src/components/CartList/CartList.tsx
+++ b/apps/store/src/components/CartList/CartList.tsx
@@ -5,7 +5,6 @@ import { Button, Space, CrossIcon } from 'ui'
 import { Text } from '@/components/Text/Text'
 import { PageLink } from '@/lib/PageLink'
 import { CartContext } from '@/services/mockCartService'
-import { getProductByMarketAndProduct } from '@/services/mockCmsService'
 import { ProductNames } from '@/services/mockProductService'
 
 const BundleWrapper = styled.div({
@@ -40,21 +39,16 @@ export const CartList = ({ filterByProductName, showBundles, showLinks }: CartLi
     ? cart.items.filter((item) => item.product.name === filterByProductName)
     : cart.items
 
-  const itemsWithCmsProducts = items.map((item) => ({
-    ...item,
-    cmsProduct: getProductByMarketAndProduct(item.product.market, item.product.name),
-  }))
-
   if (items.length === 0) return null
 
   return (
     <ul>
-      {itemsWithCmsProducts.map((item) => (
+      {items.map((item) => (
         <li key={item.id}>
           <Space x={0.5}>
             <span>
-              {showLinks && item.cmsProduct?.slug ? (
-                <Link href={PageLink.product({ id: item.cmsProduct?.slug })}>
+              {showLinks ? (
+                <Link href={PageLink.product({ id: item.product.slug })}>
                   {item.product.displayName}
                 </Link>
               ) : (

--- a/apps/store/src/components/ProductPage/ProductPage.tsx
+++ b/apps/store/src/components/ProductPage/ProductPage.tsx
@@ -21,7 +21,7 @@ export const ProductPage = ({ cmsProduct, product }: ProductPageProps) => {
   const { addProductToCart, getItemsByName } = cartContext
 
   const handleSubmit = ({ id, price }: PriceQuote) => {
-    addProductToCart(id, price, product)
+    addProductToCart(id, price, { ...product, slug: cmsProduct.slug })
   }
 
   const productsOfThisType = getItemsByName(product.name)

--- a/apps/store/src/services/mockCartService.ts
+++ b/apps/store/src/services/mockCartService.ts
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react'
 import { Product, ProductNames } from './mockProductService'
 
+type ProductWithSlug = Product & { slug: string }
+
 export type CartProduct = {
-  product: Product
+  product: ProductWithSlug
   // this kinda represents a unique instance of this product with provided details
   id: string
   price: number
@@ -16,7 +18,7 @@ type Cart = {
 // This context mocks a BE data service
 interface CartContextInterface {
   cart: Cart
-  addProductToCart: (id: string, price: number, product: Product) => void
+  addProductToCart: (id: string, price: number, product: ProductWithSlug) => void
   /**
    * Returns cart items that matches on CmsProduct::name
    */
@@ -40,7 +42,7 @@ export const useCartContextStore = (): CartContextInterface => {
     return !!cartItems.find((item) => item.id === id)
   }
 
-  const addProductToCart = (id: string, price: number, product: Product): void => {
+  const addProductToCart = (id: string, price: number, product: ProductWithSlug): void => {
     if (_isProductInCart(id)) return
 
     setCartItems((current) => [...current, { product, id, price }])

--- a/apps/store/src/services/mockCmsService.ts
+++ b/apps/store/src/services/mockCmsService.ts
@@ -49,13 +49,3 @@ export const getProductByMarketAndSlug = (market: MarketLabel, slug: string): Cm
 export const getProductsByMarket = (market: MarketLabel): CmsProduct[] => {
   return CMS_PRODUCTS.filter((product) => product.market === market)
 }
-
-export const getProductByMarketAndProduct = (
-  market: MarketLabel,
-  productName: ProductNames,
-): CmsProduct | null => {
-  return (
-    CMS_PRODUCTS.find((product) => product.market === market && product.product === productName) ??
-    null
-  )
-}


### PR DESCRIPTION
## Describe your changes

Read title ☝🏻 

## Justify why they are needed

The idea was to get ride of the code that connects info between `product` and `cmsProduct` from a component level. That's because [`getProductByMarketAndProduct`](https://github.com/HedvigInsurance/racoon/compare/refact/cart-list?expand=1#diff-c29933a30df352a916eeeb7754b07a04f2c954421e829fc29f2c0401bf55eb87L45) represents what would be one day asynchronous code and we probably don't want to fetch data from a component level when it's not necessary.
