### PR TITLE
Redirect to web onboarding to connect payment after sign

### DIFF
--- a/apps/store/.env.local.example
+++ b/apps/store/.env.local.example
@@ -6,6 +6,8 @@ NEXT_PUBLIC_GRAPHQL_ENDPOINT=
 REVALIDATE_SECRET=
 NEXT_PUBLIC_API_MOCKING=<enabled>
 
+WEB_ONBOARDING_PAYMENT_URL_AFTER_SIGN=https://www.dev.hedvigit.com/{LOCALE}/connect-payment/direct
+
 # Datadog
 DD_SERVICE=racoon-store
 NEXT_PUBLIC_DATADOG_SERVICE_NAME=racoon-store

--- a/apps/store/src/pages/checkout/payment.tsx
+++ b/apps/store/src/pages/checkout/payment.tsx
@@ -8,9 +8,11 @@ import { isRoutingLocale } from '@/lib/l10n/localeUtils'
 import { PageLink } from '@/lib/PageLink'
 import { initializeApollo } from '@/services/apollo/client'
 import { PaymentConnectionFlow } from '@/services/apollo/generated'
+import * as Auth from '@/services/Auth/Auth'
 import { fetchCurrentCheckoutSigning } from '@/services/Checkout/Checkout.helpers'
 import logger from '@/services/logger/server'
 import { getCurrentShopSessionServerSide } from '@/services/shopSession/ShopSession.helpers'
+import { getWebOnboardingPaymentURL } from '@/services/WebOnboarding/WebOnboarding.helpers'
 
 const NextCheckoutPaymentPageAdyen: NextPage<CheckoutPaymentPageAdyenProps> = (props) => {
   return <CheckoutPaymentPageAdyen {...props} />
@@ -38,6 +40,12 @@ export const getServerSideProps: GetServerSideProps<CheckoutPaymentPageAdyenProp
           permanent: false,
         },
       }
+    }
+
+    const accessToken = Auth.getAccessToken(req, res)
+    const woPaymentURL = accessToken ? getWebOnboardingPaymentURL({ locale, accessToken }) : null
+    if (woPaymentURL) {
+      return { redirect: { destination: woPaymentURL, permanent: false } }
     }
 
     const paymentMethodsResponse = await fetchAvailablePaymentMethods({

--- a/apps/store/src/services/WebOnboarding/WebOnboarding.helpers.test.ts
+++ b/apps/store/src/services/WebOnboarding/WebOnboarding.helpers.test.ts
@@ -1,0 +1,14 @@
+import { RoutingLocale } from '@/lib/l10n/types'
+import { convertRoutingLocale } from './WebOnboarding.helpers'
+
+describe('convertRoutingLocale', () => {
+  it.each<[RoutingLocale, string]>([
+    ['se', 'se'],
+    ['en-se', 'se-en'],
+    ['dk', 'dk'],
+    ['en-no', 'no-en'],
+    ['da-dk', 'dk'],
+  ])('asserts %p expecting %p', (locale, expected) => {
+    expect(convertRoutingLocale(locale)).toBe(expected)
+  })
+})

--- a/apps/store/src/services/WebOnboarding/WebOnboarding.helpers.ts
+++ b/apps/store/src/services/WebOnboarding/WebOnboarding.helpers.ts
@@ -1,0 +1,37 @@
+import { RoutingLocale } from '@/lib/l10n/types'
+
+const PAYMENT_URL_TEMPLATE = process.env.WEB_ONBOARDING_PAYMENT_URL_AFTER_SIGN
+
+// We've historically been using different locale paths in Web Onboarding
+export const convertRoutingLocale = (locale: RoutingLocale) => {
+  switch (locale) {
+    case 'dk':
+    case 'no':
+    case 'se':
+      return locale
+
+    case 'en-dk':
+    case 'en-no':
+    case 'en-se':
+      return locale.split('-').reverse().join('-')
+
+    case 'da-dk':
+    case 'sv-se':
+    case 'nb-no':
+      return locale.slice(3)
+  }
+}
+
+type Params = {
+  locale: RoutingLocale
+  accessToken: string
+}
+
+export const getWebOnboardingPaymentURL = ({ locale, accessToken }: Params) => {
+  if (PAYMENT_URL_TEMPLATE) {
+    const baseURL = PAYMENT_URL_TEMPLATE.replace('{LOCALE}', convertRoutingLocale(locale))
+    return `${baseURL}?accessToken=${accessToken}`
+  }
+
+  return null
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Redirect users to web-onboarding to connect payment (AFTER_SIGN).

Add new env var `WEB_ONBOARDING_PAYMENT_URL_AFTER_SIGN`.

Add `WebOnboarding` helpers to hide implementation details from the rest of the app.

> This only solve the AFTER_SIGN payment flow. And assumes we are only using that for SWEDEN. Web Onboarding also needs to support sending the access token in this way. A better solution would be to get an "exchange token" from the API and use that, the same way we do for the HOPE payment link feature.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

To be able to reuse Giraffe payment APIs for Hedvig.com.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
