### PR TITLE
Fix error when rendering pages that require global story

### DIFF
--- a/apps/store/next.config.js
+++ b/apps/store/next.config.js
@@ -1,6 +1,6 @@
-/** @type {import('next').NextConfig} */
 const { i18n } = require('./next-i18next.config')
 
+/** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   compiler: {

--- a/apps/store/src/components/CartNotification/CartToast.tsx
+++ b/apps/store/src/components/CartNotification/CartToast.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import Link from 'next/link'
 import { forwardRef, useImperativeHandle, useState } from 'react'
-import { Button, Heading, LinkButton, Space } from 'ui'
+import { Heading, LinkButton, Space } from 'ui'
 import * as Dialog from '@/components/Dialog/Dialog'
 import { PageLink } from '@/lib/PageLink'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
@@ -51,9 +51,11 @@ const CartNotificationContent = ({ name, price, gradient, onClose }: Props) => {
             <LinkButton fullWidth>Proceed to cart ({cartLineCount})</LinkButton>
           </Link>
 
-          <Button onClick={onClose} variant="outlined" fullWidth>
-            Continue shopping
-          </Button>
+          <Link href={PageLink.store()} passHref>
+            <LinkButton variant="outlined" fullWidth onClick={onClose}>
+              Continue shopping
+            </LinkButton>
+          </Link>
         </Space>
       </DialogContentWrapper>
     </Dialog.Content>

--- a/apps/store/src/components/CartPage/CartPageProps.types.ts
+++ b/apps/store/src/components/CartPage/CartPageProps.types.ts
@@ -1,7 +1,9 @@
+import { StoryblokPageProps } from '@/services/storyblok/storyblok'
+
 export type ProductData = { id: string; name: string; cost: number; currency: string }
 type CostData = { crossOut?: number; total: number; subTotal: number }
 
-export type CartPageProps = {
+export type CartPageProps = Pick<StoryblokPageProps, 'globalStory'> & {
   products: Array<ProductData>
   cost: CostData
 }

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
@@ -1,7 +1,9 @@
+import { StoryblokPageProps } from '@/services/storyblok/storyblok'
+
 type CostData = { total: number }
 type ProductData = { name: string; startDate: string }
 
-export type ConfirmationPageProps = {
+export type ConfirmationPageProps = Pick<StoryblokPageProps, 'globalStory'> & {
   currency: string
   cost: CostData
   firstName: string

--- a/apps/store/src/components/Page/Page.tsx
+++ b/apps/store/src/components/Page/Page.tsx
@@ -3,6 +3,5 @@ import { StoryblokPageProps } from '@/services/storyblok/storyblok'
 
 export const Page = ({ story: initialStory }: StoryblokPageProps) => {
   const story = useStoryblokState(initialStory)
-
   return <StoryblokComponent blok={story.content} />
 }

--- a/apps/store/src/components/ProductPage/ProductPage.types.ts
+++ b/apps/store/src/components/ProductPage/ProductPage.types.ts
@@ -1,9 +1,9 @@
 import { FormTemplate } from '@/services/formTemplate/FormTemplate.types'
 import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
-import { ProductStory } from '@/services/storyblok/storyblok'
+import { ProductStory, StoryblokPageProps } from '@/services/storyblok/storyblok'
 
-export type ProductPageProps = {
+export type ProductPageProps = StoryblokPageProps & {
   story: ProductStory
   priceFormTemplate: FormTemplate
   priceIntent: PriceIntent

--- a/apps/store/src/pages/[...slug].tsx
+++ b/apps/store/src/pages/[...slug].tsx
@@ -37,14 +37,7 @@ export const getStaticProps: GetStaticProps<StoryblokPageProps, StoryblokQueryPa
     getGlobalStory(preview),
   ])
 
-  return {
-    props: {
-      story: story ?? false,
-      globalStory: globalStory ?? false,
-      key: story ? story.id : false,
-      preview: preview || false,
-    },
-  }
+  return { props: { story, globalStory } }
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {

--- a/apps/store/src/pages/cart/index.tsx
+++ b/apps/store/src/pages/cart/index.tsx
@@ -5,6 +5,7 @@ import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
 import { getLocale } from '@/lib/l10n/getLocale'
 import { initializeApollo } from '@/services/apollo/client'
 import { getShopSessionServerSide } from '@/services/shopSession/ShopSession.helpers'
+import { getGlobalStory } from '@/services/storyblok/storyblok'
 
 const NextCartPage: NextPageWithLayout<CartPageProps> = (props) => {
   return <CartPage {...props} />
@@ -16,7 +17,10 @@ export const getServerSideProps: GetServerSideProps<CartPageProps> = async (cont
 
   try {
     const apolloClient = initializeApollo()
-    const shopSession = await getShopSessionServerSide({ req, res, apolloClient, countryCode })
+    const [shopSession, globalStory] = await Promise.all([
+      getShopSessionServerSide({ req, res, apolloClient, countryCode }),
+      getGlobalStory(context.preview),
+    ])
 
     const totalCost = shopSession.cart.lines
       .map((line) => parseInt(line.price.amount, 10) || 0)
@@ -24,6 +28,7 @@ export const getServerSideProps: GetServerSideProps<CartPageProps> = async (cont
 
     return {
       props: {
+        globalStory,
         products: shopSession.cart.lines.map((item) => {
           return {
             id: item.id,

--- a/apps/store/src/pages/confirmation.tsx
+++ b/apps/store/src/pages/confirmation.tsx
@@ -7,13 +7,19 @@ import { PageLink } from '@/lib/PageLink'
 import { initializeApollo } from '@/services/apollo/client'
 import { CheckoutService } from '@/services/checkout/CheckoutService'
 import { getCurrentShopSessionServerSide } from '@/services/shopSession/ShopSession.helpers'
+import { getGlobalStory } from '@/services/storyblok/storyblok'
 
 export const getServerSideProps: GetServerSideProps<ConfirmationPageProps> = async ({
   req,
   res,
 }) => {
   const apolloClient = initializeApollo()
-  const shopSession = await getCurrentShopSessionServerSide({ req, res, apolloClient })
+
+  const [shopSession, globalStory] = await Promise.all([
+    getCurrentShopSessionServerSide({ req, res, apolloClient }),
+    getGlobalStory(),
+  ])
+
   const checkoutService = new CheckoutService(shopSession, apolloClient)
 
   const checkout = checkoutService.checkout()
@@ -23,6 +29,7 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps> = asy
 
   return {
     props: {
+      globalStory,
       currency: shopSession.currencyCode,
       cost: { total: 0 },
       products: shopSession.cart.lines.map((item) => {

--- a/apps/store/src/pages/index.tsx
+++ b/apps/store/src/pages/index.tsx
@@ -9,7 +9,7 @@ const NextHomePage: NextPageWithLayout<StoryblokPageProps> = ({ story: initialSt
   return <HomePage {...story} />
 }
 
-export const getStaticProps: GetStaticProps = async ({ preview }) => {
+export const getStaticProps: GetStaticProps<StoryblokPageProps> = async ({ preview }) => {
   const slug = 'home'
   const [story, globalStory] = await Promise.all([
     getStoryBySlug(slug, preview),
@@ -17,12 +17,7 @@ export const getStaticProps: GetStaticProps = async ({ preview }) => {
   ])
 
   return {
-    props: {
-      story: story ?? false,
-      globalStory: globalStory ?? false,
-      key: story ? story.id : false,
-      preview: preview || false,
-    },
+    props: { story, globalStory },
   }
 }
 

--- a/apps/store/src/pages/products/[product].tsx
+++ b/apps/store/src/pages/products/[product].tsx
@@ -7,7 +7,7 @@ import { ProductPageProps } from '@/components/ProductPage/ProductPage.types'
 import { getLocale } from '@/lib/l10n/getLocale'
 import { APOLLO_STATE_PROP_NAME, initializeApollo } from '@/services/apollo/client'
 import { getShopSessionServerSide } from '@/services/shopSession/ShopSession.helpers'
-import { getProductStory } from '@/services/storyblok/storyblok'
+import { getGlobalStory, getProductStory } from '@/services/storyblok/storyblok'
 
 const NextProductPage: NextPageWithLayout<ProductPageProps> = (props: ProductPageProps) => {
   return (
@@ -30,9 +30,10 @@ export const getServerSideProps: GetServerSideProps<ProductPageProps> = async (c
   try {
     const apolloClient = initializeApollo()
 
-    const [shopSession, story] = await Promise.all([
+    const [shopSession, story, globalStory] = await Promise.all([
       getShopSessionServerSide({ req, res, apolloClient, countryCode }),
       getProductStory(slug, context.preview),
+      getGlobalStory(context.preview),
     ])
 
     const { template, priceIntent } = await setupPriceCalculatorForm({
@@ -46,6 +47,7 @@ export const getServerSideProps: GetServerSideProps<ProductPageProps> = async (c
     return {
       props: {
         story,
+        globalStory,
         priceFormTemplate: template,
         priceIntent,
         shopSession,

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -33,7 +33,7 @@ export type StoryblokQueryParams = {
 
 export type StoryblokPageProps = {
   story: StoryData
-  globalStory: GlobalStory | boolean
+  globalStory: GlobalStory
 }
 
 export type StoryblokImage = {
@@ -126,7 +126,7 @@ export const getStoryBySlug = async (slug: string, preview = false) => {
   const { data } = await storyblokApi.get(`cdn/stories/${slug}`, {
     version: preview ? 'draft' : 'published',
   })
-  return data.story
+  return data.story as StoryData
 }
 
 export const getAllLinks = async () => {
@@ -136,12 +136,8 @@ export const getAllLinks = async () => {
 }
 
 export const getGlobalStory = async (preview = false) => {
-  try {
-    const story = await getStoryBySlug('global', preview)
-    return story
-  } catch {
-    return null
-  }
+  const story = await getStoryBySlug('global', preview)
+  return story as GlobalStory
 }
 
 export const getProductStory = async (slug: string, preview = false) => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fetch global story on all pages that use LayoutWithMenu.

Skip passing key + preview as page props.

Update types for StoryblokPageProps and helper functions.

Avoid swallowing exception when fetching global story.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We get error when rendering the pages that use layout with menu component without loading global story.

See comments below.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
