### PR TITLE
GRW-1556 / chore / Log hostname to Datadog

### DIFF
--- a/apps/store/.env.local.example
+++ b/apps/store/.env.local.example
@@ -22,3 +22,6 @@ NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=
 
 # Apollo GraphQL VS Code extension
 APOLLO_KEY=
+
+# This can be unique for yourself, for example VERCEL_URL=localhost-my-computer
+VERCEL_URL=localhost

--- a/apps/store/src/services/logger/config.ts
+++ b/apps/store/src/services/logger/config.ts
@@ -7,6 +7,7 @@ export const COMMON_CONFIG = {
 export const SERVER_CONFIG = {
   ...COMMON_CONFIG,
   apiKey: process.env.DATADOG_API_KEY,
+  host: process.env.VERCEL_URL,
 }
 
 export const CLIENT_CONFIG = {

--- a/apps/store/src/services/logger/server.ts
+++ b/apps/store/src/services/logger/server.ts
@@ -8,6 +8,10 @@ const isLocalDev = ['dev', 'local'].includes(SERVER_CONFIG.env)
 
 const pinoConf: LoggerOptions = {
   level: 'info',
+  // base object attached to all logs. For some reason host can be added here but not in `options` in target object below...
+  base: {
+    host: SERVER_CONFIG.host,
+  },
 }
 
 const targets = [


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


Found a way to attach hostname finally! 💡 

When deployed we will use the URL of the preview/actual deployment. See explanation of `VERCEL_URL` here: https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables

We use `host` (a [Datadog Reserved attribute](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#reserved-attributes)) and attach it to the [`base` object](https://getpino.io/#/docs/api?id=base-object) which gets sent on every request.

<img width="1109" alt="image" src="https://user-images.githubusercontent.com/1343979/192551562-63d7aa09-657b-4daf-9d76-fb67f801047e.png">


### Old log object:

```json
{
	"id": "AQAAAYN-y3BtzEJY3wAAAABBWU4teTR4aUFBQUNjaFhSR0Q0c3lRQUE",
	"content": {
		"timestamp": "2022-09-27T11:53:25.357Z",
		"tags": [
			"env:dev",
			"source:nodejs"
		],
		"host": "169.254.239.53",
		"service": "racoon-store",
		"message": "Request failed with status code 404",
		"attributes": {
			"pid": 9,
			"service": "racoon-store",
			"date": 1664279605357,
			"hostname": "169.254.239.53",
			"err": {
				"status": 404,
				"code": "ERR_BAD_REQUEST",
				"name": "AxiosError",
				"message": "Request failed with status code 404",
				"config": {
					"transitional": {
						"clarifyTimeoutError": false,
						"forcedJSONParsing": true,
						"silentJSONParsing": true
					},
					"url": "/cdn/stories/sv-se//products/car",
					"baseURL": "https://api.storyblok.com/v2",
					"maxBodyLength": -1,
					"headers": {
						"Accept": "application/json, text/plain, */*",
						"User-Agent": "axios/0.27.2"
					},
					"xsrfCookieName": "XSRF-TOKEN",
					"params": {
						"token": "P4NxrZLgFUKUZ4e5UFZc1Att",
						"resolve_links": "url",
						"cv": 1664279231,
						"version": "published"
					},
					"proxy": false,
					"timeout": 0,
					"xsrfHeaderName": "X-XSRF-TOKEN",
					"method": "get",
					"maxContentLength": -1
				},
				"stack": ""
			},
			"level": "error"
		}
	}
}
```

### New log object:

```json
{
	"id": "AQAAAYN_S5e8CIGaIAAAAABBWU5fUzZVSUFBRGcxR2xyekRIV3p3QUE",
	"content": {
		"timestamp": "2022-09-27T14:13:24.028Z",
		"tags": [
			"env:dev",
			"source:nodejs"
		],
		"host": "racoon-store-j0lyo9uyq-hedvig.vercel.app",
		"service": "racoon-store",
		"message": "Request failed with status code 404",
		"attributes": {
			"service": "racoon-store",
			"date": 1664288004028,
			"host": "racoon-store-j0lyo9uyq-hedvig.vercel.app",
			"err": {
				"status": 404,
				"code": "ERR_BAD_REQUEST",
				"name": "AxiosError",
				"message": "Request failed with status code 404",
				"config": {
					"transitional": {
						"clarifyTimeoutError": false,
						"forcedJSONParsing": true,
						"silentJSONParsing": true
					},
					"url": "/cdn/stories/sv-se//products/dog",
					"baseURL": "https://api.storyblok.com/v2",
					"maxBodyLength": -1,
					"headers": {
						"Accept": "application/json, text/plain, */*",
						"User-Agent": "axios/0.27.2"
					},
					"xsrfCookieName": "XSRF-TOKEN",
					"params": {
						"token": "P4NxrZLgFUKUZ4e5UFZc1Att",
						"resolve_links": "url",
						"cv": 1664287965,
						"version": "published"
					},
					"proxy": false,
					"timeout": 0,
					"xsrfHeaderName": "X-XSRF-TOKEN",
					"method": "get",
					"maxContentLength": -1
				},
				"stack": ""
			},
			"level": "error"
		}
	}
}
```

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

It's impossible to reason about where an error occurs if we don't know if it was stagin/preview/production. Sure, the `env` helps for production vs. everything-but-production, but if we are to compare between two preview deployments it's impossible without knowing the hostname.

## Jira issue(s): [GRW-1556](https://hedvig.atlassian.net/browse/GRW-1556)

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
