### PR TITLE
Feat / Improve lint setup

### DIFF
--- a/apps/onboarding/src/components/BodyText.tsx
+++ b/apps/onboarding/src/components/BodyText.tsx
@@ -74,7 +74,10 @@ const Body3 = styled(TextBase)<StyleProps>(() => ({
   },
 }))
 
-type BodyTexts = Record<BodyTextProps['variant'], StyledComponent<{}, StyleProps, any>>
+type BodyTexts = Record<
+  BodyTextProps['variant'],
+  StyledComponent<Record<string, unknown>, StyleProps, any>
+>
 
 const textLevels: BodyTexts = {
   0: Body0,

--- a/apps/onboarding/src/components/FixedFooter.tsx
+++ b/apps/onboarding/src/components/FixedFooter.tsx
@@ -18,7 +18,7 @@ const FixedContainer = styled.div((props) => ({
   padding: '0 1rem',
 }))
 
-export const FixedFooter = ({ children }: PropsWithChildren<{}>) => {
+export const FixedFooter = ({ children }: PropsWithChildren<unknown>) => {
   return <FixedContainer>{children}</FixedContainer>
 }
 

--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import Link from 'next/link'
 import { useContext } from 'react'
 import { Heading, Space } from 'ui'

--- a/apps/store/src/components/HomePage/HomePage.tsx
+++ b/apps/store/src/components/HomePage/HomePage.tsx
@@ -2,9 +2,8 @@ import styled from '@emotion/styled'
 import { StoryblokComponent, StoryData } from '@storyblok/react'
 import Head from 'next/head'
 import Link from 'next/link'
-import { ArrowForwardIcon, Heading } from 'ui'
+import { ArrowForwardIcon } from 'ui'
 import { PageLink } from '@/lib/PageLink'
-import { StoryblokPageProps } from '@/services/storyblok/storyblok'
 
 const Wrapper = styled.main({
   height: '100vh',

--- a/apps/store/src/pages/[...slug].tsx
+++ b/apps/store/src/pages/[...slug].tsx
@@ -1,4 +1,4 @@
-import { StoryblokComponent, StoryData, useStoryblokState } from '@storyblok/react'
+import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
 import type { GetStaticPaths, GetStaticProps, NextPageWithLayout } from 'next'
 import Head from 'next/head'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
@@ -49,7 +49,7 @@ export const getStaticProps: GetStaticProps<StoryblokPageProps, StoryblokQueryPa
 export const getStaticPaths: GetStaticPaths = async () => {
   const links = await getAllLinks()
 
-  let paths: Path[] = []
+  const paths: Path[] = []
   Object.keys(links).forEach((linkKey) => {
     if (links[linkKey].is_folder) {
       return

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -1,5 +1,4 @@
 import { ApolloProvider } from '@apollo/client'
-import { storyblokInit, apiPlugin } from '@storyblok/react'
 import type { AppPropsWithLayout } from 'next/app'
 import Head from 'next/head'
 import { ThemeProvider } from 'ui'

--- a/packages/scripts/.eslintrc.js
+++ b/packages/scripts/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
-  extends: ['next/core-web-vitals', 'prettier'],
-  plugins: ['import', 'testing-library', 'jest'],
+  parser: '@typescript-eslint/parser',
+  extends: ['next/core-web-vitals', 'prettier', 'plugin:@typescript-eslint/recommended'],
+  plugins: ['import', 'testing-library', 'jest', '@typescript-eslint'],
   settings: {
     next: {
       rootDir: ['apps/*/', 'packages/*/'],

--- a/packages/scripts/.eslintrc.js
+++ b/packages/scripts/.eslintrc.js
@@ -2,11 +2,11 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   extends: [
     'next/core-web-vitals',
+    'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
-    'plugin:@typescript-eslint/eslint-recommended',
-    'prettier',
+    'prettier', // Uses eslint-config-prettier to turn off all rules that are unnecessary or might conflict with Prettier
   ],
-  plugins: ['import', 'testing-library', 'jest', '@typescript-eslint', 'prettier'],
+  plugins: ['import', 'testing-library', 'jest', '@typescript-eslint'],
   settings: {
     next: {
       rootDir: ['apps/*/', 'packages/*/'],

--- a/packages/scripts/.eslintrc.js
+++ b/packages/scripts/.eslintrc.js
@@ -1,7 +1,12 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
-  extends: ['next/core-web-vitals', 'prettier', 'plugin:@typescript-eslint/recommended'],
-  plugins: ['import', 'testing-library', 'jest', '@typescript-eslint'],
+  extends: [
+    'next/core-web-vitals',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'prettier',
+  ],
+  plugins: ['import', 'testing-library', 'jest', '@typescript-eslint', 'prettier'],
   settings: {
     next: {
       rootDir: ['apps/*/', 'packages/*/'],
@@ -38,6 +43,11 @@ module.exports = {
         pathGroupsExcludedImportTypes: ['internal'],
       },
     ],
+    '@typescript-eslint/no-empty-function': 'off',
+    '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-empty-interface': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
   },
   overrides: [
     // Only uses Testing Library lint rules in test files

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -19,7 +19,6 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.25.4",
-    "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-testing-library": "^5.0.5",
     "identity-obj-proxy": "^3.0.0"
   },

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -13,17 +13,17 @@
     "clean": "rm -rf .turbo && rm -rf node_modules"
   },
   "dependencies": {
-    "@typescript-eslint/parser": "^5.15.0",
+    "@typescript-eslint/eslint-plugin": "5.30.6",
+    "@typescript-eslint/parser": "5.30.6",
     "eslint-config-next": "12.2.0",
-    "eslint-config-prettier": "^8.3.0",
+    "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-testing-library": "^5.0.5",
     "identity-obj-proxy": "^3.0.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.30.6",
-    "@typescript-eslint/parser": "^5.30.6",
     "eslint": "^8.12.0",
     "eslint-plugin-jest": "^26.1.3",
     "next": "12.2.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -22,11 +22,13 @@
     "identity-obj-proxy": "^3.0.0"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.30.6",
+    "@typescript-eslint/parser": "^5.30.6",
     "eslint": "^8.12.0",
     "eslint-plugin-jest": "^26.1.3",
     "next": "12.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "typescript": "^4.5.5"
+    "typescript": "^4.7.4"
   }
 }

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/react'
 import { MailIcon } from '../../icons/MailIcon'
-import { Button, ButtonProps, LinkButton as LB } from './Button'
+import { Button, ButtonProps } from './Button'
 
 type StoryProps = ButtonProps & { disabled: boolean }
 

--- a/packages/ui/src/components/Heading/Heading.tsx
+++ b/packages/ui/src/components/Heading/Heading.tsx
@@ -84,7 +84,10 @@ const HeadingOverline = styled(HeadingBase)<StyleProps>(() => ({
   },
 }))
 
-type Headings = Record<HeadingProps['variant'], StyledComponent<{}, StyleProps, any>>
+type Headings = Record<
+  HeadingProps['variant'],
+  StyledComponent<Record<string, unknown>, StyleProps, any>
+>
 
 const headings: Headings = {
   xl: HeadingXL,

--- a/packages/ui/src/components/InputStepper/InputStepper.tsx
+++ b/packages/ui/src/components/InputStepper/InputStepper.tsx
@@ -53,10 +53,10 @@ const StepButton = styled(UnstyledButton)(({ theme }) => ({
   },
 }))
 
-const StepButtonRight = styled(StepButton)(({ theme }) => ({
+const StepButtonRight = styled(StepButton)({
   left: 'auto',
   right: '1rem',
-}))
+})
 
 const StyledInput = styled.input(({ theme }) => ({
   color: theme.colors.gray900,

--- a/packages/ui/src/components/Menu/MenuLink.tsx
+++ b/packages/ui/src/components/Menu/MenuLink.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { ElementType, useContext } from 'react'
+import { useContext } from 'react'
 import { ReactNode } from 'react'
 import { getColor } from '../../lib/theme/theme'
 import { MenuThemeContext } from './Menu'
@@ -12,7 +12,7 @@ export type MenuLinkProps = {
   href?: string
 }
 
-const MenuLinkElement = styled.a<MenuLinkProps>(({ as, theme, color }) => ({
+const MenuLinkElement = styled.a<MenuLinkProps>(({ theme, color }) => ({
   textDecoration: 'none',
   ':focus': {
     outline: `5px auto ${theme.colors.purple700}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10180,13 +10180,6 @@ eslint-plugin-jsx-a11y@^6.5.1:
     language-tags "^1.0.5"
     minimatch "^3.0.4"
 
-eslint-plugin-prettier@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
-  integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-
 eslint-plugin-react-hooks@^4.5.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
@@ -10761,11 +10754,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.2.6:
   version "2.2.7"
@@ -16319,13 +16307,6 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 "prettier@>=2.2.1 <=2.3.0":
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6038,15 +6038,20 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/parser@^5.15.0":
-  version "5.15.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.15.0.tgz"
-  integrity sha512-NGAYP/+RDM2sVfmKiKOCgJYPstAO40vPAgACoWPO/+yoYKSgAXIFaBKsV8P0Cc7fwKgvj27SjRNX4L7f4/jCKQ==
+"@typescript-eslint/eslint-plugin@^5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.30.6.tgz#9c6017b6c1d04894141b4a87816388967f64c359"
+  integrity sha512-J4zYMIhgrx4MgnZrSDD7sEnQp7FmhKNOaqaOpaoQ/SfdMfRB/0yvK74hTnvH+VQxndZynqs5/Hn4t+2/j9bADg==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.15.0"
-    "@typescript-eslint/types" "5.15.0"
-    "@typescript-eslint/typescript-estree" "5.15.0"
-    debug "^4.3.2"
+    "@typescript-eslint/scope-manager" "5.30.6"
+    "@typescript-eslint/type-utils" "5.30.6"
+    "@typescript-eslint/utils" "5.30.6"
+    debug "^4.3.4"
+    functional-red-black-tree "^1.0.1"
+    ignore "^5.2.0"
+    regexpp "^3.2.0"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
 
 "@typescript-eslint/parser@^5.21.0":
   version "5.30.0"
@@ -6058,6 +6063,16 @@
     "@typescript-eslint/typescript-estree" "5.30.0"
     debug "^4.3.4"
 
+"@typescript-eslint/parser@^5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.30.6.tgz#add440db038fa9d777e4ebdaf66da9e7fb7abe92"
+  integrity sha512-gfF9lZjT0p2ZSdxO70Xbw8w9sPPJGfAdjK7WikEjB3fcUI/yr9maUVEdqigBjKincUYNKOmf7QBMiTf719kbrA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.30.6"
+    "@typescript-eslint/types" "5.30.6"
+    "@typescript-eslint/typescript-estree" "5.30.6"
+    debug "^4.3.4"
+
 "@typescript-eslint/scope-manager@5.11.0":
   version "5.11.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.11.0.tgz"
@@ -6065,14 +6080,6 @@
   dependencies:
     "@typescript-eslint/types" "5.11.0"
     "@typescript-eslint/visitor-keys" "5.11.0"
-
-"@typescript-eslint/scope-manager@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.15.0.tgz"
-  integrity sha512-EFiZcSKrHh4kWk0pZaa+YNJosvKE50EnmN4IfgjkA3bTHElPtYcd2U37QQkNTqwMCS7LXeDeZzEqnsOH8chjSg==
-  dependencies:
-    "@typescript-eslint/types" "5.15.0"
-    "@typescript-eslint/visitor-keys" "5.15.0"
 
 "@typescript-eslint/scope-manager@5.17.0":
   version "5.17.0"
@@ -6090,15 +6097,27 @@
     "@typescript-eslint/types" "5.30.0"
     "@typescript-eslint/visitor-keys" "5.30.0"
 
+"@typescript-eslint/scope-manager@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.30.6.tgz#ce1b49ff5ce47f55518d63dbe8fc9181ddbd1a33"
+  integrity sha512-Hkq5PhLgtVoW1obkqYH0i4iELctEKixkhWLPTYs55doGUKCASvkjOXOd/pisVeLdO24ZX9D6yymJ/twqpJiG3g==
+  dependencies:
+    "@typescript-eslint/types" "5.30.6"
+    "@typescript-eslint/visitor-keys" "5.30.6"
+
+"@typescript-eslint/type-utils@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.30.6.tgz#a64aa9acbe609ab77f09f53434a6af2b9685f3af"
+  integrity sha512-GFVVzs2j0QPpM+NTDMXtNmJKlF842lkZKDSanIxf+ArJsGeZUIaeT4jGg+gAgHt7AcQSFwW7htzF/rbAh2jaVA==
+  dependencies:
+    "@typescript-eslint/utils" "5.30.6"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/types@5.11.0":
   version "5.11.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.11.0.tgz"
   integrity sha512-cxgBFGSRCoBEhvSVLkKw39+kMzUKHlJGVwwMbPcTZX3qEhuXhrjwaZXWMxVfxDgyMm+b5Q5b29Llo2yow8Y7xQ==
-
-"@typescript-eslint/types@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.15.0.tgz"
-  integrity sha512-yEiTN4MDy23vvsIksrShjNwQl2vl6kJeG9YkVJXjXZnkJElzVK8nfPsWKYxcsGWG8GhurYXP4/KGj3aZAxbeOA==
 
 "@typescript-eslint/types@5.17.0":
   version "5.17.0"
@@ -6110,6 +6129,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.0.tgz#db7d81d585a3da3801432a9c1d2fafbff125e110"
   integrity sha512-vfqcBrsRNWw/LBXyncMF/KrUTYYzzygCSsVqlZ1qGu1QtGs6vMkt3US0VNSQ05grXi5Yadp3qv5XZdYLjpp8ag==
 
+"@typescript-eslint/types@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.6.tgz#86369d0a7af8c67024115ac1da3e8fb2d38907e1"
+  integrity sha512-HdnP8HioL1F7CwVmT4RaaMX57RrfqsOMclZc08wGMiDYJBsLGBM7JwXM4cZJmbWLzIR/pXg1kkrBBVpxTOwfUg==
+
 "@typescript-eslint/typescript-estree@5.11.0":
   version "5.11.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.11.0.tgz"
@@ -6117,19 +6141,6 @@
   dependencies:
     "@typescript-eslint/types" "5.11.0"
     "@typescript-eslint/visitor-keys" "5.11.0"
-    debug "^4.3.2"
-    globby "^11.0.4"
-    is-glob "^4.0.3"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/typescript-estree@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.15.0.tgz"
-  integrity sha512-Hb0e3dGc35b75xLzixM3cSbG1sSbrTBQDfIScqdyvrfJZVEi4XWAT+UL/HMxEdrJNB8Yk28SKxPLtAhfCbBInA==
-  dependencies:
-    "@typescript-eslint/types" "5.15.0"
-    "@typescript-eslint/visitor-keys" "5.15.0"
     debug "^4.3.2"
     globby "^11.0.4"
     is-glob "^4.0.3"
@@ -6161,6 +6172,31 @@
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.6.tgz#a84a0d6a486f9b54042da1de3d671a2c9f14484e"
+  integrity sha512-Z7TgPoeYUm06smfEfYF0RBkpF8csMyVnqQbLYiGgmUSTaSXTP57bt8f0UFXstbGxKIreTwQCujtaH0LY9w9B+A==
+  dependencies:
+    "@typescript-eslint/types" "5.30.6"
+    "@typescript-eslint/visitor-keys" "5.30.6"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.30.6.tgz#1de2da14f678e7d187daa6f2e4cdb558ed0609dc"
+  integrity sha512-xFBLc/esUbLOJLk9jKv0E9gD/OH966M40aY9jJ8GiqpSkP2xOV908cokJqqhVd85WoIvHVHYXxSFE4cCSDzVvA==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.30.6"
+    "@typescript-eslint/types" "5.30.6"
+    "@typescript-eslint/typescript-estree" "5.30.6"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
 
 "@typescript-eslint/utils@^5.10.0":
   version "5.17.0"
@@ -6194,14 +6230,6 @@
     "@typescript-eslint/types" "5.11.0"
     eslint-visitor-keys "^3.0.0"
 
-"@typescript-eslint/visitor-keys@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.15.0.tgz"
-  integrity sha512-+vX5FKtgvyHbmIJdxMJ2jKm9z2BIlXJiuewI8dsDYMp5LzPUcuTT78Ya5iwvQg3VqSVdmxyM8Anj1Jeq7733ZQ==
-  dependencies:
-    "@typescript-eslint/types" "5.15.0"
-    eslint-visitor-keys "^3.0.0"
-
 "@typescript-eslint/visitor-keys@5.17.0":
   version "5.17.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.17.0.tgz#52daae45c61b0211b4c81b53a71841911e479128"
@@ -6216,6 +6244,14 @@
   integrity sha512-6WcIeRk2DQ3pHKxU1Ni0qMXJkjO/zLjBymlYBy/53qxe7yjEFSvzKLDToJjURUhSl2Fzhkl4SMXQoETauF74cw==
   dependencies:
     "@typescript-eslint/types" "5.30.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.6.tgz#94dd10bb481c8083378d24de1742a14b38a2678c"
+  integrity sha512-41OiCjdL2mCaSDi2SvYbzFLlqqlm5v1ZW9Ym55wXKL/Rx6OOB1IbuFGo71Fj6Xy90gJDFTlgOS+vbmtGHPTQQA==
+  dependencies:
+    "@typescript-eslint/types" "5.30.6"
     eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.1":
@@ -19249,7 +19285,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@4.7.4:
+typescript@4.7.4, typescript@^4.7.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6038,7 +6038,7 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@^5.30.6":
+"@typescript-eslint/eslint-plugin@5.30.6":
   version "5.30.6"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.30.6.tgz#9c6017b6c1d04894141b4a87816388967f64c359"
   integrity sha512-J4zYMIhgrx4MgnZrSDD7sEnQp7FmhKNOaqaOpaoQ/SfdMfRB/0yvK74hTnvH+VQxndZynqs5/Hn4t+2/j9bADg==
@@ -6053,6 +6053,16 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
+"@typescript-eslint/parser@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.30.6.tgz#add440db038fa9d777e4ebdaf66da9e7fb7abe92"
+  integrity sha512-gfF9lZjT0p2ZSdxO70Xbw8w9sPPJGfAdjK7WikEjB3fcUI/yr9maUVEdqigBjKincUYNKOmf7QBMiTf719kbrA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.30.6"
+    "@typescript-eslint/types" "5.30.6"
+    "@typescript-eslint/typescript-estree" "5.30.6"
+    debug "^4.3.4"
+
 "@typescript-eslint/parser@^5.21.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.30.0.tgz#a2184fb5f8ef2bf1db0ae61a43907e2e32aa1b8f"
@@ -6061,16 +6071,6 @@
     "@typescript-eslint/scope-manager" "5.30.0"
     "@typescript-eslint/types" "5.30.0"
     "@typescript-eslint/typescript-estree" "5.30.0"
-    debug "^4.3.4"
-
-"@typescript-eslint/parser@^5.30.6":
-  version "5.30.6"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.30.6.tgz#add440db038fa9d777e4ebdaf66da9e7fb7abe92"
-  integrity sha512-gfF9lZjT0p2ZSdxO70Xbw8w9sPPJGfAdjK7WikEjB3fcUI/yr9maUVEdqigBjKincUYNKOmf7QBMiTf719kbrA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "5.30.6"
-    "@typescript-eslint/types" "5.30.6"
-    "@typescript-eslint/typescript-estree" "5.30.6"
     debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@5.11.0":
@@ -10067,10 +10067,10 @@ eslint-config-next@12.2.0:
     eslint-plugin-react "^7.29.4"
     eslint-plugin-react-hooks "^4.5.0"
 
-eslint-config-prettier@^8.3.0:
-  version "8.3.0"
-  resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz"
-  integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
+eslint-config-prettier@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
+  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
 
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
@@ -10179,6 +10179,13 @@ eslint-plugin-jsx-a11y@^6.5.1:
     jsx-ast-utils "^3.2.1"
     language-tags "^1.0.5"
     minimatch "^3.0.4"
+
+eslint-plugin-prettier@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
+  integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-react-hooks@^4.5.0:
   version "4.6.0"
@@ -10754,6 +10761,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.2.6:
   version "2.2.7"
@@ -16307,6 +16319,13 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 "prettier@>=2.2.1 <=2.3.0":
   version "2.3.0"


### PR DESCRIPTION
## Describe your changes
Improve typescript linting (to warn for unused-vars and such) and fix warnings and errors

## Justify why they are needed
Improve code styling

Stuff to improve
- Eslint doesn't seem to highlight warnings in VSCode still. Does that work for you?

### How it looks in racoon (only ts warning)
<img width="1034" alt="Screenshot 2022-07-19 at 13 34 31" src="https://user-images.githubusercontent.com/6661511/179742549-e09d236e-68ec-4705-a6ae-2078e8e055b4.png">

### In market-web (eslint warning)
<img width="1146" alt="Screenshot 2022-07-19 at 13 43 14" src="https://user-images.githubusercontent.com/6661511/179742570-dd4936c1-963f-493e-aa1a-d63429cebf57.png">

