### PR TITLE
Turn off timed revalidation for store app

### DIFF
--- a/apps/store/src/pages/[...slug].tsx
+++ b/apps/store/src/pages/[...slug].tsx
@@ -40,7 +40,6 @@ export const getStaticProps: GetStaticProps<StoryblokPageProps, StoryblokQueryPa
       key: story ? story.id : false,
       preview: preview || false,
     },
-    revalidate: 3600,
   }
 }
 

--- a/apps/store/src/pages/index.tsx
+++ b/apps/store/src/pages/index.tsx
@@ -19,7 +19,6 @@ export const getStaticProps: GetStaticProps = async ({ preview }) => {
       key: story ? story.id : false,
       preview: preview || false,
     },
-    revalidate: 3600,
   }
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Remove revalidation based on time in favor of on-demand ISR.

## Justify why they are needed

For pages that entirely driven by CMS we know exactly when to rebuild them - when the CMS content changes.
This is communicated via a webhook to the store app - so no need for these revalidation settings!

https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#on-demand-revalidation

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
