### PR TITLE
Always revalidate CMS pages in preview deployments

### DIFF
--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -48,7 +48,10 @@ export const getStaticProps: GetStaticProps<StoryblokPageProps, StoryblokQueryPa
     return { notFound: true }
   }
 
-  return { props: { ...(await serverSideTranslations(locale)), story, globalStory } }
+  return {
+    props: { ...(await serverSideTranslations(locale)), story, globalStory },
+    revalidate: process.env.VERCEL_ENV === 'preview' ? 1 : false,
+  }
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Always revalidate CMS pages for preview deployments.

Keep using [on-demand revalidation](https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#on-demand-revalidation) for production deployments.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

It's only possible to setup one webhook in Storyblok that triggers when changes are published. This triggers on-demand revalidation for the production site.

However, all the preview deployments don't get this benefit. Therefore, I think it's best to always revalidate those pages. This means that as soon as you visit a page, Vercel will revalidate it for the next visitor.

This mimics how the production site works while allowing us to see CMS changes ASAP.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
