### PR TITLE
GRW-1494 / feat / Add HeroVideoBlock via S3

### DIFF
--- a/apps/store/README.md
+++ b/apps/store/README.md
@@ -20,3 +20,17 @@ Requirements:
 Requirements:
 
 - Add `APOLLO_KEY` to `.env.local` (see Vercel)
+
+## Using the Storyblok editor
+
+To preview your Storyblok blocks that you have developed locally, use
+
+```
+<server url>/editor.html
+```
+
+by default:
+
+```
+http://localhost:8040/editor.html
+```

--- a/apps/store/src/blocks/HeadingBlock.tsx
+++ b/apps/store/src/blocks/HeadingBlock.tsx
@@ -13,12 +13,13 @@ export type HeadingBlockProps = SbBaseBlockProps<{
   text: string
   variant: HeadingProps['variant']
   as: HeadingProps['as']
+  color: HeadingProps['color']
 }>
 
 export const HeadingBlock = ({ blok }: HeadingBlockProps) => {
   return (
     <Wrapper>
-      <Heading as={blok.as} variant={blok.variant} {...storyblokEditable(blok)}>
+      <Heading as={blok.as} variant={blok.variant} color={blok.color} {...storyblokEditable(blok)}>
         {blok.text}
       </Heading>
     </Wrapper>

--- a/apps/store/src/blocks/HeroVideoBlock.tsx
+++ b/apps/store/src/blocks/HeroVideoBlock.tsx
@@ -1,0 +1,37 @@
+import { HeroVideo } from '@/components/HeroVideo/HeroVideo'
+import {
+  ExpectedBlockType,
+  LinkField,
+  SbBaseBlockProps,
+  StoryblokImage,
+} from '@/services/storyblok/storyblok'
+import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
+import { HeadingBlockProps, HeadingBlock } from './HeadingBlock'
+
+type HeroVideoBlockProps = SbBaseBlockProps<{
+  title?: string
+  source: LinkField
+  format: string
+  height: number
+  poster: StoryblokImage
+  headingsPadding: string
+  headings: ExpectedBlockType<HeadingBlockProps>
+}>
+
+export const HeroVideoBlock = ({ blok }: HeroVideoBlockProps) => {
+  const headingBlocks = filterByBlockType(blok.headings, HeadingBlock.blockName)
+
+  return (
+    <HeroVideo
+      sources={[{ url: blok.source.url, format: blok.format }]}
+      height={blok.height}
+      poster={blok.poster.filename}
+      childrenPadding={blok.headingsPadding}
+    >
+      {headingBlocks.map((nestedBlock) => (
+        <HeadingBlock blok={nestedBlock} key={nestedBlock._uid} />
+      ))}
+    </HeroVideo>
+  )
+}
+HeroVideoBlock.blockName = 'heroVideo'

--- a/apps/store/src/components/HeroVideo/HeroVideo.stories.tsx
+++ b/apps/store/src/components/HeroVideo/HeroVideo.stories.tsx
@@ -1,0 +1,27 @@
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { HeroVideo } from './HeroVideo'
+
+export default {
+  title: 'HeroVideo',
+  component: HeroVideo,
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'iphonese2',
+    },
+  },
+} as ComponentMeta<typeof HeroVideo>
+
+const Template: ComponentStory<typeof HeroVideo> = () => {
+  const sources = [
+    {
+      url: 'https://s3.eu-central-1.amazonaws.com/cdn.dev.hedvigit.com/pexels-kelly-lacy-9722139.mp4',
+      format: 'video/mp4',
+    },
+  ]
+
+  return <HeroVideo sources={sources} />
+}
+export const Default = Template.bind({})
+Default.args = {}

--- a/apps/store/src/components/HeroVideo/HeroVideo.tsx
+++ b/apps/store/src/components/HeroVideo/HeroVideo.tsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled'
+import { PropsWithChildren } from 'react'
+
+export type VideoSource = {
+  url: string
+  /**
+   * For example "video/mp4"
+   */
+  format: string
+}
+
+type HeroVideoProps = PropsWithChildren & {
+  /**
+   * An array of videos with different supported formats
+   */
+  sources: VideoSource[]
+  /**
+   * The poster image of the video that will be displayed while the video is being loaded, or it the browser doesn't support any of the formats
+   */
+  poster?: string
+  height?: number
+  childrenPadding?: string
+}
+
+const HeroVideoWrapper = styled.div({
+  position: 'relative',
+})
+
+const ChildrenWrapper = styled.div(
+  ({ childrenPadding }: Pick<HeroVideoProps, 'childrenPadding'>) => ({
+    position: 'absolute',
+    top: childrenPadding ?? '50%',
+    width: '100%',
+  }),
+)
+
+const StyledVideo = styled.video(
+  ({ poster, height }: Pick<HeroVideoProps, 'poster' | 'height'>) => ({
+    width: '100%',
+    height: height ?? '80vh',
+    background: `url(${poster}) no-repeat`,
+    backgroundSize: 'cover',
+
+    objectFit: 'cover',
+  }),
+)
+
+export const HeroVideo = ({
+  sources,
+  poster,
+  height,
+  children,
+  childrenPadding,
+}: HeroVideoProps) => (
+  <HeroVideoWrapper>
+    <StyledVideo playsInline autoPlay muted loop preload="auto" poster={poster} height={height}>
+      {sources.map((source) => (
+        <source key={source.format} src={source.url} type={source.format} />
+      ))}
+    </StyledVideo>
+    <ChildrenWrapper childrenPadding={childrenPadding}>{children}</ChildrenWrapper>
+  </HeroVideoWrapper>
+)

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -8,6 +8,7 @@ import { ContentBlock } from '@/blocks/ContentBlock'
 import { FooterBlock, FooterLink, FooterSection } from '@/blocks/FooterBlock'
 import { HeadingBlock } from '@/blocks/HeadingBlock'
 import { HeroBlock } from '@/blocks/HeroBlock'
+import { HeroVideoBlock } from '@/blocks/HeroVideoBlock'
 import { ImageBlock } from '@/blocks/ImageBlock'
 import { InsurableLimitsBlock } from '@/blocks/InsurableLimitsBlock'
 import { PageBlock } from '@/blocks/PageBlock'
@@ -120,6 +121,7 @@ export const initStoryblok = () => {
     HeaderBlock,
     HeadingBlock,
     HeroBlock,
+    HeroVideoBlock,
     ImageBlock,
     InsurableLimitsBlock,
     NavItemBlock,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

This PR is one example of how to add videos in Storyblok for the Coverage store. 

It uses external storage for the video, in my example the video is uploaded to S3.

The user then configures the blok as follows:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/1343979/191691858-1b13c17e-a1dc-4e69-8c3a-44b0f2a0836c.png">

(note that the user can configure where the heading element should reside since different videos may have different optimal vertical point to put text on)

(@gustaveen suggested that we could pick up the format from the file extension, so that's a future improvement we could make after we decide on how to move forward 👍 )

For actually rendering the video I used the HTML5 Video element with correct props to make it [autoplay on iOS devices](https://webkit.org/blog/6784/new-video-policies-for-ios/).


All in all it looks like this:

https://user-images.githubusercontent.com/1343979/191693543-50a3b263-5158-4ac3-ab9f-6f89b37f96ee.mov



<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Jira issue(s): [GRW-1494]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1494]: https://hedvig.atlassian.net/browse/GRW-1494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ