### PR TITLE
Add callback to web-onboarding payment URL

### DIFF
--- a/apps/store/src/lib/PageLink.ts
+++ b/apps/store/src/lib/PageLink.ts
@@ -22,6 +22,8 @@ export const PageLink = {
     const queryString = authStatusQueryParam ? `?${authStatusQueryParam}` : ''
     return `${localePrefix(locale)}/checkout/payment${queryString}`
   },
+  checkoutPaymentRedirectBase: ({ locale }: Required<BaseParams>) =>
+    `${localePrefix(locale)}/checkout/payment`,
   checkoutSign: ({ locale }: BaseParams = {}) => `${localePrefix(locale)}/checkout/sign`,
   confirmation: ({ locale, shopSessionId }: ConfirmationPage) =>
     `${localePrefix(locale)}/confirmation/${shopSessionId}`,

--- a/apps/store/src/pages/checkout/payment.tsx
+++ b/apps/store/src/pages/checkout/payment.tsx
@@ -41,9 +41,12 @@ export const getServerSideProps: GetServerSideProps<CheckoutPaymentPageAdyenProp
       }
     }
 
-    const woPaymentURL = getWebOnboardingPaymentURL({ locale })
-    if (woPaymentURL) {
-      return { redirect: { destination: woPaymentURL, permanent: false } }
+    if (!isPaymentBeforeSign) {
+      const redirectURL = new URL(PageLink.checkoutPaymentRedirectBase({ locale }))
+      const woPaymentURL = getWebOnboardingPaymentURL({ locale, redirectURL })
+      if (woPaymentURL) {
+        return { redirect: { destination: woPaymentURL, permanent: false } }
+      }
     }
 
     const paymentMethodsResponse = await fetchAvailablePaymentMethods({

--- a/apps/store/src/pages/checkout/payment/[status].tsx
+++ b/apps/store/src/pages/checkout/payment/[status].tsx
@@ -1,0 +1,64 @@
+import type { GetServerSideProps, NextPage } from 'next'
+import Link from 'next/link'
+import { isRoutingLocale } from '@/lib/l10n/localeUtils'
+import { PageLink } from '@/lib/PageLink'
+import { initializeApollo } from '@/services/apollo/client'
+import { PaymentConnectionFlow } from '@/services/apollo/generated'
+import logger from '@/services/logger/server'
+import { getCurrentShopSessionServerSide } from '@/services/shopSession/ShopSession.helpers'
+
+const PaymentRedirectPage: NextPage = () => {
+  return (
+    <div>
+      Something went wrong. Please <Link href={PageLink.checkoutPayment()}>try again</Link>.
+    </div>
+  )
+}
+
+type Props = Record<string, unknown>
+type Params = { status: string }
+
+export const getServerSideProps: GetServerSideProps<Props, Params> = async (context) => {
+  const { req, res, locale, params } = context
+  const status = params?.status
+
+  if (!status) return { notFound: true }
+  if (!isRoutingLocale(locale)) return { notFound: true }
+
+  try {
+    const apolloClient = initializeApollo({ req, res })
+    const shopSession = await getCurrentShopSessionServerSide({ req, res, apolloClient })
+
+    const isPaymentBeforeSign =
+      shopSession.checkout.paymentConnectionFlow === PaymentConnectionFlow.BeforeSign
+
+    if (isPaymentBeforeSign) {
+      // This should not happen
+      logger.warn('BEFORE_SIGN ShopSession incorrectly on payment redirect page', {
+        shopSessionId: shopSession.id,
+      })
+      return {
+        redirect: {
+          destination: PageLink.checkoutPayment({ locale }),
+          permanent: false,
+        },
+      }
+    }
+
+    if (status === 'success') {
+      return {
+        redirect: {
+          destination: PageLink.confirmation({ locale, shopSessionId: shopSession.id }),
+          permanent: false,
+        },
+      }
+    } else {
+      return { props: {} }
+    }
+  } catch (error) {
+    logger.error(error, 'Failed to get server side props for checkout page')
+    return { notFound: true }
+  }
+}
+
+export default PaymentRedirectPage

--- a/apps/store/src/services/WebOnboarding/WebOnboarding.helpers.ts
+++ b/apps/store/src/services/WebOnboarding/WebOnboarding.helpers.ts
@@ -24,11 +24,13 @@ export const convertRoutingLocale = (locale: RoutingLocale) => {
 
 type Params = {
   locale: RoutingLocale
+  redirectURL: URL
 }
 
-export const getWebOnboardingPaymentURL = ({ locale }: Params) => {
+export const getWebOnboardingPaymentURL = ({ locale, redirectURL }: Params) => {
   if (PAYMENT_URL_TEMPLATE) {
-    return PAYMENT_URL_TEMPLATE.replace('{LOCALE}', convertRoutingLocale(locale))
+    const baseURL = PAYMENT_URL_TEMPLATE.replace('{LOCALE}', convertRoutingLocale(locale))
+    return `${baseURL}?redirect_url=${redirectURL.toString()}`
   }
 
   return null


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add callback URL as query parameter `redirect_url` that is passed to Web Onboarding to connect payments.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We need a way for Web Onboarding to communicate back to Racoon Store after the payment connection flow is complete.

We don't have designs for the fail case where the payment was not connected - will ask for designs for this :)

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
