### PR TITLE
Implement device id header

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-switch": "1.0.0",
     "@radix-ui/react-tabs": "1.0.0",
     "@storyblok/react": "1.3.2",
+    "@types/uuid": "8.3.4",
     "ajv": "8.11.0",
     "cookies-next": "2.1.1",
     "dd-trace": "3.3.1",
@@ -45,7 +46,8 @@
     "pino-pretty": "9.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "ui": "workspace:"
+    "ui": "workspace:",
+    "uuid": "9.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.19.3",

--- a/apps/store/src/pages/checkout/payment.tsx
+++ b/apps/store/src/pages/checkout/payment.tsx
@@ -8,7 +8,6 @@ import { isRoutingLocale } from '@/lib/l10n/localeUtils'
 import { PageLink } from '@/lib/PageLink'
 import { initializeApollo } from '@/services/apollo/client'
 import { PaymentConnectionFlow } from '@/services/apollo/generated'
-import * as Auth from '@/services/Auth/Auth'
 import { fetchCurrentCheckoutSigning } from '@/services/Checkout/Checkout.helpers'
 import logger from '@/services/logger/server'
 import { getCurrentShopSessionServerSide } from '@/services/shopSession/ShopSession.helpers'
@@ -42,8 +41,7 @@ export const getServerSideProps: GetServerSideProps<CheckoutPaymentPageAdyenProp
       }
     }
 
-    const accessToken = Auth.getAccessToken(req, res)
-    const woPaymentURL = accessToken ? getWebOnboardingPaymentURL({ locale, accessToken }) : null
+    const woPaymentURL = getWebOnboardingPaymentURL({ locale })
     if (woPaymentURL) {
       return { redirect: { destination: woPaymentURL, permanent: false } }
     }

--- a/apps/store/src/services/Auth/Auth.ts
+++ b/apps/store/src/services/Auth/Auth.ts
@@ -1,5 +1,5 @@
 import { getCookie, setCookie } from 'cookies-next'
-import { GetServerSidePropsContext } from 'next'
+import { OptionsType } from 'cookies-next/lib/types'
 
 const AUTH_COOKIE_KEY = 'HEDVIG_ACCESS_TOKEN'
 const MAX_AGE = 60 * 60 * 24 // 24 hours
@@ -13,10 +13,15 @@ export const save = (accessToken: string) => {
   })
 }
 
-export const getAccessToken = (
-  req?: GetServerSidePropsContext['req'],
-  res?: GetServerSidePropsContext['res'],
-) => {
+type CookieParams = Pick<OptionsType, 'req' | 'res'>
+
+const getAccessToken = ({ req, res }: CookieParams) => {
   const value = getCookie(AUTH_COOKIE_KEY, { req, res })
   return typeof value === 'string' ? value : undefined
+}
+
+export const getAuthHeader = (params: CookieParams = {}): Record<string, string> => {
+  const accessToken = getAccessToken(params)
+  if (accessToken) return { authorization: accessToken }
+  return {}
 }

--- a/apps/store/src/services/LocalContext/LocalContext.helpers.ts
+++ b/apps/store/src/services/LocalContext/LocalContext.helpers.ts
@@ -1,0 +1,28 @@
+import { getCookie, setCookie } from 'cookies-next'
+import { OptionsType } from 'cookies-next/lib/types'
+import { v4 as uuidv4 } from 'uuid'
+
+const DEVICE_ID_COOKIE_KEY = '_hv_device_id'
+const MAX_AGE = 10 * 365 * 24 * 60 * 60 // 10 years
+
+type Params = Pick<OptionsType, 'req' | 'res'>
+
+const getOrCreateDeviceId = ({ req, res }: Params) => {
+  const currentDeviceId = getDeviceId({ req, res })
+  if (currentDeviceId) return currentDeviceId
+
+  const newDeviceId = uuidv4()
+  setCookie(DEVICE_ID_COOKIE_KEY, newDeviceId, { req, res, maxAge: MAX_AGE })
+  return newDeviceId
+}
+
+const getDeviceId = ({ req, res }: Params) => {
+  const value = getCookie(DEVICE_ID_COOKIE_KEY, { req, res })
+  return typeof value === 'string' ? value : undefined
+}
+
+export const getDeviceIdHeader = (params: Params) => {
+  return {
+    'hedvig-device-id': getOrCreateDeviceId(params),
+  }
+}

--- a/apps/store/src/services/WebOnboarding/WebOnboarding.helpers.ts
+++ b/apps/store/src/services/WebOnboarding/WebOnboarding.helpers.ts
@@ -24,13 +24,11 @@ export const convertRoutingLocale = (locale: RoutingLocale) => {
 
 type Params = {
   locale: RoutingLocale
-  accessToken: string
 }
 
-export const getWebOnboardingPaymentURL = ({ locale, accessToken }: Params) => {
+export const getWebOnboardingPaymentURL = ({ locale }: Params) => {
   if (PAYMENT_URL_TEMPLATE) {
-    const baseURL = PAYMENT_URL_TEMPLATE.replace('{LOCALE}', convertRoutingLocale(locale))
-    return `${baseURL}?accessToken=${accessToken}`
+    return PAYMENT_URL_TEMPLATE.replace('{LOCALE}', convertRoutingLocale(locale))
   }
 
   return null

--- a/yarn.lock
+++ b/yarn.lock
@@ -6483,6 +6483,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/uuid@npm:8.3.4":
+  version: 8.3.4
+  resolution: "@types/uuid@npm:8.3.4"
+  checksum: 6f11f3ff70f30210edaa8071422d405e9c1d4e53abbe50fdce365150d3c698fe7bbff65c1e71ae080cbfb8fded860dbb5e174da96fdbbdfcaa3fb3daa474d20f
+  languageName: node
+  linkType: hard
+
 "@types/webpack-env@npm:^1.16.0":
   version: 1.16.3
   resolution: "@types/webpack-env@npm:1.16.3"
@@ -20980,6 +20987,7 @@ __metadata:
     "@types/js-cookie": 3.0.2
     "@types/node": 16.11.64
     "@types/react": 18.0.21
+    "@types/uuid": 8.3.4
     ajv: 8.11.0
     babel-loader: 8.2.5
     cookies-next: 2.1.1
@@ -21011,6 +21019,7 @@ __metadata:
     tsconfig: "workspace:"
     typescript: 4.8.4
     ui: "workspace:"
+    uuid: 9.0.0
     whatwg-fetch: 3.6.2
   languageName: unknown
   linkType: soft
@@ -22930,6 +22939,15 @@ __metadata:
   version: 3.1.0
   resolution: "uuid-browser@npm:3.1.0"
   checksum: 951ec47593865c7cc746df671f7b0f0ff48fcab583fcdaeab6c517a5222af0f5e144a6fcea5fa9620a5b3be047e2f9412a80267ea5c45050e07d51774197d49e
+  languageName: node
+  linkType: hard
+
+"uuid@npm:9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes

Implement the device ID setup that we have on Web Onboarding.

Bascially we create a unique UUID that we store in the browser.
Then we send this as a header with all requests to the backend.

## Justify why they are needed

I decided to link this to the Apollo Client setup to ensure that the UUID is created before we send any API requests.

I talked with Aleks about collecting things like this in a `LocalContext` -- let's iterate on exactly how it should work!

The purpose with the header is to link a `ShopSession` with a `PaymentConnection` on the backend.

## Jira issue(s): [GRW-1609]

## Checklist before requesting a review

- [x] I have performed a self-review of my code


[GRW-1609]: https://hedvig.atlassian.net/browse/GRW-1609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ