### PR TITLE
GRW-1350 / Feature / Add ContentBlock for text

### DIFF
--- a/apps/store/src/blocks/AccordionItemBlock.tsx
+++ b/apps/store/src/blocks/AccordionItemBlock.tsx
@@ -1,4 +1,4 @@
-import { getStoryblokApi, Richtext } from '@storyblok/react'
+import { getStoryblokApi, Richtext, storyblokEditable } from '@storyblok/react'
 import * as Accordion from '@/components/Accordion/Accordion'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
@@ -10,7 +10,7 @@ export type Props = SbBaseBlockProps<{
 export const AccordionItemBlock = ({ blok }: Props) => {
   const contentHtml = getStoryblokApi().richTextResolver.render(blok.body)
   return (
-    <Accordion.Item value={blok._uid}>
+    <Accordion.Item value={blok._uid} {...storyblokEditable(blok)}>
       <Accordion.HeaderWithTrigger>{blok.title}</Accordion.HeaderWithTrigger>
       <Accordion.Content>
         <div dangerouslySetInnerHTML={{ __html: contentHtml }} />

--- a/apps/store/src/blocks/ContentBlock.tsx
+++ b/apps/store/src/blocks/ContentBlock.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled'
+import { getStoryblokApi, Richtext, storyblokEditable } from '@storyblok/react'
+import { useMemo } from 'react'
+import { Space } from 'ui'
+import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+
+export type Props = SbBaseBlockProps<{
+  body: Richtext
+}>
+
+export const ContentBlock = ({ blok }: Props) => {
+  const contentHtml = useRichText(blok.body)
+  return (
+    <Wrapper {...storyblokEditable(blok)}>
+      <Space y={1} dangerouslySetInnerHTML={{ __html: contentHtml }} />
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div(({ theme }) => ({
+  paddingLeft: theme.space[4],
+  paddingRight: theme.space[4],
+  textAlign: 'center',
+}))
+
+const useRichText = (body: Richtext) => {
+  return useMemo(() => getStoryblokApi().richTextResolver.render(body), [body])
+}

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -3,6 +3,7 @@ import { AccordionBlock } from '@/blocks/AccordionBlock'
 import { AccordionItemBlock } from '@/blocks/AccordionItemBlock'
 import { ButtonBlock } from '@/blocks/ButtonBlock'
 import { ContactSupportBlock } from '@/blocks/ContactSupportBlock'
+import { ContentBlock } from '@/blocks/ContentBlock'
 import { HeadingBlock } from '@/blocks/HeadingBlock'
 import { HeroBlock } from '@/blocks/HeroBlock'
 import { PageBlock } from '@/blocks/PageBlock'
@@ -74,6 +75,7 @@ export enum StoryblokBlockName {
   // Used only inside TabsBlock
   Tab = 'tab',
   ContactSupport = 'contactSupport',
+  Content = 'content',
 }
 
 export const initStoryblok = () => {
@@ -94,6 +96,7 @@ export const initStoryblok = () => {
     [StoryblokBlockName.AccordionItem]: AccordionItemBlock,
     [StoryblokBlockName.Tabs]: TabsBlock,
     [StoryblokBlockName.ContactSupport]: ContactSupportBlock,
+    [StoryblokBlockName.Content]: ContentBlock,
   }
 
   storyblokInit({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Also add Storyblok editor props to AccordionItemBlock.

![Screenshot 2022-08-12 at 11.19.36.png](https://graphite-user-uploaded-assets.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/a9f5bff9-40dd-40d7-8650-51320e0c0fe4/Screenshot%202022-08-12%20at%2011.19.36.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

The rich text field seems to require all embedded components to be rendered as strings (https://www.storyblok.com/docs/richtext-field#javascript-sdk). At least when using the JavaScript SDK. I, therefore, limited the inputs to only text + images. The editors would have to add headings using the `HeadingBlock` etc.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
