### PR TITLE
Fix tabs stacking to show below navigation

### DIFF
--- a/apps/store/src/components/ProductPage/Tabs.tsx
+++ b/apps/store/src/components/ProductPage/Tabs.tsx
@@ -6,6 +6,7 @@ export const Tabs = styled(RadixTabs.Root)({
   position: 'relative',
   display: 'flex',
   flexDirection: 'column',
+  isolation: 'isolate',
 })
 
 export const TabsList = styled(RadixTabs.TabsList)(({ theme }) => ({


### PR DESCRIPTION
## Describe your changes

Create separate stacking context for tabs so they don't show up above modals etc.

![Screenshot 2022-11-16 at 15.55.52.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/e2da3c37-03e6-455c-a9cd-61cb80b8a1b7/Screenshot%202022-11-16%20at%2015.55.52.png)

![Screenshot 2022-11-16 at 15.55.58.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/8b8e06a9-e555-42d7-87ec-8da1b91ba614/Screenshot%202022-11-16%20at%2015.55.58.png)

## Justify why they are needed

Let's try out to use this apporach rather than go crazy with z-index values :)

## Jira issue(s): []

## Checklist before requesting a review

- [ ] I have performed a self-review of my code