### PR TITLE
Auto-focus first input when accordion is expanded

### DIFF
--- a/apps/store/.eslintrc.js
+++ b/apps/store/.eslintrc.js
@@ -1,1 +1,14 @@
-module.exports = require('scripts/eslint-preset-next')
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const config = require('scripts/eslint-preset-next')
+module.exports = {
+  ...config,
+  rules: {
+    ...config.rules,
+    // This allows us to use to auto-focus attribute on input elements (or all elements, really)
+    // It's used for the accordion effects in PriceForm. Without auto-focus user would have to tab
+    // through the entire page to get to the newly shown form items, which is worse than messing
+    // with auto-focus. Probably.
+    // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-autofocus.md
+    'jsx-a11y/no-autofocus': [0],
+  },
+}

--- a/apps/store/src/components/InputSelect/InputSelect.tsx
+++ b/apps/store/src/components/InputSelect/InputSelect.tsx
@@ -50,6 +50,7 @@ type InputSelectProps = InputBaseProps & {
   onChange?: React.ChangeEventHandler<HTMLSelectElement>
   required?: boolean
   placeholder?: string
+  autoFocus?: boolean
 }
 
 export const InputSelect = ({

--- a/apps/store/src/components/PriceForm/AutomaticField.tsx
+++ b/apps/store/src/components/PriceForm/AutomaticField.tsx
@@ -10,9 +10,10 @@ type Props = {
   field: InputFieldType
   onSubmit: (data: JSONData) => Promise<void>
   loading: boolean
+  autoFocus?: boolean
 }
 
-export const AutomaticField = ({ field, onSubmit, loading }: Props) => {
+export const AutomaticField = ({ field, onSubmit, loading, autoFocus }: Props) => {
   const translateLabel = useTranslateTextLabel({ data: {} })
 
   switch (field.type) {
@@ -27,6 +28,7 @@ export const AutomaticField = ({ field, onSubmit, loading }: Props) => {
           maxLength={field.maxLength}
           required={field.required}
           defaultValue={field.value ?? field.defaultValue}
+          autoFocus={autoFocus}
         />
       )
 
@@ -40,6 +42,7 @@ export const AutomaticField = ({ field, onSubmit, loading }: Props) => {
           max={field.max}
           required={field.required}
           defaultValue={field.value ?? field.defaultValue}
+          autoFocus={autoFocus}
         />
       )
 
@@ -53,6 +56,7 @@ export const AutomaticField = ({ field, onSubmit, loading }: Props) => {
           defaultValue={field.value ?? field.defaultValue}
           min={field.min}
           max={field.max}
+          autoFocus={autoFocus}
         />
       )
 
@@ -67,6 +71,7 @@ export const AutomaticField = ({ field, onSubmit, loading }: Props) => {
             ...option,
             label: translateLabel(option.label),
           }))}
+          autoFocus={autoFocus}
         />
       )
 
@@ -81,6 +86,7 @@ export const AutomaticField = ({ field, onSubmit, loading }: Props) => {
             ...option,
             name: translateLabel(option.label),
           }))}
+          autoFocus={autoFocus}
         />
       )
 

--- a/apps/store/src/components/PriceForm/FormGrid.tsx
+++ b/apps/store/src/components/PriceForm/FormGrid.tsx
@@ -17,15 +17,15 @@ const GridItem = styled.div<GridItemProps>(({ columnSpan }) => ({
 
 type FormSectionProps = {
   items: Array<SectionItem>
-  children(field: InputField): ReactNode
+  children(field: InputField, index: number): ReactNode
 }
 
 export const FormGrid = ({ items, children }: FormSectionProps) => {
   return (
     <Grid>
-      {items.map((item) => (
+      {items.map((item, index) => (
         <GridItem key={item.field.name} columnSpan={item.layout.columnSpan}>
-          {children(item.field)}
+          {children(item.field, index)}
         </GridItem>
       ))}
     </Grid>

--- a/apps/store/src/components/PriceForm/InputRadio.tsx
+++ b/apps/store/src/components/PriceForm/InputRadio.tsx
@@ -59,6 +59,7 @@ type InputRadioProps = InputBaseProps & {
   onValueChange?: (value: string) => void
   required?: boolean
   placeholder?: string
+  autoFocus?: boolean
 }
 
 export const InputRadio = ({
@@ -68,6 +69,7 @@ export const InputRadio = ({
   value,
   defaultValue,
   required,
+  autoFocus,
   ...rest
 }: InputRadioProps) => {
   return (
@@ -81,8 +83,8 @@ export const InputRadio = ({
           required={required}
         >
           <SpaceFlex direction="horizontal" space={0.5}>
-            {options.map(({ label, value: optionValue }) => (
-              <Item key={optionValue} value={optionValue}>
+            {options.map(({ label, value: optionValue }, index) => (
+              <Item key={optionValue} value={optionValue} autoFocus={autoFocus && index === 0}>
                 <InnerWrapper>
                   <IndicatorWrapper>
                     <Indicator>

--- a/apps/store/src/components/PriceForm/PriceForm.tsx
+++ b/apps/store/src/components/PriceForm/PriceForm.tsx
@@ -34,11 +34,20 @@ export const PriceForm = ({ form, priceIntent, onSuccess, loading }: Props) => {
 
   return (
     <PriceFormAccordion form={form}>
-      {(section) => (
+      {(section, sectionIndex) => (
         <PriceFormSection section={section} onSubmit={handleSubmit} loading={isLoading}>
           <FormGrid items={section.items}>
-            {(field) => (
-              <AutomaticField field={field} onSubmit={handleSubmit} loading={isLoading} />
+            {(field, index) => (
+              <AutomaticField
+                field={field}
+                onSubmit={handleSubmit}
+                loading={isLoading}
+                // We don't want to mess up focusing for the user by setting autoFocus on the
+                // first item in the form, since that would make it unintuitive to navigate our
+                // site. But when the user is in the form editing, even having submitted the first
+                // section, we want to set autoFocus for the next section. Hence sectionIndex > 0
+                autoFocus={sectionIndex > 0 && index === 0}
+              />
             )}
           </FormGrid>
         </PriceFormSection>

--- a/apps/store/src/components/PriceForm/PriceFormAccordion.tsx
+++ b/apps/store/src/components/PriceForm/PriceFormAccordion.tsx
@@ -9,7 +9,7 @@ import { useTranslateTextLabel } from './useTranslateTextLabel'
 
 type Props = {
   form: Form
-  children(section: FormSection): ReactNode
+  children(section: FormSection, index: number): ReactNode
 }
 
 export const PriceFormAccordion = ({ form, children }: Props) => {
@@ -33,7 +33,7 @@ export const PriceFormAccordion = ({ form, children }: Props) => {
             </SpaceFlex>
             <Accordion.Trigger />
           </Accordion.Header>
-          <Accordion.Content>{children(section)}</Accordion.Content>
+          <Accordion.Content>{children(section, index)}</Accordion.Content>
         </Accordion.Item>
       ))}
     </Accordion.Root>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

Consider this a proposal to solve an a11y issues by using a non-recommended (in terms of a11y) solution

## Describe your changes

Set `auto-focus` on a PriceForm input when
1. It's any section after the first
2. It's the first input in the section

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Otherwise, the user has to tab through the entire page every time they submit the form.

The use of `auto-focus` is [discouraged](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-autofocus.md) since it can cause usability and a11y issues, but as it solves the current issue, which is also a11y, I think it's worth the trade-off.

The user interaction would be (for https://racoon-store.vercel.app/sv-se/products/home):
1. Tab to the form
2. Fill in SSN
3. Enter to submit section
4. Tab to next input (Ownership type)
5. Fill in section
6. Enter to submit section
7. Tab to next input (Ownership type)
5. Fill in section
6. Enter to submit section and calculate price

After this PR:
1. Tab to the form
2. Fill in SSN
3. Enter to submit section
5. Fill in section
6. Enter to submit section
5. Fill in section
6. Enter to submit section and calculate price


#### Video before


https://user-images.githubusercontent.com/1343979/192765337-4573d940-180d-4092-8c3a-39078ddadc4b.mov


#### Video after


https://user-images.githubusercontent.com/1343979/192765388-41473e34-db84-41d0-aa1d-c94284833e56.mov



## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
