### PR TITLE
Support calculating price for multiple products

### DIFF
--- a/apps/store/src/blocks/PriceCalculatorBlock.tsx
+++ b/apps/store/src/blocks/PriceCalculatorBlock.tsx
@@ -24,7 +24,8 @@ export const PriceCalculatorBlock = ({ blok: { title } }: StoryblokPriceCalculat
   const lineItem = priceIntent.lines?.[0]
   const product = {
     slug: story.slug,
-    name: story.content.name,
+    name: story.content.productId,
+    displayName: story.content.name,
     price: parseInt(lineItem?.price.amount, 10) || null,
     currencyCode: shopSession.currencyCode,
     gradient: PLACEHOLDER_GRADIENT,
@@ -39,10 +40,12 @@ export const PriceCalculatorBlock = ({ blok: { title } }: StoryblokPriceCalculat
   })
 
   const [handleSubmitAddToCart, loadingAddToCart] = useHandleSubmitAddToCart({
+    shopSession,
     cartId: shopSession.cart.id,
+    productName: product.name,
     onSuccess: () => {
       toastRef.current?.publish({
-        name: product.name,
+        name: product.displayName,
         price: formatter.format(product.price ?? 0),
         gradient: product.gradient,
       })
@@ -68,7 +71,7 @@ export const PriceCalculatorBlock = ({ blok: { title } }: StoryblokPriceCalculat
 
         <SectionWithPadding>
           <PriceCardForm
-            title={product.name}
+            title={product.displayName}
             cost={product.price ?? undefined}
             currencyCode={product.currencyCode}
             gradient={product.gradient}

--- a/apps/store/src/components/ProductPage/useHandleClickAddToCart.ts
+++ b/apps/store/src/components/ProductPage/useHandleClickAddToCart.ts
@@ -1,18 +1,28 @@
+import { useApolloClient } from '@apollo/client'
 import { FormEventHandler } from 'react'
 import { useCartLinesAddMutation } from '@/services/apollo/generated'
 import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntent.helpers'
+import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { getOrThrowFormValue } from '@/utils/getOrThrowFormValue'
 import { useRefreshData } from '@/utils/useRefreshData'
 import { FormElement } from './ProductPage.constants'
 
 type Params = {
+  shopSession: ShopSession
   cartId: string
+  productName: string
   onSuccess: () => void
 }
 
-export const useHandleSubmitAddToCart = ({ cartId, onSuccess }: Params) => {
+export const useHandleSubmitAddToCart = ({
+  shopSession,
+  cartId,
+  productName,
+  onSuccess,
+}: Params) => {
   const [addLineItems, { loading }] = useCartLinesAddMutation()
   const [refreshData, loadingData] = useRefreshData()
+  const apolloClient = useApolloClient()
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault()
@@ -22,7 +32,7 @@ export const useHandleSubmitAddToCart = ({ cartId, onSuccess }: Params) => {
 
     await addLineItems({ variables: { cartId, lineItemId } })
 
-    priceIntentServiceInitClientSide().reset()
+    priceIntentServiceInitClientSide({ shopSession, apolloClient }).clear(productName)
     // Refresh route since data is fetched server-side (product page)
     await refreshData()
 

--- a/apps/store/src/services/formTemplate/FormTemplateService.ts
+++ b/apps/store/src/services/formTemplate/FormTemplateService.ts
@@ -2,6 +2,8 @@ import { JSONSchemaType } from 'ajv'
 import { combineFormTemplate } from './combineFormTemplate'
 import NO_HOME_CONTENT_SCHEMA from './data/NO_HOME_CONTENT.json'
 import { NO_HOME_CONTENT_UI } from './data/NO_HOME_CONTENT_UI'
+import NO_TRAVEL from './data/NO_TRAVEL.json'
+import { NO_TRAVEL_UI } from './data/NO_TRAVEL_UI'
 import SWEDISH_APARTMENT_SCHEMA from './data/SWEDISH_APARTMENT.json'
 import { SWEDISH_APARTMENT_UI } from './data/SWEDISH_APARTMENT_UI'
 import { FormTemplate, FormTemplateUISchema } from './FormTemplate.types'
@@ -11,10 +13,12 @@ type Schema = JSONSchemaType<Record<string, unknown>>
 const SCHEMA: Record<string, Schema> = {
   SWEDISH_APARTMENT: SWEDISH_APARTMENT_SCHEMA as unknown as Schema,
   NO_HOME_CONTENT: NO_HOME_CONTENT_SCHEMA as unknown as Schema,
+  NO_TRAVEL: NO_TRAVEL as unknown as Schema,
 }
 const UI_SCHEMA: Record<string, FormTemplateUISchema> = {
   SWEDISH_APARTMENT: SWEDISH_APARTMENT_UI,
   NO_HOME_CONTENT: NO_HOME_CONTENT_UI,
+  NO_TRAVEL: NO_TRAVEL_UI,
 }
 
 type FetchParams = {

--- a/apps/store/src/services/formTemplate/FormTemplateService.ts
+++ b/apps/store/src/services/formTemplate/FormTemplateService.ts
@@ -4,6 +4,8 @@ import NO_HOME_CONTENT_SCHEMA from './data/NO_HOME_CONTENT.json'
 import { NO_HOME_CONTENT_UI } from './data/NO_HOME_CONTENT_UI'
 import NO_TRAVEL from './data/NO_TRAVEL.json'
 import { NO_TRAVEL_UI } from './data/NO_TRAVEL_UI'
+import SE_ACCIDENT_SCHEMA from './data/SE_ACCIDENT.json'
+import { SE_ACCIDENT_UI } from './data/SE_ACCIDENT_UI'
 import SWEDISH_APARTMENT_SCHEMA from './data/SWEDISH_APARTMENT.json'
 import { SWEDISH_APARTMENT_UI } from './data/SWEDISH_APARTMENT_UI'
 import { FormTemplate, FormTemplateUISchema } from './FormTemplate.types'
@@ -11,12 +13,15 @@ import { FormTemplate, FormTemplateUISchema } from './FormTemplate.types'
 type Schema = JSONSchemaType<Record<string, unknown>>
 
 const SCHEMA: Record<string, Schema> = {
+  // TODO: investigate why we need explicit casting
   SWEDISH_APARTMENT: SWEDISH_APARTMENT_SCHEMA as unknown as Schema,
+  SE_ACCIDENT: SE_ACCIDENT_SCHEMA as unknown as Schema,
   NO_HOME_CONTENT: NO_HOME_CONTENT_SCHEMA as unknown as Schema,
   NO_TRAVEL: NO_TRAVEL as unknown as Schema,
 }
 const UI_SCHEMA: Record<string, FormTemplateUISchema> = {
   SWEDISH_APARTMENT: SWEDISH_APARTMENT_UI,
+  SE_ACCIDENT: SE_ACCIDENT_UI,
   NO_HOME_CONTENT: NO_HOME_CONTENT_UI,
   NO_TRAVEL: NO_TRAVEL_UI,
 }

--- a/apps/store/src/services/formTemplate/data/NO_TRAVEL.json
+++ b/apps/store/src/services/formTemplate/data/NO_TRAVEL.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "numberCoInsured": {
+      "type": "integer",
+      "title": "Number Co-Insured",
+      "minimum": 0
+    },
+    "isYouth": {
+      "type": "boolean",
+      "title": "Is Youth"
+    },
+    "isStudent": {
+      "type": "boolean",
+      "title": "Is Student"
+    }
+  },
+  "required": ["numberCoInsured"],
+  "$id": "NORWEGIAN_TRAVEL"
+}

--- a/apps/store/src/services/formTemplate/data/NO_TRAVEL_UI.ts
+++ b/apps/store/src/services/formTemplate/data/NO_TRAVEL_UI.ts
@@ -1,0 +1,38 @@
+import { FormTemplateUISchema } from '../FormTemplate.types'
+
+export const NO_TRAVEL_UI: FormTemplateUISchema = {
+  layout: {
+    sections: [
+      {
+        id: 'you',
+        title: { key: 'Your info' },
+        fields: [
+          { name: 'numberCoInsured', columnSpan: 6 },
+          { name: 'isStudent', columnSpan: 6 },
+        ],
+        submit: { key: 'Calculate price' },
+      },
+    ],
+  },
+
+  fields: {
+    numberCoInsured: {
+      title: { key: 'No. of people' },
+      defaultValue: '1',
+    },
+    isStudent: {
+      title: { key: 'Student?' },
+      type: 'radio',
+      options: [
+        {
+          label: { key: 'Yes' },
+          value: 'true',
+        },
+        {
+          label: { key: 'No' },
+          value: 'false',
+        },
+      ],
+    },
+  },
+}

--- a/apps/store/src/services/formTemplate/data/SE_ACCIDENT.json
+++ b/apps/store/src/services/formTemplate/data/SE_ACCIDENT.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "street": {
+      "type": "string",
+      "title": "Street"
+    },
+    "zipCode": {
+      "type": "string",
+      "title": "Zip Code",
+      "minLength": 5,
+      "maxLength": 5
+    },
+    "city": {
+      "type": "string",
+      "title": "City"
+    },
+    "livingSpace": {
+      "type": "integer",
+      "title": "Living Space",
+      "minimum": 0
+    },
+    "numberCoInsured": {
+      "type": "integer",
+      "title": "Number Co-Insured",
+      "minimum": 0
+    },
+    "isStudent": {
+      "type": "boolean",
+      "title": "Is Student",
+      "default": false
+    }
+  },
+  "required": ["street", "zipCode", "livingSpace", "numberCoInsured"],
+  "$id": "SWEDISH_ACCIDENT"
+}

--- a/apps/store/src/services/formTemplate/data/SE_ACCIDENT_UI.ts
+++ b/apps/store/src/services/formTemplate/data/SE_ACCIDENT_UI.ts
@@ -1,0 +1,46 @@
+import { FormTemplateUISchema } from '../FormTemplate.types'
+
+export const SE_ACCIDENT_UI: FormTemplateUISchema = {
+  layout: {
+    sections: [
+      {
+        id: 'your-home',
+        title: { key: 'Your home' },
+        fields: [
+          { name: 'street', columnSpan: 6 },
+          { name: 'zipCode', columnSpan: 3 },
+          { name: 'livingSpace', columnSpan: 3 },
+        ],
+        submit: { key: 'Next step' },
+      },
+      {
+        id: 'insured-people',
+        title: { key: 'Insured people' },
+        fields: [
+          { name: 'ssn', columnSpan: 6 },
+          { name: 'numberCoInsured', columnSpan: 6 },
+        ],
+        submit: { key: 'Calculate price' },
+      },
+    ],
+  },
+
+  fields: {
+    street: {
+      title: { key: 'Address' },
+    },
+    zipCode: {
+      title: { key: 'Postal code' },
+    },
+    livingSpace: {
+      title: { key: 'Apartment size' },
+    },
+    ssn: {
+      title: { key: 'Personal number' },
+    },
+    numberCoInsured: {
+      title: { key: 'No. of people' },
+      defaultValue: '1',
+    },
+  },
+}

--- a/apps/store/src/services/persister/CookiePersister.ts
+++ b/apps/store/src/services/persister/CookiePersister.ts
@@ -4,15 +4,15 @@ import { SimplePersister } from './Persister.types'
 export class CookiePersister implements SimplePersister {
   constructor(private readonly cookieKey: string) {}
 
-  public save(id: string) {
-    Cookies.set(this.cookieKey, id, { path: '/' })
+  public save(id: string, cookieKey = this.cookieKey) {
+    Cookies.set(cookieKey, id, { path: '/' })
   }
 
-  public fetch() {
-    return Cookies.get(this.cookieKey) ?? null
+  public fetch(cookieKey = this.cookieKey) {
+    return Cookies.get(cookieKey) ?? null
   }
 
-  public reset() {
-    Cookies.remove(this.cookieKey)
+  public reset(cookieKey = this.cookieKey) {
+    Cookies.remove(cookieKey)
   }
 }

--- a/apps/store/src/services/persister/Persister.types.ts
+++ b/apps/store/src/services/persister/Persister.types.ts
@@ -1,5 +1,7 @@
 export interface SimplePersister {
-  save(id: string): void
-  fetch(): string | null
-  reset(): void
+  save(id: string, key?: string): void
+
+  fetch(key?: string): string | null
+
+  reset(key?: string): void
 }

--- a/apps/store/src/services/persister/ServerCookiePersister.ts
+++ b/apps/store/src/services/persister/ServerCookiePersister.ts
@@ -8,17 +8,17 @@ export class ServerCookiePersister implements SimplePersister {
     private readonly response: GetServerSidePropsContext['res'],
   ) {}
 
-  public save(id: string) {
+  public save(id: string, cookieKey = this.cookieKey) {
     const rawHeader = this.response.getHeader('Set-Cookie')
     const existingHeaders = Array.isArray(rawHeader) ? rawHeader : []
-    this.response.setHeader('Set-Cookie', [...existingHeaders, `${this.cookieKey}=${id}; Path=/`])
+    this.response.setHeader('Set-Cookie', [...existingHeaders, `${cookieKey}=${id}; Path=/`])
   }
 
-  public fetch() {
-    return this.request.cookies[this.cookieKey] ?? null
+  public fetch(cookieKey = this.cookieKey) {
+    return this.request.cookies[cookieKey] ?? null
   }
 
-  public reset() {
-    this.response.setHeader('Set-Cookie', [`${this.cookieKey}=; Max-Age=0`])
+  public reset(cookieKey = this.cookieKey) {
+    this.response.setHeader('Set-Cookie', [`${cookieKey}=; Max-Age=0`])
   }
 }

--- a/apps/store/src/services/priceIntent/PriceIntent.helpers.ts
+++ b/apps/store/src/services/priceIntent/PriceIntent.helpers.ts
@@ -19,8 +19,15 @@ export const priceIntentServiceInitServerSide = ({
   )
 }
 
-export const priceIntentServiceInitClientSide = () => {
-  return new PriceIntentService(new CookiePersister(COOKIE_KEY_PRICE_INTENT))
+export const priceIntentServiceInitClientSide = ({
+  shopSession,
+  apolloClient,
+}: Omit<Params, 'req' | 'res'>) => {
+  return new PriceIntentService(
+    new CookiePersister(COOKIE_KEY_PRICE_INTENT),
+    apolloClient,
+    shopSession,
+  )
 }
 
 type Params = {

--- a/apps/store/src/services/priceIntent/priceIntent.types.ts
+++ b/apps/store/src/services/priceIntent/priceIntent.types.ts
@@ -10,10 +10,4 @@ export type PriceIntentDataUpdateParams = Omit<
   'shopSessionId'
 >
 
-export interface SimplePersister {
-  save(id: string): void
-  fetch(): string | null
-  reset(): void
-}
-
 export type PriceIntent = Exclude<PriceIntentQuery['shopSession']['priceIntent'], null | undefined>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Support calculating price for multiple products
Allow passing in custom cookie key to SimplePersister.
Construct price intent cookie key based on ShopSession ID + product name.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We want users to be able to move between product pages.

This setup enables us to keep track of multiple price intents (one for each product).

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
