### PR TITLE
Set grid layout for desktop and aspect ratio for image

### DIFF
--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -2,9 +2,6 @@ import styled from '@emotion/styled'
 import ImageProps from 'next/image'
 import { Space } from 'ui'
 
-export const PRODUCT_CARD_IMAGE_WIDTH_SMALL = '10.5rem'
-const PRODUCT_CARD_IMAGE_HEIGHT_SMALL = '12.5rem'
-
 type ImageProps = {
   src: string
   alt?: string
@@ -38,13 +35,17 @@ export const ProductCard = ({
 
 const Wrapper = styled(Space)({
   height: '100%',
-  width: PRODUCT_CARD_IMAGE_WIDTH_SMALL,
 })
 
 const ImageWrapper = styled.div(() => ({
   position: 'relative',
-  height: PRODUCT_CARD_IMAGE_HEIGHT_SMALL,
-  width: '100%',
+  aspectRatio: '5 / 6',
+
+  '@supports not (aspect-ratio)': {
+    height: '0',
+    paddingTop: 'calc((6/5 * 100%))',
+    overflow: 'hidden',
+  },
 }))
 
 const Title = styled.p(({ theme }) => ({

--- a/apps/store/src/components/ProductGrid/ProductGrid.tsx
+++ b/apps/store/src/components/ProductGrid/ProductGrid.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
-import { Space } from 'ui'
-import { PRODUCT_CARD_IMAGE_WIDTH_SMALL } from '@/components/ProductCard/ProductCard'
+import { Fragment } from 'react'
+import { mq, Space } from 'ui'
 
 export type ProductGridProps<Item> = {
   title?: string
@@ -18,7 +18,7 @@ export const ProductGrid = <ItemType extends { key: string }>({
       {title && <Title>{title}</Title>}
       <Grid>
         {items.map((item) => (
-          <GridItem key={item.key}>{children(item)}</GridItem>
+          <Fragment key={item.key}>{children(item)}</Fragment>
         ))}
       </Grid>
     </Wrapper>
@@ -38,11 +38,11 @@ const Title = styled.p(({ theme }) => ({
 
 const Grid = styled.div({
   display: 'grid',
-  gridTemplateColumns: `repeat(auto-fill, minmax(${PRODUCT_CARD_IMAGE_WIDTH_SMALL}, 1fr))`,
+  gridTemplateColumns: `repeat(2, 1fr)`,
   gap: '1.5rem 0.5rem',
-})
 
-const GridItem = styled.div({
-  display: 'flex',
-  justifyContent: 'center',
+  [mq.md]: {
+    gridTemplateColumns: `repeat(4, 1fr)`,
+    gap: '2.5rem 1.5rem',
+  },
 })


### PR DESCRIPTION
## Describe your changes
- Set ProductGrid to 4 columns in desktop
- Set image aspect ratio rather than using hardcoded units
- Add fallback for aspect ratio to support Safari 14

## Justify why they are needed
The design should scale to desktop. Start with a set 4 column layout and adjust accordingly when we have determined variants of the ProductGrid and sharp desktop design.

https://user-images.githubusercontent.com/6661511/193932218-1aff3265-723b-4e4b-8a9a-b50ca245a3b4.mov

### Safari 14
<img width="1787" alt="Screenshot 2022-10-04 at 23 23 43" src="https://user-images.githubusercontent.com/6661511/193932738-ea2ab9a1-2198-4bd8-a9f5-0687b5892a98.png">


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
