### PR TITLE
Use HTML order instead of z-index

### DIFF
--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -24,8 +24,8 @@ export const LayoutWithMenu = ({ children }: LayoutWithMenuProps) => {
 
   return (
     <Wrapper>
-      <HeaderBlock blok={globalStory.content} />
       {children}
+      <HeaderBlock blok={globalStory.content} />
       <SiteFooter onChangeLocale={handleChangeLocale} />
     </Wrapper>
   )

--- a/apps/store/src/components/TopMenu/TopMenu.tsx
+++ b/apps/store/src/components/TopMenu/TopMenu.tsx
@@ -119,7 +119,6 @@ export const Wrapper = styled.div(({ theme }) => ({
   height: MENU_BAR_HEIGHT,
   padding: theme.space[4],
   position: 'fixed',
-  zIndex: '1000',
 }))
 
 export const StyledDialogOverlay = styled(DialogPrimitive.Overlay)({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

See title.

![Screen Shot 2022-08-27 at 16.19.46.png](https://graphite-user-uploaded-assets.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/51c5dbe4-e6fc-4bc0-b6e3-346543e17f7c/Screen%20Shot%202022-08-27%20at%2016.19.46.png)

## Justify why they are needed

z-index is really hard to work with in a design system -- seems more scalable to rely on HTML order if possible :)

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
