### PR TITLE
Fix product page revalidate bug

### DIFF
--- a/apps/store/src/blocks/PriceCalculatorBlock.tsx
+++ b/apps/store/src/blocks/PriceCalculatorBlock.tsx
@@ -10,7 +10,6 @@ import { PriceCalculatorFooter } from '@/components/ProductPage/PriceCalculatorF
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { useHandleSubmitAddToCart } from '@/components/ProductPage/useHandleClickAddToCart'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
-import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntent.helpers'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { useCurrencyFormatter } from '@/utils/useCurrencyFormatter'
 
@@ -35,12 +34,12 @@ export const PriceCalculatorBlock = ({ blok: { title } }: StoryblokPriceCalculat
   const wrapperRef = useRef<HTMLDivElement>(null)
   const toastRef = useRef<CartToastAttributes | null>(null)
   const formatter = useCurrencyFormatter(product.currencyCode)
-  const [handleSubmit, { loading: loadingUpdate }] = useHandleSubmitPriceCalculatorForm({
+  const [handleSubmit, loadingUpdate] = useHandleSubmitPriceCalculatorForm({
     priceIntentId: priceIntent.id,
     formTemplate: priceFormTemplate,
   })
 
-  const [handleSubmitAddToCart, { loading: loadingAddToCart }] = useHandleSubmitAddToCart({
+  const [handleSubmitAddToCart, loadingAddToCart] = useHandleSubmitAddToCart({
     cartId: shopSession.cart.id,
     onSuccess: () => {
       toastRef.current?.publish({
@@ -48,7 +47,6 @@ export const PriceCalculatorBlock = ({ blok: { title } }: StoryblokPriceCalculat
         price: formatter.format(product.price ?? 0),
         gradient: product.gradient,
       })
-      priceIntentServiceInitClientSide().reset()
     },
   })
 

--- a/apps/store/src/pages/products/[product].tsx
+++ b/apps/store/src/pages/products/[product].tsx
@@ -10,7 +10,11 @@ import { APOLLO_STATE_PROP_NAME, initializeApollo } from '@/services/apollo/clie
 import { getShopSessionServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { getGlobalStory, getProductStory } from '@/services/storyblok/storyblok'
 
-const NextProductPage: NextPageWithLayout<ProductPageProps> = (props: ProductPageProps) => {
+type NextPageProps = ProductPageProps & {
+  shopSessionId: string
+}
+
+const NextProductPage: NextPageWithLayout<NextPageProps> = (props) => {
   return (
     <>
       <Head>
@@ -21,7 +25,7 @@ const NextProductPage: NextPageWithLayout<ProductPageProps> = (props: ProductPag
   )
 }
 
-export const getServerSideProps: GetServerSideProps<ProductPageProps> = async (context) => {
+export const getServerSideProps: GetServerSideProps<NextPageProps> = async (context) => {
   const { locale, req, res, params: { product: slug } = {}, preview } = context
 
   if (!locale || locale === 'default') return { notFound: true }
@@ -54,6 +58,7 @@ export const getServerSideProps: GetServerSideProps<ProductPageProps> = async (c
         globalStory,
         priceFormTemplate: template,
         priceIntent,
+        shopSessionId: shopSession.id,
         shopSession,
         [APOLLO_STATE_PROP_NAME]: apolloClient.cache.extract(),
       },

--- a/apps/store/src/utils/useRefreshData.ts
+++ b/apps/store/src/utils/useRefreshData.ts
@@ -1,0 +1,22 @@
+import { useApolloClient } from '@apollo/client'
+import { useCallback, useState } from 'react'
+import useRouterRefresh from '@/utils/useRouterRefresh'
+
+export const useRefreshData = () => {
+  const [loading, setLoading] = useState(false)
+  const refreshRouter = useRouterRefresh()
+  const apolloClient = useApolloClient()
+
+  const refreshData = useCallback(async () => {
+    setLoading(true)
+    try {
+      await Promise.all([refreshRouter(), apolloClient.refetchQueries({ include: 'active' })])
+    } catch (error) {
+      console.error('Unable to refresh data')
+    } finally {
+      setLoading(false)
+    }
+  }, [refreshRouter, apolloClient])
+
+  return [refreshData, loading] as const
+}

--- a/apps/store/src/utils/useRouterRefresh.ts
+++ b/apps/store/src/utils/useRouterRefresh.ts
@@ -1,0 +1,7 @@
+import { useRouter } from 'next/router'
+import { useCallback } from 'react'
+
+export default function useRouterRefresh() {
+  const { asPath, replace } = useRouter()
+  return useCallback(() => replace(asPath, undefined, { scroll: false }), [replace, asPath])
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix bug on Product Page when revalidating data after a mutation.

Only handle data fetching server-side for Product Page.

Pass ShopSession ID to page to subscribe to query (header).

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

This should make the page interactions work for now.

In the future we should either commit to making this page SSR or move user-dependent data to client side data fetching.

But in the mean time it's better to handle all data fetching in one place.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
