### PR TITLE
Fix semantic html structure

### DIFF
--- a/apps/store/src/blocks/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock.tsx
@@ -90,7 +90,7 @@ export const FooterBlock = ({ blok }: FooterBlockProps) => {
   const footerSections = filterByBlockType(blok.footerSections, FooterSection.blockName)
 
   return (
-    <Wrapper y={2}>
+    <Wrapper as="footer" y={2}>
       <Accordion.Root type="multiple">
         {footerSections.map((nestedBlok) => (
           <FooterSection key={nestedBlok._uid} blok={nestedBlok} />

--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -6,7 +6,7 @@ import { FooterBlock } from '@/blocks/FooterBlock'
 import { HeaderBlock } from '@/blocks/TopMenuBlock'
 import { SiteFooterProps } from '@/components/SiteFooter/SiteFooter'
 
-const Wrapper = styled.main({
+const Wrapper = styled.div({
   minHeight: '100vh',
   display: 'flex',
   flexDirection: 'column',
@@ -28,8 +28,8 @@ export const LayoutWithMenu = ({ children }: LayoutWithMenuProps) => {
 
   return (
     <Wrapper>
-      {children}
       {(!story || !story.content.hideMenu) && <HeaderBlock blok={globalStory.content} />}
+      {children}
       {(!story || !story.content.hideMenu) && (
         <FooterBlock blok={globalStory.content} onChangeLocale={handleChangeLocale} />
       )}

--- a/apps/store/src/components/SiteFooter/SiteFooter.tsx
+++ b/apps/store/src/components/SiteFooter/SiteFooter.tsx
@@ -38,7 +38,7 @@ export const SiteFooter = ({ onChangeLocale }: SiteFooterProps) => {
   }
 
   return (
-    <Wrapper y={2}>
+    <Wrapper as="footer" y={2}>
       <Accordion.Root type="multiple">
         {SECTIONS.map((section, index) => (
           <Accordion.Item key={index} value={index.toString()}>

--- a/apps/store/src/components/TopMenu/TopMenu.tsx
+++ b/apps/store/src/components/TopMenu/TopMenu.tsx
@@ -111,7 +111,7 @@ export const focusableStyles = {
   },
 }
 
-export const Wrapper = styled.div(({ theme }) => ({
+export const Wrapper = styled.header(({ theme }) => ({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',

--- a/apps/store/src/components/TopMenu/TopMenu.tsx
+++ b/apps/store/src/components/TopMenu/TopMenu.tsx
@@ -9,6 +9,7 @@ import { MenuIcon } from './MenuIcon'
 import { ShoppingCartMenuItem } from './ShoppingCartMenuItem'
 
 export const MENU_BAR_HEIGHT = '3.75rem'
+const Z_INDEX_TOP_MENU = 1000
 
 export const TopMenu = () => {
   const [activeItem, setActiveItem] = useState('')
@@ -119,6 +120,7 @@ export const Wrapper = styled.header(({ theme }) => ({
   height: MENU_BAR_HEIGHT,
   padding: theme.space[4],
   position: 'fixed',
+  zIndex: Z_INDEX_TOP_MENU,
 }))
 
 export const StyledDialogOverlay = styled(DialogPrimitive.Overlay)({


### PR DESCRIPTION
## Describe your changes

- Render proper tags for `header` and `footer`
- Put header at start of document
- Remove nested `main` tags

## Justify why they are needed
The structure we should aim to follow:
```
<body>
  <header>
    <nav>…</nav>
  </header>

  <main>
  </main>

  <footer>
  </footer>
</body>
```

### Before
<img width="510" alt="Screenshot 2022-09-02 at 11 18 04" src="https://user-images.githubusercontent.com/6661511/188109737-6871f4f7-707c-4c22-8c2a-25488d20257d.png">

### After
<img width="640" alt="Screenshot 2022-09-02 at 11 28 51" src="https://user-images.githubusercontent.com/6661511/188109767-096889e7-24de-49a9-a355-905494a9bfd1.png">


It was a SEO concern from Peter if we would render the header and menu on the bottom of the page. Sorry for adding back `z-index` @robinandeer I feel your pain :D but I think it's nice to keep the low level logical order of the document as well. We have some options to colocate z-index throughout the app, I can make a proposal for it :) 

## Jira issue(s): [GRW-1454]

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1454]: https://hedvig.atlassian.net/browse/GRW-1454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ