### PR TITLE
Co-locate top level z-index values

### DIFF
--- a/apps/store/src/components/Dialog/Dialog.tsx
+++ b/apps/store/src/components/Dialog/Dialog.tsx
@@ -1,6 +1,7 @@
 import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { zIndexes } from '@/utils/zIndex'
 
 const overlayShow = keyframes({
   '0%': { opacity: 0 },
@@ -32,7 +33,7 @@ export const Window = styled.div(({ theme }) => ({
 const StyledContentWrapper = styled.div({
   position: 'fixed',
   inset: 0,
-  zIndex: 2000,
+  zIndex: zIndexes.dialog,
 })
 
 type ContentProps = {

--- a/apps/store/src/components/ProductPage/ScrollPast/ScrollPast.tsx
+++ b/apps/store/src/components/ProductPage/ScrollPast/ScrollPast.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import { motion, useScroll } from 'framer-motion'
 import { useEffect, useState } from 'react'
+import { zIndexes } from '@/utils/zIndex'
 
 export type ScrollPastProps = {
   targetRef: React.RefObject<HTMLElement>
@@ -39,5 +40,5 @@ const StyledWrapper = styled(motion.div)({
   bottom: 0,
   left: 0,
   right: 0,
-  zIndex: 1,
+  zIndex: zIndexes.scrollPast,
 })

--- a/apps/store/src/components/TopMenu/TopMenu.tsx
+++ b/apps/store/src/components/TopMenu/TopMenu.tsx
@@ -5,11 +5,11 @@ import Link, { LinkProps } from 'next/link'
 import React, { useState, useCallback } from 'react'
 import { ArrowForwardIcon, CrossIcon, theme } from 'ui'
 import { PageLink } from '@/utils/PageLink'
+import { zIndexes } from '@/utils/zIndex'
 import { MenuIcon } from './MenuIcon'
 import { ShoppingCartMenuItem } from './ShoppingCartMenuItem'
 
 export const MENU_BAR_HEIGHT = '3.75rem'
-const Z_INDEX_TOP_MENU = 1000
 
 export const TopMenu = () => {
   const [activeItem, setActiveItem] = useState('')
@@ -121,7 +121,7 @@ export const Wrapper = styled.header(({ theme }) => ({
   padding: theme.space[4],
   position: 'sticky',
   top: 0,
-  zIndex: Z_INDEX_TOP_MENU,
+  zIndex: zIndexes.header,
 }))
 
 export const StyledDialogOverlay = styled(DialogPrimitive.Overlay)({

--- a/apps/store/src/utils/zIndex.tsx
+++ b/apps/store/src/utils/zIndex.tsx
@@ -1,0 +1,12 @@
+const zIndexOrder = ['body', 'scrollPast', 'header', 'dialog'] as const
+
+type ZIndexValues = typeof zIndexOrder[number]
+type ZIndexRecord = Record<ZIndexValues, number>
+
+export const zIndexes = zIndexOrder.reduce(
+  (acc: ZIndexRecord, current: ZIndexValues, index: number) => {
+    acc[current] = index
+    return acc
+  },
+  {} as ZIndexRecord,
+)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Co-locate top level z-index values
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
An attempt to avoid arbitrary z-index values that grows over time. There's a bunch of ways to do this but I kinda liked this one: https://www.nielskrijger.com/posts/2021-08-29/zindex-with-css-in-js/ This approach sets z-index relative to each other, rather than just having an object with hardcoded values. It makes it easy to add values in between existing z-index values.
