### PR TITLE
Fix icon sizes on the Product page when zoomed

### DIFF
--- a/apps/store/src/blocks/PerilsBlock.tsx
+++ b/apps/store/src/blocks/PerilsBlock.tsx
@@ -6,7 +6,7 @@ import { ShieldIcon } from '@/components/Perils/ShieldIcon'
 const ITEMS = [
   {
     id: 'waterLeaks',
-    icon: <ShieldIcon size="22px" />,
+    icon: <ShieldIcon size="1.25rem" />,
     name: 'Water leaks',
     description:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
@@ -20,7 +20,7 @@ const ITEMS = [
   },
   {
     id: 'fire',
-    icon: <ShieldIcon size="22px" />,
+    icon: <ShieldIcon size="1.25rem" />,
     name: 'Fire',
     description:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
@@ -34,7 +34,7 @@ const ITEMS = [
   },
   {
     id: 'storms',
-    icon: <ShieldIcon size="22px" />,
+    icon: <ShieldIcon size="1.25rem" />,
     name: 'Storms',
     description:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',

--- a/apps/store/src/components/Perils/CoverageList.tsx
+++ b/apps/store/src/components/Perils/CoverageList.tsx
@@ -18,9 +18,9 @@ export const CoverageList = ({ heading, items, variant }: CoverageListProps) => 
         {items.map((item, index) => (
           <Item key={index}>
             {variant === 'covered' ? (
-              <CheckIcon color="currentColor" size="10px" />
+              <CheckIcon color="currentColor" size="0.75rem" />
             ) : (
-              <CrossIcon color="currentColor" size="10px" />
+              <CrossIcon color="currentColor" size="0.75rem" />
             )}
             {item}
           </Item>

--- a/apps/store/src/components/Perils/MinusIcon.tsx
+++ b/apps/store/src/components/Perils/MinusIcon.tsx
@@ -5,7 +5,7 @@ export type MinusIconProps = {
   size?: string
 }
 
-export const MinusIcon = ({ color = theme.colors.gray900, size = '24px' }: MinusIconProps) => {
+export const MinusIcon = ({ color = theme.colors.gray900, size = '1.5rem' }: MinusIconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/apps/store/src/components/Perils/PlusIcon.tsx
+++ b/apps/store/src/components/Perils/PlusIcon.tsx
@@ -5,7 +5,7 @@ export type PlusIconProps = {
   size?: string
 }
 
-export const PlusIcon = ({ color = theme.colors.gray900, size = '24px' }: PlusIconProps) => {
+export const PlusIcon = ({ color = theme.colors.gray900, size = '1.5rem' }: PlusIconProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/apps/store/src/components/PriceForm/InputRadio.tsx
+++ b/apps/store/src/components/PriceForm/InputRadio.tsx
@@ -86,7 +86,7 @@ export const InputRadio = ({
                 <InnerWrapper>
                   <IndicatorWrapper>
                     <Indicator>
-                      <TickIcon size={20} />
+                      <TickIcon size={'1.25rem'} />
                     </Indicator>
                   </IndicatorWrapper>
 

--- a/apps/store/src/components/PriceForm/PriceForm.constants.ts
+++ b/apps/store/src/components/PriceForm/PriceForm.constants.ts
@@ -1,1 +1,1 @@
-export const STEP_ICON_SIZE = 22
+export const STEP_ICON_SIZE = '1.25rem'

--- a/apps/store/src/components/PriceForm/StepIconValid.tsx
+++ b/apps/store/src/components/PriceForm/StepIconValid.tsx
@@ -5,7 +5,7 @@ import { TickIcon } from './TickIcon'
 
 const StyledStep = styled.div(({ theme }) => ({
   width: STEP_ICON_SIZE,
-  height: 22,
+  height: STEP_ICON_SIZE,
   borderRadius: '50%',
   backgroundColor: theme.colors.purple500,
   display: 'flex',
@@ -18,7 +18,7 @@ export const StepIconValid = () => {
 
   return (
     <StyledStep>
-      <TickIcon size={16} color={theme.colors.gray900} />
+      <TickIcon size="1rem" color={theme.colors.gray900} />
     </StyledStep>
   )
 }

--- a/apps/store/src/components/PriceForm/TickIcon.tsx
+++ b/apps/store/src/components/PriceForm/TickIcon.tsx
@@ -2,10 +2,10 @@ import { theme } from 'ui'
 
 export type TickIconProps = {
   color?: string
-  size?: number
+  size?: number | string
 }
 
-export const TickIcon = ({ color = theme.colors.gray100, size = 26 }: TickIconProps) => (
+export const TickIcon = ({ color = theme.colors.gray100, size = '1.5rem' }: TickIconProps) => (
   <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 26 26">
     <g transform="translate(1 1)" fill="none" fillRule="evenodd">
       <path

--- a/apps/store/src/components/TickIcon/TickIcon.tsx
+++ b/apps/store/src/components/TickIcon/TickIcon.tsx
@@ -7,7 +7,11 @@ export type TickIconProps = {
   width?: number
 }
 
-export const TickIcon = ({ color = theme.colors.gray900, size = 24, width = 2 }: TickIconProps) => (
+export const TickIcon = ({
+  color = theme.colors.gray900,
+  size = '1.5rem',
+  width = 2,
+}: TickIconProps) => (
   <StyledSvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 26" size={size}>
     <g transform="translate(1 1)" fill="none" fillRule="evenodd">
       <path

--- a/apps/store/src/components/TopMenu/MenuIcon.tsx
+++ b/apps/store/src/components/TopMenu/MenuIcon.tsx
@@ -5,7 +5,7 @@ export type MenuIconProps = {
   size?: string
 }
 
-export const MenuIcon = ({ color = theme.colors.gray900, size = '24px' }: MenuIconProps) => (
+export const MenuIcon = ({ color = theme.colors.gray900, size = '1.5rem' }: MenuIconProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"

--- a/apps/store/src/components/TopMenu/ShoppingBagIcon.tsx
+++ b/apps/store/src/components/TopMenu/ShoppingBagIcon.tsx
@@ -7,7 +7,7 @@ export type ShoppingBagIconProps = {
 
 export const ShoppingBagIcon = ({
   color = theme.colors.gray900,
-  size = '24px',
+  size = '1.5rem',
 }: ShoppingBagIconProps) => {
   return (
     <svg


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Took some inspiration from @guilhermespopolin and ran racoon-store with very large font size, mainly to see where we do not scale elements accordingly. I didn't care about paddings and margins but focused on fixing icons.

### Before

https://user-images.githubusercontent.com/1343979/192819134-c17381aa-ce6d-4d6e-a116-9f4f3ccb5dcf.mov


### After



https://user-images.githubusercontent.com/1343979/192819905-48cdf07b-30e6-4cd4-a3e4-427e0f9a8170.mov




<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

The user interaction looks really strange when zoomed in.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
