### PR TITLE
GRW-1513 / fix / contact support block horizontal scroll

### DIFF
--- a/apps/store/src/components/ContactSupport/ContactSupport.tsx
+++ b/apps/store/src/components/ContactSupport/ContactSupport.tsx
@@ -21,7 +21,7 @@ export const ContactSupport = ({
         </Heading>
         <AvatarImagePlaceholder />
         <Space y={1}>
-          <SpaceFlex space={0.5} wrap>
+          <SpaceFlex space={0.5} wrap="wrap">
             <FlexButton variant="outlined" onClick={() => console.log('chat')}>
               Chat with us
             </FlexButton>

--- a/apps/store/src/components/ContactSupport/ContactSupport.tsx
+++ b/apps/store/src/components/ContactSupport/ContactSupport.tsx
@@ -21,7 +21,7 @@ export const ContactSupport = ({
         </Heading>
         <AvatarImagePlaceholder />
         <Space y={1}>
-          <SpaceFlex space={0.5}>
+          <SpaceFlex space={0.5} wrap>
             <FlexButton variant="outlined" onClick={() => console.log('chat')}>
               Chat with us
             </FlexButton>

--- a/apps/store/src/components/SpaceFlex/SpaceFlex.tsx
+++ b/apps/store/src/components/SpaceFlex/SpaceFlex.tsx
@@ -6,18 +6,20 @@ type SpaceFlexProps = {
   space?: number
   direction?: 'horizontal' | 'vertical'
   align?: 'start' | 'center' | 'end'
+  wrap?: boolean
 }
 
-const SpaceFlexWrapper = styled.div(({ space, direction, align }: SpaceFlexProps) => ({
+const SpaceFlexWrapper = styled.div(({ space, direction, align, wrap }: SpaceFlexProps) => ({
   display: 'flex',
+  flexWrap: wrap ? 'wrap' : 'initial',
   gap: `${space}rem`,
   flexDirection: direction === 'horizontal' ? 'row' : 'column',
   alignItems: align,
 }))
 
 export const SpaceFlex = forwardRef<HTMLDivElement, SpaceFlexProps>(
-  ({ children, space = 1, direction = 'horizontal', align = 'start' }, ref) => (
-    <SpaceFlexWrapper ref={ref} space={space} direction={direction} align={align}>
+  ({ children, space = 1, direction = 'horizontal', align = 'start', wrap = false }, ref) => (
+    <SpaceFlexWrapper ref={ref} space={space} direction={direction} align={align} wrap={wrap}>
       {children}
     </SpaceFlexWrapper>
   ),

--- a/apps/store/src/components/SpaceFlex/SpaceFlex.tsx
+++ b/apps/store/src/components/SpaceFlex/SpaceFlex.tsx
@@ -6,19 +6,19 @@ type SpaceFlexProps = {
   space?: number
   direction?: 'horizontal' | 'vertical'
   align?: 'start' | 'center' | 'end'
-  wrap?: boolean
+  wrap?: 'wrap' | 'nowrap' | 'wrap-reverse'
 }
 
 const SpaceFlexWrapper = styled.div(({ space, direction, align, wrap }: SpaceFlexProps) => ({
   display: 'flex',
-  flexWrap: wrap ? 'wrap' : 'initial',
+  flexWrap: wrap,
   gap: `${space}rem`,
   flexDirection: direction === 'horizontal' ? 'row' : 'column',
   alignItems: align,
 }))
 
 export const SpaceFlex = forwardRef<HTMLDivElement, SpaceFlexProps>(
-  ({ children, space = 1, direction = 'horizontal', align = 'start', wrap = false }, ref) => (
+  ({ children, space = 1, direction = 'horizontal', align = 'start', wrap }, ref) => (
     <SpaceFlexWrapper ref={ref} space={space} direction={direction} align={align} wrap={wrap}>
       {children}
     </SpaceFlexWrapper>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Added a `wrap` prop to the `<SpaceFlex />` component to control the `flex-wrap` of the components children.

## Before
<img width="337" alt="Screenshot 2022-09-22 at 10 37 49" src="https://user-images.githubusercontent.com/50870173/191700401-1bcad76a-960e-47b3-9fd9-db6c3085ece4.png">

## After

<img width="243" alt="Screenshot 2022-09-22 at 10 37 12" src="https://user-images.githubusercontent.com/50870173/191700445-246fbf73-7fa9-4b1d-a79f-451d9d1e2868.png">


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

On smaller displays the buttons were overflowing outside of the viewport which caused an unwanted horizontal scroll

## Jira issue(s): [GRW-1513]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1513]: https://hedvig.atlassian.net/browse/GRW-1513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ