### PR TITLE
refactor: use enums instead of strings for referencing form elements

### DIFF
--- a/apps/store/src/blocks/PriceCalculatorBlock.tsx
+++ b/apps/store/src/blocks/PriceCalculatorBlock.tsx
@@ -7,6 +7,7 @@ import { PriceCalculatorForm } from '@/components/PriceCalculatorForm/PriceCalcu
 import { useHandleSubmitPriceCalculatorForm } from '@/components/PriceCalculatorForm/useHandleSubmitPriceCalculator'
 import { PriceCardForm } from '@/components/PriceCardForm/PriceCardForm'
 import { PriceCalculatorFooterForm } from '@/components/ProductPage/PriceCalculatorFooterForm/PriceCalculatorFooterForm'
+import { FormElement } from '@/components/ProductPage/ProductPage.constants'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { useHandleSubmitAddToCart } from '@/components/ProductPage/useHandleClickAddToCart'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
@@ -78,22 +79,25 @@ export const PriceCalculatorBlock = ({ blok: { title } }: StoryblokPriceCalculat
             loading={loadingAddToCart}
           />
           {lineId && (
-            <input form="price-card-form" type="hidden" name="lineItemId" value={lineId} />
+            <input
+              form="price-card-form"
+              type="hidden"
+              name={FormElement.LineItem}
+              value={lineId}
+            />
           )}
         </SectionWithPadding>
       </Space>
 
-      <PriceCalculatorFooterForm
-        id="price-calculator-footer-form"
-        targetRef={wrapperRef}
-        currencyCode={product.currencyCode}
-        price={product.price ?? undefined}
-        onSubmit={handleSubmitAddToCart}
-        loading={loadingAddToCart}
-      />
-      {lineId && (
-        <input form="price-calculator-footer-form" type="hidden" name="lineItemId" value={lineId} />
-      )}
+      <form onSubmit={handleSubmitAddToCart}>
+        {lineId && <input type="hidden" name={FormElement.LineItem} value={lineId} />}
+        <PriceCalculatorFooterForm
+          targetRef={wrapperRef}
+          currencyCode={product.currencyCode}
+          price={product.price ?? undefined}
+          loading={loadingAddToCart}
+        />
+      </form>
 
       <CartToast ref={toastRef} />
     </>

--- a/apps/store/src/components/CheckoutContactDetailsPage/CheckoutContactDetails.tsx
+++ b/apps/store/src/components/CheckoutContactDetailsPage/CheckoutContactDetails.tsx
@@ -1,5 +1,6 @@
 import { Button, InputField, Space } from 'ui'
 import { CheckoutContactDetailsPageProps } from './CheckoutContactDetails.types'
+import { FormElement } from './CheckoutContactDetailsPage.constants'
 import { CheckoutContactDetailsPageLayout } from './CheckoutContactDetailsPageLayout'
 
 export const CheckoutContactDetailsPage = ({ prefilledData }: CheckoutContactDetailsPageProps) => {
@@ -14,7 +15,7 @@ export const CheckoutContactDetailsPage = ({ prefilledData }: CheckoutContactDet
       <Space y={1}>
         <InputField
           label="National identity number (DDMMYYXXXXX)"
-          name="personalNumber"
+          name={FormElement.PersonalNumber}
           required
           defaultValue={prefilledData.personalNumber ?? undefined}
           infoMessage={
@@ -23,19 +24,19 @@ export const CheckoutContactDetailsPage = ({ prefilledData }: CheckoutContactDet
         />
         <InputField
           label="First name"
-          name="firstName"
+          name={FormElement.FirstName}
           required
           defaultValue={prefilledData.firstName ?? undefined}
         />
         <InputField
           label="Last name"
-          name="lastName"
+          name={FormElement.LastName}
           required
           defaultValue={prefilledData.lastName ?? undefined}
         />
         <InputField
           label="Email"
-          name="email"
+          name={FormElement.Email}
           type="email"
           required
           defaultValue={prefilledData.email ?? undefined}

--- a/apps/store/src/components/CheckoutContactDetailsPage/CheckoutContactDetailsPage.constants.ts
+++ b/apps/store/src/components/CheckoutContactDetailsPage/CheckoutContactDetailsPage.constants.ts
@@ -1,0 +1,6 @@
+export enum FormElement {
+  Email = 'email',
+  FirstName = 'firstName',
+  LastName = 'lastName',
+  PersonalNumber = 'personalNumber',
+}

--- a/apps/store/src/components/CheckoutContactDetailsPage/useHandleSubmitContactDetails.ts
+++ b/apps/store/src/components/CheckoutContactDetailsPage/useHandleSubmitContactDetails.ts
@@ -1,6 +1,7 @@
 import { FormEventHandler } from 'react'
 import { useContactDetailsUpdateMutation } from '@/services/apollo/generated'
 import { getOrThrowFormValue } from '@/utils/getOrThrowFormValue'
+import { FormElement } from './CheckoutContactDetailsPage.constants'
 
 type Params = {
   checkoutId: string
@@ -21,10 +22,10 @@ export const useHandleSubmitContactDetails = (params: Params) => {
       variables: {
         input: {
           checkoutId,
-          email: getOrThrowFormValue(formData, 'email'),
-          firstName: getOrThrowFormValue(formData, 'firstName'),
-          lastName: getOrThrowFormValue(formData, 'lastName'),
-          personalNumber: getOrThrowFormValue(formData, 'personalNumber'),
+          email: getOrThrowFormValue(formData, FormElement.Email),
+          firstName: getOrThrowFormValue(formData, FormElement.FirstName),
+          lastName: getOrThrowFormValue(formData, FormElement.LastName),
+          personalNumber: getOrThrowFormValue(formData, FormElement.PersonalNumber),
         },
       },
     })

--- a/apps/store/src/components/ProductPage/ProductPage.constants.ts
+++ b/apps/store/src/components/ProductPage/ProductPage.constants.ts
@@ -1,0 +1,3 @@
+export enum FormElement {
+  LineItem = 'lineItemId',
+}

--- a/apps/store/src/components/ProductPage/useHandleClickAddToCart.ts
+++ b/apps/store/src/components/ProductPage/useHandleClickAddToCart.ts
@@ -3,6 +3,7 @@ import { useCartLinesAddMutation } from '@/services/apollo/generated'
 import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntent.helpers'
 import { getOrThrowFormValue } from '@/utils/getOrThrowFormValue'
 import { useRefreshData } from '@/utils/useRefreshData'
+import { FormElement } from './ProductPage.constants'
 
 type Params = {
   cartId: string
@@ -17,7 +18,7 @@ export const useHandleSubmitAddToCart = ({ cartId, onSuccess }: Params) => {
     event.preventDefault()
 
     const formData = new FormData(event.currentTarget)
-    const lineItemId = getOrThrowFormValue(formData, 'lineItemId')
+    const lineItemId = getOrThrowFormValue(formData, FormElement.LineItem)
 
     await addLineItems({ variables: { cartId, lineItemId } })
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Introduce enums for form element names.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We use strings to reference form elements both in JSX and in event handlers.

There's a risk that they get out of sync which will cause bugs in the code. Therefore, it's a better idea to use an enum to reference the form element names in both contexts. One source of truth.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
