### PR TITLE
Make TopMenu float above page content

### DIFF
--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -23,9 +23,18 @@ export const LayoutWithMenu = ({ children }: LayoutWithMenuProps) => {
 
   return (
     <Wrapper>
-      <TopMenu />
+      <FixedHeader>
+        <TopMenu />
+      </FixedHeader>
       {children}
       <SiteFooter onChangeLocale={handleChangeLocale} />
     </Wrapper>
   )
 }
+
+const FixedHeader = styled.header({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+})

--- a/apps/store/src/components/TopMenu/TopMenu.tsx
+++ b/apps/store/src/components/TopMenu/TopMenu.tsx
@@ -118,8 +118,6 @@ const Wrapper = styled.div(({ theme }) => ({
   width: '100%',
   height: MENU_BAR_HEIGHT,
   padding: theme.space[4],
-  backgroundColor: theme.colors.gray200,
-  color: theme.colors.gray900,
 }))
 
 const StyledDialogOverlay = styled(DialogPrimitive.Overlay)({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Update layout component to place TopMenu on top of page content.
Remove background + color from TopMenu.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Designers are not 100% ready with the interaction so expect changes to come.

## Jira issue(s): [GRW-1310]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.


[GRW-1310]: https://hedvig.atlassian.net/browse/GRW-1310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ