### PR TITLE
Remove brand repo dependency 💅

### DIFF
--- a/apps/market-web/src/blocks/HeadlineBlock/HeadlineBlock.tsx
+++ b/apps/market-web/src/blocks/HeadlineBlock/HeadlineBlock.tsx
@@ -1,11 +1,10 @@
 import styled from '@emotion/styled'
-import { HedvigSymbol } from '@hedviginsurance/brand'
 import React from 'react'
-import { StoryblokBaseBlock } from '@/services/storyblok/types'
 import { mq } from 'ui'
 import { ContentWrapper, SectionWrapper } from '@/blocks/blockHelpers'
 import { FontSizes, Heading } from '@/components/Heading/Heading'
 import { TextPosition } from '@/helpers/textPosition'
+import { StoryblokBaseBlock } from '@/services/storyblok/types'
 
 type HeadlineBlockProps = StoryblokBaseBlock & {
   text: string
@@ -79,11 +78,7 @@ export const HeadlineBlock = ({
               __html: text,
             }}
           />
-          {show_hedvig_wordmark && (
-            <Wordmark>
-              <HedvigSymbol />
-            </Wordmark>
-          )}
+          {show_hedvig_wordmark && <Wordmark />}
         </Heading>
       </ContentWrapper>
     </SectionWrapper>

--- a/apps/market-web/src/blocks/HeroBlock/HeroBlock.tsx
+++ b/apps/market-web/src/blocks/HeroBlock/HeroBlock.tsx
@@ -1,6 +1,5 @@
 import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
-import { HedvigSymbol } from '@hedviginsurance/brand'
 import { FontSizes, Heading } from 'components/Heading/Heading'
 import React from 'react'
 import { ButtonColors } from 'ui'
@@ -194,11 +193,7 @@ export const HeroBlock = ({
             textPosition={text_position}
             dangerouslySetInnerHTML={{ __html: headline }}
           />
-          {show_hedvig_wordmark && (
-            <Wordmark>
-              <HedvigSymbol />
-            </Wordmark>
-          )}
+          {show_hedvig_wordmark && <Wordmark />}
         </HeadlineWrapper>
         {text && (
           <Text

--- a/apps/market-web/src/blocks/PageHeaderBlock/PageHeaderBlock.tsx
+++ b/apps/market-web/src/blocks/PageHeaderBlock/PageHeaderBlock.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled'
-import { colorsV3, HedvigLogo, HedvigSymbol } from '@hedviginsurance/brand'
 import React, { useCallback, useEffect, useState } from 'react'
 import AnimateHeight from 'react-animate-height'
 import { StoryData } from 'storyblok-js-client'
@@ -36,13 +35,13 @@ const HeaderBackgroundFiller = styled.div<{ transparent: boolean }>(({ transpare
   zIndex: -1,
   height: MOBILE_WRAPPER_HEIGHT,
   opacity: transparent ? 0 : 1,
-  backgroundColor: colorsV3.gray900,
+  backgroundColor: getColor('gray900'),
   transitionDuration: '300ms',
   transitionProperty: 'opacity, background-color',
 
   [mq.md]: {
     height: WRAPPER_HEIGHT,
-    backgroundColor: colorsV3.gray100,
+    backgroundColor: getColor('gray100'),
   },
 }))
 
@@ -138,9 +137,6 @@ export interface PageHeaderBlockProps extends StoryblokBaseBlock {
 export const PageHeaderBlock = (props: { story: StoryData } & PageHeaderBlockProps) => {
   const currentLocale = useCurrentLocale()
 
-  const showBanner =
-    props.story.content.show_banner && props.story.content.banner_text && !props.hide_global_banner
-
   const [isBelowThreshold, setIsBelowThreshold] = useState<boolean>(false)
   const isDesktop = useBreakpoint('md')
 
@@ -173,12 +169,6 @@ export const PageHeaderBlock = (props: { story: StoryData } & PageHeaderBlockPro
 
   return (
     <>
-      {/* {showBanner && (
-        <BannerBlock
-          color={props.story.content.banner_color}
-          text={props.story.content.banner_text}
-        />
-      )} */}
       <HeaderWrapper>
         <HeaderBackgroundFiller transparent={props.is_transparent && !isBelowThreshold} />
 
@@ -186,7 +176,7 @@ export const PageHeaderBlock = (props: { story: StoryData } & PageHeaderBlockPro
           <LeftContainer>
             <HideOnMobile>
               <LogoLink color={theme} href={'/' + currentLocale.marketLabel}>
-                <HedvigLogo width={94} />
+                H
               </LogoLink>
             </HideOnMobile>
 
@@ -201,9 +191,7 @@ export const PageHeaderBlock = (props: { story: StoryData } & PageHeaderBlockPro
           </LeftContainer>
           <RightContainer>
             <HideOnDesktop>
-              <Wordmark href={'/' + currentLocale.marketLabel}>
-                <HedvigSymbol size={28} color={colorsV3.gray100} />
-              </Wordmark>
+              <Wordmark href={'/' + currentLocale.marketLabel} />
             </HideOnDesktop>
 
             {!props.hide_menu && (

--- a/apps/market-web/src/blocks/blockHelpers.tsx
+++ b/apps/market-web/src/blocks/blockHelpers.tsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled'
-import { colorsV3, fonts } from '@hedviginsurance/brand'
 import { match } from 'matchly'
 import React from 'react'
-import { mq } from 'ui'
+import { getColor, mq } from 'ui'
 import { MinimalColorComponent, minimalColorComponentColors } from '@/services/storyblok/types'
 
 export const CONTENT_GUTTER = '2rem'
@@ -82,8 +81,8 @@ export type ColorSetGetter<TColors> = (
 
 export const getMinimalColorStyles: ColorSetGetter<minimalColorComponentColors> = (
   color,
-  standardColor = colorsV3.gray100,
-  standardInverseColor = colorsV3.gray900,
+  standardColor = getColor('gray100'),
+  standardInverseColor = getColor('gray900'),
 ) =>
   match([
     [
@@ -91,7 +90,7 @@ export const getMinimalColorStyles: ColorSetGetter<minimalColorComponentColors> 
       {
         background: standardColor,
         color: standardInverseColor,
-        secondaryColor: colorsV3.gray700,
+        secondaryColor: getColor('gray700'),
       },
     ],
     [
@@ -99,23 +98,23 @@ export const getMinimalColorStyles: ColorSetGetter<minimalColorComponentColors> 
       {
         background: standardInverseColor,
         color: standardColor,
-        secondaryColor: colorsV3.gray500,
+        secondaryColor: getColor('gray500'),
       },
     ],
-    ['gray700', { background: standardColor, color: colorsV3.gray700 }],
-    ['gray500-inverse', { background: colorsV3.gray900, color: colorsV3.gray500 }],
+    ['gray700', { background: standardColor, color: getColor('gray700') }],
+    ['gray500-inverse', { background: getColor('gray900'), color: getColor('gray500') }],
     [
       'purple300',
       {
-        background: colorsV3.purple300,
-        color: colorsV3.gray900,
+        background: getColor('purple300'),
+        color: getColor('gray900'),
       },
     ],
     [
       'purple500',
       {
-        background: colorsV3.purple500,
-        color: colorsV3.gray900,
+        background: getColor('purple500'),
+        color: getColor('gray900'),
       },
     ],
     [match.any(), { background: standardColor, color: standardInverseColor }],
@@ -159,7 +158,7 @@ type SectionProps = {
 }
 
 const SectionWrapperComponentUnstyled = styled.section<SectionProps>(
-  ({ colorComponent, size = 'lg', theme }) => ({
+  ({ colorComponent, size = 'lg' }) => ({
     position: 'relative',
     transition: 'background 300ms',
     ...getSectionSizeStyle(size),
@@ -252,7 +251,6 @@ export type ContentWrapperProps = {
 }
 
 export const ContentWrapper = ({
-  index = 0,
   contentWidth = false,
   children,
   fullWidth = false,

--- a/apps/market-web/src/components/Heading/Heading.tsx
+++ b/apps/market-web/src/components/Heading/Heading.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { fonts } from '@hedviginsurance/brand'
+import { fonts } from 'ui'
 import { mq } from 'ui'
 import { getMinimalColorStyles } from '@/blocks/blockHelpers'
 import { TextPosition } from '@/helpers/textPosition'
@@ -41,8 +41,7 @@ export const Heading = styled.h1<HeadingProps>`
   font-size: ${(props) => headingSizeMapMobile[props.mobileSize ?? props.size]};
   text-align: ${(props) => props.textPosition};
   text-transform: ${(props) => (props.capitalize ? 'uppercase' : undefined)};
-  font-family: ${(props) =>
-    props.useDisplayFont ? `${fonts.HEDVIG_LETTERS_BIG}, serif !important` : undefined};
+  font-family: ${(props) => (props.useDisplayFont ? `${fonts.big} !important` : undefined)};
   line-height: 1.2;
 
   ${mq.md} {

--- a/apps/market-web/src/components/Menu/LanguagePicker.tsx
+++ b/apps/market-web/src/components/Menu/LanguagePicker.tsx
@@ -1,9 +1,8 @@
 import styled from '@emotion/styled'
-import { colorsV3 } from '@hedviginsurance/brand'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { MenuTheme } from 'ui/src/components/Menu/Menu'
-import { LinkButton, Separate } from 'ui'
+import { getColor, LinkButton, Separate } from 'ui'
 import { useCurrentMarket } from '@/lib/l10n/useCurrentMarket'
 
 const Wrapper = styled(Separate)({
@@ -14,7 +13,7 @@ const Wrapper = styled(Separate)({
 const Separator = styled.div(() => ({
   width: 1,
   height: '1rem',
-  backgroundColor: colorsV3.gray700,
+  backgroundColor: getColor('gray700'),
 }))
 
 type LanguagePickerProps = {

--- a/apps/market-web/src/components/Menu/Menu.tsx
+++ b/apps/market-web/src/components/Menu/Menu.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled'
-import { colorsV3 } from '@hedviginsurance/brand'
 import { ReactNode } from 'react'
-import { Menu as UiMenu, MenuTheme, mq } from 'ui'
+import { getColor, Menu as UiMenu, MenuTheme, mq } from 'ui'
 import { MenuItem as StoryblokMenuItem } from '@/services/storyblok/types'
 import { LanguagePicker } from './LanguagePicker'
 
@@ -15,7 +14,7 @@ const MenuWrapper = styled.div({
   justifyContent: 'flex-end',
 
   width: '100%',
-  backgroundColor: colorsV3.gray900,
+  backgroundColor: getColor('gray900'),
 
   [mq.md]: {
     height: WRAPPER_HEIGHT,

--- a/apps/onboarding/package.json
+++ b/apps/onboarding/package.json
@@ -48,7 +48,6 @@
     "@graphql-codegen/typescript-generic-sdk": "2.5.0",
     "@graphql-codegen/typescript-operations": "2.5.2",
     "@graphql-codegen/typescript-react-apollo": "3.3.2",
-    "@hedviginsurance/brand": "^5.0.0",
     "@testing-library/jest-dom": "5.16.4",
     "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "8.0.1",

--- a/apps/onboarding/public/mockServiceWorker.js
+++ b/apps/onboarding/public/mockServiceWorker.js
@@ -2,22 +2,21 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (0.39.2).
+ * Mock Service Worker (0.44.0).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.
  */
 
-const INTEGRITY_CHECKSUM = '02f4ad4a2797f85668baf196e553d929'
-const bypassHeaderName = 'x-msw-bypass'
+const INTEGRITY_CHECKSUM = 'df0d85222361310ecbe1792c606e08f2'
 const activeClientIds = new Set()
 
 self.addEventListener('install', function () {
-  return self.skipWaiting()
+  self.skipWaiting()
 })
 
-self.addEventListener('activate', async function (event) {
-  return self.clients.claim()
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
 })
 
 self.addEventListener('message', async function (event) {
@@ -33,7 +32,9 @@ self.addEventListener('message', async function (event) {
     return
   }
 
-  const allClients = await self.clients.matchAll()
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
 
   switch (event.data) {
     case 'KEEPALIVE_REQUEST': {
@@ -83,157 +84,6 @@ self.addEventListener('message', async function (event) {
   }
 })
 
-// Resolve the "main" client for the given event.
-// Client that issues a request doesn't necessarily equal the client
-// that registered the worker. It's with the latter the worker should
-// communicate with during the response resolving phase.
-async function resolveMainClient(event) {
-  const client = await self.clients.get(event.clientId)
-
-  if (client.frameType === 'top-level') {
-    return client
-  }
-
-  const allClients = await self.clients.matchAll()
-
-  return allClients
-    .filter((client) => {
-      // Get only those clients that are currently visible.
-      return client.visibilityState === 'visible'
-    })
-    .find((client) => {
-      // Find the client ID that's recorded in the
-      // set of clients that have registered the worker.
-      return activeClientIds.has(client.id)
-    })
-}
-
-async function handleRequest(event, requestId) {
-  const client = await resolveMainClient(event)
-  const response = await getResponse(event, client, requestId)
-
-  // Send back the response clone for the "response:*" life-cycle events.
-  // Ensure MSW is active and ready to handle the message, otherwise
-  // this message will pend indefinitely.
-  if (client && activeClientIds.has(client.id)) {
-    ;(async function () {
-      const clonedResponse = response.clone()
-      sendToClient(client, {
-        type: 'RESPONSE',
-        payload: {
-          requestId,
-          type: clonedResponse.type,
-          ok: clonedResponse.ok,
-          status: clonedResponse.status,
-          statusText: clonedResponse.statusText,
-          body: clonedResponse.body === null ? null : await clonedResponse.text(),
-          headers: serializeHeaders(clonedResponse.headers),
-          redirected: clonedResponse.redirected,
-        },
-      })
-    })()
-  }
-
-  return response
-}
-
-async function getResponse(event, client, requestId) {
-  const { request } = event
-  const requestClone = request.clone()
-  const getOriginalResponse = () => fetch(requestClone)
-
-  // Bypass mocking when the request client is not active.
-  if (!client) {
-    return getOriginalResponse()
-  }
-
-  // Bypass initial page load requests (i.e. static assets).
-  // The absence of the immediate/parent client in the map of the active clients
-  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
-  // and is not ready to handle requests.
-  if (!activeClientIds.has(client.id)) {
-    return await getOriginalResponse()
-  }
-
-  // Bypass requests with the explicit bypass header
-  if (requestClone.headers.get(bypassHeaderName) === 'true') {
-    const cleanRequestHeaders = serializeHeaders(requestClone.headers)
-
-    // Remove the bypass header to comply with the CORS preflight check.
-    delete cleanRequestHeaders[bypassHeaderName]
-
-    const originalRequest = new Request(requestClone, {
-      headers: new Headers(cleanRequestHeaders),
-    })
-
-    return fetch(originalRequest)
-  }
-
-  // Send the request to the client-side MSW.
-  const reqHeaders = serializeHeaders(request.headers)
-  const body = await request.text()
-
-  const clientMessage = await sendToClient(client, {
-    type: 'REQUEST',
-    payload: {
-      id: requestId,
-      url: request.url,
-      method: request.method,
-      headers: reqHeaders,
-      cache: request.cache,
-      mode: request.mode,
-      credentials: request.credentials,
-      destination: request.destination,
-      integrity: request.integrity,
-      redirect: request.redirect,
-      referrer: request.referrer,
-      referrerPolicy: request.referrerPolicy,
-      body,
-      bodyUsed: request.bodyUsed,
-      keepalive: request.keepalive,
-    },
-  })
-
-  switch (clientMessage.type) {
-    case 'MOCK_SUCCESS': {
-      return delayPromise(() => respondWithMock(clientMessage), clientMessage.payload.delay)
-    }
-
-    case 'MOCK_NOT_FOUND': {
-      return getOriginalResponse()
-    }
-
-    case 'NETWORK_ERROR': {
-      const { name, message } = clientMessage.payload
-      const networkError = new Error(message)
-      networkError.name = name
-
-      // Rejecting a request Promise emulates a network error.
-      throw networkError
-    }
-
-    case 'INTERNAL_ERROR': {
-      const parsedBody = JSON.parse(clientMessage.payload.body)
-
-      console.error(
-        `\
-[MSW] Uncaught exception in the request handler for "%s %s":
-
-${parsedBody.location}
-
-This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error, as it indicates a mistake in your code. If you wish to mock an error response, please see this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
-`,
-        request.method,
-        request.url,
-      )
-
-      return respondWithMock(clientMessage)
-    }
-  }
-
-  return getOriginalResponse()
-}
-
 self.addEventListener('fetch', function (event) {
   const { request } = event
   const accept = request.headers.get('accept') || ''
@@ -261,9 +111,10 @@ self.addEventListener('fetch', function (event) {
     return
   }
 
-  const requestId = uuidv4()
+  // Generate unique request ID.
+  const requestId = Math.random().toString(16).slice(2)
 
-  return event.respondWith(
+  event.respondWith(
     handleRequest(event, requestId).catch((error) => {
       if (error.name === 'NetworkError') {
         console.warn(
@@ -286,12 +137,168 @@ self.addEventListener('fetch', function (event) {
   )
 })
 
-function serializeHeaders(headers) {
-  const reqHeaders = {}
-  headers.forEach((value, name) => {
-    reqHeaders[name] = reqHeaders[name] ? [].concat(reqHeaders[name]).concat(value) : value
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const clonedResponse = response.clone()
+      sendToClient(client, {
+        type: 'RESPONSE',
+        payload: {
+          requestId,
+          type: clonedResponse.type,
+          ok: clonedResponse.ok,
+          status: clonedResponse.status,
+          statusText: clonedResponse.statusText,
+          body: clonedResponse.body === null ? null : await clonedResponse.text(),
+          headers: Object.fromEntries(clonedResponse.headers.entries()),
+          redirected: clonedResponse.redirected,
+        },
+      })
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
   })
-  return reqHeaders
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+  const clonedRequest = request.clone()
+
+  function passthrough() {
+    // Clone the request because it might've been already used
+    // (i.e. its body has been read and sent to the cilent).
+    const headers = Object.fromEntries(clonedRequest.headers.entries())
+
+    // Remove MSW-specific request headers so the bypassed requests
+    // comply with the server's CORS preflight check.
+    // Operate with the headers as an object because request "Headers"
+    // are immutable.
+    delete headers['x-msw-bypass']
+
+    return fetch(clonedRequest, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Bypass requests with the explicit bypass header.
+  // Such requests can be issued by "ctx.fetch()".
+  if (request.headers.get('x-msw-bypass') === 'true') {
+    return passthrough()
+  }
+
+  // Create a communication channel scoped to the current request.
+  // This way events can be exchanged outside of the worker's global
+  // "message" event listener (i.e. abstracted into functions).
+  const operationChannel = new BroadcastChannel(`msw-response-stream-${requestId}`)
+
+  // Notify the client that a request has been intercepted.
+  const clientMessage = await sendToClient(client, {
+    type: 'REQUEST',
+    payload: {
+      id: requestId,
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries()),
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      destination: request.destination,
+      integrity: request.integrity,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      body: await request.text(),
+      bodyUsed: request.bodyUsed,
+      keepalive: request.keepalive,
+    },
+  })
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.payload)
+    }
+
+    case 'MOCK_RESPONSE_START': {
+      return respondWithMockStream(operationChannel, clientMessage.payload)
+    }
+
+    case 'MOCK_NOT_FOUND': {
+      return passthrough()
+    }
+
+    case 'NETWORK_ERROR': {
+      const { name, message } = clientMessage.payload
+      const networkError = new Error(message)
+      networkError.name = name
+
+      // Rejecting a "respondWith" promise emulates a network error.
+      throw networkError
+    }
+
+    case 'INTERNAL_ERROR': {
+      const parsedBody = JSON.parse(clientMessage.payload.body)
+
+      console.error(
+        `\
+[MSW] Uncaught exception in the request handler for "%s %s":
+
+${parsedBody.location}
+
+This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error, as it indicates a mistake in your code. If you wish to mock an error response, please see this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
+`,
+        request.method,
+        request.url,
+      )
+
+      return respondWithMock(clientMessage.payload)
+    }
+  }
+
+  return passthrough()
 }
 
 function sendToClient(client, message) {
@@ -306,27 +313,52 @@ function sendToClient(client, message) {
       resolve(event.data)
     }
 
-    client.postMessage(JSON.stringify(message), [channel.port2])
+    client.postMessage(message, [channel.port2])
   })
 }
 
-function delayPromise(cb, duration) {
+function sleep(timeMs) {
   return new Promise((resolve) => {
-    setTimeout(() => resolve(cb()), duration)
+    setTimeout(resolve, timeMs)
   })
 }
 
-function respondWithMock(clientMessage) {
-  return new Response(clientMessage.payload.body, {
-    ...clientMessage.payload,
-    headers: clientMessage.payload.headers,
-  })
+async function respondWithMock(response) {
+  await sleep(response.delay)
+  return new Response(response.body, response)
 }
 
-function uuidv4() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const r = (Math.random() * 16) | 0
-    const v = c == 'x' ? r : (r & 0x3) | 0x8
-    return v.toString(16)
+function respondWithMockStream(operationChannel, mockResponse) {
+  let streamCtrl
+  const stream = new ReadableStream({
+    start: (controller) => (streamCtrl = controller),
+  })
+
+  return new Promise(async (resolve, reject) => {
+    operationChannel.onmessageerror = (event) => {
+      operationChannel.close()
+      return reject(event.data.error)
+    }
+
+    operationChannel.onmessage = (event) => {
+      if (!event.data) {
+        return
+      }
+
+      switch (event.data.type) {
+        case 'MOCK_RESPONSE_CHUNK': {
+          streamCtrl.enqueue(event.data.payload)
+          break
+        }
+
+        case 'MOCK_RESPONSE_END': {
+          streamCtrl.close()
+          operationChannel.close()
+        }
+      }
+    }
+
+    await sleep(mockResponse.delay)
+    return resolve(new Response(stream, mockResponse))
   })
 }

--- a/apps/onboarding/src/pages/_document.tsx
+++ b/apps/onboarding/src/pages/_document.tsx
@@ -1,5 +1,5 @@
-import { fonts } from '@hedviginsurance/brand'
 import Document, { Head, Html, Main, NextScript } from 'next/document'
+import { getCDNFonts } from 'ui'
 import { locales, LocaleLabel } from '@/lib/l10n/locales'
 import { gtmDevScript, gtmProdScript } from '@/services/analytics/gtm'
 
@@ -18,13 +18,13 @@ export default class MyDocument extends Document {
     return (
       <Html lang={this.lang()}>
         <Head>
-          {Object.values(fonts).map((fontName) => (
+          {getCDNFonts().map((font) => (
             <link
-              key={fontName}
+              key={font.src}
               rel="preload"
-              href={`https://cdn.hedvig.com/identity/fonts/${fontName}.woff2`}
+              href={font.src}
               as="font"
-              type="font/woff2"
+              type={`font/${font.format}`}
               crossOrigin="anonymous"
             />
           ))}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",
-    "@hedviginsurance/brand": "^5.0.0",
     "@radix-ui/react-checkbox": "^0.1.5",
     "@radix-ui/react-radio-group": "^0.1.5",
     "react": "17.0.2",

--- a/packages/ui/src/components/BurgerButton/BurgerButton.tsx
+++ b/packages/ui/src/components/BurgerButton/BurgerButton.tsx
@@ -14,35 +14,39 @@ type AnimatedToggleButtonProps = {
   color?: BurgerButtonColors
 }
 
-const CrossBurger = styled.div<AnimatedToggleButtonProps>(({ isActive, color }) => ({
-  '&::before, &::after': {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    content: '" "',
-    width: BURGER_LINE_WIDTH,
-    height: 2,
-    backgroundColor: getColor(color),
-    transition: `background-color ${TRANSITION_TIME}ms, transform ${TRANSITION_TIME}ms, top ${TRANSITION_TIME}ms, bottom ${TRANSITION_TIME}ms`,
-  },
+const CrossBurger = styled.div<AnimatedToggleButtonProps>(({ isActive, color }) => {
+  const backgroundColor = color ? getColor(color) : 'currentColor'
 
-  '&::before': {
-    top: 2,
-    ...(isActive && {
-      transform: 'translateY(-1px) rotate(45deg)',
-      top: '50%',
-      backgroundColor: getColor(color),
-    }),
-  },
-  '&::after': {
-    bottom: 2,
-    ...(isActive && {
-      bottom: '50%',
-      transform: 'translateY(1px) rotate(-45deg)',
-      backgroundColor: getColor(color),
-    }),
-  },
-}))
+  return {
+    '&::before, &::after': {
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      content: '" "',
+      width: BURGER_LINE_WIDTH,
+      height: 2,
+      backgroundColor,
+      transition: `background-color ${TRANSITION_TIME}ms, transform ${TRANSITION_TIME}ms, top ${TRANSITION_TIME}ms, bottom ${TRANSITION_TIME}ms`,
+    },
+
+    '&::before': {
+      top: 2,
+      ...(isActive && {
+        transform: 'translateY(-1px) rotate(45deg)',
+        top: '50%',
+        backgroundColor,
+      }),
+    },
+    '&::after': {
+      bottom: 2,
+      ...(isActive && {
+        bottom: '50%',
+        transform: 'translateY(1px) rotate(-45deg)',
+        backgroundColor,
+      }),
+    },
+  }
+})
 
 const MiddleBurger = styled.div<AnimatedToggleButtonProps>(({ isActive, color }) => ({
   width: BURGER_LINE_WIDTH,
@@ -51,7 +55,7 @@ const MiddleBurger = styled.div<AnimatedToggleButtonProps>(({ isActive, color })
   left: 0,
   right: 0,
   height: 2,
-  backgroundColor: isActive ? getColor(color) : 'transparent',
+  backgroundColor: isActive ? (color ? getColor(color) : 'currentcolor') : 'transparent',
   transition: `background-color ${TRANSITION_TIME}ms`,
   transform: 'translateY(-1px)',
 }))

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -109,7 +109,7 @@ const ButtonElement = styled(UnstyledButton)<ButtonProps>(
 
     ...(variant === 'text' && {
       backgroundColor: 'transparent',
-      color: getColor(color),
+      color: color ? getColor(color) : 'currentcolor',
       border: 'none',
       ':disabled': {
         color: theme.colors.gray500,

--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -1,6 +1,5 @@
 import { Theme } from '@emotion/react'
 import styled from '@emotion/styled'
-import { colorsV3 } from '@hedviginsurance/brand'
 import { mq } from '../../lib/media-query'
 import { getColor } from '../../lib/theme/theme'
 
@@ -24,7 +23,7 @@ export const cardStyle = ({
 
   backgroundColor: getColor('light'),
   border: `1px solid transparent`,
-  borderColor: bordered ? colorsV3.gray500 : 'transparent',
+  borderColor: bordered ? getColor('gray500') : 'transparent',
 
   boxShadow: 'rgb(0 0 0 / 10%) 0px 1px 2px',
   minWidth: '16rem',

--- a/packages/ui/src/components/Card/SelectableCard.tsx
+++ b/packages/ui/src/components/Card/SelectableCard.tsx
@@ -1,9 +1,9 @@
 import { Theme } from '@emotion/react'
 import styled from '@emotion/styled'
-import { colorsV3 } from '@hedviginsurance/brand'
 import * as Checkbox from '@radix-ui/react-checkbox'
 import * as RadioGroup from '@radix-ui/react-radio-group'
 import { mq } from '../../lib/media-query'
+import { getColor } from '../../lib/theme/theme'
 import { CardContent, CardProps, cardStyle } from './Card'
 
 export type SelectableCardProps = CardProps & {
@@ -27,8 +27,8 @@ const selectableCardStyles = (props: SelectableCardProps & { theme: Theme }) => 
 
   ...cardStyle({ ...props, bordered: true }),
 
-  ':hover': { borderColor: colorsV3.gray700 },
-  ':focus': { borderColor: colorsV3.gray700 },
+  ':hover': { borderColor: getColor('gray500') },
+  ':focus': { borderColor: getColor('gray700') },
   cursor: 'pointer',
   // Make border thicker when checked
   // Adjust padding so that content doesn't shift

--- a/packages/ui/src/components/HeadingNew/HeadingNew.tsx
+++ b/packages/ui/src/components/HeadingNew/HeadingNew.tsx
@@ -15,7 +15,7 @@ type HeadingBaseProps = Pick<HeadingProps, 'color' | 'variant'> & Margins
 
 const HeadingBase = styled.h2<HeadingBaseProps>(
   ({ theme, color, variant = 'standard.32', ...props }) => ({
-    color: getColor(color),
+    color: color ? getColor(color) : 'currentColor',
     fontFamily: theme.fonts.heading,
     fontWeight: 400,
     lineHeight: 1.2,

--- a/packages/ui/src/components/Menu/MenuItem.tsx
+++ b/packages/ui/src/components/Menu/MenuItem.tsx
@@ -1,11 +1,12 @@
 import styled from '@emotion/styled'
 import { ReactNode, useContext } from 'react'
 import { mq } from '../../lib/media-query'
+import { UIColor } from '../../lib/theme/colors'
 import { getColor } from '../../lib/theme/theme'
 import { MenuThemeContext } from './Menu'
 import { MenuLink, MenuLinkProps } from './MenuLink'
 
-const MenuItemElement = styled.li<MenuItemProps>(({ color }) => ({
+const MenuItemElement = styled.li<MenuItemElementProps>(({ color }) => ({
   position: 'relative',
   display: 'inline-flex',
   alignItems: 'start',
@@ -31,6 +32,10 @@ const MenuItemElement = styled.li<MenuItemProps>(({ color }) => ({
     padding: '0.625rem',
   },
 }))
+
+type MenuItemElementProps = {
+  color: UIColor
+}
 
 type MenuItemProps = Pick<MenuLinkProps, 'href'> & {
   children: ReactNode

--- a/packages/ui/src/components/Menu/MenuItemGroup.tsx
+++ b/packages/ui/src/components/Menu/MenuItemGroup.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
-import { colorsV3 } from '@hedviginsurance/brand'
 import { ReactNode } from 'react'
 import { mq } from '../../lib/media-query'
+import { getColor } from '../../lib/theme/theme'
 import { MenuLink } from './MenuLink'
 
 const Group = styled.div({
@@ -15,7 +15,7 @@ const MenuGroupHeader = styled.span({
   padding: '0.5rem 1.125rem',
 
   textTransform: 'uppercase',
-  color: colorsV3.gray500,
+  color: getColor('gray500'),
 })
 
 const MenuGroupList = styled.ul({
@@ -35,7 +35,7 @@ export const MenuItemGroup = ({ title, href, children }: MenuItemGroupProps) => 
   return (
     <Group>
       <MenuGroupHeader>
-        <MenuLink color={colorsV3.gray500} href={href}>
+        <MenuLink color="gray500" href={href}>
           {title}
         </MenuLink>
       </MenuGroupHeader>

--- a/packages/ui/src/components/Menu/MenuLink.tsx
+++ b/packages/ui/src/components/Menu/MenuLink.tsx
@@ -1,13 +1,14 @@
 import styled from '@emotion/styled'
 import { useContext } from 'react'
 import { ReactNode } from 'react'
+import type { UIColor } from '../../lib/theme/colors'
 import { getColor } from '../../lib/theme/theme'
 import { MenuThemeContext } from './Menu'
 
 export type MenuLinkProps = {
   // Override the theme of the menu
   // For example, links in a SubMenu will always be black on desktop
-  color?: string
+  color?: UIColor
   children?: ReactNode
   href?: string
 }
@@ -17,9 +18,9 @@ const MenuLinkElement = styled.a<MenuLinkProps>(({ theme, color }) => ({
   ':focus': {
     outline: `5px auto ${theme.colors.purple700}`,
   },
-  color: getColor(color),
+  color: color ? getColor(color) : 'currentColor',
   ':hover, :focus': {
-    color: getColor(color),
+    color: color ? getColor(color) : 'currentColor',
   },
 }))
 

--- a/packages/ui/src/components/Menu/SubMenu.tsx
+++ b/packages/ui/src/components/Menu/SubMenu.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled'
-import { colorsV3 } from '@hedviginsurance/brand'
 import { ReactNode, useCallback, useContext, useState } from 'react'
 import AnimateHeight from 'react-animate-height'
 import { ChevronIcon } from '../../icons/Chevron'
 import { mq, useBreakpoint } from '../../lib/media-query'
+import { getColor } from '../../lib/theme/theme'
 import { Button } from '../Button/Button'
 import { MenuThemeContext } from './Menu'
 import { MenuItem } from './MenuItem'
@@ -18,7 +18,7 @@ const DropdownMenuContainer = styled.div<{
   opacity: isOpen ? 1 : 0,
   transition: `opacity ${TRANSITION_TIME}ms`,
   overflowY: 'hidden',
-  color: colorsV3.gray900,
+  color: getColor('gray900'),
 
   [mq.md]: {
     display: isOpen ? 'block' : 'none',
@@ -27,7 +27,7 @@ const DropdownMenuContainer = styled.div<{
     top: '100%',
     transform: 'translateX(-50%)',
 
-    background: colorsV3.gray100,
+    background: getColor('gray100'),
     boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.1), 0px 2px 5px rgba(0, 0, 0, 0.1);',
     borderRadius: '0.5rem',
   },

--- a/packages/ui/src/components/QuotePriceCard/QuotePriceCard.tsx
+++ b/packages/ui/src/components/QuotePriceCard/QuotePriceCard.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { colorsV3 } from '@hedviginsurance/brand'
+import { getColor } from '../../lib/theme/theme'
 import { Card, CardContent } from '../Card/Card'
 import { SelectableCard, SelectableCardProps } from '../Card/SelectableCard'
 import { StyledCheckbox } from '../Checkbox/Checkbox'
@@ -17,7 +17,7 @@ const HeaderElement = styled.div({
 const TitleElement = styled.div({})
 
 const ExtraElement = styled.div({
-  color: colorsV3.gray500,
+  color: getColor('gray500'),
   justifySelf: 'end',
 })
 

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -18,6 +18,7 @@ export { Heading } from './components/HeadingNew/HeadingNew'
 export type { Level } from './lib/media-query'
 export { mq, useBreakpoint } from './lib/media-query'
 
+export { getCDNFonts, fonts } from './lib/theme/typography'
 export { theme, getColor } from './lib/theme/theme'
 export { ThemeProvider } from './lib/theme/ThemeProvider'
 export { globalStyles } from './lib/globalStyles'

--- a/packages/ui/src/lib/globalStyles.ts
+++ b/packages/ui/src/lib/globalStyles.ts
@@ -1,8 +1,22 @@
 import { css } from '@emotion/react'
-import { colorsV3, fonts, getCdnFontFaces } from '@hedviginsurance/brand'
+import { getColor } from './theme/theme'
+import { fonts, getCDNFonts } from './theme/typography'
 
 export const globalStyles = css`
-  ${getCdnFontFaces()}
+  ${getCDNFonts()
+    .map(
+      (font) => `
+    @font-face {
+      font-family: ${font.family};
+      font-style: ${font.style};
+      font-weight: ${font.weight};
+      src: url("${font.src}") format("${font.format}");
+      font-display: swap;
+    }
+  `,
+    )
+    .join('\n')}
+
   /***
     The following CSS reset is heavily inspired by:
     https://github.com/elad2412/the-new-css-reset
@@ -26,9 +40,9 @@ export const globalStyles = css`
 
   /* Set default font rules and color on body */
   body {
-    color: ${colorsV3.gray900};
-    background-color: ${colorsV3.gray100};
-    font-family: ${fonts.HEDVIG_LETTERS_STANDARD}, sans-serif;
+    color: ${getColor('gray900')};
+    background-color: ${getColor('gray100')};
+    font-family: ${fonts.body};
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }

--- a/packages/ui/src/lib/theme/colors.ts
+++ b/packages/ui/src/lib/theme/colors.ts
@@ -47,3 +47,5 @@ export const colors = {
   light: gray[100],
   lavender: purple[500],
 }
+
+export type UIColor = keyof typeof colors

--- a/packages/ui/src/lib/theme/theme.test.ts
+++ b/packages/ui/src/lib/theme/theme.test.ts
@@ -1,18 +1,14 @@
-import { colorsV3 } from '@hedviginsurance/brand'
+import { colors } from './colors'
 import { getColor } from './theme'
 
 describe('theme', () => {
   describe('getColor', () => {
-    it('should return a color when found in colorsV3', () => {
-      expect(getColor('gray100')).toEqual(colorsV3.gray100)
+    it('should return a UI Color when found', () => {
+      expect(getColor('gray100')).toEqual(colors.gray100)
     })
 
     it('should return a simplified color when found in simplifiedColors', () => {
-      expect(getColor('lavender')).toEqual(colorsV3.purple500)
-    })
-
-    it('should default to currentColor when no other colors can be found', () => {
-      expect(getColor('smurf')).toEqual('currentColor')
+      expect(getColor('lavender')).toEqual(colors.purple500)
     })
   })
 })

--- a/packages/ui/src/lib/theme/theme.ts
+++ b/packages/ui/src/lib/theme/theme.ts
@@ -1,4 +1,4 @@
-import { colors } from './colors'
+import { colors, UIColor } from './colors'
 import { fonts, fontSizes } from './typography'
 
 const space = [
@@ -30,6 +30,6 @@ declare module '@emotion/react' {
   export interface Theme extends CustomTheme {}
 }
 
-export const getColor = (color?: string) => {
-  return theme.colors[color as keyof typeof theme.colors] || 'currentColor'
+export const getColor = (color: UIColor) => {
+  return theme.colors[color]
 }

--- a/packages/ui/src/lib/theme/typography.ts
+++ b/packages/ui/src/lib/theme/typography.ts
@@ -1,12 +1,28 @@
-import { fonts as hedvigFonts } from '@hedviginsurance/brand'
-
-export const fonts: Record<string, string> = {
-  standard: `'${hedvigFonts.HEDVIG_LETTERS_STANDARD}', sans-serif`,
-  small: `'${hedvigFonts.HEDVIG_LETTERS_SMALL}', serif`,
-  big: `'${hedvigFonts.HEDVIG_LETTERS_BIG}', serif`,
+enum HedvigFont {
+  HEDVIG_LETTERS_BIG = 'HedvigLetters-Big',
+  HEDVIG_LETTERS_SMALL = 'HedvigLetters-Small',
+  HEDVIG_LETTERS_STANDARD = 'HedvigLetters-Standard',
 }
-fonts.body = fonts.standard
-fonts.heading = fonts.standard
+
+const FONT_STANDARD = `'${HedvigFont.HEDVIG_LETTERS_STANDARD}', sans-serif`
+export const fonts = {
+  standard: FONT_STANDARD,
+  small: `'${HedvigFont.HEDVIG_LETTERS_SMALL}', serif`,
+  big: `'${HedvigFont.HEDVIG_LETTERS_BIG}', serif`,
+
+  body: FONT_STANDARD,
+  heading: FONT_STANDARD,
+}
+
+export const getCDNFonts = () => {
+  return Object.values(HedvigFont).map((fontName) => ({
+    family: fontName,
+    style: 'normal',
+    weight: 400,
+    src: `https://cdn.hedvig.com/identity/fonts/${fontName}.woff2`,
+    format: 'woff2',
+  }))
+}
 
 export const fontSizes: Record<number | string, string> = {
   0: '0.75rem',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2319,11 +2319,6 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@hedviginsurance/brand@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@hedviginsurance/brand/-/brand-5.0.0.tgz#b070e0031019ed51b664ee2aa0e59752c01bc07f"
-  integrity sha512-1Y7s2BeqKuAVc3ASHXPKP1TsosRxWZha8r/J1hbaQ/7/Q2jMCKalXijoA7/MXWsE82yzCbrE5YbxcU9DqXWqfw==
-
 "@humanwhocodes/config-array@^0.10.4":
   version "0.10.4"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.4.tgz#01e7366e57d2ad104feea63e72248f22015c520c"


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Remove brand from ui + onboarding workspaces.
Refactor font preloading.
Replace use of colorsV3 with getColor utility from ui package.
Add UIColor type.
Refactor @font-face and move to global styles definition.
Refactor getColor utility to not lose type safety.
Move font definitions from brand repo to ui package.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

The brand repo is deprecated so we should move stuff to the UI package instead.

I wasn't super careful with the market-web stuff but that should be removed in the future so I think that okey (sorry @gustaveen 🙏)

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
