### PR TITLE
Fix shop session fetching server-side

### DIFF
--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -33,7 +33,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
       <ApolloProvider client={apolloClient}>
         <ThemeProvider>
           <GlobalStyles />
-          <ShopSessionProvider>
+          <ShopSessionProvider shopSessionId={pageProps.shopSessionId}>
             <CartContext.Provider value={cartStore}>
               {getLayout(<Component {...pageProps} />)}
             </CartContext.Provider>

--- a/apps/store/src/services/shopSession/ShopSessionContext.tsx
+++ b/apps/store/src/services/shopSession/ShopSessionContext.tsx
@@ -13,10 +13,12 @@ type ShopSessionQueryResult = QueryResult<ShopSessionQuery, ShopSessionQueryVari
 
 export const ShopSessionContext = createContext<ShopSessionQueryResult | null>(null)
 
-export const ShopSessionProvider = ({ children }: PropsWithChildren<unknown>) => {
+type Props = PropsWithChildren<{ shopSessionId?: string }>
+
+export const ShopSessionProvider = ({ children, shopSessionId: initialShopSessionId }: Props) => {
   const { countryCode } = useCurrentLocale()
   const shopSessionService = useShopSessionService()
-  const shopSessionId = shopSessionService.shopSessionId()
+  const shopSessionId = initialShopSessionId ?? shopSessionService.shopSessionId()
 
   const [createShopSession, mutationResult] = useShopSessionCreateMutation({
     variables: { countryCode },
@@ -37,6 +39,7 @@ export const ShopSessionProvider = ({ children }: PropsWithChildren<unknown>) =>
       console.warn('ShopSession not found: ', shopSessionId, error)
       createShopSession()
     },
+    ssr: typeof window === 'undefined',
   })
 
   // Has to be wrapped to prevent duplicate execution (Apollo quirk leads do duplicate execution when called directly from render)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix shop session fetching server-side

  Pass shopSessionId to provider if we fetch it server side.
  Enable ssr for shop session query.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We get hydration error on pages that server render the header.

Not sure why Apollo require us to set `ssr`-option on the query level AND on the client.

Need to pass shop session ID to the provider since we can't read cookies inside React on the server.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
