### PR TITLE
Add InsurableLimit(s) bloks

### DIFF
--- a/apps/store/src/blocks/InsurableLimitsBlock.tsx
+++ b/apps/store/src/blocks/InsurableLimitsBlock.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled'
+import { InsurableLimits } from '@/components/InsurableLimits/InsurableLimits'
+import { Statistic } from '@/components/Statistic/Statistic'
+import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
+
+type InsurableLimitsBlockProps = SbBaseBlockProps<{
+  items: Array<InsurableLimitBlockProps['blok']>
+}>
+
+const StyledInsurableLimits = styled(InsurableLimits)(({ theme }) => ({
+  padding: theme.space[4],
+}))
+
+export const InsurableLimitsBlock = ({ blok }: InsurableLimitsBlockProps) => {
+  const items = filterByBlockType(blok.items, InsurableLimitBlock.blockName)
+  return (
+    <StyledInsurableLimits>
+      {items.map((nestedBlock) => (
+        <InsurableLimitBlock key={nestedBlock._uid} blok={nestedBlock} />
+      ))}
+    </StyledInsurableLimits>
+  )
+}
+InsurableLimitsBlock.blockName = 'insurableLimits'
+
+type InsurableLimitBlockProps = SbBaseBlockProps<{
+  label: string
+  limit: string
+}>
+const InsurableLimitBlock = ({ blok }: InsurableLimitBlockProps) => {
+  return <Statistic label={blok.label} value={blok.limit} />
+}
+InsurableLimitBlock.blockName = 'insurableLimit'

--- a/apps/store/src/components/InsurableLimits/InsurableLimits.stories.tsx
+++ b/apps/store/src/components/InsurableLimits/InsurableLimits.stories.tsx
@@ -1,5 +1,6 @@
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { Statistic } from '@/components/Statistic/Statistic'
 import { InsurableLimits } from './InsurableLimits'
 
 export default {
@@ -13,16 +14,22 @@ export default {
   },
 } as ComponentMeta<typeof InsurableLimits>
 
-const Template: ComponentStory<typeof InsurableLimits> = (props) => <InsurableLimits {...props} />
-
-export const Default = Template.bind({})
-Default.args = {
-  limits: [
+const Template: ComponentStory<typeof InsurableLimits> = () => {
+  const limits = [
     { label: 'Deductible', value: 'SEK 1,500' },
     { label: 'Insured amount', value: 'SEK 1,000,000' },
     { label: 'Travel', value: 'Up to 45 days/trip when its a long trip' },
     { label: 'Bike coverage', value: 'Up to SEK 15,000' },
     { label: 'Bike coverage', value: 'Up to SEK 15,000' },
     { label: 'Bike coverage', value: 'Up to SEK 15,000' },
-  ],
+  ]
+  return (
+    <InsurableLimits>
+      {limits.map((limit) => (
+        <Statistic key={limit.label} label={limit.label} value={limit.value} />
+      ))}
+    </InsurableLimits>
+  )
 }
+export const Default = Template.bind({})
+Default.args = {}

--- a/apps/store/src/components/InsurableLimits/InsurableLimits.tsx
+++ b/apps/store/src/components/InsurableLimits/InsurableLimits.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled'
-import { Statistic } from '../Statistic/Statistic'
 
 const Wrapper = styled.div(({ theme }) => ({
   display: 'grid',
@@ -8,21 +7,11 @@ const Wrapper = styled.div(({ theme }) => ({
   gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
 }))
 
-type InsurableLimit = {
-  value: string
-  label: string
-}
-
 type InsurableLimitsProps = {
-  limits: InsurableLimit[]
+  children: React.ReactNode
+  className?: string
 }
 
-export const InsurableLimits = ({ limits }: InsurableLimitsProps) => {
-  return (
-    <Wrapper>
-      {limits.map((limit) => (
-        <Statistic key={limit.label} label={limit.label} value={limit.value} />
-      ))}
-    </Wrapper>
-  )
+export const InsurableLimits = ({ children, className }: InsurableLimitsProps) => {
+  return <Wrapper className={className}>{children}</Wrapper>
 }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -9,6 +9,7 @@ import { FooterBlock, FooterLink, FooterSection } from '@/blocks/FooterBlock'
 import { HeadingBlock } from '@/blocks/HeadingBlock'
 import { HeroBlock } from '@/blocks/HeroBlock'
 import { ImageBlock } from '@/blocks/ImageBlock'
+import { InsurableLimitsBlock } from '@/blocks/InsurableLimitsBlock'
 import { PageBlock } from '@/blocks/PageBlock'
 import { PriceCalculatorBlock } from '@/blocks/PriceCalculatorBlock'
 import { ProductCardBlock } from '@/blocks/ProductCardBlock'
@@ -91,6 +92,7 @@ export const initStoryblok = () => {
     HeadingBlock,
     HeroBlock,
     ImageBlock,
+    InsurableLimitsBlock,
     NavItemBlock,
     NestedNavContainerBlock,
     PageBlock,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

* Adds `InsurableLimitsBlock` and `InsurableLimitBlock` components
* Refactored `InsurableLimits` component since `InsurableLimitsBlock` loops out `InsurableLimitBlock`

**Question:** 
Should we for clarity's sake keep `InsurableLimits` component? It's pretty meaningless in itself and its styling could just as easily be in the `InsurableLimitsBlock` component. But if we want to use `InsurableLimits` outside of Storyblok's context it could still be useful... What's our stance on this?


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Jira issue(s): [GRW-1366]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/1343979/187387265-249bfe63-13a0-464a-8075-8c51f30483df.png">


<img width="1439" alt="image" src="https://user-images.githubusercontent.com/1343979/187387318-98086d57-32fb-491b-9296-e2bbe02d89e1.png">


## Checklist before requesting a review

- [x] I have performed a self-review of my code


[GRW-1366]: https://hedvig.atlassian.net/browse/GRW-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ