### PR TITLE
Only initialize Datadog RUM/logs in the browser

### DIFF
--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -14,8 +14,11 @@ if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
   require('../mocks')
 }
 
-Datadog.initDatadog()
+if (typeof window === 'undefined') {
+  Datadog.initDatadog()
+}
 
+// @TODO - should this be initialized unless running in browser?
 initStoryblok()
 
 const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Make sure we don't try to initialize Datadog RUM/browser logs when doing SSR.

## Justify why they are needed

It's only meant to run in the browser.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
