### PR TITLE
Implement extra buildings field component

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-dialog": "1.0.0",
     "@radix-ui/react-navigation-menu": "1.0.0",
     "@radix-ui/react-radio-group": "1.0.0",
+    "@radix-ui/react-switch": "1.0.0",
     "@radix-ui/react-tabs": "1.0.0",
     "@storyblok/react": "1.1.6",
     "ajv": "8.11.0",

--- a/apps/store/src/components/PriceForm/AutomaticField.tsx
+++ b/apps/store/src/components/PriceForm/AutomaticField.tsx
@@ -8,7 +8,7 @@ import { useTranslateTextLabel } from './useTranslateTextLabel'
 
 type Props = {
   field: InputFieldType
-  onSubmit: (data: JSONData) => void
+  onSubmit: (data: JSONData) => Promise<void>
   loading: boolean
 }
 

--- a/apps/store/src/components/PriceForm/ExtraBuildingsField.tsx
+++ b/apps/store/src/components/PriceForm/ExtraBuildingsField.tsx
@@ -1,59 +1,142 @@
-import { FormEventHandler } from 'react'
-import { Button } from 'ui'
+import styled from '@emotion/styled'
+import { FormEventHandler, useState } from 'react'
+import { Button, Heading, InputField, Space } from 'ui'
 import * as Dialog from '@/components/Dialog/Dialog'
+import { InputSelect } from '@/components/InputSelect/InputSelect'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import {
   ExtraBuildingsField as InputFieldExtraBuildings,
   ExtraBuilding,
 } from '@/services/PriceForm/Field.types'
 import { JSONData } from '@/services/PriceForm/PriceForm.types'
+import { MENU_BAR_HEIGHT } from '../TopMenu/TopMenu'
+import { InputSwitch } from './InputSwitch'
 import { useTranslateTextLabel } from './useTranslateTextLabel'
 
 type ExtraBuildingsFieldProps = {
   field: InputFieldExtraBuildings
-  onSubmit: (data: JSONData) => void
+  onSubmit: (data: JSONData) => Promise<void>
   loading: boolean
 }
 
 export const ExtraBuildingsField = ({ field, onSubmit, loading }: ExtraBuildingsFieldProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+
   const translateLabel = useTranslateTextLabel({ data: {} })
 
-  const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault()
+    event.stopPropagation()
 
     const formData = new FormData(event.currentTarget)
     const data = Object.fromEntries(formData.entries())
 
-    onSubmit({
+    await onSubmit({
       [field.name]: [...(field.value || []), convertExtraBuilding(data)],
+    })
+    setIsOpen(false)
+  }
+
+  const handleRemove = async (extraBuilding: ExtraBuilding) => {
+    const identifier = JSON.stringify(extraBuilding)
+
+    await onSubmit({
+      [field.name]: (field.value || []).filter((item) => {
+        const itemIdentifier = JSON.stringify(item)
+        return itemIdentifier !== identifier
+      }),
     })
   }
 
   return (
-    <Dialog.Root>
-      <Dialog.Trigger asChild>
-        <Button type="button">{translateLabel(field.label)}</Button>
-      </Dialog.Trigger>
+    <Dialog.Root open={isOpen} onOpenChange={() => setIsOpen((prev) => !prev)}>
+      <Space y={0.5}>
+        <Label>{translateLabel(field.label)}</Label>
+
+        <Space y={0.5} as="ul">
+          {field.value?.map((item) => {
+            const identifier = JSON.stringify(item)
+
+            return (
+              <Preview key={identifier}>
+                <SpaceFlex space={0.25} align="end">
+                  <p>{item.type}</p>
+                  <MutedText>
+                    {item.area} m<Sup>2</Sup>
+                  </MutedText>
+                </SpaceFlex>
+                <Button type="button" variant="text" onClick={() => handleRemove(item)}>
+                  Delete
+                </Button>
+              </Preview>
+            )
+          })}
+        </Space>
+
+        <Dialog.Trigger asChild>
+          <Button type="button" fullWidth variant="outlined">
+            Add extra building
+          </Button>
+        </Dialog.Trigger>
+      </Space>
 
       <Dialog.Content>
-        <h3>{translateLabel(field.label)}</h3>
+        <DialogContentWrapper>
+          <Space y={1.5}>
+            <SpaceFlex align="center" direction="vertical">
+              <Heading as="h2" variant="standard.18">
+                Add extra building
+              </Heading>
+            </SpaceFlex>
 
-        <form onSubmit={handleSubmit}>
-          <SpaceFlex space={1}>
-            <Dialog.Close asChild>
-              <Button type="button" variant="text">
-                Close
-              </Button>
-            </Dialog.Close>
-            <Button type="submit" disabled={loading}>
-              Add
-            </Button>
-          </SpaceFlex>
-        </form>
+            <form onSubmit={handleSubmit}>
+              <Space y={1}>
+                <Space y={1}>
+                  <SpaceFlex align="center" space={1}>
+                    <Flex>
+                      <InputSelect
+                        name="type"
+                        label="Building type"
+                        options={BUILDING_TYPES}
+                        required={true}
+                      />
+                    </Flex>
+                    <Flex>
+                      <InputField type="number" name="area" label="Size" min={0} required={true} />
+                    </Flex>
+                  </SpaceFlex>
+                  <InputSwitch name="hasWaterConnected" label="Water connected" />
+                </Space>
+
+                <SpaceFlex space={1}>
+                  <Dialog.Close asChild>
+                    <Button type="button" variant="text" fullWidth>
+                      Cancel
+                    </Button>
+                  </Dialog.Close>
+                  <Button type="submit" disabled={loading} fullWidth>
+                    Add
+                  </Button>
+                </SpaceFlex>
+              </Space>
+            </form>
+          </Space>
+        </DialogContentWrapper>
       </Dialog.Content>
     </Dialog.Root>
   )
 }
+
+const BUILDING_TYPES = [
+  {
+    name: 'Garage',
+    value: 'GARAGE',
+  },
+  {
+    name: 'Carport',
+    value: 'CARPORT',
+  },
+]
 
 const convertExtraBuilding = (data: Record<string, FormDataEntryValue>): ExtraBuilding => {
   if (typeof data.type !== 'string') {
@@ -71,3 +154,40 @@ const convertExtraBuilding = (data: Record<string, FormDataEntryValue>): ExtraBu
     hasWaterConnected: data.hasConnectedWater === 'YES',
   }
 }
+
+const DialogContentWrapper = styled(Dialog.Window)(({ theme }) => ({
+  marginTop: MENU_BAR_HEIGHT,
+  marginRight: theme.space[3],
+  marginLeft: theme.space[3],
+  padding: theme.space[4],
+  borderRadius: 8,
+}))
+
+const Flex = styled.div({ flex: 1 })
+
+const Label = styled.p(({ theme }) => ({
+  fontFamily: theme.fonts.body,
+  fontSize: theme.fontSizes[1],
+}))
+
+const Preview = styled.li(({ theme }) => ({
+  border: `1px solid ${theme.colors.gray500}`,
+  borderRadius: 8,
+  paddingLeft: theme.space[5],
+
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+}))
+
+const MutedText = styled.p(({ theme }) => ({
+  fontFamily: theme.fonts.body,
+  fontSize: theme.fontSizes[1],
+  color: theme.colors.gray700,
+}))
+
+const Sup = styled.sup({
+  verticalAlign: 'super',
+  fontSize: '70%',
+  lineHeight: 1,
+})

--- a/apps/store/src/components/PriceForm/InputSwitch.tsx
+++ b/apps/store/src/components/PriceForm/InputSwitch.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled'
+import * as RadixSwitch from '@radix-ui/react-switch'
+import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
+
+type Props = RadixSwitch.SwitchProps & {
+  label: string
+}
+
+export const InputSwitch = ({ label, ...props }: Props) => {
+  const identifier = `checkbox-${props.name}`
+
+  return (
+    <SpaceFlex align="center" space={0.5}>
+      <SwitchWrapper id={identifier} {...props}>
+        <SwitchHandle />
+      </SwitchWrapper>
+      <Label htmlFor={identifier}>{label}</Label>
+    </SpaceFlex>
+  )
+}
+
+const Label = styled.label(({ theme }) => ({
+  fontSize: theme.fontSizes[2],
+  fontFamily: theme.fonts.body,
+}))
+
+const SwitchWrapper = styled(RadixSwitch.Root)(({ theme }) => ({
+  width: 48,
+  height: 24,
+  borderRadius: 12,
+  border: `2px solid ${theme.colors.gray500}`,
+  borderWidth: 2,
+  borderStyle: 'solid',
+  borderColor: theme.colors.gray500,
+  padding: 4,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-start',
+
+  ':focus': {
+    outline: `5px auto ${theme.colors.purple700}`,
+  },
+
+  '&[data-state=checked]': {
+    borderColor: theme.colors.black,
+    backgroundColor: theme.colors.black,
+    justifyContent: 'flex-end',
+  },
+}))
+
+const SwitchHandle = styled(RadixSwitch.Thumb)(({ theme }) => ({
+  width: 12,
+  height: 12,
+  backgroundColor: theme.colors.gray500,
+  borderRadius: 12,
+
+  '&[data-state=checked]': {
+    backgroundColor: theme.colors.white,
+  },
+}))

--- a/apps/store/src/services/PriceForm/data/SE_HOUSE.ts
+++ b/apps/store/src/services/PriceForm/data/SE_HOUSE.ts
@@ -45,7 +45,7 @@ export const SE_HOUSE: Template = {
           field: {
             type: 'extra-buildings',
             name: 'extraBuildings',
-            label: { key: 'Add extra building' },
+            label: { key: 'Extra buildings' },
             defaultValue: [],
           },
           layout: { columnSpan: 6 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4093,6 +4093,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-switch@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@radix-ui/react-switch@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": 1.0.0
+    "@radix-ui/react-compose-refs": 1.0.0
+    "@radix-ui/react-context": 1.0.0
+    "@radix-ui/react-label": 1.0.0
+    "@radix-ui/react-primitive": 1.0.0
+    "@radix-ui/react-use-controllable-state": 1.0.0
+    "@radix-ui/react-use-previous": 1.0.0
+    "@radix-ui/react-use-size": 1.0.0
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  checksum: 7b5096c11e07062acce6e37bd6fcdd65adf1e7f468c67b61d9691c786e0d2b3775c389f32a37fd65d57cef9ed00cd98499806be64ab564cc4e984eb484e477f7
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-tabs@npm:1.0.0":
   version: 1.0.0
   resolution: "@radix-ui/react-tabs@npm:1.0.0"
@@ -20502,6 +20522,7 @@ __metadata:
     "@radix-ui/react-dialog": 1.0.0
     "@radix-ui/react-navigation-menu": 1.0.0
     "@radix-ui/react-radio-group": 1.0.0
+    "@radix-ui/react-switch": 1.0.0
     "@radix-ui/react-tabs": 1.0.0
     "@storyblok/react": 1.1.6
     "@storybook/addon-actions": 6.5.12


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Implement extra buildings field component
- Add basic Switch component (checkbox).
- Update onSubmit prop to accept async callback function.
- Update label for extra building input.

[Screen Recording 2022-09-27 at 09.56.03.mov](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/4886c887-b69f-4b49-a4ca-70ca2f9e87bd/Screen%20Recording%202022-09-27%20at%2009.56.03.mov)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

There's no design for how to display added extra buildings so I just came up with something minimal.

The Switch is not complete/animated but I don't consider that the most critical to work on now.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
