### PR TITLE
Update Renovate config ⚙️

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
+  "extends": ["config:base"],
+  "schedule": ["before 3am on Monday"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true,
+      "labels": ["dependencies"]
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "labels": ["dependencies"]
+    }
   ]
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

#### Updated the Renovate config

- Automerge `patch`, `pin`, `digest` for `dependencies`
- Automerge `minor`, `patch`, `pin`, `digest` for `devDependencies`

[Renovate docs](https://docs.renovatebot.com/configuration-options/#automerge)

Created a new 'dependencies' label in Github

Decided to get a little more aggressive with devDeps since there is a lower chance of causing issues with those being updated automatically.


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

[Renovate Notion doc](https://www.notion.so/hedviginsurance/Renovate-in-Racoon-89e0dee39ae74793b9f1ad93216d1a92)

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [x] I have performed a self-review of my code


## notes

At the moment the limit for how many PRs Renovate is allowed to have open at once is two.

Even with Renovate being run every Monday morning, this is not going to cause a bunch of PRs to be crated on Monday if there are more than two PRs currently open.

