### PR TITLE
GRW-1514 / Refactor global story

### DIFF
--- a/apps/store/src/blocks/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock.tsx
@@ -60,8 +60,8 @@ export const FooterSection = ({ blok }: FooterSectionProps) => {
 }
 FooterSection.blockName = 'footerSection' as const
 
-type FooterBlockProps = SbBaseBlockProps<{
-  footerSections: ExpectedBlockType<FooterSectionProps>
+export type FooterBlockProps = SbBaseBlockProps<{
+  sections: ExpectedBlockType<FooterSectionProps>
 }>
 export const FooterBlock = ({ blok }: FooterBlockProps) => {
   const formRef = useRef<HTMLFormElement>(null)
@@ -98,9 +98,7 @@ export const FooterBlock = ({ blok }: FooterBlockProps) => {
       ),
     )
   }
-
-  const footerSections = filterByBlockType(blok.footerSections, FooterSection.blockName)
-
+  const footerSections = filterByBlockType(blok.sections, FooterSection.blockName)
   return (
     <Wrapper as="footer" y={2}>
       <Accordion.Root type="multiple">

--- a/apps/store/src/blocks/TopMenuBlock.tsx
+++ b/apps/store/src/blocks/TopMenuBlock.tsx
@@ -79,7 +79,7 @@ const StyledNavigationTrigger = styled(NavigationTrigger)({
   },
 })
 
-type HeaderBlockProps = SbBaseBlockProps<{
+export type HeaderBlockProps = SbBaseBlockProps<{
   navMenuContainer: ExpectedBlockType<NestedNavContainerBlockProps | NavItemBlockProps>
 }>
 

--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -3,6 +3,8 @@ import { StoryData } from '@storyblok/react'
 import { ReactElement } from 'react'
 import { FooterBlock } from '@/blocks/FooterBlock'
 import { HeaderBlock } from '@/blocks/TopMenuBlock'
+import { GlobalStory } from '@/services/storyblok/storyblok'
+import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 
 const Wrapper = styled.div({
   minHeight: '100vh',
@@ -17,13 +19,21 @@ type LayoutWithMenuProps = {
 
 export const LayoutWithMenu = ({ children }: LayoutWithMenuProps) => {
   const story = children.props.story as StoryData | undefined
-  const globalStory = children.props.globalStory
+  const globalStory = children.props.globalStory as GlobalStory | undefined
+  const headerBlock = filterByBlockType(globalStory?.content.header, HeaderBlock.blockName)
+  const footerBlock = filterByBlockType(globalStory?.content.footer, FooterBlock.blockName)
 
   return (
     <Wrapper>
-      {(!story || !story.content.hideMenu) && <HeaderBlock blok={globalStory.content} />}
+      {(!story || !story.content.hideMenu) &&
+        headerBlock?.map((nestedBlock) => (
+          <HeaderBlock key={nestedBlock._uid} blok={nestedBlock} />
+        ))}
       {children}
-      {(!story || !story.content.hideMenu) && <FooterBlock blok={globalStory.content} />}
+      {(!story || !story.content.hideMenu) &&
+        footerBlock?.map((nestedBlock) => (
+          <FooterBlock key={nestedBlock._uid} blok={nestedBlock as any} />
+        ))}
     </Wrapper>
   )
 }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -5,7 +5,7 @@ import { ButtonBlock } from '@/blocks/ButtonBlock'
 import { CheckListBlock } from '@/blocks/CheckListBlock'
 import { ContactSupportBlock } from '@/blocks/ContactSupportBlock'
 import { ContentBlock } from '@/blocks/ContentBlock'
-import { FooterBlock, FooterLink, FooterSection } from '@/blocks/FooterBlock'
+import { FooterBlock, FooterBlockProps, FooterLink, FooterSection } from '@/blocks/FooterBlock'
 import { HeadingBlock } from '@/blocks/HeadingBlock'
 import { HeroBlock } from '@/blocks/HeroBlock'
 import { ImageBlock } from '@/blocks/ImageBlock'
@@ -22,7 +22,12 @@ import { TabsBlock } from '@/blocks/TabsBlock'
 import { TextBlock } from '@/blocks/TextBlock'
 import { TimelineBlock } from '@/blocks/TimelineBlock'
 import { TimelineItemBlock } from '@/blocks/TimelineItemBlock'
-import { NavItemBlock, NestedNavContainerBlock, HeaderBlock } from '@/blocks/TopMenuBlock'
+import {
+  NavItemBlock,
+  NestedNavContainerBlock,
+  HeaderBlock,
+  HeaderBlockProps,
+} from '@/blocks/TopMenuBlock'
 import { TopPickCardBlock } from '@/blocks/TopPickCardBlock'
 import { countries, getCountryByLocale } from '@/lib/l10n/countries'
 import { getLocaleOrFallback } from '@/lib/l10n/locales'
@@ -84,9 +89,10 @@ export type ProductStory = StoryData & {
   }
 }
 
-type GlobalStory = StoryData & {
+export type GlobalStory = StoryData & {
   content: StoryData['content'] & {
-    navMenuContainer: Array<SbBlokData>
+    header: ExpectedBlockType<HeaderBlockProps>
+    footer: ExpectedBlockType<FooterBlockProps>
   }
 }
 


### PR DESCRIPTION
## Describe your changes
Refactor Global story schema: 
```js
content:  {
    header: ExpectedBlockType<HeaderBlockProps>
    footer: ExpectedBlockType<FooterBlockProps>
  }
```

The header and footer field only allows on block of the corresponding type.

Also create a folder, `Global`, to collect all global stories.

I have not updated the prod space yet, so let me know if you want to view it in my space.

## Justify why they are needed
Follow the same pattern as other blocks. Makes it easier to add other settings to the header or footer block, and if we would need to have alternative headers for partnership pages.

https://user-images.githubusercontent.com/6661511/191773034-596c0f01-edf7-4cab-898d-82ee5e470b1f.mov
