### PR TITLE
GRW-1728 / Migrate to new image component

### DIFF
--- a/apps/store/src/blocks/HeroBlock.tsx
+++ b/apps/store/src/blocks/HeroBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
-import Image from 'next/legacy/image'
+import Image from 'next/image'
 import { ButtonBlock, ButtonBlockProps } from '@/blocks/ButtonBlock'
 import { HeadingBlock, HeadingBlockProps } from '@/blocks/HeadingBlock'
 import { ExpectedBlockType, SbBaseBlockProps, StoryblokImage } from '@/services/storyblok/storyblok'
@@ -23,9 +23,12 @@ export const HeroBlock = ({ blok }: HeroBlockProps) => {
           priority
           src={blok.background.filename}
           alt={blok.background.alt}
-          layout="fill"
-          objectFit="cover"
-          objectPosition="center"
+          fill
+          sizes="100vw"
+          style={{
+            objectFit: 'cover',
+            objectPosition: 'center',
+          }}
         />
       </HeroImageWrapper>
       <HeroContent>

--- a/apps/store/src/blocks/HeroBlock.tsx
+++ b/apps/store/src/blocks/HeroBlock.tsx
@@ -19,16 +19,12 @@ export const HeroBlock = ({ blok }: HeroBlockProps) => {
   return (
     <HeroSection {...storyblokEditable(blok)}>
       <HeroImageWrapper>
-        <Image
+        <HeroImage
           priority
           src={blok.background.filename}
           alt={blok.background.alt}
           fill
           sizes="100vw"
-          style={{
-            objectFit: 'cover',
-            objectPosition: 'center',
-          }}
         />
       </HeroImageWrapper>
       <HeroContent>
@@ -60,6 +56,11 @@ const HeroSection = styled.section(({ theme }) => ({
 
 const HeroImageWrapper = styled.div({
   zIndex: '-1',
+})
+
+const HeroImage = styled(Image)({
+  objectFit: 'cover',
+  objectPosition: 'center',
 })
 
 const HeroContent = styled.div({

--- a/apps/store/src/blocks/ImageBlock.tsx
+++ b/apps/store/src/blocks/ImageBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
-import Image from 'next/legacy/image'
+import Image from 'next/image'
 import { HeadingBlock, HeadingBlockProps } from '@/blocks/HeadingBlock'
 import { ExpectedBlockType, SbBaseBlockProps, StoryblokImage } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
@@ -17,7 +17,15 @@ export const ImageBlock = ({ blok }: ImageBlockProps) => {
 
   return (
     <Wrapper {...storyblokEditable(blok)} margins={blok.fullBleed ?? false}>
-      <Image src={blok.image.filename} {...sizeProps} alt={blok.image.alt} />
+      <Image
+        src={blok.image.filename}
+        {...sizeProps}
+        alt={blok.image.alt}
+        style={{
+          maxWidth: '100%',
+          height: 'auto',
+        }}
+      />
       <BodyWrapper>
         {headingBlocks.map((nestedBlock) => (
           <HeadingBlock key={nestedBlock._uid} blok={nestedBlock} />

--- a/apps/store/src/blocks/ImageBlock.tsx
+++ b/apps/store/src/blocks/ImageBlock.tsx
@@ -17,15 +17,7 @@ export const ImageBlock = ({ blok }: ImageBlockProps) => {
 
   return (
     <Wrapper {...storyblokEditable(blok)} margins={blok.fullBleed ?? false}>
-      <Image
-        src={blok.image.filename}
-        {...sizeProps}
-        alt={blok.image.alt}
-        style={{
-          maxWidth: '100%',
-          height: 'auto',
-        }}
-      />
+      <Image src={blok.image.filename} {...sizeProps} alt={blok.image.alt} />
       <BodyWrapper>
         {headingBlocks.map((nestedBlock) => (
           <HeadingBlock key={nestedBlock._uid} blok={nestedBlock} />

--- a/apps/store/src/components/AppStoreBadge/AppStoreBadge.tsx
+++ b/apps/store/src/components/AppStoreBadge/AppStoreBadge.tsx
@@ -1,4 +1,4 @@
-import Image, { StaticImageData } from 'next/legacy/image'
+import Image, { StaticImageData } from 'next/image'
 import { IsoLocale, Locale } from '@/utils/l10n/types'
 import { AppleDaDk } from './AppleDaDk'
 import { AppleEn } from './AppleEn'
@@ -45,6 +45,10 @@ export const AppStoreBadge = ({ type, locale }: AppStoreBadgeProps) => {
       height={48}
       width={161.14285}
       placeholder="blur"
+      style={{
+        maxWidth: '100%',
+        height: 'auto',
+      }}
     />
   )
 }

--- a/apps/store/src/components/AppStoreBadge/AppStoreBadge.tsx
+++ b/apps/store/src/components/AppStoreBadge/AppStoreBadge.tsx
@@ -45,10 +45,6 @@ export const AppStoreBadge = ({ type, locale }: AppStoreBadgeProps) => {
       height={48}
       width={161.14285}
       placeholder="blur"
-      style={{
-        maxWidth: '100%',
-        height: 'auto',
-      }}
     />
   )
 }

--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import ImageProps from 'next/image'
+import { default as NextImage } from 'next/image'
 import { Space } from 'ui'
 
 type ImageProps = {
@@ -23,15 +23,7 @@ export const ProductCard = ({
   return (
     <Wrapper y={0.25}>
       <ImageWrapper>
-        <ImageProps
-          {...imageProps}
-          alt={alt}
-          fill
-          sizes="100vw"
-          style={{
-            objectFit: 'cover',
-          }}
-        />
+        <Image {...imageProps} alt={alt} fill sizes="100vw" />
       </ImageWrapper>
       <Space y={0.125}>
         <Title>{title}</Title>
@@ -55,6 +47,10 @@ const ImageWrapper = styled.div(() => ({
     overflow: 'hidden',
   },
 }))
+
+const Image = styled(NextImage)({
+  objectFit: 'cover',
+})
 
 const Title = styled.p(({ theme }) => ({
   fontSize: theme.fontSizes[2],

--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import ImageProps from 'next/legacy/image'
+import ImageProps from 'next/image'
 import { Space } from 'ui'
 
 type ImageProps = {
@@ -23,7 +23,15 @@ export const ProductCard = ({
   return (
     <Wrapper y={0.25}>
       <ImageWrapper>
-        <ImageProps {...imageProps} alt={alt} layout="fill" objectFit="cover" />
+        <ImageProps
+          {...imageProps}
+          alt={alt}
+          fill
+          sizes="100vw"
+          style={{
+            objectFit: 'cover',
+          }}
+        />
       </ImageWrapper>
       <Space y={0.125}>
         <Title>{title}</Title>

--- a/apps/store/src/components/TopPickCard/TopPickCard.tsx
+++ b/apps/store/src/components/TopPickCard/TopPickCard.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import ImageProps from 'next/legacy/image'
+import ImageProps from 'next/image'
 import { Space } from 'ui'
 
 const PRODUCT_CARD_IMAGE_WIDTH_SMALL = '20.43rem'
@@ -26,7 +26,15 @@ export const TopPickCard = ({
   return (
     <Wrapper y={0.25}>
       <ImageWrapper>
-        <ImageProps {...imageProps} alt={alt} layout="fill" objectFit="cover" />
+        <ImageProps
+          {...imageProps}
+          alt={alt}
+          fill
+          sizes="100vw"
+          style={{
+            objectFit: 'cover',
+          }}
+        />
       </ImageWrapper>
       <Space y={0.125}>
         <Title>{title}</Title>

--- a/apps/store/src/components/TopPickCard/TopPickCard.tsx
+++ b/apps/store/src/components/TopPickCard/TopPickCard.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import ImageProps from 'next/image'
+import { default as NextImage } from 'next/image'
 import { Space } from 'ui'
 
 const PRODUCT_CARD_IMAGE_WIDTH_SMALL = '20.43rem'
@@ -26,15 +26,7 @@ export const TopPickCard = ({
   return (
     <Wrapper y={0.25}>
       <ImageWrapper>
-        <ImageProps
-          {...imageProps}
-          alt={alt}
-          fill
-          sizes="100vw"
-          style={{
-            objectFit: 'cover',
-          }}
-        />
+        <Image {...imageProps} alt={alt} fill sizes="100vw" />
       </ImageWrapper>
       <Space y={0.125}>
         <Title>{title}</Title>
@@ -54,6 +46,10 @@ const ImageWrapper = styled.div(() => ({
   height: PRODUCT_CARD_IMAGE_HEIGHT_SMALL,
   width: '100%',
 }))
+
+const Image = styled(NextImage)({
+  objectFit: 'cover',
+})
 
 const Title = styled.h1(({ theme }) => ({
   fontSize: theme.fontSizes[2],


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Use the new Image component from Next

## Justify why they are needed
The new Image component relies on [native lazy loading](https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading) and outputs much less html which makes it easier to style.

You can read more about the Image component here https://nextjs.org/docs/api-reference/next/image

What we need to consider if we have good enough browser support https://caniuse.com/loading-lazy-attr since it's not supported in Safari below 15.4 It does fallback to eager loading. 

Looking at the split between browser version on our site from 1/9 we have 1,4% sitting on version 14.1.2 and with other versions below 15.4 it's a total around 2,4%. Given that we will go live next year the number will decrease so I think we can go ahead and use it. For onboarding it might not be worthwhile to migrate.

<img width="1159" alt="Screenshot 2022-11-02 at 17 31 07" src="https://user-images.githubusercontent.com/6661511/199550028-8d14727d-7112-4739-a76b-7afb76860ee6.png">


### Html before 
<img width="777" alt="Screenshot 2022-11-02 at 17 18 52" src="https://user-images.githubusercontent.com/6661511/199547816-9ee72b65-0132-4efd-9e35-690a35a37d6e.png">

### Html after
<img width="763" alt="Screenshot 2022-11-02 at 17 18 18" src="https://user-images.githubusercontent.com/6661511/199547883-72bbf6ba-5ed4-49a0-8612-f8df15874e06.png">


## Jira issue(s): [GRW-1728]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1728]: https://hedvig.atlassian.net/browse/GRW-1728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ