### PR TITLE
fix(diagram): Add & commit job

### DIFF
--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -36,5 +36,3 @@ jobs:
         with:
           add: 'repo-diagram.svg'
           message: 'Repo visualizer: updated diagram'
-          branch: assets
-          pull: NO-PULL


### PR DESCRIPTION
## Describe your changes

Fix `diagram.yml` action

## Justify why they are needed

I've noticed that action was [failing](https://github.com/HedvigInsurance/racoon/actions/runs/3329110641/jobs/5505917379). Based on the logs I:

*  Removed `branch` field since it's an unknown field for `EndBug/add-and-commit` 3rd party action. I thought that maybe that was a typo and we wanted to use `new_branch` field, but I realised that config is unnecessary since we're already checking out to the correct branch before executing that job;
* Removed [`pull`](https://github.com/EndBug/add-and-commit#:~:text=pull.%0A%20%20%20%20%23%20Default%3A%20%27%27-,pull,-%3A%20%27%2D%2Drebase) field since not including it means "no pull". Also I'm sure if NO-PULL as a valid value 🤔
I guess that was causing the issue btw

<img width="1314" alt="image" src="https://user-images.githubusercontent.com/19200662/198034660-04d6737f-30ec-41e2-afa3-d3bcdd027a35.png">

I've tested [running it against this branch](https://github.com/HedvigInsurance/racoon/actions/runs/3329256882) and it seems it's working properly.

