### PR TITLE
Add Statistics and InsurableLimits components

### DIFF
--- a/apps/store/src/components/InsurableLimits/InsurableLimits.stories.tsx
+++ b/apps/store/src/components/InsurableLimits/InsurableLimits.stories.tsx
@@ -1,0 +1,28 @@
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { InsurableLimits } from './InsurableLimits'
+
+export default {
+  title: 'InsurableLimits',
+  component: InsurableLimits,
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'iphonese2',
+    },
+  },
+} as ComponentMeta<typeof InsurableLimits>
+
+const Template: ComponentStory<typeof InsurableLimits> = (props) => <InsurableLimits {...props} />
+
+export const Default = Template.bind({})
+Default.args = {
+  limits: [
+    { label: 'Deductible', value: 'SEK 1,500' },
+    { label: 'Insured amount', value: 'SEK 1,000,000' },
+    { label: 'Travel', value: 'Up to 45 days/trip when its a long trip' },
+    { label: 'Bike coverage', value: 'Up to SEK 15,000' },
+    { label: 'Bike coverage', value: 'Up to SEK 15,000' },
+    { label: 'Bike coverage', value: 'Up to SEK 15,000' },
+  ],
+}

--- a/apps/store/src/components/InsurableLimits/InsurableLimits.tsx
+++ b/apps/store/src/components/InsurableLimits/InsurableLimits.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled'
+import { Statistic } from '../Statistic/Statistic'
+
+const Wrapper = styled.div(({ theme }) => ({
+  display: 'grid',
+  gap: theme.space[2],
+  // fit as many columns as possible in the container without the width subceeding 200px
+  gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+}))
+
+type InsurableLimit = {
+  value: string
+  label: string
+}
+
+type InsurableLimitsProps = {
+  limits: InsurableLimit[]
+}
+
+export const InsurableLimits = ({ limits }: InsurableLimitsProps) => {
+  return (
+    <Wrapper>
+      {limits.map((limit) => (
+        <Statistic key={limit.label} label={limit.label} value={limit.value} />
+      ))}
+    </Wrapper>
+  )
+}

--- a/apps/store/src/components/Statistic/Statistic.stories.tsx
+++ b/apps/store/src/components/Statistic/Statistic.stories.tsx
@@ -1,0 +1,22 @@
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { Statistic } from './Statistic'
+
+export default {
+  title: 'Statistic',
+  component: Statistic,
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'iphonese2',
+    },
+  },
+} as ComponentMeta<typeof Statistic>
+
+const Template: ComponentStory<typeof Statistic> = (props) => <Statistic {...props} />
+
+export const Default = Template.bind({})
+Default.args = {
+  label: 'Deductible',
+  value: 'SEK 1,500',
+}

--- a/apps/store/src/components/Statistic/Statistic.tsx
+++ b/apps/store/src/components/Statistic/Statistic.tsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled'
+
+export type StatisticProps = {
+  value: string
+  label: string
+}
+
+const Wrapper = styled.div(({ theme }) => ({
+  padding: theme.space[4],
+  paddingTop: theme.space[2],
+  borderRadius: theme.space[2],
+  border: `1px solid ${theme.colors.gray600}`,
+  backgroundColor: theme.colors.gray300,
+  minHeight: theme.space[9],
+  display: 'grid',
+  justifyItems: 'start',
+}))
+
+const Label = styled.p(({ theme }) => ({
+  color: theme.colors.gray600,
+  fontSize: theme.fontSizes[1],
+}))
+
+const Value = styled.p(({ theme }) => ({
+  color: theme.colors.black,
+  fontSize: theme.fontSizes[4],
+}))
+
+export const Statistic = ({ label, value }: StatisticProps) => {
+  return (
+    <Wrapper>
+      <Label>{label}</Label>
+      <Value>{value}</Value>
+    </Wrapper>
+  )
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

* Add a `<Statistics>` component that can display `value` and `label`
* Add a `<InsurableLimits>` component that takes in an array of objects with `value` and `label` and displays a grid of `<Statistics>` components

## Justify why they are needed

Ticket https://hedvig.atlassian.net/browse/GRW-1361

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->


https://user-images.githubusercontent.com/1343979/187166483-0f19802b-a441-4a9a-a15b-54bb6cc28a95.mov



(the reason it looks like it's a bit glitchy when resizing the window is because I added a _very_ long value for the travel insurance to see how it behaves. In edge cases it will be like this:

<img width="1293" alt="image" src="https://user-images.githubusercontent.com/1343979/187166280-b1369978-e2ad-471e-828c-764be56c4002.png">

Obviously the user wouldn't see that as they probably do not resize the window.


## Checklist before requesting a review

- [x] I have performed a self-review of my code
