### PR TITLE
Use template instead of product name for price intent key

### DIFF
--- a/apps/store/src/blocks/PriceCalculatorBlock.tsx
+++ b/apps/store/src/blocks/PriceCalculatorBlock.tsx
@@ -44,7 +44,7 @@ export const PriceCalculatorBlock = ({ blok }: Props) => {
       gradient: product.gradient,
     })
 
-    priceIntentServiceInitClientSide({ shopSession, apolloClient }).clear(product.name)
+    priceIntentServiceInitClientSide({ shopSession, apolloClient }).clear(priceTemplate.name)
     refreshData()
   }
 

--- a/apps/store/src/pages/products/[product].tsx
+++ b/apps/store/src/pages/products/[product].tsx
@@ -55,10 +55,10 @@ export const getServerSideProps: GetServerSideProps<NextPageProps> = async (cont
       shopSession,
       apolloClient,
     })
-    const priceIntent = await priceIntentService.fetch(
-      story.content.productId,
-      priceTemplate.initialData,
-    )
+    const priceIntent = await priceIntentService.fetch({
+      productName: story.content.productId,
+      priceTemplate,
+    })
 
     return {
       props: {

--- a/apps/store/src/services/PriceForm/PriceForm.types.ts
+++ b/apps/store/src/services/PriceForm/PriceForm.types.ts
@@ -25,6 +25,7 @@ export type Label = {
 }
 
 export type Template = {
+  name: string
   initialData?: JSONData
   sections: Array<TemplateSection>
 }

--- a/apps/store/src/services/PriceForm/data/SE_ACCIDENT.ts
+++ b/apps/store/src/services/PriceForm/data/SE_ACCIDENT.ts
@@ -1,6 +1,7 @@
 import { Template } from '../PriceForm.types'
 
 export const SE_ACCIDENT: Template = {
+  name: 'SE_ACCIDENT',
   sections: [
     {
       id: 'your-info',

--- a/apps/store/src/services/PriceForm/data/SE_APARTMENT.ts
+++ b/apps/store/src/services/PriceForm/data/SE_APARTMENT.ts
@@ -1,6 +1,7 @@
 import { Template } from '../PriceForm.types'
 
 export const SE_APARTMENT: Template = {
+  name: 'SE_APARTMENT',
   sections: [
     {
       id: 'your-info',

--- a/apps/store/src/services/PriceForm/data/SE_HOUSE.ts
+++ b/apps/store/src/services/PriceForm/data/SE_HOUSE.ts
@@ -1,6 +1,7 @@
 import { Template } from '../PriceForm.types'
 
 export const SE_HOUSE: Template = {
+  name: 'SE_HOUSE',
   sections: [
     {
       id: 'your-info',

--- a/apps/store/src/services/PriceForm/data/SE_STUDENT_APARTMENT.ts
+++ b/apps/store/src/services/PriceForm/data/SE_STUDENT_APARTMENT.ts
@@ -1,6 +1,7 @@
 import { Template } from '../PriceForm.types'
 
 export const SE_STUDENT_APARTMENT: Template = {
+  name: 'SE_STUDENT_APARTMENT',
   initialData: {
     isStudent: true,
   },

--- a/apps/store/src/services/priceIntent/priceIntent.types.ts
+++ b/apps/store/src/services/priceIntent/priceIntent.types.ts
@@ -3,10 +3,10 @@ import type {
   PriceIntentDataUpdateMutationVariables,
   PriceIntentQuery,
 } from '@/services/apollo/generated'
-import { JSONData } from '@/services/PriceForm/PriceForm.types'
+import { Template } from '@/services/PriceForm/PriceForm.types'
 
 export type PriceIntentCreateParams = Omit<PriceIntentCreateMutationVariables, 'shopSessionId'> & {
-  initialData?: JSONData
+  priceTemplate: Template
 }
 export type PriceIntentDataUpdateParams = Omit<
   PriceIntentDataUpdateMutationVariables,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Use template instead of product name for price intent key

Pass the whole price template when fetching/creating price intent.

Add unique name property to Template.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

This is needed to support using the same product on multiple product pages.

We don't want to mix up the price intents in these cases tho so we need a different identifier than shop session + product name.

Since the template will be different for different product pages I decided to use that combo instead.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
