### PR TITLE
Add support for publishing to Chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,25 @@
+name: Chromatic
+
+on: push
+
+jobs:
+  chromatic-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Install
+        run: yarn install --prefer-offline --frozen-lockfile
+
+      - name: Publish to Chromatic (store)
+        run: yarn chromatic --filter=store
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit",
     "storybook": "start-storybook -p 6008",
     "storybook:build": "build-storybook",
+    "chromatic": "npx chromatic --exit-zero-on-changes --storybook-build-dir ./storybook-static",
     "codegen": "graphql-codegen -r dotenv/config && prettier --write ./src/services/**/generated.ts && yarn lint --fix"
   },
   "dependencies": {

--- a/apps/store/src/components/CartCard/CartCard.stories.tsx
+++ b/apps/store/src/components/CartCard/CartCard.stories.tsx
@@ -15,4 +15,5 @@ export const Default = Template.bind({})
 Default.args = {
   price: 149,
   title: 'Hedvig Home',
+  currency: 'SEK',
 }

--- a/apps/store/src/components/CartCard/CartCard.tsx
+++ b/apps/store/src/components/CartCard/CartCard.tsx
@@ -48,7 +48,6 @@ export type CartCardProps = {
 }
 
 export const CartCard = ({ title, price, currency }: CartCardProps) => {
-
   const currencyFormatter = useCurrencyFormatter(currency)
 
   return (
@@ -59,9 +58,7 @@ export const CartCard = ({ title, price, currency }: CartCardProps) => {
           {title && <TitleElement>{title}</TitleElement>}
           <RemoveButton>Remove</RemoveButton>
         </HeaderElement>
-        {price &&
-          <ExtraElement>{currencyFormatter.format(price)}/mo.</ExtraElement>
-}
+        {price && <ExtraElement>{currencyFormatter.format(price)}/mo.</ExtraElement>}
       </Content>
     </ProductCard>
   )

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "prepare": "husky install",
     "typecheck": "turbo run typecheck",
     "storybook": "turbo run storybook",
-    "storybook:build": "turbo run storybook:build"
+    "storybook:build": "turbo run storybook:build",
+    "chromatic": "turbo run chromatic"
   },
   "devDependencies": {
     "husky": "^7.0.4",

--- a/turbo.json
+++ b/turbo.json
@@ -86,6 +86,9 @@
       "outputs": ["storybook-static/**"],
       "dependsOn": ["^build", "codegen"]
     },
+    "chromatic": {
+      "dependsOn": ["storybook:build"]
+    },
     "typecheck": {
       "outputs": []
     },


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Integrate with the basic version of Chromatic platform to include Storybook in code review process.
https://www.chromatic.com/docs/

## Justify why they are needed

Let's try out this platform. The basic plan is "free forever". It also let's us off load the Storybook deployments from Vercel.

I didn't add "chromatic" as a deployment - better see if we can make it work with just the latest version (using npx).
It's also not a mission critical tool.

## Jira issue(s): [GRW-1312]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.


[GRW-1312]: https://hedvig.atlassian.net/browse/GRW-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ