### PR TITLE
Add Tabs + Tab blocks to CMS setup

### DIFF
--- a/apps/store/src/blocks/TabsBlock.tsx
+++ b/apps/store/src/blocks/TabsBlock.tsx
@@ -1,0 +1,51 @@
+import { SbBlokData, StoryblokComponent, storyblokEditable } from '@storyblok/react'
+import { useMemo } from 'react'
+import * as Tabs from '@/components/ProductPage/Tabs'
+import { SbBaseBlockProps, StoryblokBlockName } from '@/services/storyblok/storyblok'
+
+type TabsBlockProps = SbBaseBlockProps<{
+  items: Array<SbBlokData>
+}>
+
+type TabBlockFields = {
+  title: string
+  body: Array<SbBlokData>
+}
+
+type TabBlockData = SbBlokData & TabBlockFields
+
+type TabBlockProps = SbBaseBlockProps<TabBlockFields>
+
+export const TabsBlock = ({ blok }: TabsBlockProps) => {
+  const tabBlocks = useMemo(() => blok.items.filter(isTabBlock), [blok.items])
+  const firstTabValue = blok.items[0]?._uid
+
+  return (
+    <Tabs.Tabs defaultValue={firstTabValue} {...storyblokEditable(blok)}>
+      <Tabs.TabsList>
+        {tabBlocks.map((tabBlock) => (
+          <Tabs.TabsTrigger key={tabBlock._uid} value={tabBlock._uid}>
+            {tabBlock.title}
+          </Tabs.TabsTrigger>
+        ))}
+      </Tabs.TabsList>
+      {tabBlocks.map((tabBlock) => (
+        <TabBlock key={tabBlock._uid} blok={tabBlock} />
+      ))}
+    </Tabs.Tabs>
+  )
+}
+
+const TabBlock = ({ blok }: TabBlockProps) => {
+  return (
+    <Tabs.TabsContent value={blok._uid}>
+      {blok.body.map((nestedBlock) => (
+        <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} />
+      ))}
+    </Tabs.TabsContent>
+  )
+}
+
+const isTabBlock = (blok: SbBlokData): blok is TabBlockData => {
+  return blok.component === StoryblokBlockName.Tab
+}

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -11,6 +11,7 @@ import { ProductGridBlock } from '@/blocks/ProductGridBlock'
 import { ProductSlideshowBlock } from '@/blocks/ProductSlideshowBlock'
 import { ProductSummaryBlock } from '@/blocks/ProductSummaryBlock'
 import { SpacerBlock } from '@/blocks/SpacerBlock'
+import { TabsBlock } from '@/blocks/TabsBlock'
 import { TopPickCardBlock } from '@/blocks/TopPickCardBlock'
 
 export type SbBaseBlockProps<T> = {
@@ -68,6 +69,9 @@ export enum StoryblokBlockName {
   ProductSlideshow = 'productSlideshow',
   Accordion = 'accordion',
   AccordionItem = 'accordionItem',
+  Tabs = 'tabs',
+  // Used only inside TabsBlock
+  Tab = 'tab',
 }
 
 export const initStoryblok = () => {
@@ -86,6 +90,7 @@ export const initStoryblok = () => {
     [StoryblokBlockName.ProductSlideshow]: ProductSlideshowBlock,
     [StoryblokBlockName.Accordion]: AccordionBlock,
     [StoryblokBlockName.AccordionItem]: AccordionItemBlock,
+    [StoryblokBlockName.Tabs]: TabsBlock,
   }
 
   storyblokInit({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add Tabs + Tab blocks to CMS setup

Add types module for shared types between blocks.

![Screenshot 2022-08-05 at 11.46.40.png](https://graphite-user-uploaded-assets.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/666e591b-7762-4ff9-a48f-5175389bc523/Screenshot%202022-08-05%20at%2011.46.40.png)

## Justify why they are needed

Used on the product page.

I considered adding it to the product page content type but seems a bit too early - this is more flexible.

## Jira issue(s): [GRW-1320]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.


[GRW-1320]: https://hedvig.atlassian.net/browse/GRW-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ