### PR TITLE
Switch from bgImage to Next Image in Hero block

### DIFF
--- a/apps/store/src/blocks/HeroBlock.tsx
+++ b/apps/store/src/blocks/HeroBlock.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
+import Image from 'next/image'
 import { ButtonBlock, ButtonBlockProps } from '@/blocks/ButtonBlock'
 import { HeadingBlock, HeadingBlockProps } from '@/blocks/HeadingBlock'
 import { ExpectedBlockType, SbBaseBlockProps, StoryblokImage } from '@/services/storyblok/storyblok'
@@ -16,31 +17,53 @@ export const HeroBlock = ({ blok }: HeroBlockProps) => {
   const buttonBlocks = filterByBlockType(blok.buttons, ButtonBlock.blockName)
 
   return (
-    <HeroSection {...storyblokEditable(blok)} bgImage={blok.background.filename}>
-      <div>
-        {headingBlocks.map((nestedBlock) => (
-          <HeadingBlock blok={nestedBlock} key={nestedBlock._uid} />
-        ))}
-      </div>
-      <div>
-        {buttonBlocks.map((nestedBlock) => (
-          <ButtonBlock blok={nestedBlock} key={nestedBlock._uid} />
-        ))}
-      </div>
+    <HeroSection {...storyblokEditable(blok)}>
+      <HeroImageWrapper>
+        <Image
+          src={blok.background.filename}
+          alt={blok.background.alt}
+          layout="fill"
+          objectFit="cover"
+          objectPosition="center"
+        />
+      </HeroImageWrapper>
+      <HeroContent>
+        <div>
+          {headingBlocks.map((nestedBlock) => (
+            <HeadingBlock blok={nestedBlock} key={nestedBlock._uid} />
+          ))}
+        </div>
+        <div>
+          {buttonBlocks.map((nestedBlock) => (
+            <ButtonBlock blok={nestedBlock} key={nestedBlock._uid} />
+          ))}
+        </div>
+      </HeroContent>
     </HeroSection>
   )
 }
 HeroBlock.blockName = 'hero'
 
-const HeroSection = styled.section<{ bgImage: string }>(({ theme, bgImage }) => ({
+const HeroSection = styled.section(({ theme }) => ({
+  position: 'relative',
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'space-between',
   minHeight: '80vh',
   paddingTop: theme.space[9],
   paddingBottom: theme.space[9],
-  backgroundImage: `url(${bgImage})`,
-  backgroundSize: 'cover',
-  backgroundPosition: 'center',
-  textAlign: 'center',
 }))
+
+const HeroImageWrapper = styled.div({
+  zIndex: '-1',
+})
+
+const HeroContent = styled.div({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  flexGrow: 1,
+  textAlign: 'center',
+})

--- a/apps/store/src/blocks/HeroBlock.tsx
+++ b/apps/store/src/blocks/HeroBlock.tsx
@@ -20,6 +20,7 @@ export const HeroBlock = ({ blok }: HeroBlockProps) => {
     <HeroSection {...storyblokEditable(blok)}>
       <HeroImageWrapper>
         <Image
+          priority
           src={blok.background.filename}
           alt={blok.background.alt}
           layout="fill"


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Use Next `Image` instead of background-image in Hero block
- Prioritize loading of Hero block image
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Get all benefits with Next image and preload above the fold image

### Before
<img width="1792" alt="Screenshot 2022-10-13 at 14 12 45" src="https://user-images.githubusercontent.com/6661511/195593716-f97165f7-d8c9-4505-82c3-450779cd9ab0.png">

### After
<img width="1792" alt="Screenshot 2022-10-13 at 14 12 50" src="https://user-images.githubusercontent.com/6661511/195593757-de0c4920-341f-4abf-81a6-221a525883fc.png">


<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
