### PR TITLE
GRW-1759 / fix maxLength of car register

### DIFF
--- a/apps/store/src/components/PriceForm/CarRegistrationField.tsx
+++ b/apps/store/src/components/PriceForm/CarRegistrationField.tsx
@@ -30,7 +30,7 @@ export const CarRegistrationNumberField = ({ field }: RegistrationFieldProps) =>
       label={field.label ? translateLabel(field.label) : undefined}
       pattern={CAR_REGISTRATION_NUMBER_REGEX}
       placeholder="ABC 123"
-      minLength={7}
+      maxLength={7}
       required={field.required}
       value={value}
       defaultValue={field.defaultValue}

--- a/apps/store/src/components/PriceForm/CarRegistrationField.tsx
+++ b/apps/store/src/components/PriceForm/CarRegistrationField.tsx
@@ -4,6 +4,7 @@ import { CarRegistrationNumberField as CarRegistrationNumberFieldType } from '@/
 import { useTranslateTextLabel } from './useTranslateTextLabel'
 
 const CAR_REGISTRATION_NUMBER_REGEX = '[A-Za-z]{3} [0-9]{2}[A-Za-z0-9]{1}'
+const CAR_REGISTRATION_NUMBER_LENGTH = 7
 
 type RegistrationFieldProps = {
   field: CarRegistrationNumberFieldType
@@ -28,9 +29,9 @@ export const CarRegistrationNumberField = ({ field }: RegistrationFieldProps) =>
       type="text"
       name={field.name}
       label={field.label ? translateLabel(field.label) : undefined}
-      pattern={CAR_REGISTRATION_NUMBER_REGEX}
       placeholder="ABC 123"
-      maxLength={7}
+      pattern={CAR_REGISTRATION_NUMBER_REGEX}
+      maxLength={CAR_REGISTRATION_NUMBER_LENGTH}
       required={field.required}
       value={value}
       defaultValue={field.defaultValue}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

fixed mac length for the car register input field. 

**Before**
<img width="400" alt="Screenshot 2022-11-14 at 15 00 55" src="https://user-images.githubusercontent.com/50870173/201854562-c54ea08e-7bb2-4d25-91f6-f150b45c801f.png">

**After**
<img width="352" alt="Screenshot 2022-11-14 at 15 00 42" src="https://user-images.githubusercontent.com/50870173/201854601-f17bbd84-c73d-4344-9819-2c2280c7488b.png">

## Justify why they are needed

previously you could add as many chars as you'd like. 

## Jira issue(s): [GRW-1759]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1759]: https://hedvig.atlassian.net/browse/GRW-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ