### PR TITLE
Add central Track service (Datadog/GTM)

### DIFF
--- a/apps/store/src/services/Track/Track.ts
+++ b/apps/store/src/services/Track/Track.ts
@@ -1,0 +1,7 @@
+import { datadogLogs } from '@datadog/browser-logs'
+
+export class Track {
+  public static addContext(key: string, value: any) {
+    datadogLogs.logger.addContext(key, value)
+  }
+}

--- a/apps/store/src/services/shopSession/ShopSessionContext.tsx
+++ b/apps/store/src/services/shopSession/ShopSessionContext.tsx
@@ -1,5 +1,4 @@
 import { QueryHookOptions, QueryResult, useApolloClient } from '@apollo/client'
-import { datadogLogs } from '@datadog/browser-logs'
 import { createContext, PropsWithChildren, useContext, useEffect } from 'react'
 import { useCurrentCountry } from '@/lib/l10n/useCurrentCountry'
 import {
@@ -8,6 +7,7 @@ import {
   useShopSessionCreateMutation,
   useShopSessionQuery as useShopSessionApolloQuery,
 } from '@/services/apollo/generated'
+import { Track } from '@/services/Track/Track'
 import { setupShopSessionServiceClientSide } from './ShopSession.helpers'
 
 type ShopSessionQueryResult = QueryResult<ShopSessionQuery, ShopSessionQueryVariables>
@@ -31,7 +31,7 @@ export const ShopSessionProvider = ({ children, shopSessionId: initialShopSessio
   const queryResult = useShopSessionQuery({
     shopSessionId,
     onCompleted: ({ shopSession }) => {
-      datadogLogs.logger.addContext('shopSessionId', shopSession.id)
+      Track.addContext('shopSessionId', shopSession.id)
       if (shopSession.countryCode !== countryCode) {
         console.warn('ShopSession CountryCode does not match')
         createShopSession()


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Centralize Track stuff in a single service.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Then we can add context data to both Datadog/GTM for example.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
