### PR TITLE
GRW-1702 / Feat  / Sticky TopMenu and Tablist

### DIFF
--- a/apps/store/src/blocks/TopMenuBlock.tsx
+++ b/apps/store/src/blocks/TopMenuBlock.tsx
@@ -19,6 +19,7 @@ import {
   ToggleMenu,
   Wrapper,
 } from '@/components/TopMenu/TopMenu'
+import { useStickyTopMenuOffset } from '@/components/TopMenu/useTopMenuStickyOffset'
 import { ExpectedBlockType, LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import {
   checkBlockType,
@@ -95,8 +96,10 @@ export const HeaderBlock = ({ blok }: HeaderBlockProps) => {
     return () => router.events.off('routeChangeComplete', closeDialog)
   }, [router.events])
 
+  const { topOffset, navRef } = useStickyTopMenuOffset()
+
   return (
-    <Wrapper {...storyblokEditable(blok)}>
+    <Wrapper ref={navRef} topOffset={topOffset} {...storyblokEditable(blok)}>
       <DialogPrimitive.Root open={open} onOpenChange={() => setOpen((prevOpen) => !prevOpen)}>
         <DialogPrimitive.Trigger asChild>
           <ToggleMenu>{open ? null : <MenuIcon />}</ToggleMenu>

--- a/apps/store/src/components/ProductPage/Tabs.tsx
+++ b/apps/store/src/components/ProductPage/Tabs.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled'
 import * as RadixTabs from '@radix-ui/react-tabs'
+import { zIndexes } from '@/utils/zIndex'
 
 export const Tabs = styled(RadixTabs.Root)({
+  position: 'relative',
   display: 'flex',
   flexDirection: 'column',
 })
@@ -9,6 +11,10 @@ export const Tabs = styled(RadixTabs.Root)({
 export const TabsList = styled(RadixTabs.TabsList)(({ theme }) => ({
   display: 'flex',
   borderBottom: `1px solid ${theme.colors.gray500}`,
+  backgroundColor: theme.colors.white,
+  position: 'sticky',
+  top: 0,
+  zIndex: zIndexes.tabs,
 }))
 
 export const TabsTrigger = styled(RadixTabs.Trigger)(({ theme }) => ({

--- a/apps/store/src/components/TopMenu/TopMenu.tsx
+++ b/apps/store/src/components/TopMenu/TopMenu.tsx
@@ -8,6 +8,7 @@ import { PageLink } from '@/utils/PageLink'
 import { zIndexes } from '@/utils/zIndex'
 import { MenuIcon } from './MenuIcon'
 import { ShoppingCartMenuItem } from './ShoppingCartMenuItem'
+import { useStickyTopMenuOffset } from './useTopMenuStickyOffset'
 
 export const MENU_BAR_HEIGHT = '3.75rem'
 
@@ -19,9 +20,10 @@ export const TopMenu = () => {
     setOpen(false)
     setActiveItem('')
   }, [])
+  const { topOffset, navRef } = useStickyTopMenuOffset()
 
   return (
-    <Wrapper>
+    <Wrapper topOffset={topOffset} ref={navRef}>
       <DialogPrimitive.Root open={open} onOpenChange={() => setOpen((prevOpen) => !prevOpen)}>
         <DialogPrimitive.Trigger asChild>
           <ToggleMenu>
@@ -112,7 +114,7 @@ export const focusableStyles = {
   },
 }
 
-export const Wrapper = styled.header(({ theme }) => ({
+export const Wrapper = styled.header<{ topOffset: number }>(({ theme, topOffset = 0 }) => ({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
@@ -120,7 +122,7 @@ export const Wrapper = styled.header(({ theme }) => ({
   height: MENU_BAR_HEIGHT,
   padding: theme.space[4],
   position: 'sticky',
-  top: 0,
+  top: `${topOffset}px`,
   zIndex: zIndexes.header,
 }))
 

--- a/apps/store/src/components/TopMenu/useTopMenuStickyOffset.tsx
+++ b/apps/store/src/components/TopMenu/useTopMenuStickyOffset.tsx
@@ -1,0 +1,27 @@
+import { useScroll } from 'framer-motion'
+import { useEffect, useRef, useState } from 'react'
+import { useIsIntersecting } from '@/utils/useIsIntersecting'
+
+export const useStickyTopMenuOffset = () => {
+  const [topOffset, setTopOffset] = useState(0)
+  const [targetNode, setTargetNode] = useState<Element | null>(null)
+  const { scrollY } = useScroll()
+  const [isTargetNodeIntersecting] = useIsIntersecting(targetNode)
+  const navRef = useRef<HTMLHeadingElement>(null)
+
+  useEffect(() => {
+    setTargetNode(document.querySelector('[role=tablist]'))
+
+    if (targetNode && isTargetNodeIntersecting) {
+      scrollY.onChange(() => {
+        const { top: targetNodeTop } = targetNode.getBoundingClientRect()
+        const navHeight = navRef.current?.getBoundingClientRect().height ?? 0
+        const calculatedOffset = (targetNodeTop < navHeight ? navHeight - targetNodeTop : 0) * -1
+        setTopOffset(calculatedOffset)
+      })
+      return () => scrollY.destroy()
+    }
+  }, [isTargetNodeIntersecting, scrollY, targetNode])
+
+  return { topOffset, navRef }
+}

--- a/apps/store/src/utils/useIsIntersecting.tsx
+++ b/apps/store/src/utils/useIsIntersecting.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react'
 
-export const useIsIntersecting = (node: Element | null, options = {}) => {
+type UseIsIntersectingType = (
+  node: Element | null,
+  options?: IntersectionObserverInit,
+) => readonly boolean[]
+
+export const useIsIntersecting: UseIsIntersectingType = (node, options = {}) => {
   const [isIntersecting, setIsIntersecting] = useState(false)
   useEffect(() => {
     if (node) {

--- a/apps/store/src/utils/useIsIntersecting.tsx
+++ b/apps/store/src/utils/useIsIntersecting.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+
+export const useIsIntersecting = (node: Element | null, options = {}) => {
+  const [isIntersecting, setIsIntersecting] = useState(false)
+  useEffect(() => {
+    if (node) {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            setIsIntersecting(entry.isIntersecting)
+          })
+        },
+        { ...options },
+      )
+      observer.observe(node)
+      return () => observer.disconnect()
+    }
+  }, [node, options])
+
+  return [isIntersecting] as const
+}

--- a/apps/store/src/utils/zIndex.tsx
+++ b/apps/store/src/utils/zIndex.tsx
@@ -1,4 +1,4 @@
-const zIndexOrder = ['body', 'scrollPast', 'header', 'dialog'] as const
+const zIndexOrder = ['body', 'tabs', 'scrollPast', 'header', 'dialog'] as const
 
 type ZIndexValues = typeof zIndexOrder[number]
 type ZIndexRecord = Record<ZIndexValues, number>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

(Third time is the charm)

Implemented a css sticky type interaction between the TopMenu and TabList components. 

## Scroll Video
In the logs here you can see that the `onScroll` is not running when the TabList is not intersecting on the page.
That said, it'd be even better if we could not run the onScroll after the TabList replaces the TopNav. It's possible, but may take some time to sort that out.

https://user-images.githubusercontent.com/50870173/200874127-7e045f63-574e-4f4a-8b08-8f22bb6962a5.mov
The 🧽 emoji means that the `onScroll` is not running. 

The 🎽 emoji shows when`onScroll` is running


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Designs require the TabList be stuck to the top of the page once a user scrolls past it. 

## Jira issue(s): [GRW-1702]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [x] I have performed a self-review of my code


[GRW-1702]: https://hedvig.atlassian.net/browse/GRW-1702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ