### PR TITLE
GRW-1331 - fix(hedvig-logo-link): consider locale path

### DIFF
--- a/apps/onboarding/src/components/Nav/Header.tsx
+++ b/apps/onboarding/src/components/Nav/Header.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import React from 'react'
 import { HedvigLogo, mq } from 'ui'
+import { useCurrentLocale } from '@/lib/l10n/use-current-locale'
 import { LanguageSwitcher } from '../language-switcher'
 
 const HeaderContainer = styled.div((props) => ({
@@ -24,10 +25,12 @@ const HeaderMenu = styled.div({
 })
 
 export const Header = () => {
+  const locale = useCurrentLocale()
+
   return (
     <HeaderContainer>
       {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-      <a href="/">
+      <a href={`/${locale.path}`}>
         <HedvigLogo />
       </a>
       <HeaderMenu>


### PR DESCRIPTION
## Describe your changes

Fix _Hedvig Logo Link_ so it redirects to the correct place

## Justify why they are needed

Currently by clicking on, _Landing Page_'s Hedvig Logo would always redirect to hedvig.com/se which is not correct for other markets like NO and DK. 

## Jira issue(s): [GRW-1331](https://hedvig.atlassian.net/browse/GRW-1331)