### PR TITLE
Product summary with large Pillow

### DIFF
--- a/apps/store/src/components/Pillow/Pillow.tsx
+++ b/apps/store/src/components/Pillow/Pillow.tsx
@@ -3,20 +3,29 @@ import styled from '@emotion/styled'
 type PillowProps = {
   fromColor: string
   toColor: string
-  size?: 'small' | 'medium' | 'large'
+  size?: 'small' | 'medium' | 'large' | 'xlarge'
 }
 
-export const Pillow = styled.div<PillowProps>(({ fromColor, toColor, size = 'medium' }) => ({
+export const PillowShape = styled.div<PillowProps>(({ fromColor, toColor, size = 'medium' }) => ({
   height: getSize(size),
   width: getSize(size),
   background: `linear-gradient(116.75deg, ${fromColor} 0%, ${toColor} 100%)`,
   backgroundClip: 'padding-box',
-  clipPath: `path(
-    'M44.458 55.22a173.915 173.915 0 0 1-32.919 0A11.924 11.924 0 0 1 .781 44.457a173.895 173.895 0 0 1 0-32.916A11.926 11.926 0 0 1 11.539.781a173.922 173.922 0 0 1 32.919 0 11.932 11.932 0 0 1 10.761 10.761 173.887 173.887 0 0 1 0 32.916 11.928 11.928 0 0 1-10.761 10.761Z'
-  )`,
+  clipPath: 'url(#pillowClipPath)',
 }))
 
-const getSize = (size: 'small' | 'medium' | 'large') => {
+export const Pillow = (props: PillowProps) => (
+  <>
+    <svg width="0" height="0">
+      <clipPath id="pillowClipPath" clipPathUnits="objectBoundingBox">
+        <path d="M0.794,0.986 a3,3,0,0,1,-0.588,0 a0.213,0.213,0,0,1,-0.192,-0.192 a3,3,0,0,1,0,-0.588 A0.213,0.213,0,0,1,0.206,0.014 a3,3,0,0,1,0.588,0 a0.213,0.213,0,0,1,0.192,0.192 a3,3,0,0,1,0,0.588 a0.213,0.213,0,0,1,-0.192,0.192"></path>
+      </clipPath>
+    </svg>
+    <PillowShape {...props} />
+  </>
+)
+
+const getSize = (size: 'small' | 'medium' | 'large' | 'xlarge') => {
   switch (size) {
     case 'small':
       return '3rem'
@@ -24,5 +33,7 @@ const getSize = (size: 'small' | 'medium' | 'large') => {
       return '3.5rem'
     case 'large':
       return '4rem'
+    case 'xlarge':
+      return '12.5rem'
   }
 }

--- a/apps/store/src/components/ProductPage/ProductSummary/ProductSummary.tsx
+++ b/apps/store/src/components/ProductPage/ProductSummary/ProductSummary.tsx
@@ -17,7 +17,7 @@ export const ProductSummary = ({
   return (
     <Space y={1}>
       <SpaceFlex space={1} align="center" direction="vertical">
-        <Pillow size="medium" fromColor={fromColor} toColor={toColor} />
+        <Pillow size="xlarge" fromColor={fromColor} toColor={toColor} />
         <div>
           <Heading as="h2" variant="standard.20">
             {title}

--- a/apps/store/src/components/TopMenu/TopMenu.tsx
+++ b/apps/store/src/components/TopMenu/TopMenu.tsx
@@ -119,7 +119,8 @@ export const Wrapper = styled.header(({ theme }) => ({
   width: '100%',
   height: MENU_BAR_HEIGHT,
   padding: theme.space[4],
-  position: 'fixed',
+  position: 'sticky',
+  top: 0,
   zIndex: Z_INDEX_TOP_MENU,
 }))
 


### PR DESCRIPTION
## Describe your changes
- Use x-large Pillow in Product Summary

To make a SVG clip path responsive, you need to reference a path that has the property `clipPathUnits="objectBoundingBox"` and transform the absolute path values to relative values. (Found this little tool to hel me out https://yoksel.github.io/relative-clip-path/)


## Justify why they are needed
This should be the "hero" of Product pages

<img width="429" alt="Screenshot 2022-10-27 at 17 55 52" src="https://user-images.githubusercontent.com/6661511/198339545-f455ba6c-3358-4c84-a867-68ae318decb5.png">

## Checklist before requesting a review

- [x] I have performed a self-review of my code
