### PR TITLE
Add form template for SE student home

### DIFF
--- a/apps/store/src/pages/products/[product].tsx
+++ b/apps/store/src/pages/products/[product].tsx
@@ -44,18 +44,21 @@ export const getServerSideProps: GetServerSideProps<NextPageProps> = async (cont
       getGlobalStory({ locale, preview }),
     ])
 
+    const priceTemplate = fetchPriceTemplate(story.content.priceFormTemplateId)
+    if (priceTemplate === undefined) {
+      throw new Error(`Unknown price template: ${story.content.priceFormTemplateId}`)
+    }
+
     const priceIntentService = priceIntentServiceInitServerSide({
       req,
       res,
       shopSession,
       apolloClient,
     })
-    const priceIntent = await priceIntentService.fetch(story.content.productId)
-
-    const priceTemplate = fetchPriceTemplate(story.content.priceFormTemplateId)
-    if (priceTemplate === undefined) {
-      throw new Error(`Unknown price template: ${story.content.priceFormTemplateId}`)
-    }
+    const priceIntent = await priceIntentService.fetch(
+      story.content.productId,
+      priceTemplate.initialData,
+    )
 
     return {
       props: {

--- a/apps/store/src/services/PriceForm/PriceForm.helpers.ts
+++ b/apps/store/src/services/PriceForm/PriceForm.helpers.ts
@@ -1,6 +1,7 @@
 import { SE_ACCIDENT } from './data/SE_ACCIDENT'
 import { SE_APARTMENT } from './data/SE_APARTMENT'
 import { SE_HOUSE } from './data/SE_HOUSE'
+import { SE_STUDENT_APARTMENT } from './data/SE_STUDENT_APARTMENT'
 import { InputField } from './Field.types'
 import { Form, FormSection, JSONData, Template } from './PriceForm.types'
 
@@ -8,6 +9,7 @@ const TEMPLATES: Record<string, Template | undefined> = {
   SE_HOUSE,
   SE_APARTMENT,
   SE_ACCIDENT,
+  SE_STUDENT_APARTMENT,
 }
 
 export const fetchPriceTemplate = (id: string) => {

--- a/apps/store/src/services/PriceForm/PriceForm.types.ts
+++ b/apps/store/src/services/PriceForm/PriceForm.types.ts
@@ -25,6 +25,7 @@ export type Label = {
 }
 
 export type Template = {
+  initialData?: JSONData
   sections: Array<TemplateSection>
 }
 

--- a/apps/store/src/services/PriceForm/data/SE_STUDENT_APARTMENT.ts
+++ b/apps/store/src/services/PriceForm/data/SE_STUDENT_APARTMENT.ts
@@ -1,0 +1,99 @@
+import { Template } from '../PriceForm.types'
+
+export const SE_STUDENT_APARTMENT: Template = {
+  initialData: {
+    isStudent: true,
+  },
+  sections: [
+    {
+      id: 'your-info',
+      title: { key: 'Your info' },
+      submitLabel: { key: 'Next step' },
+      items: [
+        {
+          field: {
+            type: 'text',
+            name: 'ssn',
+            label: { key: 'Personal number' },
+            required: true,
+          },
+          layout: { columnSpan: 6 },
+        },
+      ],
+    },
+    {
+      id: 'your-home',
+      title: { key: 'Your home' },
+      submitLabel: { key: 'Next step' },
+      items: [
+        {
+          field: {
+            type: 'radio',
+            name: 'subType',
+            label: { key: 'Ownership type' },
+            options: [
+              {
+                label: { key: 'I rent' },
+                value: 'RENT',
+              },
+              {
+                label: { key: 'I own' },
+                value: 'BRF',
+              },
+            ],
+            required: true,
+          },
+          layout: { columnSpan: 6 },
+        },
+        {
+          field: {
+            type: 'text',
+            name: 'street',
+            label: { key: 'Address' },
+            required: true,
+          },
+          layout: { columnSpan: 6 },
+        },
+        {
+          field: {
+            type: 'text',
+            name: 'zipCode',
+            label: { key: 'Postal code' },
+            minLength: 5,
+            maxLength: 5,
+            required: true,
+          },
+          layout: { columnSpan: 3 },
+        },
+        {
+          field: {
+            type: 'number',
+            name: 'livingSpace',
+            label: { key: 'Apartment size' },
+            required: true,
+            min: 0,
+          },
+          layout: { columnSpan: 3 },
+        },
+      ],
+    },
+    {
+      id: 'insured-people',
+      title: { key: 'Insured people' },
+      submitLabel: { key: 'Calculate price' },
+      items: [
+        {
+          field: {
+            type: 'number',
+            min: 0,
+            max: 5,
+            name: 'numberCoInsured',
+            label: { key: 'Number of co-insured' },
+            required: true,
+          },
+          layout: { columnSpan: 6 },
+        },
+      ],
+    },
+  ],
+}

--- a/apps/store/src/services/priceIntent/PriceIntent.helpers.ts
+++ b/apps/store/src/services/priceIntent/PriceIntent.helpers.ts
@@ -1,5 +1,13 @@
 import { ApolloClient } from '@apollo/client'
 import { GetServerSidePropsContext } from 'next'
+import {
+  PriceIntentCreateDocument,
+  PriceIntentCreateMutation,
+  PriceIntentCreateMutationVariables,
+  PriceIntentDataUpdateDocument,
+  PriceIntentDataUpdateMutation,
+  PriceIntentDataUpdateMutationVariables,
+} from '@/services/apollo/generated'
 import { CookiePersister } from '@/services/persister/CookiePersister'
 import { ServerCookiePersister } from '@/services/persister/ServerCookiePersister'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
@@ -35,4 +43,48 @@ type Params = {
   res: GetServerSidePropsContext['res']
   shopSession: ShopSession
   apolloClient: ApolloClient<unknown>
+}
+
+type UpdatePriceIntentDataParams = PriceIntentDataUpdateMutationVariables & {
+  apolloClient: ApolloClient<unknown>
+}
+
+export const updatePriceIntentData = async (params: UpdatePriceIntentDataParams) => {
+  const { apolloClient, priceIntentId, data } = params
+
+  const updatedResult = await apolloClient.mutate<
+    PriceIntentDataUpdateMutation,
+    PriceIntentDataUpdateMutationVariables
+  >({
+    mutation: PriceIntentDataUpdateDocument,
+    variables: { priceIntentId, data },
+  })
+
+  const updatedPriceIntent = updatedResult.data?.priceIntentDataUpdate.priceIntent
+  if (!updatedPriceIntent) {
+    throw new Error('Could not update price intent with initial data')
+  }
+
+  return updatedPriceIntent
+}
+
+type CreatePriceIntentParams = PriceIntentCreateMutationVariables & {
+  apolloClient: ApolloClient<unknown>
+}
+
+export const createPriceIntent = async (params: CreatePriceIntentParams) => {
+  const { apolloClient, shopSessionId, productName } = params
+
+  const result = await apolloClient.mutate<
+    PriceIntentCreateMutation,
+    PriceIntentCreateMutationVariables
+  >({
+    mutation: PriceIntentCreateDocument,
+    variables: { shopSessionId, productName },
+  })
+
+  const priceIntent = result.data?.priceIntentCreate
+  if (!priceIntent) throw new Error('Could not create price intent')
+
+  return priceIntent
 }

--- a/apps/store/src/services/priceIntent/priceIntent.types.ts
+++ b/apps/store/src/services/priceIntent/priceIntent.types.ts
@@ -3,8 +3,11 @@ import type {
   PriceIntentDataUpdateMutationVariables,
   PriceIntentQuery,
 } from '@/services/apollo/generated'
+import { JSONData } from '@/services/PriceForm/PriceForm.types'
 
-export type PriceIntentCreateParams = Omit<PriceIntentCreateMutationVariables, 'shopSessionId'>
+export type PriceIntentCreateParams = Omit<PriceIntentCreateMutationVariables, 'shopSessionId'> & {
+  initialData?: JSONData
+}
 export type PriceIntentDataUpdateParams = Omit<
   PriceIntentDataUpdateMutationVariables,
   'shopSessionId'


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add form template for SE student home

Add support for initial price form data.

Make API call to update price intent with initial data after creating.

Refactor price intent service a bit.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

I considered adding "hidden" input fields but I think this appraoch feel less hacky.

In the future we could update the API to accept "initialData" when creating a new price intent.

## Jira issue(s): [GRW-1555]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1555]: https://hedvig.atlassian.net/browse/GRW-1555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ