### PR TITLE
Checkout start dates: Only call success callback if there are no user errors

### DIFF
--- a/apps/store/src/components/CheckoutPage/useHandleSubmitStartDates.ts
+++ b/apps/store/src/components/CheckoutPage/useHandleSubmitStartDates.ts
@@ -20,9 +20,10 @@ export const useHandleSubmitStartDates = ({ cartId, products, onSuccess }: Param
       const inputElement = event.currentTarget.elements.namedItem(product.pricedVariantId)
 
       if (!isDateInputElement(inputElement)) {
-        console.log('Unable to update start dates')
-        console.log('Input element', inputElement)
-        console.log('All elements', event.currentTarget.elements)
+        datadogLogs.logger.warn('Unable to update start dates', {
+          input: inputElement,
+          elements: event.currentTarget.elements,
+        })
         throw new Error(`No date input for ${product.pricedVariantId}`)
       }
 
@@ -34,8 +35,12 @@ export const useHandleSubmitStartDates = ({ cartId, products, onSuccess }: Param
       }
     })
 
-    await updateStartDate({ variables: { input: { cartId, updates } } })
-    onSuccess()
+    const result = await updateStartDate({ variables: { input: { cartId, updates } } })
+
+    const data = result.data
+    if (data && data.cartEntriesStartDateUpdate.userErrors.length === 0) {
+      onSuccess()
+    }
   }
 
   return [handleSubmit, result] as const


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Avoid calling `onSuccess` if API responds with user errors.

Update to use Datadog logger.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
