### PR TITLE
GRW-1707 / Feature / Track offer_created event

### DIFF
--- a/apps/store/src/services/gtm.tsx
+++ b/apps/store/src/services/gtm.tsx
@@ -120,6 +120,8 @@ export const useGTMEvents = () => {
   }, [router.events])
 }
 
+// TODO: Refactor this module and move event tracking to Track service
+
 export const trackPageView = (urlPath: string) => {
   // Intentionally not logging to Datadog, since we log to Analytics here
   console.debug('pageview', urlPath)
@@ -144,5 +146,25 @@ export const trackExperimentImpression = (urlPath: string) => {
       experiment_id: redirect.optimizeExperimentId,
       variant_id: variantId,
     },
+  })
+}
+
+// TODO: Add shopSessionId from context instead of passing it explicitly
+export const trackOffer = (offerData: {
+  shopSessionId: string
+  contractType: string
+  amount: number
+  currency: string
+}) => {
+  const eventData = {
+    shop_session_id: offerData.shopSessionId,
+    insurance_type: offerData.contractType,
+    insurance_price: String(offerData.amount),
+    currency: offerData.currency,
+  }
+  console.debug('offer_created', eventData)
+  pushToGTMDataLayer({
+    event: 'offer_created',
+    eventData,
   })
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Quick and dirty support for offer_created event tracking
- Send event via GTM
- Include very basic metadata
- Some TODOs for future improvement of tracking

Screenshot of event from GTM test page:
<img width="1032" alt="Screenshot 2022-10-31 at 12 57 29" src="https://user-images.githubusercontent.com/6847/199005703-275e5608-fe55-4084-8aed-bc4725640acd.png">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We want to track conversion somehow when A/B testing, this adds first conversion event

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
