### PR TITLE
Fix Timeline block padding

### DIFF
--- a/apps/store/src/components/Timeline/Timeline.tsx
+++ b/apps/store/src/components/Timeline/Timeline.tsx
@@ -3,10 +3,11 @@ import { CheckCircleIcon } from './CheckCircleIcon'
 
 const ICON_SIZE = '2.5rem'
 
-export const Root = styled.ul({
+export const Root = styled.ul(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
-})
+  paddingRight: theme.space[4],
+}))
 
 export const Item = styled.li(({ theme }) => ({
   position: 'relative',


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Added right padding to the timeline block to match the other blocks.

### Before
<img width="478" alt="before" src="https://user-images.githubusercontent.com/50870173/186859201-3c6b2f81-fe04-4614-8c94-212f6ea111f0.png">

### After 

<img width="503" alt="after" src="https://user-images.githubusercontent.com/50870173/186859271-234cd59c-b491-4b16-9cc9-b68f5eff1109.png">


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Currently the block has no right padding and goes all the way to the right edge. This looks a bit odd since none of the other content works like this. 

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
