### PR TITLE
GRW-1415 / Render HeaderBlock in LayoutWithMenu component

### DIFF
--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import { useRouter } from 'next/router'
-import { ReactNode } from 'react'
+import { ReactElement } from 'react'
+import { HeaderBlock } from '@/blocks/TopMenuBlock'
 import { SiteFooter, SiteFooterProps } from '@/components/SiteFooter/SiteFooter'
 
 const Wrapper = styled.main({
@@ -11,10 +12,11 @@ const Wrapper = styled.main({
 })
 
 type LayoutWithMenuProps = {
-  children: ReactNode
+  children: ReactElement
 }
 
 export const LayoutWithMenu = ({ children }: LayoutWithMenuProps) => {
+  const globalStory = children.props.globalStory
   const router = useRouter()
   const handleChangeLocale: SiteFooterProps['onChangeLocale'] = (locale) => {
     router.push(router.asPath, undefined, { locale })
@@ -22,6 +24,7 @@ export const LayoutWithMenu = ({ children }: LayoutWithMenuProps) => {
 
   return (
     <Wrapper>
+      <HeaderBlock blok={globalStory.content} />
       {children}
       <SiteFooter onChangeLocale={handleChangeLocale} />
     </Wrapper>

--- a/apps/store/src/components/Page/Page.tsx
+++ b/apps/store/src/components/Page/Page.tsx
@@ -1,16 +1,8 @@
-import { StoryblokComponent, StoryData, useStoryblokState } from '@storyblok/react'
+import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
 import { StoryblokPageProps } from '@/services/storyblok/storyblok'
 
-const isStoryData = (value: unknown): value is StoryData => {
-  return (value as any).content !== undefined
-}
-
-export const Page = ({ story: initialStory, globalStory }: StoryblokPageProps) => {
+export const Page = ({ story: initialStory }: StoryblokPageProps) => {
   const story = useStoryblokState(initialStory)
-  return (
-    <>
-      {isStoryData(globalStory) && <StoryblokComponent blok={globalStory.content} />}
-      <StoryblokComponent blok={story.content} />
-    </>
-  )
+
+  return <StoryblokComponent blok={story.content} />
 }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -31,7 +31,7 @@ export type StoryblokQueryParams = {
 
 export type StoryblokPageProps = {
   story: StoryData
-  globalStory: StoryData | boolean
+  globalStory: GlobalStory | boolean
 }
 
 export type StoryblokImage = {
@@ -63,7 +63,11 @@ export type ProductStory = StoryData & {
   }
 }
 
-type GlobalStory = StoryData
+type GlobalStory = StoryData & {
+  content: StoryData['content'] & {
+    navMenuContainer: Array<SbBlokData>
+  }
+}
 
 type NamedBlock = {
   blockName: string
@@ -125,7 +129,7 @@ export const getAllLinks = async () => {
 export const getGlobalStory = async (preview = false) => {
   try {
     const story = await getStoryBySlug('global', preview)
-    return story as GlobalStory
+    return story
   } catch {
     return null
   }


### PR DESCRIPTION
## Describe your changes
Rendering the menu in the `LayoutWithMenu` component. Took me a while to figure out that the `pageProps` were actually accessible in the `Layout` component 😄
```ts
// _app.tsx
{getLayout(<Component {...pageProps} />)}
```

## Justify why they are needed
Only need to add the menu in one place. 
Also didn't know about the benefit of Next layouts before reading up on it: https://nextjs.org/docs/basic-features/layouts 🎉

> This layout pattern enables state persistence because the React component tree is maintained between page transitions


https://user-images.githubusercontent.com/6661511/186625495-1553b45c-964c-4b1d-9620-834e20641071.mov


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
