### PR TITLE
GRW-1766 / Feature / Use @next/font in onboarding and storybook

### DIFF
--- a/apps/onboarding/package.json
+++ b/apps/onboarding/package.json
@@ -23,6 +23,7 @@
     "@datadog/browser-rum": "4.24.0",
     "@emotion/react": "11.10.5",
     "@emotion/styled": "11.10.5",
+    "@next/font": "13.0.3",
     "@radix-ui/react-radio-group": "1.1.0",
     "classnames": "2.3.2",
     "cookies-next": "2.1.1",

--- a/apps/onboarding/src/lib/fonts.ts
+++ b/apps/onboarding/src/lib/fonts.ts
@@ -1,0 +1,33 @@
+import localFont from '@next/font/local'
+
+// NOTE:
+// - Font loaders have to be const expressions at top level
+// - Cannot reference path from packages/ui published version, font path is always local
+export const smallFont = localFont({
+  src: '../../../../packages/ui/fonts/HedvigLetters-Small.woff2',
+  weight: '400',
+  fallback: ['serif'],
+  variable: '--hedvig-font-small',
+  display: 'swap',
+})
+export const standardFont = localFont({
+  src: '../../../../packages/ui/fonts/HedvigLetters-Standard.woff2',
+  weight: '400',
+  fallback: ['sans-serif'],
+  variable: '--hedvig-font-standard',
+  display: 'swap',
+})
+export const bigFont = localFont({
+  src: '../../../../packages/ui/fonts/HedvigLetters-Big.woff2',
+  weight: '400',
+  fallback: ['serif'],
+  variable: '--hedvig-font-big',
+  display: 'swap',
+})
+// Apply variables for theme and standard font as default
+export const contentFontClassName = [
+  smallFont.variable,
+  standardFont.variable,
+  bigFont.variable,
+  standardFont.className,
+].join(' ')

--- a/apps/onboarding/src/pages/_app.tsx
+++ b/apps/onboarding/src/pages/_app.tsx
@@ -1,15 +1,15 @@
 import { ApolloProvider } from '@apollo/client'
-import { Global } from '@emotion/react'
 import { appWithTranslation } from 'next-i18next'
 import type { AppProps } from 'next/app'
 import Head from 'next/head'
 import Script from 'next/script'
-import { ThemeProvider, globalFontStyles } from 'ui'
+import { ThemeProvider } from 'ui'
 import { MetaFavicons } from '@/components/meta-favicons'
 import { useApollo } from '@/hooks/useApollo'
 import { useDebugTranslationKeys } from '@/hooks/useDebugTranslationsKeys'
 import { useSetupQuoteCartEffect } from '@/hooks/useSetupQuoteCartEffect'
 import { useTrackPageViews } from '@/hooks/useTrackPageViews'
+import { contentFontClassName } from '@/lib/fonts'
 import { useCurrentLocale } from '@/lib/l10n/use-current-locale'
 import { gtmDevScript, gtmProdScript, useGTMUserProperties } from '@/services/analytics/gtm'
 import * as Datadog from '@/services/datadog'
@@ -44,9 +44,8 @@ function MyApp({ Component, pageProps }: AppProps) {
       </Head>
 
       <ApolloProvider client={apolloClient}>
-        <Global styles={globalFontStyles} />
         <ThemeProvider>
-          <Component {...pageProps} />
+          <Component {...pageProps} className={contentFontClassName} />
         </ThemeProvider>
       </ApolloProvider>
 

--- a/apps/onboarding/src/pages/_document.tsx
+++ b/apps/onboarding/src/pages/_document.tsx
@@ -1,5 +1,5 @@
 import Document, { Head, Html, Main, NextScript } from 'next/document'
-import { getCDNFonts } from 'ui'
+import { contentFontClassName } from '@/lib/fonts'
 import { locales, LocaleLabel } from '@/lib/l10n/locales'
 import { gtmDevScript, gtmProdScript } from '@/services/analytics/gtm'
 
@@ -17,19 +17,9 @@ export default class MyDocument extends Document {
   render() {
     return (
       <Html lang={this.lang()}>
-        <Head>
-          {getCDNFonts().map((font) => (
-            <link
-              key={font.src}
-              rel="preload"
-              href={font.src}
-              as="font"
-              type={`font/${font.format}`}
-              crossOrigin="anonymous"
-            />
-          ))}
-        </Head>
-        <body>
+        <Head />
+        {/* Fallback for pages that don't pass className down to DOM */}
+        <body className={contentFontClassName}>
           <noscript>
             <iframe
               src={

--- a/apps/store/.storybook/preview.js
+++ b/apps/store/.storybook/preview.js
@@ -1,4 +1,6 @@
 import { ThemeProvider } from 'ui'
+import { storybookFontStyles } from 'ui/src/lib/storybookFontStyles'
+import { Global } from '@emotion/react'
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -13,6 +15,7 @@ export const parameters = {
 export const decorators = [
   (Story) => (
     <>
+      <Global styles={storybookFontStyles} />
       <ThemeProvider>
         <Story />
       </ThemeProvider>

--- a/packages/ui/.storybook/preview.js
+++ b/packages/ui/.storybook/preview.js
@@ -1,6 +1,6 @@
 import { theme, ThemeProvider } from '../src'
 import { Global } from '@emotion/react'
-import { globalFontStyles } from '../src'
+import { storybookFontStyles } from '../src/lib/storybookFontStyles'
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -23,7 +23,7 @@ export const parameters = {
 export const decorators = [
   (Story) => (
     <>
-      <Global styles={globalFontStyles} />
+      <Global styles={storybookFontStyles} />
       <ThemeProvider>
         <Story />
       </ThemeProvider>

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -19,11 +19,11 @@ export type { HeadingProps } from './components/HeadingNew/HeadingNew'
 export type { Level } from './lib/media-query'
 export { mq, useBreakpoint } from './lib/media-query'
 
-export { getCDNFonts, fonts } from './lib/theme/typography'
+export { fonts } from './lib/theme/typography'
 export { theme, getColor } from './lib/theme/theme'
 export type { UIColor } from './lib/theme/colors'
 export { ThemeProvider } from './lib/theme/ThemeProvider'
-export { globalStyles, globalFontStyles } from './lib/globalStyles'
+export { globalStyles } from './lib/globalStyles'
 
 export { MailIcon } from './icons/MailIcon'
 export { PhoneIcon } from './icons/PhoneIcon'

--- a/packages/ui/src/lib/globalStyles.ts
+++ b/packages/ui/src/lib/globalStyles.ts
@@ -1,29 +1,5 @@
 import { css } from '@emotion/react'
 import { getColor } from './theme/theme'
-import { getCDNFonts, HedvigFont } from './theme/typography'
-
-export const globalFontStyles = css`
-  ${getCDNFonts()
-    .map(
-      (font) => `
-    @font-face {
-      font-family: ${font.family};
-      font-style: ${font.style};
-      font-weight: ${font.weight};
-      src: url("${font.src}") format("${font.format}");
-      font-display: swap;
-    }
-  `,
-    )
-    .join('\n')}
-
-  body {
-    --hedvig-font-small: ${HedvigFont.HEDVIG_LETTERS_SMALL};
-    --hedvig-font-standard: ${HedvigFont.HEDVIG_LETTERS_STANDARD};
-    --hedvig-font-big: ${HedvigFont.HEDVIG_LETTERS_BIG};
-    font-family: var(--hedvig-font-standard);
-  }
-`
 
 export const globalStyles = css`
   /***

--- a/packages/ui/src/lib/storybookFontStyles.ts
+++ b/packages/ui/src/lib/storybookFontStyles.ts
@@ -1,0 +1,37 @@
+import { css } from '@emotion/react'
+import { HedvigFont } from './theme/typography'
+
+// Replacement for @next/font/local for storybook
+
+const getFonts = () => {
+  return Object.values(HedvigFont).map((fontName) => ({
+    family: fontName,
+    style: 'normal',
+    weight: 400,
+    src: require(`ui/fonts/${fontName}.woff2`),
+    format: 'woff2',
+  }))
+}
+
+export const storybookFontStyles = css`
+  ${getFonts()
+    .map(
+      (font) => `
+    @font-face {
+      font-family: ${font.family};
+      font-style: ${font.style};
+      font-weight: ${font.weight};
+      src: url("${font.src}") format("${font.format}");
+      font-display: swap;
+    }
+  `,
+    )
+    .join('\n')}
+
+  body {
+    --hedvig-font-small: ${HedvigFont.HEDVIG_LETTERS_SMALL};
+    --hedvig-font-standard: ${HedvigFont.HEDVIG_LETTERS_STANDARD};
+    --hedvig-font-big: ${HedvigFont.HEDVIG_LETTERS_BIG};
+    font-family: var(--hedvig-font-standard);
+  }
+`

--- a/packages/ui/src/lib/theme/typography.stories.tsx
+++ b/packages/ui/src/lib/theme/typography.stories.tsx
@@ -1,11 +1,5 @@
-// TODO: Continue when solution or workaround is available for https://github.com/storybookjs/storybook/issues/19711
-
-// import localFont from '@next/font/local'
-// const hedvigFonts = {
-//   standard: localFont({ src: '../../fonts/HedvigLetters-Standard.woff2' }),
-// }
-//
-// console.log(hedvigFonts)
+import { Heading } from '../../components/HeadingNew/HeadingNew'
+import { theme } from './theme'
 
 const config = {
   title: 'Theme / Typography',
@@ -16,11 +10,17 @@ const Template = () => {
   // TODO: use Heading for headers
   return (
     <div>
-      <h1>h1. Page header</h1>
-      <h2>h2. Section header</h2>
-      <h3>h3. Small header</h3>
+      <Heading as="h1" variant="standard.48">
+        h1. Page header
+      </Heading>
+      <Heading as="h2" variant="serif.32">
+        h2. Section header (serif)
+      </Heading>
+      <Heading as="h3" variant="standard.24">
+        h3. Small header
+      </Heading>
       <p>Some regular text</p>
-      <div>Some secondary text</div>
+      <p style={{ color: theme.colors.gray500 }}>Some secondary text</p>
     </div>
   )
 }

--- a/packages/ui/src/lib/theme/typography.ts
+++ b/packages/ui/src/lib/theme/typography.ts
@@ -14,16 +14,6 @@ export const fonts = {
   heading: FONT_STANDARD,
 }
 
-export const getCDNFonts = () => {
-  return Object.values(HedvigFont).map((fontName) => ({
-    family: fontName,
-    style: 'normal',
-    weight: 400,
-    src: `https://cdn.hedvig.com/identity/fonts/${fontName}.woff2`,
-    format: 'woff2',
-  }))
-}
-
 export const fontSizes: Record<number | string, string> = {
   0: '0.75rem',
   1: '0.875rem',

--- a/yarn.lock
+++ b/yarn.lock
@@ -17579,6 +17579,7 @@ __metadata:
     "@graphql-codegen/typescript-generic-sdk": 3.0.4
     "@graphql-codegen/typescript-operations": 2.5.6
     "@graphql-codegen/typescript-react-apollo": 3.3.6
+    "@next/font": 13.0.3
     "@radix-ui/react-radio-group": 1.1.0
     "@testing-library/dom": 8.17.1
     "@testing-library/jest-dom": 5.16.5


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Replace remaining usages of CDN fonts:
- with local fonts for storybook
- with @next/font for onboarding

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Stop depending on CDN fonts, unify font loading

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
