### PR TITLE
Integrate checkout signing API

### DIFF
--- a/apps/store/src/components/CheckoutContactDetailsPage/CheckoutContactDetails.tsx
+++ b/apps/store/src/components/CheckoutContactDetailsPage/CheckoutContactDetails.tsx
@@ -2,46 +2,55 @@ import { Button, InputField, Space } from 'ui'
 import { CheckoutContactDetailsPageProps } from './CheckoutContactDetails.types'
 import { FormElement } from './CheckoutContactDetailsPage.constants'
 import { CheckoutContactDetailsPageLayout } from './CheckoutContactDetailsPageLayout'
+import { useHandleSubmitContactDetails } from './useHandleSubmitContactDetails'
 
-export const CheckoutContactDetailsPage = ({ prefilledData }: CheckoutContactDetailsPageProps) => {
+export const CheckoutContactDetailsPage = ({
+  checkoutId,
+  prefilledData,
+  onSuccess,
+}: CheckoutContactDetailsPageProps) => {
+  const [handleSubmit, { loading }] = useHandleSubmitContactDetails({ checkoutId, onSuccess })
+
   return (
-    <CheckoutContactDetailsPageLayout
-      Footer={
-        <Button type="submit" fullWidth>
-          Continue to payment
-        </Button>
-      }
-    >
-      <Space y={1}>
-        <InputField
-          label="National identity number (DDMMYYXXXXX)"
-          name={FormElement.PersonalNumber}
-          required
-          defaultValue={prefilledData.personalNumber ?? undefined}
-          infoMessage={
-            'We credit assess all new customers. Those who have payment remarks will in some cases be asked to pay in advance.'
-          }
-        />
-        <InputField
-          label="First name"
-          name={FormElement.FirstName}
-          required
-          defaultValue={prefilledData.firstName ?? undefined}
-        />
-        <InputField
-          label="Last name"
-          name={FormElement.LastName}
-          required
-          defaultValue={prefilledData.lastName ?? undefined}
-        />
-        <InputField
-          label="Email"
-          name={FormElement.Email}
-          type="email"
-          required
-          defaultValue={prefilledData.email ?? undefined}
-        />
-      </Space>
-    </CheckoutContactDetailsPageLayout>
+    <form onSubmit={handleSubmit}>
+      <CheckoutContactDetailsPageLayout
+        Footer={
+          <Button type="submit" disabled={loading} fullWidth>
+            Continue to payment
+          </Button>
+        }
+      >
+        <Space y={1}>
+          <InputField
+            label="National identity number (DDMMYYXXXXX)"
+            name={FormElement.PersonalNumber}
+            required
+            defaultValue={prefilledData.personalNumber ?? undefined}
+            infoMessage={
+              'We credit assess all new customers. Those who have payment remarks will in some cases be asked to pay in advance.'
+            }
+          />
+          <InputField
+            label="First name"
+            name={FormElement.FirstName}
+            required
+            defaultValue={prefilledData.firstName ?? undefined}
+          />
+          <InputField
+            label="Last name"
+            name={FormElement.LastName}
+            required
+            defaultValue={prefilledData.lastName ?? undefined}
+          />
+          <InputField
+            label="Email"
+            name={FormElement.Email}
+            type="email"
+            required
+            defaultValue={prefilledData.email ?? undefined}
+          />
+        </Space>
+      </CheckoutContactDetailsPageLayout>
+    </form>
   )
 }

--- a/apps/store/src/components/CheckoutContactDetailsPage/CheckoutContactDetails.types.tsx
+++ b/apps/store/src/components/CheckoutContactDetailsPage/CheckoutContactDetails.types.tsx
@@ -1,5 +1,8 @@
 import { CheckoutFragment } from '@/services/apollo/generated'
 
 export type CheckoutContactDetailsPageProps = {
+  checkoutId: string
+  checkoutSigningId: string | null
   prefilledData: CheckoutFragment['contactDetails']
+  onSuccess: () => void
 }

--- a/apps/store/src/components/CheckoutContactDetailsPage/CheckoutContactDetailsPage.helpers.ts
+++ b/apps/store/src/components/CheckoutContactDetailsPage/CheckoutContactDetailsPage.helpers.ts
@@ -1,0 +1,39 @@
+import { ApolloClient } from '@apollo/client'
+import { GetServerSidePropsContext } from 'next'
+import {
+  CheckoutSigningDocument,
+  CheckoutSigningQuery,
+  CheckoutSigningQueryVariables,
+} from '@/services/apollo/generated'
+
+type FetchParams = CheckoutSigningQueryVariables & {
+  apolloClient: ApolloClient<unknown>
+}
+
+const fetchCheckoutSigning = async ({ apolloClient, ...variables }: FetchParams) => {
+  const result = await apolloClient.query<CheckoutSigningQuery, CheckoutSigningQueryVariables>({
+    query: CheckoutSigningDocument,
+    variables,
+  })
+
+  return result.data.checkoutSigning
+}
+
+type FetchCurrentParams = Omit<FetchParams, 'checkoutSigningId'> & {
+  req: GetServerSidePropsContext['req']
+  checkoutId: string
+}
+
+export const fetchCurrentCheckoutSigning = async ({
+  req,
+  checkoutId,
+  ...params
+}: FetchCurrentParams) => {
+  const checkoutSigningId = req.cookies[checkoutId]
+
+  if (checkoutSigningId) {
+    return await fetchCheckoutSigning({ ...params, checkoutSigningId })
+  }
+
+  return null
+}

--- a/apps/store/src/components/CheckoutContactDetailsPage/CheckoutSignPage.tsx
+++ b/apps/store/src/components/CheckoutContactDetailsPage/CheckoutSignPage.tsx
@@ -2,50 +2,67 @@ import styled from '@emotion/styled'
 import { Button, InputField, Space } from 'ui'
 import { CheckoutContactDetailsPageProps } from './CheckoutContactDetails.types'
 import { CheckoutContactDetailsPageLayout } from './CheckoutContactDetailsPageLayout'
+import { useHandleSubmitContactDetailsAndSign } from './useHandleSubmitContactDetailsAndSign'
 
-export const CheckoutSignPage = ({ prefilledData }: CheckoutContactDetailsPageProps) => {
+export const CheckoutSignPage = ({
+  checkoutId,
+  checkoutSigningId,
+  prefilledData,
+  onSuccess: onSignSuccess,
+}: CheckoutContactDetailsPageProps) => {
+  const [handleSubmit, loading] = useHandleSubmitContactDetailsAndSign({
+    checkoutId,
+    checkoutSigningId,
+    onSuccess() {
+      // @TODO: add access token to session
+      onSignSuccess()
+    },
+  })
+
   return (
-    <CheckoutContactDetailsPageLayout
-      Footer={
-        <Space y={1.5}>
-          <MutedText>
-            By clicking &quot;Sign with BankID&quot; I confirm that I have read and understood the
-            terms and conditions, and that I approve that Hedvig handles my personal information.
-          </MutedText>
-          <Button type="submit" fullWidth>
-            Sign with BankID
-          </Button>
+    <form onSubmit={handleSubmit}>
+      <CheckoutContactDetailsPageLayout
+        Footer={
+          <Space y={1.5}>
+            <MutedText>
+              By clicking &quot;Sign with BankID&quot; I confirm that I have read and understood the
+              terms and conditions, and that I approve that Hedvig handles my personal information.
+            </MutedText>
+            <Button type="submit" disabled={loading} fullWidth>
+              Sign with BankID
+            </Button>
+          </Space>
+        }
+      >
+        <Space y={1}>
+          <InputField
+            label="Personal number"
+            name="personalNumber"
+            required
+            defaultValue={prefilledData.personalNumber ?? undefined}
+          />
+          <InputField
+            label="First name"
+            name="firstName"
+            required
+            defaultValue={prefilledData.firstName ?? undefined}
+          />
+          <InputField
+            label="Last name"
+            name="lastName"
+            required
+            defaultValue={prefilledData.lastName ?? undefined}
+          />
+          <InputField
+            label="Email"
+            name="email"
+            type="email"
+            required
+            defaultValue={prefilledData.email ?? undefined}
+          />
         </Space>
-      }
-    >
-      <Space y={1}>
-        <InputField
-          label="Personal number"
-          name="personalNumber"
-          required
-          defaultValue={prefilledData.personalNumber ?? undefined}
-        />
-        <InputField
-          label="First name"
-          name="firstName"
-          required
-          defaultValue={prefilledData.firstName ?? undefined}
-        />
-        <InputField
-          label="Last name"
-          name="lastName"
-          required
-          defaultValue={prefilledData.lastName ?? undefined}
-        />
-        <InputField
-          label="Email"
-          name="email"
-          type="email"
-          required
-          defaultValue={prefilledData.email ?? undefined}
-        />
-      </Space>
-    </CheckoutContactDetailsPageLayout>
+      </CheckoutContactDetailsPageLayout>
+    </form>
   )
 }
 

--- a/apps/store/src/components/CheckoutContactDetailsPage/useHandleSubmitContactDetailsAndSign.ts
+++ b/apps/store/src/components/CheckoutContactDetailsPage/useHandleSubmitContactDetailsAndSign.ts
@@ -1,0 +1,49 @@
+import { setCookie, deleteCookie } from 'cookies-next'
+import { useState } from 'react'
+import { useCheckoutSigningQuery, useCheckoutStartSignMutation } from '@/services/apollo/generated'
+import { useHandleSubmitContactDetails } from './useHandleSubmitContactDetails'
+
+type Params = {
+  checkoutId: string
+  checkoutSigningId: string | null
+  onSuccess: (accessToken: string) => void
+}
+
+export const useHandleSubmitContactDetailsAndSign = (params: Params) => {
+  const { checkoutId, checkoutSigningId: initialCheckoutSigningId, onSuccess } = params
+  const [checkoutSigningId, setCheckoutSigningId] = useState(initialCheckoutSigningId)
+
+  const { data } = useCheckoutSigningQuery({
+    skip: checkoutSigningId === null,
+    variables: checkoutSigningId ? { checkoutSigningId } : undefined,
+    pollInterval: 1000,
+    onCompleted(data) {
+      // @TODO: investigate which status codes are sent from backend
+      if (data.checkoutSigning.completion) {
+        onSuccess(data.checkoutSigning.completion.accessToken)
+
+        setCheckoutSigningId(null)
+        deleteCookie(checkoutId)
+      }
+    },
+  })
+
+  const [startSign, { loading: loadingStartSign }] = useCheckoutStartSignMutation({
+    variables: { checkoutId },
+    onCompleted(data) {
+      setCheckoutSigningId(data.checkoutStartSign.signing.id)
+      setCookie(checkoutId, data.checkoutStartSign.signing.id)
+    },
+  })
+
+  const [handleSubmit, { loading: loadingContactDetails }] = useHandleSubmitContactDetails({
+    checkoutId,
+    onSuccess: startSign,
+  })
+
+  const hasAccessToken = data?.checkoutSigning.completion
+  const isLoading = Boolean(
+    loadingContactDetails || loadingStartSign || checkoutSigningId || hasAccessToken,
+  )
+  return [handleSubmit, isLoading] as const
+}

--- a/apps/store/src/graphql/CheckoutSigning.graphql
+++ b/apps/store/src/graphql/CheckoutSigning.graphql
@@ -1,0 +1,5 @@
+query CheckoutSigning($checkoutSigningId: ID!) {
+  checkoutSigning(id: $checkoutSigningId) {
+    ...CheckoutSigning
+  }
+}

--- a/apps/store/src/graphql/CheckoutSigningFragment.graphql
+++ b/apps/store/src/graphql/CheckoutSigningFragment.graphql
@@ -1,0 +1,7 @@
+fragment CheckoutSigning on CheckoutSigning {
+  id
+  status
+  completion {
+    accessToken
+  }
+}

--- a/apps/store/src/graphql/CheckoutStartSign.graphql
+++ b/apps/store/src/graphql/CheckoutStartSign.graphql
@@ -1,0 +1,7 @@
+mutation CheckoutStartSign($checkoutId: ID!) {
+  checkoutStartSign(checkoutId: $checkoutId) {
+    signing {
+      ...CheckoutSigning
+    }
+  }
+}

--- a/apps/store/src/graphql/ShopSession.graphql
+++ b/apps/store/src/graphql/ShopSession.graphql
@@ -1,13 +1,5 @@
 query ShopSession($shopSessionId: ID!) {
   shopSession(id: $shopSessionId) {
-    id
-    countryCode
-    currencyCode
-    cart {
-      ...CartFragment
-    }
-    checkout {
-      ...Checkout
-    }
+    ...ShopSession
   }
 }

--- a/apps/store/src/graphql/ShopSessionCreate.graphql
+++ b/apps/store/src/graphql/ShopSessionCreate.graphql
@@ -1,13 +1,5 @@
 mutation ShopSessionCreate($countryCode: CountryCode!) {
   shopSessionCreate(input: { countryCode: $countryCode }) {
-    id
-    countryCode
-    currencyCode
-    cart {
-      ...CartFragment
-    }
-    checkout {
-      ...Checkout
-    }
+    ...ShopSession
   }
 }

--- a/apps/store/src/graphql/ShopSessionFragment.graphql
+++ b/apps/store/src/graphql/ShopSessionFragment.graphql
@@ -1,0 +1,11 @@
+fragment ShopSession on ShopSession {
+  id
+  countryCode
+  currencyCode
+  cart {
+    ...CartFragment
+  }
+  checkout {
+    ...Checkout
+  }
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Integrate Checkout signing API on checkout / contact details page.

Move form logic inside checkout details pages.

Keep track of started "checkout signing" in cookie (key = checkoutId).

Flow: update contact details -> start sign -> poll for updates to checkout signing.

Still to be done:

- store the access token in a cookie after it's generated
- update cookie settings to be secure

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Needed to support the "after sign" payment flow.

We stored the checkout signing ID in a cookie in case the user reloads the page while a signing is ongoing.

## Jira issue(s): [GRW-1562]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1562]: https://hedvig.atlassian.net/browse/GRW-1562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ