### PR TITLE
GRW-1604 / feat/  Add page for rendering reusable-blocks stories

### DIFF
--- a/apps/store/src/blocks/ReusableBlockReference.tsx
+++ b/apps/store/src/blocks/ReusableBlockReference.tsx
@@ -1,8 +1,8 @@
 import { StoryblokComponent } from '@storyblok/react'
-import { ReferenceStory, SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { ReusableStory, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
 type ReusableBlockReferenceProps = SbBaseBlockProps<{
-  reference: ReferenceStory
+  reference: ReusableStory
 }>
 
 export const ReusableBlockReference = ({ blok }: ReusableBlockReferenceProps) => {

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -8,7 +8,7 @@ import {
   getStoryBySlug,
   StoryblokPageProps,
   StoryblokQueryParams,
-  getNonProductPageLinks,
+  getFilteredPageLinks,
   StoryblokPreviewData,
 } from '@/services/storyblok/storyblok'
 
@@ -58,7 +58,7 @@ export const getStaticProps: GetStaticProps<
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const pageLinks = await getNonProductPageLinks()
+  const pageLinks = await getFilteredPageLinks()
   const paths: RoutingPath[] = pageLinks.map(({ locale, slugParts }) => {
     return { params: { slug: slugParts }, locale }
   })

--- a/apps/store/src/pages/reusable-blocks/[...slug].tsx
+++ b/apps/store/src/pages/reusable-blocks/[...slug].tsx
@@ -1,0 +1,53 @@
+import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
+import { GetServerSideProps, NextPage } from 'next'
+import Head from 'next/head'
+import { isRoutingLocale } from '@/lib/l10n/localeUtils'
+import {
+  getStoryBySlug,
+  ReusableStory,
+  StoryblokPreviewData,
+  StoryblokQueryParams,
+} from '@/services/storyblok/storyblok'
+
+type ReusableBlockPageProps = {
+  story: ReusableStory
+}
+
+const NextReusableBlockPage: NextPage<ReusableBlockPageProps> = (props) => {
+  const story = useStoryblokState(props.story)
+  return (
+    <>
+      <Head>
+        <title>{props.story.content.name}</title>
+      </Head>
+      <StoryblokComponent blok={story.content} />
+    </>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps<
+  ReusableBlockPageProps,
+  StoryblokQueryParams,
+  StoryblokPreviewData
+> = async (context) => {
+  const { locale, params, previewData: { version } = {} } = context
+  const slug = (params?.slug ?? []).join('/')
+
+  if (typeof slug !== 'string') return { notFound: true }
+  if (!isRoutingLocale(locale)) return { notFound: true }
+
+  const story = await getStoryBySlug(`/reusable-blocks/${slug}`, { locale, version })
+
+  if (story === undefined) {
+    console.warn(`Page not found: /reusable-blocks/${slug}, locale: ${locale}`)
+    return { notFound: true }
+  }
+
+  return {
+    props: {
+      story,
+    },
+  }
+}
+
+export default NextReusableBlockPage

--- a/apps/store/src/pages/reusable-blocks/[...slug].tsx
+++ b/apps/store/src/pages/reusable-blocks/[...slug].tsx
@@ -2,6 +2,7 @@ import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
 import { GetServerSideProps, NextPage } from 'next'
 import Head from 'next/head'
 import { isRoutingLocale } from '@/lib/l10n/localeUtils'
+import logger from '@/services/logger/server'
 import {
   getStoryBySlug,
   ReusableStory,
@@ -31,25 +32,25 @@ export const getServerSideProps: GetServerSideProps<
   StoryblokPreviewData
 > = async (context) => {
   const { locale, params, previewData: { version } = {} } = context
-  const slug = (params?.slug ?? []).join('/')
 
-  if (typeof slug !== 'string') return { notFound: true }
   if (!isRoutingLocale(locale)) return { notFound: true }
 
-  const story = (await getStoryBySlug(`/reusable-blocks/${slug}`, {
-    locale,
-    version,
-  })) as ReusableStory
+  const slug = (params?.slug ?? []).join('/')
 
-  if (story === undefined) {
-    console.warn(`Page not found: /reusable-blocks/${slug}, locale: ${locale}`)
+  try {
+    const story = (await getStoryBySlug(`/reusable-blocks/${slug}`, {
+      locale,
+      version,
+    })) as ReusableStory
+
+    return {
+      props: {
+        story,
+      },
+    }
+  } catch (error) {
+    logger.error(error)
     return { notFound: true }
-  }
-
-  return {
-    props: {
-      story,
-    },
   }
 }
 

--- a/apps/store/src/pages/reusable-blocks/[...slug].tsx
+++ b/apps/store/src/pages/reusable-blocks/[...slug].tsx
@@ -36,7 +36,10 @@ export const getServerSideProps: GetServerSideProps<
   if (typeof slug !== 'string') return { notFound: true }
   if (!isRoutingLocale(locale)) return { notFound: true }
 
-  const story = await getStoryBySlug(`/reusable-blocks/${slug}`, { locale, version })
+  const story = (await getStoryBySlug(`/reusable-blocks/${slug}`, {
+    locale,
+    version,
+  })) as ReusableStory
 
   if (story === undefined) {
     console.warn(`Page not found: /reusable-blocks/${slug}, locale: ${locale}`)

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -216,9 +216,12 @@ export const getPageLinks = async (): Promise<PageLink[]> => {
 }
 
 const PRODUCTS_SLUG = 'products'
-export const getNonProductPageLinks = async () => {
+const REUSABLE_BLOCK = 'reusable-blocks'
+export const getFilteredPageLinks = async () => {
   const allLinks = await getPageLinks()
-  return allLinks.filter(({ slugParts }) => slugParts[0] !== PRODUCTS_SLUG)
+  return allLinks.filter(
+    ({ slugParts }) => slugParts[0] !== PRODUCTS_SLUG && slugParts[0] !== REUSABLE_BLOCK,
+  )
 }
 
 export const getGlobalStory = async (options: StoryOptions) => {

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -105,7 +105,7 @@ export type GlobalStory = StoryData & {
   }
 }
 
-export type ReferenceStory = StoryData & {
+export type ReusableStory = StoryData & {
   content: StoryData['content'] & {
     body: Array<SbBlokData>
   }
@@ -162,7 +162,7 @@ export const initStoryblok = () => {
     TopPickCardBlock,
     PerilsBlock,
   ]
-  const blockAliases = { product: PageBlock }
+  const blockAliases = { product: PageBlock, reusableBlock: PageBlock }
   const components = {
     ...Object.fromEntries(
       blockComponents.map((blockComponent) => [blockComponent.blockName, blockComponent]),


### PR DESCRIPTION
## Describe your changes
Add a new route and page template for `/reusable-blocks`

## Justify why they are needed
Render Reusable block stories in Storyblok

I get a type error I can't figure out though... 

```js
store:build: Type error: 
Type '(context: GetServerSidePropsContext<StoryblokQueryParams, StoryblokPreviewData>) => 
Promise<{ notFound: true; props?: undefined; } | { ...; }>' is not assignable to type
'GetServerSideProps<ReusableBlockPageProps, StoryblokQueryParams, StoryblokPreviewData>'.
```

### Storyblok
<img width="1792" alt="Screenshot 2022-10-06 at 16 44 02 (2)" src="https://user-images.githubusercontent.com/6661511/194359817-730a0c9c-dae8-4782-9124-36718de16a67.png">


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
