### PR TITLE
Infer proper type on colors

### DIFF
--- a/packages/ui/src/lib/theme/colors.ts
+++ b/packages/ui/src/lib/theme/colors.ts
@@ -1,0 +1,49 @@
+const gray = {
+  100: '#fafafa',
+  200: '#f2f2f2',
+  300: '#eaeaea',
+  500: '#aaaaaa',
+  600: '#777777',
+  700: '#505050',
+  800: '#272727',
+  900: '#121212',
+}
+
+const purple = {
+  100: '#f5ebf5',
+  300: '#e3d7ee',
+  500: '#d7c6e6',
+  700: '#ccb9df',
+  800: '#bea4d5',
+  900: '#8c67ad',
+}
+
+const red = {
+  500: '#e24646',
+  600: '#dd2727',
+}
+
+export const colors = {
+  gray100: gray[100],
+  gray200: gray[200],
+  gray300: gray[300],
+  gray500: gray[500],
+  gray600: gray[600],
+  gray700: gray[700],
+  gray800: gray[800],
+  gray900: gray[900],
+  purple100: purple[100],
+  purple300: purple[300],
+  purple500: purple[500],
+  purple700: purple[700],
+  purple800: purple[800],
+  purple900: purple[900],
+  red500: red[500],
+  red600: red[600],
+  black: '#000000',
+  white: '#ffffff',
+  // Alias colors
+  dark: gray[900],
+  light: gray[100],
+  lavender: purple[500],
+}

--- a/packages/ui/src/lib/theme/theme.ts
+++ b/packages/ui/src/lib/theme/theme.ts
@@ -1,12 +1,5 @@
-import { colorsV3 } from '@hedviginsurance/brand'
+import { colors } from './colors'
 import { fonts, fontSizes } from './typography'
-
-const colors: Record<string, string> = {
-  ...colorsV3,
-}
-colors.dark = colors.gray900
-colors.light = colors.gray100
-colors.lavender = colors.purple500
 
 const space = [
   0,


### PR DESCRIPTION
## Describe your changes

- Make sure theme get inferred color types
- Stop using colors from brand repo - this will be deprecated when we go live with the store

## Justify why they are needed
The thought is that we have set of brand colors that we reference for color aliases.