### PR TITLE
GRW-1401 / Add hideMenu option to Page in storyblok

### DIFF
--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -16,6 +16,7 @@ type LayoutWithMenuProps = {
 }
 
 export const LayoutWithMenu = ({ children }: LayoutWithMenuProps) => {
+  const story = children.props.story
   const globalStory = children.props.globalStory
   const router = useRouter()
   const handleChangeLocale: SiteFooterProps['onChangeLocale'] = (locale) => {
@@ -25,7 +26,7 @@ export const LayoutWithMenu = ({ children }: LayoutWithMenuProps) => {
   return (
     <Wrapper>
       {children}
-      <HeaderBlock blok={globalStory.content} />
+      {!story.content.hideMenu && <HeaderBlock blok={globalStory.content} />}
       <SiteFooter onChangeLocale={handleChangeLocale} />
     </Wrapper>
   )


### PR DESCRIPTION
Co-authored-by: karnell schultz <karnellschultz@gmail.com>

## Describe your changes

Add a Page config group to Page content type with a `hideMenu` checkbox.


https://user-images.githubusercontent.com/6661511/187471774-44ec1343-7a08-4aba-9114-d8e2eed199df.mov


## Justify why they are needed

Add possibility to hide menu/header on some pages.
However, haven't seen in design what pages this option is relevant for. So we might need to tweak the functionality. Do we want to hide the whole header (with Hedvig logo and cart icon) or just the menu in the header? 

## Jira issue(s): []

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
