### PR TITLE
Change default size for Pillow component

### DIFF
--- a/apps/store/src/components/Pillow/Pillow.tsx
+++ b/apps/store/src/components/Pillow/Pillow.tsx
@@ -6,7 +6,7 @@ type PillowProps = {
   size?: 'small' | 'medium' | 'large'
 }
 
-export const Pillow = styled.div<PillowProps>(({ fromColor, toColor, size = 'medium' }) => ({
+export const Pillow = styled.div<PillowProps>(({ fromColor, toColor, size = 'small' }) => ({
   height: getSize(size),
   width: getSize(size),
   background: `linear-gradient(180deg, ${fromColor} 0%, ${toColor} 100%)`,


### PR DESCRIPTION
## Describe your changes

Change default size for Pillow component to `small`

## Screenshot
<img width="608" alt="Screenshot 2022-09-16 at 15 25 21" src="https://user-images.githubusercontent.com/6661511/190649606-aa384826-b510-4d27-9d7b-438f8d4f25f0.png">

