### PR TITLE
GRW-1745 / feat / Add standalone video block

### DIFF
--- a/apps/store/src/blocks/HeroBlock.tsx
+++ b/apps/store/src/blocks/HeroBlock.tsx
@@ -3,12 +3,12 @@ import { storyblokEditable } from '@storyblok/react'
 import Image from 'next/image'
 import { ButtonBlock, ButtonBlockProps } from '@/blocks/ButtonBlock'
 import { HeadingBlock, HeadingBlockProps } from '@/blocks/HeadingBlock'
-import { ExpectedBlockType, SbBaseBlockProps, StoryblokImage } from '@/services/storyblok/storyblok'
+import { ExpectedBlockType, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 
 type HeroBlockProps = SbBaseBlockProps<{
   content: ExpectedBlockType<HeadingBlockProps>
-  background: StoryblokImage
+  background: StoryblokAsset
   buttons: ExpectedBlockType<ButtonBlockProps>
 }>
 

--- a/apps/store/src/blocks/HeroVideoBlock.tsx
+++ b/apps/store/src/blocks/HeroVideoBlock.tsx
@@ -1,13 +1,13 @@
 import { HeroVideo } from '@/components/HeroVideo/HeroVideo'
-import { ExpectedBlockType, SbBaseBlockProps, StoryblokImage } from '@/services/storyblok/storyblok'
+import { ExpectedBlockType, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 import { HeadingBlockProps, HeadingBlock } from './HeadingBlock'
 
 type HeroVideoBlockProps = SbBaseBlockProps<{
-  video: StoryblokImage
+  video: StoryblokAsset
   format: string
   height: number
-  poster?: StoryblokImage
+  poster?: StoryblokAsset
   headingsPadding: string
   headings: ExpectedBlockType<HeadingBlockProps>
 }>

--- a/apps/store/src/blocks/ImageBlock.tsx
+++ b/apps/store/src/blocks/ImageBlock.tsx
@@ -2,11 +2,11 @@ import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import Image from 'next/image'
 import { HeadingBlock, HeadingBlockProps } from '@/blocks/HeadingBlock'
-import { ExpectedBlockType, SbBaseBlockProps, StoryblokImage } from '@/services/storyblok/storyblok'
+import { ExpectedBlockType, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 
 type ImageBlockProps = SbBaseBlockProps<{
-  image: StoryblokImage
+  image: StoryblokAsset
   fullBleed?: boolean
   body?: ExpectedBlockType<HeadingBlockProps>
 }>

--- a/apps/store/src/blocks/ProductCardBlock.tsx
+++ b/apps/store/src/blocks/ProductCardBlock.tsx
@@ -2,13 +2,13 @@ import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import Link from 'next/link'
 import { ProductCard } from '@/components/ProductCard/ProductCard'
-import { SbBaseBlockProps, LinkField, StoryblokImage } from '@/services/storyblok/storyblok'
+import { SbBaseBlockProps, LinkField, StoryblokAsset } from '@/services/storyblok/storyblok'
 import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
 
 export type ProductCardBlockProps = SbBaseBlockProps<{
   title: string
   subtitle: string
-  image: StoryblokImage
+  image: StoryblokAsset
   link: LinkField
 }>
 

--- a/apps/store/src/blocks/TopPickCardBlock.tsx
+++ b/apps/store/src/blocks/TopPickCardBlock.tsx
@@ -2,13 +2,13 @@ import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import Link from 'next/link'
 import { TopPickCard } from '@/components/TopPickCard/TopPickCard'
-import { SbBaseBlockProps, LinkField, StoryblokImage } from '@/services/storyblok/storyblok'
+import { SbBaseBlockProps, LinkField, StoryblokAsset } from '@/services/storyblok/storyblok'
 import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
 
 export type TopPickCardBlockProps = SbBaseBlockProps<{
   title: string
   subtitle: string
-  image: StoryblokImage
+  image: StoryblokAsset
   link: LinkField
 }>
 

--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -1,12 +1,13 @@
 import { Video } from '@/components/Video/Video'
-import { SbBaseBlockProps, StoryblokImage } from '@/services/storyblok/storyblok'
+import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 
 type VideoBlockProps = SbBaseBlockProps<{
-  video: StoryblokImage
-  poster?: StoryblokImage
+  video: StoryblokAsset
+  poster?: StoryblokAsset
 }>
 
 export const VideoBlock = ({ blok }: VideoBlockProps) => {
+  console.log('test', blok.video)
   return <Video sources={[{ url: blok.video.filename }]} poster={blok.poster?.filename} />
 }
 VideoBlock.blockName = 'videoBlock'

--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -1,0 +1,12 @@
+import { Video } from '@/components/Video/Video'
+import { SbBaseBlockProps, StoryblokImage } from '@/services/storyblok/storyblok'
+
+type VideoBlockProps = SbBaseBlockProps<{
+  video: StoryblokImage
+  poster?: StoryblokImage
+}>
+
+export const VideoBlock = ({ blok }: VideoBlockProps) => {
+  return <Video sources={[{ url: blok.video.filename }]} poster={blok.poster?.filename} />
+}
+VideoBlock.blockName = 'videoBlock'

--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled'
+import { PropsWithChildren } from 'react'
+
+export type VideoSource = {
+  url: string
+}
+
+type HeroVideoProps = PropsWithChildren & {
+  /**
+   * An array of videos with different supported formats
+   */
+  sources: VideoSource[]
+  poster?: string
+}
+
+const VideoWrapper = styled.div({
+  position: 'relative',
+})
+
+const StyledVideo = styled.video({
+  width: '100%',
+  height: 'auto',
+  backgroundSize: 'cover',
+  objectFit: 'cover',
+})
+
+export const Video = ({ sources, poster }: HeroVideoProps) => {
+  return (
+    <VideoWrapper>
+      {/*
+    Some special attributes here need more explanation.
+    - Safari on iOS only allows autoplay when the video is `muted`.
+    - Safari on iOS will default to autoplay videos in fullscreen unless `playsInline` is added
+    Read more: https://webkit.org/blog/6784/new-video-policies-for-ios/
+    */}
+      <StyledVideo playsInline autoPlay muted loop preload="auto" poster={poster}>
+        {sources.map((source) => (
+          <source key={source.url} src={source.url} />
+        ))}
+      </StyledVideo>
+    </VideoWrapper>
+  )
+}

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -32,6 +32,7 @@ import {
   HeaderBlockProps,
 } from '@/blocks/TopMenuBlock'
 import { TopPickCardBlock } from '@/blocks/TopPickCardBlock'
+import { VideoBlock } from '@/blocks/VideoBlock'
 import { fetchStory, StoryblokFetchParams } from '@/services/storyblok/Storyblok.helpers'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { RoutingLocale } from '@/utils/l10n/types'
@@ -162,6 +163,7 @@ export const initStoryblok = () => {
     TextBlock,
     TopPickCardBlock,
     PerilsBlock,
+    VideoBlock,
   ]
   const blockAliases = { product: PageBlock, reusableBlock: PageBlock }
   const components = {

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -62,7 +62,7 @@ export type StoryblokPreviewData = {
   version?: StoryblokVersion
 }
 
-export type StoryblokImage = {
+export type StoryblokAsset = {
   alt: string
   copyright: string
   fieldtype: 'asset'


### PR DESCRIPTION
## Describe your changes

First step for PDP product video
- Add a simple video block to start with
- Rename asset type to match Storyblok field name

## Justify why they are needed
Make it possible to add videos throughout the page. Will add more settings and functionality in upcoming PRs


https://user-images.githubusercontent.com/6661511/201108450-13d34b15-ba77-4ef4-912d-dc7eb47da592.mov


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
