### PR TITLE
GRW-1664 - fix(LandingPage): removed intro section

### DIFF
--- a/apps/onboarding/src/components/LandingPage/LandingPage.tsx
+++ b/apps/onboarding/src/components/LandingPage/LandingPage.tsx
@@ -2,11 +2,9 @@ import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
 import { useMemo, useState } from 'react'
-import { Button, HeadingOLD, mq, Space } from 'ui'
-import { BodyText } from '@/components/BodyText'
+import { Button, HeadingOLD, mq } from 'ui'
 import { FixedFooter } from '@/components/FixedFooter'
 import { Header } from '@/components/Nav/Header'
-import { useFeature, Feature } from '@/hooks/useFeature'
 import { useCurrentLocale } from '@/lib/l10n'
 import { PageLink } from '@/lib/PageLink'
 import { Embark } from '@/services/embark'
@@ -66,11 +64,6 @@ const FooterButton = styled(Button)({
   },
 })
 
-const ContentCard = styled.div({
-  margin: '1rem 1rem 0 0',
-  [mq.sm]: { margin: '0 8rem', marginTop: '3.5rem', textAlign: 'center' },
-})
-
 export type LandingPageProps = {
   mainCoverageInsurances: Insurances
   additionalCoverageInsurances: Insurances
@@ -89,11 +82,6 @@ export const LandingPage = ({
 
   const [formState, setFormState] = useState(formInitialState)
   const [isRedirecting, setIsRedirecting] = useState(false)
-
-  const [IS_HOUSE_INSURANCE_ENABLED, IS_CROSS_SELL_ENABLED] = useFeature([
-    Feature.HOUSE_INSURANCE,
-    Feature.CROSS_SELL,
-  ])
 
   const hasSelectedAtLeastOneMainInsurance = useMemo(
     () => mainCoverageInsurances.some((insurance) => formState[insurance.fieldName]),
@@ -114,26 +102,6 @@ export const LandingPage = ({
       <PageContainer>
         <Header />
         <Main>
-          <ContentCard>
-            <Space y={1.5}>
-              <HeadingOLD variant="m" headingLevel="h1" colorVariant="dark">
-                {t('LANDING_PAGE_HEADLINE')}
-              </HeadingOLD>
-              <BodyText variant={1} colorVariant="medium" displayBlock>
-                {t(
-                  IS_HOUSE_INSURANCE_ENABLED
-                    ? 'LANDING_PAGE_MULTI_MAIN_COVERAGE_SUBHEADING'
-                    : 'LANDING_PAGE_SUBHEADING',
-                )}
-              </BodyText>
-              {IS_CROSS_SELL_ENABLED && (
-                <BodyText variant={1} colorVariant="medium" displayBlock>
-                  {t('LANDING_PAGE_UPDATE_CHOICES_SUBHEADING')}
-                </BodyText>
-              )}
-            </Space>
-          </ContentCard>
-
           <TitleContainer>
             <HeadingOLD variant="xs" colorVariant="dark" headingLevel="h3">
               {t('LANDING_PAGE_SECTION_TITLE_MAIN')}


### PR DESCRIPTION
## Describe your changes

Removes intro section from _Landing Page_

## Justify why they are needed

We’ve noticed a constant drop on conversion rate since Pentagon related changes added in June. As response it was decided to change the UI a little bit by removing the intro section (for both NO and DK) and keep analysing it so we can better understand if the drop is related with UI/UX. 

<img width="1160" alt="Screenshot 2022-10-18 at 16 49 59" src="https://user-images.githubusercontent.com/19200662/196468725-0fce5979-3abf-4228-8c27-5f82d5d8efd8.png">

![image](https://user-images.githubusercontent.com/19200662/196621180-edb55b1c-fe81-4347-8c7e-94c5798d873b.png)

## Jira issue(s): [GRW-1664](https://hedvig.atlassian.net/browse/GRW-1664)

