### PR TITLE
GRW-1402 TopMenu floating over content

### DIFF
--- a/apps/store/src/blocks/TopMenuBlock.tsx
+++ b/apps/store/src/blocks/TopMenuBlock.tsx
@@ -6,6 +6,7 @@ import { ArrowForwardIcon, CrossIcon } from 'ui'
 import { MenuIcon } from '@/components/TopMenu/MenuIcon'
 import { ShoppingCartMenuItem } from '@/components/TopMenu/ShoppingCartMenuItem'
 import {
+  DialogCloseIcon,
   DialogContent,
   IconButton,
   Navigation,
@@ -91,9 +92,7 @@ export const HeaderBlock = ({ blok }: HeaderBlockProps) => {
     <Wrapper>
       <DialogPrimitive.Root open={open} onOpenChange={() => setOpen((prevOpen) => !prevOpen)}>
         <DialogPrimitive.Trigger asChild>
-          <ToggleMenu>
-            <MenuIcon />
-          </ToggleMenu>
+          <ToggleMenu>{open ? null : <MenuIcon />}</ToggleMenu>
         </DialogPrimitive.Trigger>
         <DialogContent>
           <Navigation value={activeItem} onValueChange={(activeItem) => setActiveItem(activeItem)}>
@@ -109,11 +108,11 @@ export const HeaderBlock = ({ blok }: HeaderBlockProps) => {
               ))}
             </NavigationPrimaryList>
           </Navigation>
-          <DialogPrimitive.DialogClose asChild>
+          <DialogCloseIcon asChild>
             <IconButton>
               <CrossIcon />
             </IconButton>
-          </DialogPrimitive.DialogClose>
+          </DialogCloseIcon>
         </DialogContent>
       </DialogPrimitive.Root>
       <ShoppingCartMenuItem />

--- a/apps/store/src/components/TopMenu/TopMenu.tsx
+++ b/apps/store/src/components/TopMenu/TopMenu.tsx
@@ -91,11 +91,11 @@ export const TopMenu = () => {
             </NavigationPrimaryList>
           </Navigation>
 
-          <DialogPrimitive.DialogClose asChild>
+          <DialogCloseIcon asChild>
             <IconButton>
               <CrossIcon />
             </IconButton>
-          </DialogPrimitive.DialogClose>
+          </DialogCloseIcon>
         </DialogContent>
       </DialogPrimitive.Root>
 
@@ -118,6 +118,8 @@ export const Wrapper = styled.div(({ theme }) => ({
   width: '100%',
   height: MENU_BAR_HEIGHT,
   padding: theme.space[4],
+  position: 'fixed',
+  zIndex: '1000',
 }))
 
 export const StyledDialogOverlay = styled(DialogPrimitive.Overlay)({
@@ -196,3 +198,7 @@ export const NavigationLink = ({ href, ...rest }: NavigationLinkProps) => {
     </Link>
   )
 }
+
+export const DialogCloseIcon = styled(DialogPrimitive.DialogClose)({
+  position: 'fixed',
+})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Made the top menu stick to the top of the page and float over the content under it.

<img width="409" alt="floating-image" src="https://user-images.githubusercontent.com/50870173/186854869-3b808e6b-f144-4296-8c64-6d04e06957e2.png">

See video below for more context.

https://user-images.githubusercontent.com/50870173/186854034-f6cb40e6-d109-494a-b294-00f7c133cbd2.mov

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Previously the top menu was only shown at the top of the page. When the user scrolled away from the top they were no longer able to see the top menu. 

## Jira issue(s): [GRW-1402]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1402]: https://hedvig.atlassian.net/browse/GRW-1402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ