### PR TITLE
Add new Heading component with variants

### DIFF
--- a/packages/ui/src/components/Heading/Heading.tsx
+++ b/packages/ui/src/components/Heading/Heading.tsx
@@ -19,7 +19,7 @@ const HeadingBase = styled.span<ColorProp>(({ theme, colorVariant }) => ({
   color: colorVariant === 'light' ? theme.colors.gray100 : theme.colors.gray900,
   margin: 0,
   padding: 0,
-  fontFamily: theme.fonts.heading,
+  fontFamily: theme.fonts.body,
   fontWeight: 400,
 }))
 

--- a/packages/ui/src/components/HeadingNew/HeadingNew.helpers.ts
+++ b/packages/ui/src/components/HeadingNew/HeadingNew.helpers.ts
@@ -1,0 +1,100 @@
+import { Theme } from '@emotion/react'
+
+type HeadingSize = '18' | '20' | '24' | '32' | '40' | '48' | '56' | '72' | '96'
+
+type HeadingStyles = {
+  [key in HeadingSize]: object
+}
+
+type HeadingVariants = {
+  standard: HeadingStyles
+  serif: Omit<HeadingStyles, '18'>
+}
+
+export type HeadingVariant = `standard.${HeadingSize}` | `serif.${Exclude<HeadingSize, '18'>}`
+
+export const getHeadingVariant = (variant: HeadingVariant, theme: Theme) => {
+  const headings = {
+    standard: {
+      18: {
+        fontSize: theme.fontSizes[3],
+      },
+      20: {
+        fontSize: theme.fontSizes[4],
+      },
+      24: {
+        fontSize: theme.fontSizes[5],
+      },
+      32: {
+        fontSize: theme.fontSizes[6],
+        letterSpacing: '-0.01em',
+      },
+      40: {
+        fontSize: theme.fontSizes[7],
+        letterSpacing: '-0.01em',
+      },
+      48: {
+        fontSize: theme.fontSizes[8],
+        letterSpacing: '-0.01em',
+      },
+      56: {
+        fontSize: theme.fontSizes[9],
+        letterSpacing: '-0.02em',
+      },
+      72: {
+        fontSize: theme.fontSizes[10],
+        letterSpacing: '-0.02em',
+      },
+      96: {
+        fontSize: theme.fontSizes[11],
+        letterSpacing: '-0.02em',
+      },
+    },
+    serif: {
+      18: {
+        fontSize: theme.fontSizes[3],
+        fontFamily: theme.fonts.small,
+      },
+      20: {
+        fontSize: theme.fontSizes[4],
+        fontFamily: theme.fonts.small,
+      },
+      24: {
+        fontSize: theme.fontSizes[5],
+        fontFamily: theme.fonts.small,
+      },
+      32: {
+        fontSize: theme.fontSizes[6],
+        letterSpacing: '-0.01em',
+        fontFamily: theme.fonts.small,
+      },
+      40: {
+        fontSize: theme.fontSizes[7],
+        letterSpacing: '-0.01em',
+        fontFamily: theme.fonts.small,
+      },
+      48: {
+        fontSize: theme.fontSizes[8],
+        letterSpacing: '-0.01em',
+        fontFamily: theme.fonts.small,
+      },
+      56: {
+        fontSize: theme.fontSizes[9],
+        fontFamily: theme.fonts.big,
+      },
+      72: {
+        fontSize: theme.fontSizes[10],
+        fontFamily: theme.fonts.big,
+      },
+      96: {
+        fontSize: theme.fontSizes[11],
+        fontFamily: theme.fonts.big,
+      },
+    },
+  }
+  const variantProperties = variant.split('.')
+  const flavour = variantProperties[0] as keyof HeadingVariants
+  const size = variantProperties[1] as HeadingSize
+  const headingVariant = headings[flavour][size]
+  return headingVariant
+}

--- a/packages/ui/src/components/HeadingNew/HeadingNew.stories.tsx
+++ b/packages/ui/src/components/HeadingNew/HeadingNew.stories.tsx
@@ -1,0 +1,28 @@
+import { ComponentMeta, Story } from '@storybook/react'
+import { Heading, HeadingProps } from './HeadingNew'
+
+export default {
+  title: 'Heading New',
+  component: Heading,
+  parameters: {
+    backgrounds: {
+      default: 'Light',
+    },
+  },
+  args: {
+    variant: 'serif.72',
+    children: 'This is a Heading',
+  },
+} as ComponentMeta<typeof Heading>
+
+const Template: Story<HeadingProps> = ({ children, ...rest }) => (
+  <Heading {...rest}>{children}</Heading>
+)
+
+export const LightBackground = Template.bind({})
+LightBackground.parameters = { backgrounds: { default: 'Light' } }
+LightBackground.args = { color: 'dark' }
+
+export const DarkBackground = Template.bind({})
+DarkBackground.parameters = { backgrounds: { default: 'Dark' } }
+DarkBackground.args = { color: 'light' }

--- a/packages/ui/src/components/HeadingNew/HeadingNew.tsx
+++ b/packages/ui/src/components/HeadingNew/HeadingNew.tsx
@@ -8,27 +8,23 @@ export type HeadingProps = Margins & {
   as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
   color?: 'dark' | 'light'
   children: React.ReactNode
-  variant: HeadingVariant
+  variant?: HeadingVariant
 }
 
 type HeadingBaseProps = Pick<HeadingProps, 'color' | 'variant'> & Margins
 
-const HeadingBase = styled.h2<HeadingBaseProps>(({ theme, color, variant, ...props }) => ({
-  color: getColor(color),
-  fontFamily: theme.fonts.heading,
-  fontWeight: 400,
-  lineHeight: 1.2,
-  ...getMargins(props),
-  ...getHeadingVariant(variant, theme),
-}))
+const HeadingBase = styled.h2<HeadingBaseProps>(
+  ({ theme, color, variant = 'standard.32', ...props }) => ({
+    color: getColor(color),
+    fontFamily: theme.fonts.heading,
+    fontWeight: 400,
+    lineHeight: 1.2,
+    ...getMargins(props),
+    ...getHeadingVariant(variant, theme),
+  }),
+)
 
-export const Heading = ({
-  as,
-  color,
-  children,
-  variant = 'standard.32',
-  ...rest
-}: HeadingProps) => {
+export const Heading = ({ as, color, children, variant, ...rest }: HeadingProps) => {
   return (
     <HeadingBase as={as} color={color} variant={variant} {...rest}>
       {children}

--- a/packages/ui/src/components/HeadingNew/HeadingNew.tsx
+++ b/packages/ui/src/components/HeadingNew/HeadingNew.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import { getColor } from 'ui'
+import { getMargins, Margins } from '../../lib/margins'
+import { getHeadingVariant, HeadingVariant } from './HeadingNew.helpers'
+
+export type HeadingProps = Margins & {
+  as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  color?: 'dark' | 'light'
+  children: React.ReactNode
+  variant: HeadingVariant
+}
+
+type HeadingBaseProps = Pick<HeadingProps, 'color' | 'variant'> & Margins
+
+const HeadingBase = styled.h2<HeadingBaseProps>(({ theme, color, variant, ...props }) => ({
+  color: getColor(color),
+  fontFamily: theme.fonts.heading,
+  fontWeight: 400,
+  lineHeight: 1.2,
+  ...getMargins(props),
+  ...getHeadingVariant(variant, theme),
+}))
+
+export const Heading = ({
+  as,
+  color,
+  children,
+  variant = 'standard.32',
+  ...rest
+}: HeadingProps) => {
+  return (
+    <HeadingBase as={as} color={color} variant={variant} {...rest}>
+      {children}
+    </HeadingBase>
+  )
+}


### PR DESCRIPTION
## Describe your changes
New Heading component to support the new fonts. Since the serif font is actually different fonts depending on size and letter-spacing varies between standard and serif, I combined them into variants.

We could split up the `fontSize` (where we pass in the theme fontSize values instead) and `fontFamily` into two props. But all sizes shouldn't be supported in the serif fonts (the serif font is not supposed to be used smaller than 20px). 

https://user-images.githubusercontent.com/6661511/179250740-377acd3a-4b21-4350-8850-a7eb24134f24.mov

![typography](https://user-images.githubusercontent.com/6661511/179250972-b1b36412-dcaf-4f30-a1bc-13f11f0334c5.png)


### 
Next steps:
- Add media query support
