### PR TITLE
GRW-1471 / Fix / Locale-specific URLs

### DIFF
--- a/apps/store/src/blocks/ButtonBlock.tsx
+++ b/apps/store/src/blocks/ButtonBlock.tsx
@@ -3,6 +3,7 @@ import { storyblokEditable } from '@storyblok/react'
 import NextLink from 'next/link'
 import { ButtonVariant, LinkButton } from 'ui'
 import { LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { useStroryblokLinkURL } from '@/utils/useStroryblokLinkURL'
 
 export type ButtonBlockProps = SbBaseBlockProps<{
   text: string
@@ -11,9 +12,10 @@ export type ButtonBlockProps = SbBaseBlockProps<{
 }>
 
 export const ButtonBlock = ({ blok }: ButtonBlockProps) => {
+  const href = useStroryblokLinkURL(blok.link)
   return (
     <Wrapper {...storyblokEditable(blok)}>
-      <NextLink href={blok.link.cached_url} passHref>
+      <NextLink href={href} passHref>
         <LinkButton variant={blok.variant} color="dark" size="lg">
           {blok.text}
         </LinkButton>

--- a/apps/store/src/blocks/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock.tsx
@@ -8,7 +8,12 @@ import * as Accordion from '@/components/Accordion/Accordion'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { getCountryLocale, countries } from '@/lib/l10n/countries'
-import { getLocaleOrFallback, LocaleField, TEMP_TRANSLATIONS } from '@/lib/l10n/locales'
+import {
+  getLocaleOrFallback,
+  LocaleField,
+  routingLocale,
+  TEMP_TRANSLATIONS,
+} from '@/lib/l10n/locales'
 import { Locale } from '@/lib/l10n/types'
 import { useCurrentCountry } from '@/lib/l10n/useCurrentCountry'
 import { useCurrentLocale } from '@/lib/l10n/useCurrentLocale'
@@ -81,8 +86,8 @@ export const FooterBlock = ({ blok }: FooterBlockProps) => {
   }
 
   const router = useRouter()
-  const onChangeLocale = (locale: Locale | undefined) => {
-    router.push(router.asPath, undefined, { locale })
+  const onChangeLocale = (locale: Locale) => {
+    router.push(router.asPath, undefined, { locale: routingLocale(locale) })
   }
   const handleSubmit = (event: ChangeEvent<HTMLFormElement>) => {
     event.preventDefault()

--- a/apps/store/src/blocks/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock.tsx
@@ -7,24 +7,28 @@ import { Space } from 'ui'
 import * as Accordion from '@/components/Accordion/Accordion'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
-import { getLocaleOrFallback, LocaleField, TEMP_TRANSLATIONS } from '@/lib/l10n/locales'
 import { getCountryLocale, countries } from '@/lib/l10n/countries'
+import { getLocaleOrFallback, LocaleField, TEMP_TRANSLATIONS } from '@/lib/l10n/locales'
 import { Locale } from '@/lib/l10n/types'
-import { useCurrentLocale } from '@/lib/l10n/useCurrentLocale'
 import { useCurrentCountry } from '@/lib/l10n/useCurrentCountry'
+import { useCurrentLocale } from '@/lib/l10n/useCurrentLocale'
 import { ExpectedBlockType, LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
+import { useStroryblokLinkURL } from '@/utils/useStroryblokLinkURL'
 
 type FooterLinkProps = SbBaseBlockProps<{
   link: LinkField
   linkText: string
 }>
 
-export const FooterLink = ({ blok }: FooterLinkProps) => (
-  <Link href={blok.link.cached_url} passHref {...storyblokEditable(blok)}>
-    <StyledLink>{blok.linkText}</StyledLink>
-  </Link>
-)
+export const FooterLink = ({ blok }: FooterLinkProps) => {
+  const href = useStroryblokLinkURL(blok.link)
+  return (
+    <Link href={href} passHref {...storyblokEditable(blok)}>
+      <StyledLink>{blok.linkText}</StyledLink>
+    </Link>
+  )
+}
 FooterLink.blockName = 'footerLink' as const
 
 type FooterSectionProps = SbBaseBlockProps<{

--- a/apps/store/src/blocks/TopMenuBlock.tsx
+++ b/apps/store/src/blocks/TopMenuBlock.tsx
@@ -20,11 +20,8 @@ import {
   Wrapper,
 } from '@/components/TopMenu/TopMenu'
 import { ExpectedBlockType, LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
-import {
-  checkBlockType,
-  filterByBlockType,
-  getLinkFieldURL,
-} from '@/services/storyblok/Storyblok.helpers'
+import { checkBlockType, filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
+import { useStroryblokLinkURL } from '@/utils/useStroryblokLinkURL'
 
 type NavItemBlockProps = SbBaseBlockProps<{
   name: string
@@ -32,9 +29,10 @@ type NavItemBlockProps = SbBaseBlockProps<{
 }>
 
 export const NavItemBlock = ({ blok }: NavItemBlockProps) => {
+  const url = useStroryblokLinkURL(blok.link)
   return (
     <NavigationMenuPrimitive.Item value={blok.name} {...storyblokEditable(blok)}>
-      <NavigationLink href={getLinkFieldURL(blok.link)}>{blok.name}</NavigationLink>
+      <NavigationLink href={url}>{blok.name}</NavigationLink>
     </NavigationMenuPrimitive.Item>
   )
 }

--- a/apps/store/src/lib/l10n/locales.ts
+++ b/apps/store/src/lib/l10n/locales.ts
@@ -59,6 +59,9 @@ export const normalizeLocale = (locale: string | undefined): string | undefined 
   return `${parts[0].toLowerCase()}-${parts[1].toUpperCase()}`
 }
 
+// We use en-SE ISO format for settings but downcase it for routing to get nicer URLs
+export const routingLocale = (locale: string) => locale.toLowerCase()
+
 // TODO: Make fallback market-specific
 export const getLocaleOrFallback = (locale: Locale | string | undefined): LocaleData => {
   return locales[normalizeLocale(locale) as Locale] ?? locales[FALLBACK_LOCALE]

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -4,6 +4,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Head from 'next/head'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
 import { countries } from '@/lib/l10n/countries'
+import { routingLocale } from '@/lib/l10n/locales'
 import {
   getPageLinks,
   getGlobalStory,
@@ -61,9 +62,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
       return
     }
     countries[countryId].locales.forEach((locale) => {
-      // We use en-SE ISO format for settings but downcase it for routing to get nicer URLs
-      const routingLocale = locale.toLowerCase()
-      paths.push({ params: { slug: slugParts }, locale: routingLocale })
+      paths.push({ params: { slug: slugParts }, locale: routingLocale(locale) })
     })
   })
   return {

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -1,4 +1,6 @@
 import { SbBlokData } from '@storyblok/react'
+import { getCountryByLocale } from '@/lib/l10n/countries'
+import { LocaleData } from '@/lib/l10n/locales'
 import { LinkField } from './storyblok'
 
 export const filterByBlockType = <BlockData extends SbBlokData>(
@@ -27,6 +29,18 @@ export const checkBlockType = <BlockData extends SbBlokData>(
   else return null
 }
 
-export const getLinkFieldURL = (link: LinkField) => {
-  return link.cached_url === 'home' ? '/' : `/${link.cached_url}`
+export const getLinkFieldURL = (link: LinkField, locale: LocaleData) => {
+  const fragments = link.story.full_slug.split('/')
+
+  // en/SE/page => SE/page, SE/page => unchanged
+  const country = getCountryByLocale(locale.locale)
+  const hasLangPrefix = locale.locale !== country.defaultLocale
+  if (hasLangPrefix) {
+    fragments.shift()
+  }
+
+  // SE/page => /page
+  fragments.shift()
+
+  return `/${fragments.join('/')}`
 }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -62,7 +62,15 @@ export type LinkField = {
   id: string
   url: string
   linktype: 'story' | 'url'
-  cached_url: string // use this
+  // Assumes we're using resolve_links=url
+  story: {
+    id: number
+    uuid: string
+    name: string
+    slug: string
+    url: string
+    full_slug: string
+  }
 }
 
 export type ProductStory = StoryData & {
@@ -153,6 +161,7 @@ export const getStoryBySlug = async (slug: string, { preview, locale }: StoryOpt
   const country = getCountryByLocale(locale)
   const params: Record<string, string> = {
     version: preview ? 'draft' : 'published',
+    resolve_links: 'url',
   }
   // Special case: in Storyblok default language means country default, ie Swedish in Sweden, Danish in Denmark, etc
   // Therefore we're not passing language code from NextJs locale here

--- a/apps/store/src/utils/useStroryblokLinkURL.ts
+++ b/apps/store/src/utils/useStroryblokLinkURL.ts
@@ -1,0 +1,8 @@
+import { useCurrentLocale } from '@/lib/l10n/useCurrentLocale'
+import { LinkField } from '@/services/storyblok/storyblok'
+import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
+
+export const useStroryblokLinkURL = (link: LinkField) => {
+  const locale = useCurrentLocale()
+  return getLinkFieldURL(link, locale)
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## GRW-1481 / Fix / Locale-specific URLs

Fix link generation logic
- Use resolve_links=url to ensure we get fresh links from storyblok, cached_url is unsafe
- Handle $lang slug prefix for non-default languages
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Ensure we always get correct URLs in menu

## Jira issue(s): [GRW-1471]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1471]: https://hedvig.atlassian.net/browse/GRW-1471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
