### PR TITLE
Fix how to get a URL from Storyblok link field

### DIFF
--- a/apps/store/src/blocks/ButtonBlock.tsx
+++ b/apps/store/src/blocks/ButtonBlock.tsx
@@ -3,7 +3,7 @@ import { storyblokEditable } from '@storyblok/react'
 import NextLink from 'next/link'
 import { ButtonVariant, LinkButton } from 'ui'
 import { LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
-import { useStroryblokLinkURL } from '@/utils/useStroryblokLinkURL'
+import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
 
 export type ButtonBlockProps = SbBaseBlockProps<{
   text: string
@@ -12,10 +12,9 @@ export type ButtonBlockProps = SbBaseBlockProps<{
 }>
 
 export const ButtonBlock = ({ blok }: ButtonBlockProps) => {
-  const href = useStroryblokLinkURL(blok.link)
   return (
     <Wrapper {...storyblokEditable(blok)}>
-      <NextLink href={href} passHref>
+      <NextLink href={getLinkFieldURL(blok.link)} passHref>
         <LinkButton variant={blok.variant} color="dark" size="lg">
           {blok.text}
         </LinkButton>

--- a/apps/store/src/blocks/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock.tsx
@@ -18,8 +18,7 @@ import { LocaleValue } from '@/lib/l10n/types'
 import { useCurrentCountry } from '@/lib/l10n/useCurrentCountry'
 import { useCurrentLocale } from '@/lib/l10n/useCurrentLocale'
 import { ExpectedBlockType, LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
-import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
-import { useStroryblokLinkURL } from '@/utils/useStroryblokLinkURL'
+import { filterByBlockType, getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
 
 type FooterLinkProps = SbBaseBlockProps<{
   link: LinkField
@@ -27,9 +26,8 @@ type FooterLinkProps = SbBaseBlockProps<{
 }>
 
 export const FooterLink = ({ blok }: FooterLinkProps) => {
-  const href = useStroryblokLinkURL(blok.link)
   return (
-    <Link href={href} passHref {...storyblokEditable(blok)}>
+    <Link href={getLinkFieldURL(blok.link)} passHref {...storyblokEditable(blok)}>
       <StyledLink>{blok.linkText}</StyledLink>
     </Link>
   )

--- a/apps/store/src/blocks/ProductCardBlock.tsx
+++ b/apps/store/src/blocks/ProductCardBlock.tsx
@@ -3,6 +3,7 @@ import { storyblokEditable } from '@storyblok/react'
 import Link from 'next/link'
 import { ProductCard } from '@/components/ProductCard/ProductCard'
 import { SbBaseBlockProps, LinkField, StoryblokImage } from '@/services/storyblok/storyblok'
+import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
 
 export type ProductCardBlockProps = SbBaseBlockProps<{
   title: string
@@ -13,7 +14,7 @@ export type ProductCardBlockProps = SbBaseBlockProps<{
 
 export const ProductCardBlock = ({ blok }: ProductCardBlockProps) => {
   return (
-    <Link href={blok.link.url} passHref {...storyblokEditable(blok)}>
+    <Link href={getLinkFieldURL(blok.link)} passHref {...storyblokEditable(blok)}>
       <StyledAnchor>
         <ProductCard
           title={blok.title}

--- a/apps/store/src/blocks/TopMenuBlock.tsx
+++ b/apps/store/src/blocks/TopMenuBlock.tsx
@@ -20,8 +20,11 @@ import {
   Wrapper,
 } from '@/components/TopMenu/TopMenu'
 import { ExpectedBlockType, LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
-import { checkBlockType, filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
-import { useStroryblokLinkURL } from '@/utils/useStroryblokLinkURL'
+import {
+  checkBlockType,
+  filterByBlockType,
+  getLinkFieldURL,
+} from '@/services/storyblok/Storyblok.helpers'
 
 type NavItemBlockProps = SbBaseBlockProps<{
   name: string
@@ -29,10 +32,9 @@ type NavItemBlockProps = SbBaseBlockProps<{
 }>
 
 export const NavItemBlock = ({ blok }: NavItemBlockProps) => {
-  const url = useStroryblokLinkURL(blok.link)
   return (
     <NavigationMenuPrimitive.Item value={blok.name} {...storyblokEditable(blok)}>
-      <NavigationLink href={url}>{blok.name}</NavigationLink>
+      <NavigationLink href={getLinkFieldURL(blok.link)}>{blok.name}</NavigationLink>
     </NavigationMenuPrimitive.Item>
   )
 }

--- a/apps/store/src/blocks/TopPickCardBlock.tsx
+++ b/apps/store/src/blocks/TopPickCardBlock.tsx
@@ -3,6 +3,7 @@ import { storyblokEditable } from '@storyblok/react'
 import Link from 'next/link'
 import { TopPickCard } from '@/components/TopPickCard/TopPickCard'
 import { SbBaseBlockProps, LinkField, StoryblokImage } from '@/services/storyblok/storyblok'
+import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
 
 export type TopPickCardBlockProps = SbBaseBlockProps<{
   title: string
@@ -13,7 +14,7 @@ export type TopPickCardBlockProps = SbBaseBlockProps<{
 
 export const TopPickCardBlock = ({ blok }: TopPickCardBlockProps) => {
   return (
-    <Link href={blok.link.url} passHref {...storyblokEditable(blok)}>
+    <Link href={getLinkFieldURL(blok.link)} passHref {...storyblokEditable(blok)}>
       <StyledAnchor>
         <TopPickCard
           title={blok.title}

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -1,7 +1,5 @@
 import { StoryblokClient } from '@storyblok/js'
 import { SbBlokData, StoryData } from '@storyblok/react'
-import { getCountryByLocale } from '@/lib/l10n/countries'
-import { LocaleData } from '@/lib/l10n/locales'
 import { Language } from '@/lib/l10n/types'
 import { LinkField } from './storyblok'
 
@@ -47,23 +45,12 @@ export const fetchStory = async (
   return story
 }
 
-export const getLinkFieldURL = (link: LinkField, locale: LocaleData) => {
-  if (!link.story) {
-    // Should never happen, but let's simplify debugging when it does
-    console.error('Did not see story field in link, returning empty URL', link)
-    return '/'
-  }
-  const fragments = link.story.full_slug.split('/')
+export const getLinkFieldURL = (link: LinkField) => {
+  if (link.story) return link.story.url
 
-  // en/SE/page => SE/page, SE/page => unchanged
-  const country = getCountryByLocale(locale.locale)
-  const hasLangPrefix = locale.locale !== country.defaultLocale
-  if (hasLangPrefix) {
-    fragments.shift()
-  }
+  if (link.linktype === 'url') return link.url
 
-  // SE/page => /page
-  fragments.shift()
-
-  return `/${fragments.join('/')}`
+  // Should never happen, but let's simplify debugging when it does
+  console.warn('Did not see story field in link, returning empty URL', link)
+  return '/'
 }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -67,13 +67,14 @@ export type StoryblokImage = {
 export type LinkField = {
   id: string
   url: string
-  linktype: 'story' | 'url'
-  // Assumes we're using resolve_links=url
-  story: {
+  linktype: 'multilink' | 'story' | 'url'
+  story?: {
     id: number
     uuid: string
     name: string
     slug: string
+    // Same as "full_slug" by default.
+    // Can be overridden in Storyblok editor: "Entry configuration" > "Real path".
     url: string
     full_slug: string
   }
@@ -186,12 +187,8 @@ export const getPageLinks = async (): Promise<PageLink[]> => {
     }
     const [firstFragment, ...slugParts] = link.slug.split('/')
     const locale = normalizeLocale(firstFragment)
-    if (!isLocale(locale)) {
-      return
-    }
-    if (slugParts[0] === 'global') {
-      return
-    }
+    if (!isLocale(locale)) return
+    if (slugParts[0] === 'global') return
     pageLinks.push({
       link,
       locale: routingLocale(locale),

--- a/apps/store/src/utils/useStroryblokLinkURL.ts
+++ b/apps/store/src/utils/useStroryblokLinkURL.ts
@@ -1,8 +1,0 @@
-import { useCurrentLocale } from '@/lib/l10n/useCurrentLocale'
-import { LinkField } from '@/services/storyblok/storyblok'
-import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
-
-export const useStroryblokLinkURL = (link: LinkField) => {
-  const locale = useCurrentLocale()
-  return getLinkFieldURL(link, locale)
-}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix how to get a URL from Storyblok link field

Remove unused `useStroryblokLinkURL` hook.

Remove locale handling.

Update `LinkField` type to make story-field optional.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We don't need to fiddle with the locale since it will come directly from Storyblok.

The "story" field should be marked optional as there is no guarantee that the link field is related to an existing story.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
