### PR TITLE
GRW-1471 / Feature / Map country default locale to Storyblok default language

### DIFF
--- a/apps/store/src/pages/api/preview.ts
+++ b/apps/store/src/pages/api/preview.ts
@@ -20,12 +20,11 @@ const preview = async (req: NextApiRequest, res: NextApiResponse) => {
 
   const [countryLabel, ...slugFragments] = story.full_slug.split('/')
 
-  // Convert default => English if applicable
-  let locale = req.query._storyblok_lang
-  if (locale === 'default') {
-    const country = countries[countryLabel as CountryLabel]
-    locale = country.locales.find((locale) => locale.startsWith('en')) ?? country.defaultLocale
-  }
+  // Convert storyblok language to locale
+  const storyblokLang = req.query._storyblok_lang as string
+  const country = countries[countryLabel as CountryLabel]
+  const locale =
+    country.locales.find((locale) => locale.startsWith(storyblokLang)) ?? country.defaultLocale
 
   res.setPreviewData({})
   // Set cookie to None, so it can be read in the Storyblok iframe

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -144,10 +144,15 @@ type StoryOptions = {
 
 export const getStoryBySlug = async (slug: string, { preview, locale }: StoryOptions) => {
   const country = getCountryByLocale(locale)
-  const { data } = await getStoryblokApi().get(`cdn/stories/${country.id}/${slug}`, {
+  const params: Record<string, string> = {
     version: preview ? 'draft' : 'published',
-    language: getLocaleOrFallback(locale).language,
-  })
+  }
+  // Special case: in Storyblok default language means country default, ie Swedish in Sweden, Danish in Denmark, etc
+  // Therefore we're not passing language code from NextJs locale here
+  if (locale !== country.defaultLocale) {
+    params.language = getLocaleOrFallback(locale).language
+  }
+  const { data } = await getStoryblokApi().get(`cdn/stories/${country.id}/${slug}`, params)
   return data.story as StoryData | undefined
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Map Storyblok default locale to country-specific default locale
Assume Storyblok uses 2-char language codes for other languages

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Implement default language logic for localization experiment

## Jira issue(s): [GRW-1471]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [x] I have performed a self-review of my code


[GRW-1471]: https://hedvig.atlassian.net/browse/GRW-1471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ