### PR TITLE
Fetch insurable limits from PCMS API

### DIFF
--- a/apps/store/src/blocks/InsurableLimitsBlock.tsx
+++ b/apps/store/src/blocks/InsurableLimitsBlock.tsx
@@ -1,34 +1,31 @@
 import styled from '@emotion/styled'
+import { storyblokEditable } from '@storyblok/react'
 import { InsurableLimits } from '@/components/InsurableLimits/InsurableLimits'
+import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { Statistic } from '@/components/Statistic/Statistic'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
-import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 
-type InsurableLimitsBlockProps = SbBaseBlockProps<{
-  items: Array<InsurableLimitBlockProps['blok']>
-}>
+type InsurableLimitsBlockProps = SbBaseBlockProps<unknown>
 
 const StyledInsurableLimits = styled(InsurableLimits)(({ theme }) => ({
   padding: theme.space[4],
 }))
 
 export const InsurableLimitsBlock = ({ blok }: InsurableLimitsBlockProps) => {
-  const items = filterByBlockType(blok.items, InsurableLimitBlock.blockName)
+  const { productData, selectedVariant } = useProductPageContext()
+
+  const selectedProductVariant = productData.variants.find(
+    (item) => item.typeOfContract === selectedVariant?.typeOfContract,
+  )
+
+  const productVariant = selectedProductVariant ?? productData.variants[0]
+
   return (
-    <StyledInsurableLimits>
-      {items.map((nestedBlock) => (
-        <InsurableLimitBlock key={nestedBlock._uid} blok={nestedBlock} />
+    <StyledInsurableLimits {...storyblokEditable(blok)}>
+      {productVariant.insurableLimits.map((item) => (
+        <Statistic key={item.label} label={item.label} value={item.limit} />
       ))}
     </StyledInsurableLimits>
   )
 }
 InsurableLimitsBlock.blockName = 'insurableLimits'
-
-type InsurableLimitBlockProps = SbBaseBlockProps<{
-  label: string
-  limit: string
-}>
-const InsurableLimitBlock = ({ blok }: InsurableLimitBlockProps) => {
-  return <Statistic label={blok.label} value={blok.limit} />
-}
-InsurableLimitBlock.blockName = 'insurableLimit'

--- a/apps/store/src/graphql/ProductData.graphql
+++ b/apps/store/src/graphql/ProductData.graphql
@@ -16,6 +16,12 @@ query ProductData($productName: String!, $locale: String!) {
         covered
         exceptions
       }
+      insurableLimits(locale: $locale) {
+        type
+        label
+        limit
+        description
+      }
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

Fetch insurable limits from the API (PCMS).

Show selected product variant or the first item.

![Screenshot 2022-11-17 at 13.52.54.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/4c8fa88b-6343-4ae0-8f51-4a35fbd51d30/Screenshot%202022-11-17%20at%2013.52.54.png)

## Justify why they are needed

We should figure out how this works to also select a product variant before you calculated prices.

## Jira issue(s): [GRW-1783]

## Checklist before requesting a review

- [x] I have performed a self-review of my code


[GRW-1783]: https://hedvig.atlassian.net/browse/GRW-1783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ