### PR TITLE
Ignore shop session when countryCode does not match current locale

### DIFF
--- a/apps/store/src/services/shopSession/ShopSessionContext.tsx
+++ b/apps/store/src/services/shopSession/ShopSessionContext.tsx
@@ -51,16 +51,25 @@ export const ShopSessionProvider = ({ children }: PropsWithChildren<unknown>) =>
 }
 
 export const useShopSession = () => {
+  const { countryCode } = useCurrentLocale()
+
   const queryResult = useContext(ShopSessionContext)
   if (!queryResult) {
     throw new Error(
       'useShopSession called from outside ShopSessionContextProvider, no value in context',
     )
   }
+
   const { data, ...other } = queryResult
+
+  let shopSession = data?.shopSession
+  if (shopSession?.countryCode !== countryCode) {
+    // Ignore session from different country.  This probably means old session was fetched and new one is being created
+    shopSession = undefined
+  }
   return {
     ...other,
-    shopSession: data?.shopSession,
+    shopSession,
   }
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## GRW-1335 / Fix / Ignore shop session if country does not match current

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We may get old session that does not match current country.  In this case new session is created and while we wait, old session data should not be displayed in UI

## Jira issue(s): [GRW-1335]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.


[GRW-1335]: https://hedvig.atlassian.net/browse/GRW-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ