### PR TITLE
Add PriceCalculatorFooter to block

### DIFF
--- a/apps/store/src/blocks/PriceCalculatorBlock.tsx
+++ b/apps/store/src/blocks/PriceCalculatorBlock.tsx
@@ -6,6 +6,7 @@ import { CartToast, CartToastAttributes } from '@/components/CartNotification/Ca
 import { PriceCalculatorForm } from '@/components/PriceCalculatorForm/PriceCalculatorForm'
 import { useHandleSubmitPriceCalculatorForm } from '@/components/PriceCalculatorForm/useHandleSubmitPriceCalculator'
 import { PriceCard } from '@/components/PriceCard/PriceCard'
+import { PriceCalculatorFooter } from '@/components/ProductPage/PriceCalculatorFooter/PriceCalculatorFooter'
 import { useHandleClickAddToCart } from '@/components/ProductPage/useHandleClickAddToCart'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { CurrencyCode, CountryCode } from '@/services/apollo/generated'
@@ -36,6 +37,7 @@ type StoryblokPriceCalculatorBlockProps = SbBaseBlockProps<PriceCalculatorBlockP
 export const PriceCalculatorBlock = ({
   blok: { title, lineId, priceFormTemplate, countryCode, product },
 }: StoryblokPriceCalculatorBlockProps) => {
+  const wrapperRef = useRef<HTMLDivElement>(null)
   const toastRef = useRef<CartToastAttributes | null>(null)
   const formatter = useCurrencyFormatter(product.currencyCode)
   const { handleSubmit } = useHandleSubmitPriceCalculatorForm({ productSlug: product.slug })
@@ -54,7 +56,7 @@ export const PriceCalculatorBlock = ({
 
   return (
     <>
-      <Space y={2} {...storyblokEditable}>
+      <Space y={2} ref={wrapperRef} {...storyblokEditable}>
         <Space y={1}>
           <SpaceFlex align="center" direction="vertical">
             <Heading as="h3" variant="standard.18">
@@ -78,6 +80,13 @@ export const PriceCalculatorBlock = ({
           />
         </SectionWithPadding>
       </Space>
+
+      <PriceCalculatorFooter
+        targetRef={wrapperRef}
+        currencyCode={product.currencyCode}
+        price={product.price ?? undefined}
+        onClickAddToCart={handleClickAddToCart}
+      />
 
       <CartToast ref={toastRef} />
     </>

--- a/apps/store/src/components/ProductPage/PriceCalculatorFooter/PriceCalculatorFooter.tsx
+++ b/apps/store/src/components/ProductPage/PriceCalculatorFooter/PriceCalculatorFooter.tsx
@@ -1,0 +1,40 @@
+import { useCurrencyFormatter } from '@/utils/useCurrencyFormatter'
+import * as PriceFooter from '../PriceFooter/PriceFooter'
+import { ScrollPast } from '../ScrollPast/ScrollPast'
+import { ScrollToButton } from '../ScrollToButton/ScrollToButton'
+
+type Props = {
+  currencyCode: string
+  price?: number
+  targetRef: React.RefObject<HTMLElement>
+  onClickAddToCart: () => void
+}
+
+export const PriceCalculatorFooter = ({
+  price,
+  currencyCode,
+  targetRef,
+  onClickAddToCart,
+}: Props) => {
+  const formatter = useCurrencyFormatter(currencyCode)
+
+  const handleClick = () => {
+    targetRef.current?.scrollIntoView({ behavior: 'smooth' })
+    onClickAddToCart()
+  }
+
+  return (
+    <ScrollPast targetRef={targetRef}>
+      {price ? (
+        <PriceFooter.Footer>
+          <PriceFooter.Button onClick={handleClick}>
+            <span>{formatter.format(price)}</span>
+            <span>Add to cart</span>
+          </PriceFooter.Button>
+        </PriceFooter.Footer>
+      ) : (
+        <ScrollToButton targetRef={targetRef}>Calculate your price</ScrollToButton>
+      )}
+    </ScrollPast>
+  )
+}

--- a/apps/store/src/components/ProductPage/PriceFooter/PriceFooter.stories.tsx
+++ b/apps/store/src/components/ProductPage/PriceFooter/PriceFooter.stories.tsx
@@ -1,18 +1,22 @@
 import { ComponentMeta, Story } from '@storybook/react'
-import { PriceFooter, PriceFooterProps } from './PriceFooter'
+import * as PriceFooter from './PriceFooter'
 
 export default {
   title: 'Product Page / Price Footer',
-  component: PriceFooter,
-  argTypes: {},
-} as ComponentMeta<typeof PriceFooter>
+  component: PriceFooter.Footer,
+  argTypes: {
+    onClick: { action: 'clicked' },
+  },
+} as ComponentMeta<typeof PriceFooter.Footer>
 
-const Template: Story<PriceFooterProps> = (props) => {
+const Template: Story<PriceFooter.ButtonProps> = (props) => {
   return (
-    <PriceFooter {...props}>
-      <span>SEK 149/mp.</span>
-      <span>Add to cart</span>
-    </PriceFooter>
+    <PriceFooter.Footer {...props}>
+      <PriceFooter.Button onClick={props.onClick}>
+        <span>SEK 149/mp.</span>
+        <span>Add to cart</span>
+      </PriceFooter.Button>
+    </PriceFooter.Footer>
   )
 }
 

--- a/apps/store/src/components/ProductPage/PriceFooter/PriceFooter.tsx
+++ b/apps/store/src/components/ProductPage/PriceFooter/PriceFooter.tsx
@@ -1,27 +1,35 @@
 import styled from '@emotion/styled'
-import { Button, Separate, Space } from 'ui'
+import { Button as UIButton, Separate, Space } from 'ui'
 
-export type PriceFooterProps = {
+export type FooterProps = {
   children: React.ReactNode
 }
 
-export const PriceFooter = ({ children }: PriceFooterProps) => {
-  return (
-    <Wrapper y={1}>
-      <FlexButton fullWidth>
-        <Separate Separator={<Separator />}>{children}</Separate>
-      </FlexButton>
-    </Wrapper>
-  )
+export const Footer = ({ children }: FooterProps) => {
+  return <Wrapper y={1}>{children}</Wrapper>
 }
 
 const Wrapper = styled(Space)(({ theme }) => ({
   backgroundColor: theme.colors.white,
   boxShadow: '0px -1px 1px rgba(0, 0, 0, 0.1), 0px -4px 8px rgba(0, 0, 0, 0.1)',
   padding: `${theme.space[3]} ${theme.space[4]}`,
+  width: '100%',
 }))
 
-const FlexButton = styled(Button)(() => ({
+export type ButtonProps = {
+  children: React.ReactNode
+  onClick: () => void
+}
+
+export const Button = ({ onClick, children }: ButtonProps) => {
+  return (
+    <FlexButton fullWidth onClick={onClick}>
+      <Separate Separator={<Separator />}>{children}</Separate>
+    </FlexButton>
+  )
+}
+
+const FlexButton = styled(UIButton)(() => ({
   display: 'flex',
 }))
 

--- a/apps/store/src/components/ProductPage/ScrollPast/ScrollPast.tsx
+++ b/apps/store/src/components/ProductPage/ScrollPast/ScrollPast.tsx
@@ -34,12 +34,10 @@ export const ScrollPast = ({ targetRef, children }: ScrollPastProps) => {
   )
 }
 
-const StyledWrapper = styled(motion.div)(({ theme }) => ({
+const StyledWrapper = styled(motion.div)({
   position: 'fixed',
   bottom: 0,
   left: 0,
   right: 0,
-  paddingBottom: theme.space[4],
-  display: 'flex',
-  justifyContent: 'center',
-}))
+  zIndex: 1,
+})

--- a/apps/store/src/components/ProductPage/ScrollToButton/ScrollToButton.tsx
+++ b/apps/store/src/components/ProductPage/ScrollToButton/ScrollToButton.tsx
@@ -26,6 +26,7 @@ const Wrappper = styled.div(({ theme }) => ({
   display: 'flex',
   justifyContent: 'center',
   paddingBottom: theme.space[5],
+  width: '100%',
 }))
 
 const StyledPillButton = styled.button(({ theme }) => ({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add PriceCalculatorFooter component.
Integrate price calculator footer in CMS block.
Refactor PriceFooter and ScrollPast components.

[Screen Recording 2022-08-02 at 15.31.53.mov](https://graphite-user-uploaded-assets.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/1765789b-70f9-4839-af47-49c7497f9ab5/Screen%20Recording%202022-08-02%20at%2015.31.53.mov)

## Justify why they are needed

I think it make sense that everything to do with the price calculator goes along with the CMS block.

## Jira issue(s): [GRW-1304]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.


[GRW-1304]: https://hedvig.atlassian.net/browse/GRW-1304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ