### PR TITLE
Fix / Allow require() calls when linting NodeJs files

### DIFF
--- a/packages/scripts/.eslintrc.js
+++ b/packages/scripts/.eslintrc.js
@@ -61,5 +61,15 @@ module.exports = {
         'testing-library/no-container': 'off',
       },
     },
+    // Allow requires in node js modules (assuming we don't have JS on frontend side)
+    {
+      files: ['**/*.js'],
+      env: {
+        node: true,
+      },
+      rules: {
+        '@typescript-eslint/no-var-requires': 'off',
+      },
+    },
   ],
 }

--- a/packages/scripts/eslint-preset-next.js
+++ b/packages/scripts/eslint-preset-next.js
@@ -1,6 +1,4 @@
-// eslint-disable-next-line no-undef, @typescript-eslint/no-var-requires
 const config = require('./.eslintrc')
-// eslint-disable-next-line no-undef
 module.exports = {
   ...config,
   extends: [...config.extends, 'next/core-web-vitals'],

--- a/packages/ui/.eslintrc.js
+++ b/packages/ui/.eslintrc.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires, no-undef
 module.exports = require('scripts/eslint-preset')

--- a/packages/ui/jest.transform.js
+++ b/packages/ui/jest.transform.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 // OK to use require in node context
 // eslint-disable-next-line
 const babel = require('babel-jest')


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Overwrite eslint config to recognise JS files as Node environment
Stop complaining about require() calls there

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
