### PR TITLE
Set domain option for auth session cookie

### DIFF
--- a/apps/store/src/services/Auth/Auth.ts
+++ b/apps/store/src/services/Auth/Auth.ts
@@ -1,5 +1,6 @@
 import { getCookie, setCookie } from 'cookies-next'
 import { OptionsType } from 'cookies-next/lib/types'
+import { ORIGIN_URL } from '@/utils/PageLink'
 
 const COOKIE_KEY = '_hvsession'
 const ACCESS_TOKEN_SESSION_FIELD = 'token'
@@ -9,11 +10,20 @@ export const save = (accessToken: string) => {
   setCookie(COOKIE_KEY, serialize(accessToken), {
     maxAge: MAX_AGE,
     path: '/',
+    domain: getRootDomain(),
     ...(process.env.NODE_ENV === 'production' && {
       sameSite: 'none',
       secure: true,
     }),
   })
+}
+
+const getRootDomain = () => {
+  const url = new URL(ORIGIN_URL)
+  const hostname = url.hostname
+  const parts = hostname.split('.')
+  const rootDomtainParts = parts.slice(-2, parts.length + 1)
+  return rootDomtainParts.join('.')
 }
 
 type CookieParams = Pick<OptionsType, 'req' | 'res'>

--- a/apps/store/src/services/Auth/Auth.ts
+++ b/apps/store/src/services/Auth/Auth.ts
@@ -19,11 +19,9 @@ export const save = (accessToken: string) => {
 }
 
 const getRootDomain = () => {
-  const url = new URL(ORIGIN_URL)
-  const hostname = url.hostname
-  const parts = hostname.split('.')
-  const rootDomtainParts = parts.slice(-2, parts.length + 1)
-  return rootDomtainParts.join('.')
+  const parts = new URL(ORIGIN_URL).hostname.split('.')
+  const rootDomainParts = parts.slice(-2)
+  return rootDomainParts.join('.')
 }
 
 type CookieParams = Pick<OptionsType, 'req' | 'res'>


### PR DESCRIPTION
## Describe your changes

Set the domain option for the auth session cookie.

## Justify why they are needed

We need to to be able to share the cookie between different subdomains.

It's not possible to test this locally which is unfortunate.

Perhaps we can consider a similar solution to how the "payment link" in HOPE works? There we inlude the "exchange token" in the URL which web onboarding uses to get an access token...

## Jira issue(s): []

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
