### PR TITLE
Suppress expected console error in media-query test

### DIFF
--- a/packages/ui/src/lib/media-query.test.ts
+++ b/packages/ui/src/lib/media-query.test.ts
@@ -28,11 +28,13 @@ describe('media-query', () => {
       // align
       const breakpoint = 'smurf'
 
+      // Suppress log
+      jest.spyOn(global.console, 'error').mockImplementationOnce(() => {})
+
       // act
       const { result } = renderHook(() => useBreakpoint(breakpoint as Level))
-
       // assert
-      expect(result.error?.message).toBe(`Unknown breakpoint ${breakpoint}`)
+      expect(result.error).toEqual(new Error(`Unknown breakpoint ${breakpoint}`))
     })
   })
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Remove console.error noise from test where it's expected
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Make output cleaner, do not confuse developers with expected error that does not fail test

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [x] I have performed a self-review of my code