### PR TITLE
Fetch perils from PCMS API

### DIFF
--- a/apps/store/next.config.js
+++ b/apps/store/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
     emotion: true,
   },
   images: {
-    domains: ['a.storyblok.com'],
+    domains: ['a.storyblok.com', 'promise.hedvig.com'],
   },
   productionBrowserSourceMaps: true,
   i18n,

--- a/apps/store/src/blocks/PerilsBlock.tsx
+++ b/apps/store/src/blocks/PerilsBlock.tsx
@@ -1,56 +1,33 @@
 import styled from '@emotion/styled'
 import { SbBlokData, storyblokEditable } from '@storyblok/react'
+import Image from 'next/image'
+import { useMemo } from 'react'
 import { Perils } from '@/components/Perils/Perils'
-import { ShieldIcon } from '@/components/Perils/ShieldIcon'
-
-const ITEMS = [
-  {
-    id: 'waterLeaks',
-    icon: <ShieldIcon size="1.25rem" />,
-    name: 'Water leaks',
-    description:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
-    covered: [
-      'Lorem ipsum dolor sit amet',
-      'Sed fermentum tempus',
-      'Morbi at egestas tortor',
-      'Quisque venenatis lacus dolor',
-    ],
-    notCovered: ['Morbi vitae elit sapien', 'Duis sed viverra nibh'],
-  },
-  {
-    id: 'fire',
-    icon: <ShieldIcon size="1.25rem" />,
-    name: 'Fire',
-    description:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
-    covered: ['Lorem ipsum dolor sit amet', 'Sed fermentum tempus'],
-    notCovered: [
-      'Morbi at egestas tortor',
-      'Morbi vitae elit sapien',
-      'Duis sed viverra nibh',
-      'Quisque venenatis lacus dolor',
-    ],
-  },
-  {
-    id: 'storms',
-    icon: <ShieldIcon size="1.25rem" />,
-    name: 'Storms',
-    description:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
-    covered: [
-      'Lorem ipsum dolor sit amet',
-      'Sed fermentum tempus',
-      'Quisque venenatis lacus dolor',
-    ],
-    notCovered: ['Morbi vitae elit sapien'],
-  },
-]
+import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 
 export const PerilsBlock = (blok: SbBlokData) => {
+  const { productData, selectedVariant } = useProductPageContext()
+
+  const items = useMemo(() => {
+    const selectedProductVariant = productData.variants.find(
+      (item) => item.typeOfContract === selectedVariant?.typeOfContract,
+    )
+
+    const productVariant = selectedProductVariant ?? productData.variants[0]
+
+    return productVariant.perils.map((item) => ({
+      id: item.title,
+      name: item.title,
+      description: item.description,
+      covered: item.covered,
+      notCovered: item.exceptions,
+      icon: <Image src={item.icon.variants.light.svgUrl} alt="" width={24} height={24} />,
+    }))
+  }, [productData, selectedVariant])
+
   return (
     <Wrapper {...storyblokEditable(blok)}>
-      <Perils items={ITEMS} />
+      <Perils items={items} />
     </Wrapper>
   )
 }

--- a/apps/store/src/components/Perils/CoverageList.tsx
+++ b/apps/store/src/components/Perils/CoverageList.tsx
@@ -17,11 +17,13 @@ export const CoverageList = ({ heading, items, variant }: CoverageListProps) => 
       <List>
         {items.map((item, index) => (
           <Item key={index}>
-            {variant === 'covered' ? (
-              <CheckIcon color="currentColor" size="0.75rem" />
-            ) : (
-              <CrossIcon color="currentColor" size="0.75rem" />
-            )}
+            <NoShrink>
+              {variant === 'covered' ? (
+                <CheckIcon color="currentColor" size="0.75rem" />
+              ) : (
+                <CrossIcon color="currentColor" size="0.75rem" />
+              )}
+            </NoShrink>
             {item}
           </Item>
         ))}
@@ -51,3 +53,5 @@ const Item = styled.li(({ theme }) => ({
   alignItems: 'center',
   gap: theme.space[2],
 }))
+
+const NoShrink = styled.div({ flexShrink: 0 })

--- a/apps/store/src/components/ProductPage/ProductPage.helpers.ts
+++ b/apps/store/src/components/ProductPage/ProductPage.helpers.ts
@@ -1,0 +1,28 @@
+import { ApolloClient } from '@apollo/client'
+import {
+  ProductDataDocument,
+  ProductDataQuery,
+  ProductDataQueryVariables,
+} from '@/services/apollo/generated'
+import { ProductData } from './ProductPage.types'
+
+type GetProductDataParams = {
+  apolloClient: ApolloClient<unknown>
+  productName: string
+  locale: string
+}
+
+export const getProductData = async (params: GetProductDataParams): Promise<ProductData> => {
+  const { apolloClient, productName, locale } = params
+
+  const { data } = await apolloClient.query<ProductDataQuery, ProductDataQueryVariables>({
+    query: ProductDataDocument,
+    variables: { productName, locale },
+  })
+
+  if (!data.product) {
+    throw new Error(`Unable to fetch product data: ${productName}`)
+  }
+
+  return data.product
+}

--- a/apps/store/src/components/ProductPage/ProductPage.types.ts
+++ b/apps/store/src/components/ProductPage/ProductPage.types.ts
@@ -1,11 +1,15 @@
+import { ProductDataQuery } from '@/services/apollo/generated'
 import { Template } from '@/services/PriceForm/PriceForm.types'
 import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { ProductStory, StoryblokPageProps } from '@/services/storyblok/storyblok'
 
+export type ProductData = Exclude<ProductDataQuery['product'], null | undefined>
+
 export type ProductPageProps = StoryblokPageProps & {
   story: ProductStory
   priceTemplate: Template
+  productData: ProductData
   priceIntent: PriceIntent
   shopSession: ShopSession
 }

--- a/apps/store/src/graphql/ProductData.graphql
+++ b/apps/store/src/graphql/ProductData.graphql
@@ -1,0 +1,21 @@
+query ProductData($productName: String!, $locale: String!) {
+  product(productName: $productName) {
+    id
+    variants {
+      typeOfContract
+      perils(locale: $locale) {
+        title
+        description
+        icon {
+          variants {
+            light {
+              svgUrl
+            }
+          }
+        }
+        covered
+        exceptions
+      }
+    }
+  }
+}

--- a/apps/store/src/pages/products/[product].tsx
+++ b/apps/store/src/pages/products/[product].tsx
@@ -5,6 +5,7 @@ import Head from 'next/head'
 import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
 import { ProductPage } from '@/components/ProductPage/ProductPage'
+import { getProductData } from '@/components/ProductPage/ProductPage.helpers'
 import { ProductPageProps } from '@/components/ProductPage/ProductPage.types'
 import { APOLLO_STATE_PROP_NAME, initializeApollo } from '@/services/apollo/client'
 import logger from '@/services/logger/server'
@@ -19,7 +20,7 @@ import {
 } from '@/services/storyblok/storyblok'
 import { GLOBAL_STORY_PROP_NAME, STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
 import { getCountryByLocale } from '@/utils/l10n/countryUtils'
-import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+import { isRoutingLocale, toApiLocale } from '@/utils/l10n/localeUtils'
 
 type NextPageProps = ProductPageProps & {
   shopSessionId: string
@@ -83,14 +84,22 @@ export const getServerSideProps: GetServerSideProps<
       shopSession,
       apolloClient,
     })
-    const priceIntent = await priceIntentService.fetch({
-      productName: story.content.productId,
-      priceTemplate,
-    })
+    const [productData, priceIntent] = await Promise.all([
+      getProductData({
+        apolloClient,
+        productName: story.content.productId,
+        locale: toApiLocale(locale),
+      }),
+      priceIntentService.fetch({
+        productName: story.content.productId,
+        priceTemplate,
+      }),
+    ])
 
     return {
       props: {
         ...translations,
+        productData,
         priceTemplate,
         priceIntent,
         shopSession,

--- a/apps/store/src/utils/l10n/localeUtils.ts
+++ b/apps/store/src/utils/l10n/localeUtils.ts
@@ -14,6 +14,11 @@ export const toIsoLocale = (locale: UiLocale): IsoLocale => {
   return locale
 }
 
+export const toApiLocale = (locale: UiLocale): string => {
+  const isoLocale = toIsoLocale(locale)
+  return isoLocale.replace('-', '_')
+}
+
 export const toRoutingLocale = (locale: UiLocale): RoutingLocale => {
   if (isIsoLocale(locale)) return isoToRoutingLocales[locale]
   return locale


### PR DESCRIPTION
## Describe your changes

Fetch perils from PCMS API.

Map between product page context and perils component in CMS block.

Fix icons in coverage lists.

Add utility to translate between "UI locale" and "API locale".

![Screenshot 2022-11-17 at 12.04.19.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/d3689acb-3e32-46d5-89c9-8b6b9a46c95b/Screenshot%202022-11-17%20at%2012.04.19.png)

## Justify why they are needed

The CMS block seems the most reasonable place to access page context. Then we can reuse the perils component on other pages (but not the CMS block).

Let's unify how we deal with locales going forward.

I didn't include a selector for product variants since that isn't part of the perils block in the design but rather a different component on the product page.

## Jira issue(s): [GRW-1781]

## Checklist before requesting a review

- [x] I have performed a self-review of my code


[GRW-1781]: https://hedvig.atlassian.net/browse/GRW-1781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ