### PR TITLE
feat / Introduce custom field for Swedish SSN

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -38,6 +38,7 @@
     "js-cookie": "3.0.1",
     "next": "12.2.2",
     "next-i18next": "12.0.1",
+    "personnummer": "3.1.4",
     "pino": "8.6.0",
     "pino-datadog-transport": "1.2.2",
     "pino-pretty": "9.1.0",

--- a/apps/store/src/components/PriceForm/AutomaticField.tsx
+++ b/apps/store/src/components/PriceForm/AutomaticField.tsx
@@ -4,6 +4,7 @@ import { InputField as InputFieldType } from '@/services/PriceForm/Field.types'
 import { JSONData } from '@/services/PriceForm/PriceForm.types'
 import { ExtraBuildingsField } from './ExtraBuildingsField'
 import { InputRadio } from './InputRadio'
+import { SsnSeField } from './SsnSeField'
 import { useTranslateTextLabel } from './useTranslateTextLabel'
 
 type Props = {
@@ -89,6 +90,9 @@ export const AutomaticField = ({ field, onSubmit, loading, autoFocus }: Props) =
           autoFocus={autoFocus}
         />
       )
+
+    case 'ssn-se':
+      return <SsnSeField field={field} />
 
     case 'extra-buildings':
       return <ExtraBuildingsField field={field} onSubmit={onSubmit} loading={loading} />

--- a/apps/store/src/components/PriceForm/SsnSeField.tsx
+++ b/apps/store/src/components/PriceForm/SsnSeField.tsx
@@ -1,0 +1,46 @@
+import Personnummer from 'personnummer'
+import { ChangeEventHandler, useState } from 'react'
+import { InputField } from 'ui'
+import { SsnSeField as SsnSeFieldType } from '@/services/PriceForm/Field.types'
+import { useTranslateTextLabel } from './useTranslateTextLabel'
+
+type SsnSeFieldProps = {
+  field: SsnSeFieldType
+}
+
+export const SsnSeField = ({ field }: SsnSeFieldProps) => {
+  const translateLabel = useTranslateTextLabel({ data: {} })
+  const [value, setValue] = useState(field.defaultValue)
+
+  const handleOnChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    let value = event.target.value
+
+    if (typeof value === 'string' && Personnummer.valid(value)) {
+      value = Personnummer.parse(value).format(true)
+    }
+    setValue(value)
+  }
+
+  return (
+    <>
+      <input
+        type="text"
+        name={field.name}
+        required={field.required}
+        defaultValue={field.value ?? field.defaultValue}
+        value={value}
+        hidden
+      />
+      <InputField
+        type="text"
+        name={`${field.name}-visible-input`}
+        label={field.label ? translateLabel(field.label) : undefined}
+        minLength={10}
+        maxLength={13}
+        required={field.required}
+        defaultValue={field.value ?? field.defaultValue}
+        onChange={handleOnChange}
+      />
+    </>
+  )
+}

--- a/apps/store/src/services/PriceForm/Field.types.ts
+++ b/apps/store/src/services/PriceForm/Field.types.ts
@@ -15,6 +15,10 @@ export type TextField = BaseField<string> & {
   maxLength?: number
 }
 
+export type SsnSeField = BaseField<string> & {
+  type: 'ssn-se'
+}
+
 export type NumberField = BaseField<number> & {
   type: 'number'
   min?: number
@@ -59,3 +63,4 @@ export type InputField =
   | RadioField
   | SelectField
   | ExtraBuildingsField
+  | SsnSeField

--- a/apps/store/src/services/PriceForm/data/SE_ACCIDENT.ts
+++ b/apps/store/src/services/PriceForm/data/SE_ACCIDENT.ts
@@ -10,7 +10,7 @@ export const SE_ACCIDENT: Template = {
       items: [
         {
           field: {
-            type: 'text',
+            type: 'ssn-se',
             name: 'ssn',
             label: { key: 'Personal number' },
             required: true,

--- a/apps/store/src/services/PriceForm/data/SE_APARTMENT.ts
+++ b/apps/store/src/services/PriceForm/data/SE_APARTMENT.ts
@@ -10,7 +10,7 @@ export const SE_APARTMENT: Template = {
       items: [
         {
           field: {
-            type: 'text',
+            type: 'ssn-se',
             name: 'ssn',
             label: { key: 'Personal number' },
             required: true,

--- a/apps/store/src/services/PriceForm/data/SE_HOUSE.ts
+++ b/apps/store/src/services/PriceForm/data/SE_HOUSE.ts
@@ -10,7 +10,7 @@ export const SE_HOUSE: Template = {
       items: [
         {
           field: {
-            type: 'text',
+            type: 'ssn-se',
             name: 'ssn',
             label: { key: 'Personal number' },
             required: true,

--- a/apps/store/src/services/PriceForm/data/SE_STUDENT_APARTMENT.ts
+++ b/apps/store/src/services/PriceForm/data/SE_STUDENT_APARTMENT.ts
@@ -13,7 +13,7 @@ export const SE_STUDENT_APARTMENT: Template = {
       items: [
         {
           field: {
-            type: 'text',
+            type: 'ssn-se',
             name: 'ssn',
             label: { key: 'Personal number' },
             required: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -18059,6 +18059,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"personnummer@npm:3.1.4":
+  version: 3.1.4
+  resolution: "personnummer@npm:3.1.4"
+  checksum: 25bd050637e42ba6db1cd9fb5bdfb2fdfbe04fe3d44225bf6514cc5b08f62d9ce68db3b8c79444bd0b2d67601eba888307459b037310eb45e3b0b631a0f61889
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^0.2.1":
   version: 0.2.1
   resolution: "picocolors@npm:0.2.1"
@@ -20872,6 +20879,7 @@ __metadata:
     next: 12.2.2
     next-i18next: 12.0.1
     next-router-mock: 0.7.4
+    personnummer: 3.1.4
     pino: 8.6.0
     pino-datadog-transport: 1.2.2
     pino-pretty: 9.1.0


### PR DESCRIPTION

<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Introduce custom field that formats Swedish SSN to a format that is acceptable by BE. The `personnummer` lib handles validation and formatting in an easy way.


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We should allow the user to type in SSN in all different variations and always send it in the correct format to BE. The format that they accept is "long" according to [personnummer docs](https://personnummer.dev/) -> `yyyymmddNNNN`.

Maybe @robinandeer knows some good way to get rid of the `useState`? 🙃 

### Video

https://user-images.githubusercontent.com/1343979/192812438-fff5d157-ba17-4063-bb64-f76ef7188509.mov


## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
