### PR TITLE
GRW-1587 - refact(initializeApollo): updated functions signature to accept a configuration object

### DIFF
--- a/apps/store/src/pages/cart.tsx
+++ b/apps/store/src/pages/cart.tsx
@@ -61,7 +61,7 @@ export const getServerSideProps: GetServerSideProps<
   const { countryCode } = getCountryByLocale(locale)
 
   try {
-    const apolloClient = initializeApollo(undefined, req, res)
+    const apolloClient = initializeApollo({ req, res })
     const [shopSession, globalStory] = await Promise.all([
       getShopSessionServerSide({ req, res, apolloClient, countryCode }),
       getGlobalStory({ locale, version }),

--- a/apps/store/src/pages/checkout/contact-details.tsx
+++ b/apps/store/src/pages/checkout/contact-details.tsx
@@ -34,7 +34,7 @@ export const getServerSideProps: GetServerSideProps<NextPageProps> = async (para
   if (!isRoutingLocale(locale)) return { notFound: true }
 
   try {
-    const apolloClient = initializeApollo(undefined, req, res)
+    const apolloClient = initializeApollo({ req, res })
 
     const shopSession = await getCurrentShopSessionServerSide({ req, res, apolloClient })
     const checkoutId = shopSession.checkout.id

--- a/apps/store/src/pages/checkout/index.tsx
+++ b/apps/store/src/pages/checkout/index.tsx
@@ -46,7 +46,7 @@ export const getServerSideProps: GetServerSideProps<NextPageProps> = async (cont
   if (!locale || locale === 'default') return { notFound: true }
 
   try {
-    const apolloClient = initializeApollo(undefined, req, res)
+    const apolloClient = initializeApollo({ req, res })
     const shopSession = await getCurrentShopSessionServerSide({
       req,
       res,

--- a/apps/store/src/pages/checkout/payment.tsx
+++ b/apps/store/src/pages/checkout/payment.tsx
@@ -24,7 +24,7 @@ export const getServerSideProps: GetServerSideProps<CheckoutPaymentPageAdyenProp
   if (!isRoutingLocale(locale)) return { notFound: true }
 
   try {
-    const apolloClient = initializeApollo(undefined, req, res)
+    const apolloClient = initializeApollo({ req, res })
     const shopSession = await getCurrentShopSessionServerSide({ req, res, apolloClient })
 
     const isPaymentBeforeSign =

--- a/apps/store/src/pages/confirmation/[shopSessionId].tsx
+++ b/apps/store/src/pages/confirmation/[shopSessionId].tsx
@@ -22,7 +22,7 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
   const shopSessionId = params?.shopSessionId
   if (!shopSessionId) return { notFound: true }
 
-  const apolloClient = initializeApollo(undefined, req, res)
+  const apolloClient = initializeApollo({ req, res })
   const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
 
   try {

--- a/apps/store/src/pages/products/[product].tsx
+++ b/apps/store/src/pages/products/[product].tsx
@@ -55,7 +55,7 @@ export const getServerSideProps: GetServerSideProps<
   const { countryCode } = getCountryByLocale(locale)
 
   try {
-    const apolloClient = initializeApollo(undefined, req, res)
+    const apolloClient = initializeApollo({ req, res })
 
     const [shopSession, story, globalStory] = await Promise.all([
       getShopSessionServerSide({ req, res, apolloClient, countryCode }),

--- a/apps/store/src/services/apollo/client.ts
+++ b/apps/store/src/services/apollo/client.ts
@@ -49,9 +49,11 @@ type InitializeApolloParams = {
   res?: GetServerSidePropsContext['res']
 }
 
-export const initializeApollo = (
-  { initialState, req, res }: InitializeApolloParams = { initialState: null },
-) => {
+export const initializeApollo = ({
+  initialState = null,
+  req,
+  res,
+}: InitializeApolloParams = {}) => {
   const _apolloClient = apolloClient ?? createApolloClient(Auth.getAccessToken(req, res))
 
   if (initialState) {

--- a/apps/store/src/services/apollo/client.ts
+++ b/apps/store/src/services/apollo/client.ts
@@ -43,10 +43,14 @@ const createApolloClient = (accessToken?: string) => {
   })
 }
 
+type InitializeApolloParams = {
+  initialState?: unknown
+  req?: GetServerSidePropsContext['req']
+  res?: GetServerSidePropsContext['res']
+}
+
 export const initializeApollo = (
-  initialState: unknown = null,
-  req?: GetServerSidePropsContext['req'],
-  res?: GetServerSidePropsContext['res'],
+  { initialState, req, res }: InitializeApolloParams = { initialState: null },
 ) => {
   const _apolloClient = apolloClient ?? createApolloClient(Auth.getAccessToken(req, res))
 


### PR DESCRIPTION
## Describe your changes

Updated `initializeApollo` function signature to accept a configuration object instead of a list of arguments

## Justify why they are needed

It simplifies its usage

## Jira issue(s): [GRW-1587](https://hedvig.atlassian.net/browse/GRW-1587)