### PR TITLE
Store users language preference in cookie

### DIFF
--- a/apps/store/src/blocks/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock.tsx
@@ -9,7 +9,12 @@ import { InputSelect } from '@/components/InputSelect/InputSelect'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { countries } from '@/lib/l10n/countries'
 import { getCountryLocale } from '@/lib/l10n/countryUtils'
-import { LocaleField, TEMP_TRANSLATIONS } from '@/lib/l10n/locales'
+import {
+  LocaleField,
+  LOCALE_COOKIE_EXPIRY,
+  LOCALE_COOKIE_KEY,
+  TEMP_TRANSLATIONS,
+} from '@/lib/l10n/locales'
 import { getLocaleOrFallback, toRoutingLocale } from '@/lib/l10n/localeUtils'
 import { IsoLocale } from '@/lib/l10n/types'
 import { useCurrentCountry } from '@/lib/l10n/useCurrentCountry'
@@ -63,7 +68,7 @@ export const FooterBlock = ({ blok }: FooterBlockProps) => {
   const formRef = useRef<HTMLFormElement>(null)
   const { language: currentLanguage } = useCurrentLocale()
   const currentCountry = useCurrentCountry()
-  const cookiePersister = new CookiePersister('HEDVIG_LOCALE')
+  const cookiePersister = new CookiePersister(LOCALE_COOKIE_KEY)
 
   const countryList = Object.keys(countries).map((country) => ({
     name: TEMP_TRANSLATIONS[`COUNTRY_LABEL_${country}`],
@@ -84,7 +89,7 @@ export const FooterBlock = ({ blok }: FooterBlockProps) => {
 
   const router = useRouter()
   const onChangeLocale = (locale: IsoLocale) => {
-    cookiePersister.save(toRoutingLocale(locale))
+    cookiePersister.save(toRoutingLocale(locale), undefined, { expires: LOCALE_COOKIE_EXPIRY })
     router.push(router.asPath, undefined, { locale: toRoutingLocale(locale) })
   }
   const handleSubmit = (event: ChangeEvent<HTMLFormElement>) => {

--- a/apps/store/src/blocks/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock.tsx
@@ -14,6 +14,7 @@ import { getLocaleOrFallback, toRoutingLocale } from '@/lib/l10n/localeUtils'
 import { IsoLocale } from '@/lib/l10n/types'
 import { useCurrentCountry } from '@/lib/l10n/useCurrentCountry'
 import { useCurrentLocale } from '@/lib/l10n/useCurrentLocale'
+import { CookiePersister } from '@/services/persister/CookiePersister'
 import { ExpectedBlockType, LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { filterByBlockType, getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
 
@@ -62,6 +63,7 @@ export const FooterBlock = ({ blok }: FooterBlockProps) => {
   const formRef = useRef<HTMLFormElement>(null)
   const { language: currentLanguage } = useCurrentLocale()
   const currentCountry = useCurrentCountry()
+  const cookiePersister = new CookiePersister('HEDVIG_LOCALE')
 
   const countryList = Object.keys(countries).map((country) => ({
     name: TEMP_TRANSLATIONS[`COUNTRY_LABEL_${country}`],
@@ -82,6 +84,7 @@ export const FooterBlock = ({ blok }: FooterBlockProps) => {
 
   const router = useRouter()
   const onChangeLocale = (locale: IsoLocale) => {
+    cookiePersister.save(toRoutingLocale(locale))
     router.push(router.asPath, undefined, { locale: toRoutingLocale(locale) })
   }
   const handleSubmit = (event: ChangeEvent<HTMLFormElement>) => {

--- a/apps/store/src/components/CountrySelectorPage/CountrySelectorPage.tsx
+++ b/apps/store/src/components/CountrySelectorPage/CountrySelectorPage.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import Link from 'next/link'
 import { LinkButton, Space, Heading } from 'ui'
 import { countries } from '@/lib/l10n/countries'
-import { TEMP_TRANSLATIONS } from '@/lib/l10n/locales'
+import { LOCALE_COOKIE_EXPIRY, LOCALE_COOKIE_KEY, TEMP_TRANSLATIONS } from '@/lib/l10n/locales'
 import { toRoutingLocale } from '@/lib/l10n/localeUtils'
 import { IsoLocale } from '@/lib/l10n/types'
 import { CookiePersister } from '@/services/persister/CookiePersister'
@@ -22,9 +22,10 @@ const CountryOptionsContainer = styled.div({
 })
 
 export const CountrySelectorPage = (props: StoryblokPageProps) => {
-  const cookiePersister = new CookiePersister('HEDVIG_LOCALE')
+  const cookiePersister = new CookiePersister(LOCALE_COOKIE_KEY)
 
-  const onHandleClick = (locale: IsoLocale) => cookiePersister.save(toRoutingLocale(locale))
+  const onHandleClick = (locale: IsoLocale) =>
+    cookiePersister.save(toRoutingLocale(locale), undefined, { expires: LOCALE_COOKIE_EXPIRY })
 
   return (
     <Container {...props}>

--- a/apps/store/src/components/CountrySelectorPage/CountrySelectorPage.tsx
+++ b/apps/store/src/components/CountrySelectorPage/CountrySelectorPage.tsx
@@ -4,6 +4,8 @@ import { LinkButton, Space, Heading } from 'ui'
 import { countries } from '@/lib/l10n/countries'
 import { TEMP_TRANSLATIONS } from '@/lib/l10n/locales'
 import { toRoutingLocale } from '@/lib/l10n/localeUtils'
+import { IsoLocale } from '@/lib/l10n/types'
+import { CookiePersister } from '@/services/persister/CookiePersister'
 import { StoryblokPageProps } from '@/services/storyblok/storyblok'
 
 const Container = styled.div({
@@ -20,6 +22,10 @@ const CountryOptionsContainer = styled.div({
 })
 
 export const CountrySelectorPage = (props: StoryblokPageProps) => {
+  const cookiePersister = new CookiePersister('HEDVIG_LOCALE')
+
+  const onHandleClick = (locale: IsoLocale) => cookiePersister.save(toRoutingLocale(locale))
+
   return (
     <Container {...props}>
       <Space y={3}>
@@ -29,7 +35,9 @@ export const CountrySelectorPage = (props: StoryblokPageProps) => {
         <CountryOptionsContainer>
           {Object.entries(countries).map(([country, countryData]) => (
             <Link key={country} href={`/${toRoutingLocale(countryData.defaultLocale)}`} passHref>
-              <LinkButton>{TEMP_TRANSLATIONS[`COUNTRY_LABEL_${country}`]}</LinkButton>
+              <LinkButton onClick={() => onHandleClick(countryData.defaultLocale)}>
+                {TEMP_TRANSLATIONS[`COUNTRY_LABEL_${country}`]}
+              </LinkButton>
             </Link>
           ))}
         </CountryOptionsContainer>

--- a/apps/store/src/lib/l10n/locales.ts
+++ b/apps/store/src/lib/l10n/locales.ts
@@ -1,6 +1,8 @@
 import { IsoLocale, Language, Locale, RoutingLocale } from './types'
 
 export const FALLBACK_LOCALE = Locale.EnSe
+export const LOCALE_COOKIE_KEY = 'NEXT_LOCALE'
+export const LOCALE_COOKIE_EXPIRY = 365 // js-cookies expects a number which is interpreted as days
 
 export type LocaleData = {
   locale: IsoLocale

--- a/apps/store/src/middleware.ts
+++ b/apps/store/src/middleware.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { countries } from '@/lib/l10n/countries'
 import { isRoutingLocale, toRoutingLocale } from '@/lib/l10n/localeUtils'
+import { LOCALE_COOKIE_KEY } from './lib/l10n/locales'
 
 export const config = {
   matcher: '/',
@@ -13,11 +14,11 @@ export function middleware(req: NextRequest) {
   }
 
   const nextURL = req.nextUrl.clone()
-  const cookiePath = req.cookies.get('HEDVIG_LOCALE')
+  const cookiePath = req.cookies.get(LOCALE_COOKIE_KEY)
 
   if (cookiePath) {
     nextURL.pathname = cookiePath
-    console.log(`Found user preference in cookies: ${cookiePath}`)
+    console.log(`Found user preference in cookies: ${cookiePath}, redirecting`)
     return NextResponse.redirect(nextURL)
   }
 

--- a/apps/store/src/middleware.ts
+++ b/apps/store/src/middleware.ts
@@ -12,8 +12,17 @@ export function middleware(req: NextRequest) {
     return
   }
 
-  const country = req.geo?.country
   const nextURL = req.nextUrl.clone()
+  const cookiePath = req.cookies.get('HEDVIG_LOCALE')
+
+  if (cookiePath) {
+    nextURL.pathname = cookiePath
+    console.log(`Found user preference in cookies: ${cookiePath}`)
+    return NextResponse.redirect(nextURL)
+  }
+
+  const country = req.geo?.country
+
   switch (country) {
     case countries.NO.id:
       nextURL.pathname = toRoutingLocale(countries.NO.defaultLocale)
@@ -25,13 +34,13 @@ export function middleware(req: NextRequest) {
       nextURL.pathname = toRoutingLocale(countries.SE.defaultLocale)
       break
     default:
-      console.debug(`Routing visitor from ${country} to country selector`)
+      console.log(`Routing visitor from ${country} to country selector`)
       nextURL.pathname = '/country-selector'
       return NextResponse.rewrite(nextURL)
   }
 
   // DD logger cannot be used in middleware since Pino isn't support in Edge runtime (2022-09-27//siau)
   // Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime
-  console.debug(`Routing visitor from ${country} to ${nextURL}`)
+  console.log(`Routing visitor from ${country} to ${nextURL}`)
   return NextResponse.redirect(nextURL)
 }

--- a/apps/store/src/services/persister/CookiePersister.ts
+++ b/apps/store/src/services/persister/CookiePersister.ts
@@ -4,8 +4,8 @@ import { SimplePersister } from './Persister.types'
 export class CookiePersister implements SimplePersister {
   constructor(private readonly cookieKey: string) {}
 
-  public save(id: string, cookieKey = this.cookieKey) {
-    Cookies.set(cookieKey, id, { path: '/' })
+  public save(value: string, cookieKey = this.cookieKey, options?: Cookies.CookieAttributes) {
+    Cookies.set(cookieKey, value, { path: '/', ...options })
   }
 
   public fetch(cookieKey = this.cookieKey) {

--- a/apps/store/src/services/persister/Persister.types.ts
+++ b/apps/store/src/services/persister/Persister.types.ts
@@ -1,5 +1,7 @@
+import Cookies from 'js-cookie'
+
 export interface SimplePersister {
-  save(id: string, key?: string): void
+  save(value: string, key?: string, options?: Cookies.CookieAttributes): void
 
   fetch(key?: string): string | null
 

--- a/apps/store/src/services/persister/ServerCookiePersister.ts
+++ b/apps/store/src/services/persister/ServerCookiePersister.ts
@@ -1,3 +1,4 @@
+import Cookies from 'js-cookie'
 import { GetServerSidePropsContext } from 'next'
 import { SimplePersister } from './Persister.types'
 
@@ -8,10 +9,14 @@ export class ServerCookiePersister implements SimplePersister {
     private readonly response: GetServerSidePropsContext['res'],
   ) {}
 
-  public save(id: string, cookieKey = this.cookieKey) {
+  public save(value: string, cookieKey = this.cookieKey, options?: Cookies.CookieAttributes) {
     const rawHeader = this.response.getHeader('Set-Cookie')
     const existingHeaders = Array.isArray(rawHeader) ? rawHeader : []
-    this.response.setHeader('Set-Cookie', [...existingHeaders, `${cookieKey}=${id}; Path=/`])
+    const { expires } = options || {}
+    this.response.setHeader('Set-Cookie', [
+      ...existingHeaders,
+      `${cookieKey}=${value}; Max-Age=${this.calculateMaxAge(expires)} Path=/`,
+    ])
   }
 
   public fetch(cookieKey = this.cookieKey) {
@@ -20,5 +25,17 @@ export class ServerCookiePersister implements SimplePersister {
 
   public reset(cookieKey = this.cookieKey) {
     this.response.setHeader('Set-Cookie', [`${cookieKey}=; Max-Age=0`])
+  }
+
+  /**
+   * Converts a Date into Unix Epoc since that's what Max-Age expects
+   * @param value Possible values for expires option. If number, treated as number of days to conform to js-cookie's implementation
+   * @returns Undefined or number: milliseconds until expiry
+   */
+  private calculateMaxAge(value: number | Date | undefined) {
+    if (typeof value === 'undefined') return value
+    if (typeof value === 'number') return value * 1000 * 60 * 60 * 24
+
+    return value.getTime()
   }
 }

--- a/apps/store/src/services/priceIntent/PriceIntent.helpers.ts
+++ b/apps/store/src/services/priceIntent/PriceIntent.helpers.ts
@@ -21,7 +21,7 @@ export const priceIntentServiceInitServerSide = ({
   apolloClient,
 }: Params) => {
   return new PriceIntentService(
-    new ServerCookiePersister(COOKIE_KEY_PRICE_INTENT, req, res),
+    new ServerCookiePersister(COOKIE_KEY_PRICE_INTENT, req, res), // FIXME: it makes no sense to pass in this key anymore since it's always overridden
     apolloClient,
     shopSession,
   )
@@ -32,7 +32,7 @@ export const priceIntentServiceInitClientSide = ({
   apolloClient,
 }: Omit<Params, 'req' | 'res'>) => {
   return new PriceIntentService(
-    new CookiePersister(COOKIE_KEY_PRICE_INTENT),
+    new CookiePersister(COOKIE_KEY_PRICE_INTENT), // FIXME: it makes no sense to pass in this key anymore since it's always overridden
     apolloClient,
     shopSession,
   )


### PR DESCRIPTION
Use it in middleware to redirect to instead of country picker

<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Store users' preference of language in cookie.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

If the user has picked a language preference they shouldn't need to see the Country selector again. And if they picked English in Sweden the country selector page would still route to `/se`, not `/en-se`.

## Jira issue(s): []

Don't mind the error messages. They appear when clearing cookies.

https://user-images.githubusercontent.com/1343979/193598594-23414fa9-605a-4cbb-9c30-b665758c28af.mov


<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
