### PR TITLE
fix(store: CartNotificationHeader): remove missing ref warning

### DIFF
--- a/apps/store/src/components/CartNotification/Header.tsx
+++ b/apps/store/src/components/CartNotification/Header.tsx
@@ -1,16 +1,20 @@
 import styled from '@emotion/styled'
+import React from 'react'
 
 type HeaderProps = {
   children: string
 }
 
-export const Header = ({ children }: HeaderProps) => {
-  return (
-    <Wrapper>
-      <StyledTitle>{children}</StyledTitle>
-    </Wrapper>
-  )
-}
+export const Header = React.forwardRef<HTMLDivElement, HeaderProps>(
+  ({ children }, forwardedRef) => {
+    return (
+      <Wrapper ref={forwardedRef}>
+        <StyledTitle>{children}</StyledTitle>
+      </Wrapper>
+    )
+  },
+)
+Header.displayName = 'Header'
 
 const ROW_HEIGHT = '4.5rem'
 


### PR DESCRIPTION
## Describe your changes

Even though not describe in the documentation, it seems Dialog title components should be able to accept a ref. Since our custom component used [here](https://github.com/HedvigInsurance/racoon/blob/main/apps/store/src/components/CartNotification/CartToast.tsx#L45) a warning is raised.

<img width="857" alt="Screenshot 2022-08-01 at 13 47 49" src="https://user-images.githubusercontent.com/19200662/182141403-77aa38fb-19cc-444c-9219-81c3ed1da989.png">

