### PR TITLE
GRW-1412 POC Upgrade to React 18  ⚛️

### DIFF
--- a/apps/onboarding/package.json
+++ b/apps/onboarding/package.json
@@ -38,8 +38,8 @@
     "next-i18next": "^11.0.0",
     "pino-datadog": "https://github.com/simonauner/pino-datadog#rename-hostname-to-host",
     "pino-multi-stream": "6.0.0",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "ui": "workspace:"
   },
   "devDependencies": {
@@ -58,7 +58,7 @@
     "@types/lodash-es": "4.17.6",
     "@types/marked": "^4.0.3",
     "@types/node": "^17.0.24",
-    "@types/react": "17.0.48",
+    "@types/react": "18.0.17",
     "cypress": "^9.5.4",
     "eslint-plugin-cypress": "2.12.1",
     "jest": "28.1.3",

--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -34,8 +34,8 @@
     "graphql": "16.5.0",
     "js-cookie": "3.0.1",
     "next": "12.2.2",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "ui": "workspace:"
   },
   "devDependencies": {
@@ -57,7 +57,7 @@
     "@testing-library/user-event": "14.4.1",
     "@types/js-cookie": "3.0.2",
     "@types/node": "17.0.24",
-    "@types/react": "17.0.48",
+    "@types/react": "18.0.17",
     "babel-loader": "8.2.5",
     "eslint": "8.21.0",
     "eslint-plugin-cypress": "2.12.1",

--- a/apps/store/src/blocks/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock.tsx
@@ -26,7 +26,7 @@ type FooterLinkProps = SbBaseBlockProps<{
 export const FooterLink = ({ blok }: FooterLinkProps) => {
   return (
     <Link href={blok.link.cached_url} passHref {...storyblokEditable(blok)}>
-      <StyledLink>{blok.title}</StyledLink>
+      <StyledLink>{blok.name}</StyledLink>
     </Link>
   )
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "turbo": "1.4.2"
   },
   "resolutions": {
-    "next-i18next/@types/react": "17.0.48"
+    "next-i18next/@types/react": "18.0.17"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,5 @@
     "lint-staged": "^12.3.7",
     "prettier": "2.7.1",
     "turbo": "1.4.2"
-  },
-  "resolutions": {
-    "next-i18next/@types/react": "18.0.17"
   }
 }

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -22,8 +22,8 @@
     "eslint": "8.21.0",
     "eslint-plugin-jest": "26.7.0",
     "next": "12.2.2",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "typescript": "4.7.4"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,8 +33,8 @@
     "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.4.1",
     "@types/jest": "28.1.6",
-    "@types/react": "17.0.48",
-    "@types/react-dom": "17.0.17",
+    "@types/react": "18.0.17",
+    "@types/react-dom": "18.0.6",
     "babel-jest": "28.1.3",
     "babel-loader": "8.2.5",
     "jest": "28.1.3",
@@ -49,8 +49,8 @@
     "@emotion/styled": "11.10.0",
     "@radix-ui/react-checkbox": "^0.1.5",
     "@radix-ui/react-radio-group": "^0.1.5",
-    "react": "17.0.2",
+    "react": "18.2.0",
     "react-animate-height": "2.1.2",
-    "react-dom": "17.0.2"
+    "react-dom": "18.2.0"
   }
 }

--- a/packages/ui/src/components/Menu/SubMenu.tsx
+++ b/packages/ui/src/components/Menu/SubMenu.tsx
@@ -62,8 +62,8 @@ type ChildrenBlurProps = {
 }
 const ChildrenBlur = ({ children, onBlur, ...props }: ChildrenBlurProps) => {
   const handleBlur = useCallback(
-    (e: React.FocusEvent<HTMLDivElement, Element>) => {
-      const currentTarget = e.currentTarget
+    (event: React.FocusEvent<HTMLElement>) => {
+      const currentTarget = event.currentTarget
 
       // Give browser time to focus the next element
       requestAnimationFrame(() => {

--- a/packages/ui/src/components/Menu/SubMenu.tsx
+++ b/packages/ui/src/components/Menu/SubMenu.tsx
@@ -52,7 +52,6 @@ const DropdownMenuItemList = styled.ul({
     },
   },
 })
-
 // This component makes sure that we close the menu when it loses
 // focus. It's hopefully useful when navigating with keyboard.
 //
@@ -63,7 +62,7 @@ type ChildrenBlurProps = {
 }
 const ChildrenBlur = ({ children, onBlur, ...props }: ChildrenBlurProps) => {
   const handleBlur = useCallback(
-    (e) => {
+    (e: React.FocusEvent<HTMLDivElement, Element>) => {
       const currentTarget = e.currentTarget
 
       // Give browser time to focus the next element

--- a/yarn.lock
+++ b/yarn.lock
@@ -6346,7 +6346,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:17.0.17, @types/react-dom@npm:<18.0.0":
+"@types/react-dom@npm:18.0.6":
+  version: 18.0.6
+  resolution: "@types/react-dom@npm:18.0.6"
+  dependencies:
+    "@types/react": "*"
+  checksum: db571047af1a567631758700b9f7d143e566df939cfe5fbf7535347cc0c726a1cdbb5e3f8566d076e54cf708b6c1166689de194a9ba09ee35efc9e1d45911685
+  languageName: node
+  linkType: hard
+
+"@types/react-dom@npm:<18.0.0":
   version: 17.0.17
   resolution: "@types/react-dom@npm:17.0.17"
   dependencies:
@@ -6364,7 +6373,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:17.0.48, @types/react@npm:^17":
+"@types/react@npm:*, @types/react@npm:^17":
   version: 17.0.48
   resolution: "@types/react@npm:17.0.48"
   dependencies:
@@ -6372,6 +6381,17 @@ __metadata:
     "@types/scheduler": "*"
     csstype: ^3.0.2
   checksum: b683fa33f751ced0b8c8715df9f40de15513c1d7ce66064a75cdfb8805cc913b0b214a2e7022ef0b724bd62a1e8651d040cd265dd0452bde03cca9b8e495742d
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:18.0.17":
+  version: 18.0.17
+  resolution: "@types/react@npm:18.0.17"
+  dependencies:
+    "@types/prop-types": "*"
+    "@types/scheduler": "*"
+    csstype: ^3.0.2
+  checksum: 18cae64f5bfd6bb58fbd8ee2ba52ec82de844f114254e26de7b513e4b86621f643f9b71d7066958cd571b0d78cb86cbceda449c5289f9349ca573df29ab69252
   languageName: node
   linkType: hard
 
@@ -17792,7 +17812,7 @@ __metadata:
     "@types/lodash-es": 4.17.6
     "@types/marked": ^4.0.3
     "@types/node": ^17.0.24
-    "@types/react": 17.0.48
+    "@types/react": 18.0.17
     classnames: 2.3.1
     cookies-next: 2.1.1
     cypress: ^9.5.4
@@ -17813,8 +17833,8 @@ __metadata:
     pino-datadog: "https://github.com/simonauner/pino-datadog#rename-hostname-to-host"
     pino-multi-stream: 6.0.0
     prettier: 2.7.1
-    react: 17.0.2
-    react-dom: 17.0.2
+    react: 18.2.0
+    react-dom: 18.2.0
     scripts: "workspace:"
     serve: ^13.0.2
     start-server-and-test: 1.14.0
@@ -19441,16 +19461,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:17.0.2":
-  version: 17.0.2
-  resolution: "react-dom@npm:17.0.2"
+"react-dom@npm:18.2.0":
+  version: 18.2.0
+  resolution: "react-dom@npm:18.2.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-    scheduler: ^0.20.2
+    scheduler: ^0.23.0
   peerDependencies:
-    react: 17.0.2
-  checksum: 1c1eaa3bca7c7228d24b70932e3d7c99e70d1d04e13bb0843bbf321582bc25d7961d6b8a6978a58a598af2af496d1cedcfb1bf65f6b0960a0a8161cb8dab743c
+    react: ^18.2.0
+  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
   languageName: node
   linkType: hard
 
@@ -19606,13 +19625,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:17.0.2":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
+"react@npm:18.2.0":
+  version: 18.2.0
+  resolution: "react@npm:18.2.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: b254cc17ce3011788330f7bbf383ab653c6848902d7936a87b09d835d091e3f295f7e9dd1597c6daac5dc80f90e778c8230218ba8ad599f74adcc11e33b9d61b
+  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
   languageName: node
   linkType: hard
 
@@ -20437,13 +20455,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "scheduler@npm:0.20.2"
+"scheduler@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "scheduler@npm:0.23.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: c4b35cf967c8f0d3e65753252d0f260271f81a81e427241295c5a7b783abf4ea9e905f22f815ab66676f5313be0a25f47be582254db8f9241b259213e999b8fc
+  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
   languageName: node
   linkType: hard
 
@@ -20505,8 +20522,8 @@ __metadata:
     eslint-plugin-testing-library: 5.6.0
     identity-obj-proxy: ^3.0.0
     next: 12.2.2
-    react: 17.0.2
-    react-dom: 17.0.2
+    react: 18.2.0
+    react-dom: 18.2.0
     typescript: 4.7.4
   languageName: unknown
   linkType: soft
@@ -21302,7 +21319,7 @@ __metadata:
     "@testing-library/user-event": 14.4.1
     "@types/js-cookie": 3.0.2
     "@types/node": 17.0.24
-    "@types/react": 17.0.48
+    "@types/react": 18.0.17
     ajv: ^8.11.0
     babel-loader: 8.2.5
     dd-trace: 2.10.0
@@ -21319,8 +21336,8 @@ __metadata:
     next: 12.2.2
     next-router-mock: 0.7.4
     prettier: 2.7.1
-    react: 17.0.2
-    react-dom: 17.0.2
+    react: 18.2.0
+    react-dom: 18.2.0
     scripts: "workspace:"
     storybook-addon-next: 1.6.7
     subscriptions-transport-ws: 0.11.0
@@ -22881,14 +22898,14 @@ __metadata:
     "@testing-library/react-hooks": 8.0.1
     "@testing-library/user-event": 14.4.1
     "@types/jest": 28.1.6
-    "@types/react": 17.0.48
-    "@types/react-dom": 17.0.17
+    "@types/react": 18.0.17
+    "@types/react-dom": 18.0.6
     babel-jest: 28.1.3
     babel-loader: 8.2.5
     jest: 28.1.3
-    react: 17.0.2
+    react: 18.2.0
     react-animate-height: 2.1.2
-    react-dom: 17.0.2
+    react-dom: 18.2.0
     scripts: "workspace:"
     ts-jest: 28.0.7
     tsconfig: "workspace:"


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Upgrade all packages within Racoon to [React 18](https://reactjs.org/blog/2022/03/29/react-v18.html)

In general some possible concerns are around our major dependencies i.e. [Next](https://nextjs.org/docs/advanced-features/react-18/overview), Apollo Client, Emotion, Storybook

To read more about our motivations, check out the Notion document [here](https://www.notion.so/hedviginsurance/Use-React-18-for-Coverage-Store-a182a7a30cae433dbc075228bf577dda).

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

- Upgraded the following packages to work with React 18
- `react`
- `react-dom`
- `@react/types`
- `@react-dom/types`


## Justify why they are needed

Proactively keeping this repository up to date.

## Jira issue(s): [GRW-1412]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1412]: https://hedvig.atlassian.net/browse/GRW-1412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ