### PR TITLE
Add generic personal number field to Checkout

### DIFF
--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import Link from 'next/link'
 import { ArrowForwardIcon, Button, Heading, HedvigLogo, InputField, Space } from 'ui'
 import { CartInventory } from '@/components/CartInventory/CartInventory'
+import { PersonalNumberField } from '@/components/PersonalNumberField/PersonalNumberField'
 import { PageLink } from '@/utils/PageLink'
 import { FormElement } from './CheckoutPage.constants'
 import { formatAPIDate } from './CheckoutPage.helpers'
@@ -66,10 +67,8 @@ const CheckoutPage = (props: CheckoutPageProps) => {
               <Heading as="h2" variant="standard.24">
                 2. Your contact info
               </Heading>
-              <InputField
-                label="Personal Number"
+              <PersonalNumberField
                 name={FormElement.PersonalNumber}
-                type="text"
                 required
                 defaultValue={prefilledData.personalNumber ?? undefined}
                 errorMessage={userErrors[FormElement.PersonalNumber]}

--- a/apps/store/src/components/PersonalNumberField/PersonalNumberField.tsx
+++ b/apps/store/src/components/PersonalNumberField/PersonalNumberField.tsx
@@ -1,0 +1,46 @@
+import Personnummer from 'personnummer'
+import { ChangeEventHandler, useState } from 'react'
+import { InputField, InputFieldProps } from 'ui'
+
+type Props = Omit<InputFieldProps, 'suffix'>
+
+/**
+ * Personal Number input field.
+ * Only supports Swedish personal numbers.
+ */
+export const PersonalNumberField = (props: Props) => {
+  const { value: propValue, defaultValue, label, infoMessage, errorMessage, ...baseProps } = props
+
+  const [value, setValue] = useState(() => {
+    if (typeof propValue === 'string') return propValue
+    if (typeof defaultValue === 'string') return defaultValue
+    return ''
+  })
+
+  const handleOnChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    let value = event.target.value
+
+    if (Personnummer.valid(value)) {
+      value = Personnummer.parse(value).format(true)
+    }
+    setValue(value)
+  }
+
+  return (
+    <>
+      <input {...baseProps} type="text" value={value} readOnly hidden />
+      <InputField
+        {...baseProps}
+        type="text"
+        name={`${props.name}-visible-input`}
+        label={label}
+        infoMessage={infoMessage}
+        errorMessage={errorMessage}
+        minLength={10}
+        maxLength={13}
+        value={value}
+        onChange={handleOnChange}
+      />
+    </>
+  )
+}

--- a/apps/store/src/components/PriceForm/SsnSeField.tsx
+++ b/apps/store/src/components/PriceForm/SsnSeField.tsx
@@ -1,6 +1,4 @@
-import Personnummer from 'personnummer'
-import { ChangeEventHandler, useState } from 'react'
-import { InputField } from 'ui'
+import { PersonalNumberField } from '@/components/PersonalNumberField/PersonalNumberField'
 import { SsnSeField as SsnSeFieldType } from '@/services/PriceForm/Field.types'
 import { useTranslateTextLabel } from './useTranslateTextLabel'
 
@@ -10,37 +8,8 @@ type SsnSeFieldProps = {
 
 export const SsnSeField = ({ field }: SsnSeFieldProps) => {
   const translateLabel = useTranslateTextLabel({ data: {} })
-  const [value, setValue] = useState<string>(field.value ?? field.defaultValue ?? '')
-
-  const handleOnChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    let value = event.target.value
-
-    if (Personnummer.valid(value)) {
-      value = Personnummer.parse(value).format(true)
-    }
-    setValue(value)
-  }
 
   return (
-    <>
-      <input
-        type="text"
-        name={field.name}
-        required={field.required}
-        value={value}
-        readOnly
-        hidden
-      />
-      <InputField
-        type="text"
-        name={`${field.name}-visible-input`}
-        label={field.label ? translateLabel(field.label) : undefined}
-        minLength={10}
-        maxLength={13}
-        required={field.required}
-        value={value}
-        onChange={handleOnChange}
-      />
-    </>
+    <PersonalNumberField {...field} label={field.label ? translateLabel(field.label) : undefined} />
   )
 }


### PR DESCRIPTION
## Describe your changes

Create generic `PersonalNumberField` component.

Use new field in `SsnSeField`.

Integrate new field in `CheckoutPage`.

## Justify why they are needed

We want to do the same client-side validations whenever we deal with personal numbers.

According to our Hedvig dictionaly with refer to it as Personal Number rather than SSN.

## Jira issue(s): []

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
