### PR TITLE
Store access token in cookie

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-tabs": "1.0.0",
     "@storyblok/react": "1.1.6",
     "ajv": "8.11.0",
+    "cookies-next": "2.1.1",
     "dd-trace": "2.10.0",
     "framer-motion": "7.2.1",
     "graphql": "16.6.0",

--- a/apps/store/src/components/CheckoutContactDetailsPage/CheckoutSignPage.tsx
+++ b/apps/store/src/components/CheckoutContactDetailsPage/CheckoutSignPage.tsx
@@ -1,8 +1,12 @@
 import styled from '@emotion/styled'
+import { setCookie } from 'cookies-next'
 import { Button, InputField, Space } from 'ui'
+import { AUTH_COOKIE_KEY } from '@/services/apollo/client'
 import { CheckoutContactDetailsPageProps } from './CheckoutContactDetails.types'
 import { CheckoutContactDetailsPageLayout } from './CheckoutContactDetailsPageLayout'
 import { useHandleSubmitContactDetailsAndSign } from './useHandleSubmitContactDetailsAndSign'
+
+const MAX_AGE = 60 * 60 * 24 // 24 hours
 
 export const CheckoutSignPage = ({
   checkoutId,
@@ -13,8 +17,14 @@ export const CheckoutSignPage = ({
   const [handleSubmit, loading] = useHandleSubmitContactDetailsAndSign({
     checkoutId,
     checkoutSigningId,
-    onSuccess() {
-      // @TODO: add access token to session
+    onSuccess(accessToken) {
+      setCookie(AUTH_COOKIE_KEY, accessToken, {
+        maxAge: MAX_AGE,
+        expires: new Date(Date.now() + MAX_AGE * 1000),
+        sameSite: 'strict',
+        secure: process.env.NODE_ENV === 'production',
+        path: '/',
+      })
       onSignSuccess()
     },
   })

--- a/apps/store/src/pages/cart.tsx
+++ b/apps/store/src/pages/cart.tsx
@@ -52,7 +52,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (context) => 
   const { countryCode } = getCountryByLocale(locale)
 
   try {
-    const apolloClient = initializeApollo()
+    const apolloClient = initializeApollo(undefined, req, res)
     const [shopSession, globalStory] = await Promise.all([
       getShopSessionServerSide({ req, res, apolloClient, countryCode }),
       getGlobalStory({ locale, preview }),

--- a/apps/store/src/pages/checkout/contact-details.tsx
+++ b/apps/store/src/pages/checkout/contact-details.tsx
@@ -34,7 +34,7 @@ export const getServerSideProps: GetServerSideProps<NextPageProps> = async (para
   if (!isRoutingLocale(locale)) return { notFound: true }
 
   try {
-    const apolloClient = initializeApollo()
+    const apolloClient = initializeApollo(undefined, req, res)
 
     const shopSession = await getCurrentShopSessionServerSide({ req, res, apolloClient })
     const checkoutId = shopSession.checkout.id

--- a/apps/store/src/pages/checkout/index.tsx
+++ b/apps/store/src/pages/checkout/index.tsx
@@ -46,7 +46,7 @@ export const getServerSideProps: GetServerSideProps<NextPageProps> = async (cont
   if (!locale || locale === 'default') return { notFound: true }
 
   try {
-    const apolloClient = initializeApollo()
+    const apolloClient = initializeApollo(undefined, req, res)
     const shopSession = await getCurrentShopSessionServerSide({
       req,
       res,

--- a/apps/store/src/pages/checkout/payment.tsx
+++ b/apps/store/src/pages/checkout/payment.tsx
@@ -23,7 +23,7 @@ export const getServerSideProps: GetServerSideProps<CheckoutPaymentPageAdyenProp
   if (!isRoutingLocale(locale)) return { notFound: true }
 
   try {
-    const apolloClient = initializeApollo()
+    const apolloClient = initializeApollo(undefined, req, res)
     const shopSession = await getCurrentShopSessionServerSide({ req, res, apolloClient })
 
     // @TODO: remove after implementing After Sign connection flow

--- a/apps/store/src/pages/confirmation.tsx
+++ b/apps/store/src/pages/confirmation.tsx
@@ -17,7 +17,7 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps> = asy
 }) => {
   if (!isRoutingLocale(locale)) return { notFound: true }
 
-  const apolloClient = initializeApollo()
+  const apolloClient = initializeApollo(undefined, req, res)
 
   const [shopSession, globalStory] = await Promise.all([
     getCurrentShopSessionServerSide({ req, res, apolloClient }),

--- a/apps/store/src/pages/products/[product].tsx
+++ b/apps/store/src/pages/products/[product].tsx
@@ -37,7 +37,7 @@ export const getServerSideProps: GetServerSideProps<NextPageProps> = async (cont
   const { countryCode } = getCountryByLocale(locale)
 
   try {
-    const apolloClient = initializeApollo()
+    const apolloClient = initializeApollo(undefined, req, res)
 
     const [shopSession, story, globalStory] = await Promise.all([
       getShopSessionServerSide({ req, res, apolloClient, countryCode }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -20819,6 +20819,7 @@ __metadata:
     "@types/react": 18.0.21
     ajv: 8.11.0
     babel-loader: 8.2.5
+    cookies-next: 2.1.1
     dd-trace: 2.10.0
     eslint: 8.23.1
     eslint-plugin-cypress: 2.12.1


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Store access token in encrypted cookie after successful signing.

Add `cookies-next` as dependency to store app. We already used it.

Pass req + res when initializing apollo to get access token from cookies server side.

Use "auth link" from official example to pick up access token from cookies client side.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We need the authorization header to make authenticated calls to the API.

We want to access the token both client and server-side so best way to store it is in a cookie.

We should probably replace the `js-cookie` dependency and just use `cookies-next`.

## Jira issue(s): [GRW-1564]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1564]: https://hedvig.atlassian.net/browse/GRW-1564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ