### PR TITLE
Split up ESLint configs to isolate Next.js rules

### DIFF
--- a/apps/onboarding/.eslintrc.js
+++ b/apps/onboarding/.eslintrc.js
@@ -1,1 +1,1 @@
-module.exports = require('scripts/eslint-preset')
+module.exports = require('scripts/eslint-preset-next')

--- a/apps/store/.eslintrc.js
+++ b/apps/store/.eslintrc.js
@@ -1,1 +1,1 @@
-module.exports = require('scripts/eslint-preset')
+module.exports = require('scripts/eslint-preset-next')

--- a/packages/scripts/.eslintrc.js
+++ b/packages/scripts/.eslintrc.js
@@ -1,7 +1,7 @@
+// eslint-disable-next-line no-undef
 module.exports = {
   parser: '@typescript-eslint/parser',
   extends: [
-    'next/core-web-vitals',
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'prettier', // Uses eslint-config-prettier to turn off all rules that are unnecessary or might conflict with Prettier
@@ -9,9 +9,6 @@ module.exports = {
   plugins: ['import', 'testing-library', 'jest', '@typescript-eslint'],
   ignorePatterns: ['next.config.js'],
   settings: {
-    next: {
-      rootDir: ['apps/*/', 'packages/*/'],
-    },
     'import/parsers': {
       '@typescript-eslint/parser': ['.ts', '.tsx'],
     },

--- a/packages/scripts/eslint-preset-next.js
+++ b/packages/scripts/eslint-preset-next.js
@@ -1,0 +1,13 @@
+// eslint-disable-next-line no-undef, @typescript-eslint/no-var-requires
+const config = require('./.eslintrc')
+// eslint-disable-next-line no-undef
+module.exports = {
+  ...config,
+  extends: [...config.extends, 'next/core-web-vitals'],
+  settings: {
+    ...config.settings,
+    next: {
+      rootDir: ['apps/*/', 'packages/*/'],
+    },
+  },
+}

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "files": [
-    "eslint-preset.js"
+    "eslint-preset.js",
+    "eslint-preset-next.js"
   ],
   "scripts": {
     "clean": "rm -rf .turbo && rm -rf node_modules"

--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -74,6 +74,5 @@ const Img = styled.img({
 })
 
 export const CardMedia = ({ image, height, alt }: CardMediaProps) => {
-  // eslint-disable-next-line @next/next/no-img-element
   return <Img src={image} height={height} alt={alt} />
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Split up ESLint configs in UI package so that it's easy to see what is Next.js-specific.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

As suggested by @alebedev here it is easier to see what has been added for Next.js than to somehow understand that we filter away rules and config in the UI package: https://github.com/HedvigInsurance/racoon/pull/457/files/4afe2632057ef76fd037722fe7e35c81f8c3147b#diff-ad31f895bb498d335c09f2aa7eb18d512c87e8df3bffe91929d0e1506b17ca74

## Jira issue(s): [GRW-1439]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1439]: https://hedvig.atlassian.net/browse/GRW-1439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ