### PR TITLE
Discard ShopSession after successful sign

### DIFF
--- a/apps/store/src/pages/checkout/index.tsx
+++ b/apps/store/src/pages/checkout/index.tsx
@@ -1,3 +1,4 @@
+import { useApolloClient } from '@apollo/client'
 import type { GetServerSideProps, NextPage } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useRouter } from 'next/router'
@@ -10,7 +11,10 @@ import * as Auth from '@/services/Auth/Auth'
 import { fetchCurrentCheckoutSigning } from '@/services/Checkout/Checkout.helpers'
 import logger from '@/services/logger/server'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
-import { getCurrentShopSessionServerSide } from '@/services/shopSession/ShopSession.helpers'
+import {
+  getCurrentShopSessionServerSide,
+  setupShopSessionServiceClientSide,
+} from '@/services/shopSession/ShopSession.helpers'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { PageLink } from '@/utils/PageLink'
 
@@ -24,12 +28,14 @@ const NextCheckoutPage: NextPage<NextPageProps> = (props) => {
   const { cartId, products, checkoutId, checkoutSigningId, ...pageProps } = props
   const router = useRouter()
 
+  const apolloClient = useApolloClient()
   const [handleSubmit, { loading, userErrors, signingStatus }] = useHandleSubmitCheckout({
     cartId,
     products,
     checkoutId,
     checkoutSigningId,
     onSuccess(accessToken) {
+      setupShopSessionServiceClientSide(apolloClient).reset()
       Auth.save(accessToken)
       router.push(PageLink.checkoutPayment())
     },

--- a/apps/store/src/pages/checkout/payment.tsx
+++ b/apps/store/src/pages/checkout/payment.tsx
@@ -1,9 +1,5 @@
 import type { GetServerSideProps, NextPage } from 'next'
-import { initializeApollo } from '@/services/apollo/client'
-import { PaymentConnectionFlow } from '@/services/apollo/generated'
 import logger from '@/services/logger/server'
-import { getCurrentShopSessionServerSide } from '@/services/shopSession/ShopSession.helpers'
-import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { getWebOnboardingPaymentURL } from '@/services/WebOnboarding/WebOnboarding.helpers'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { PageLink } from '@/utils/PageLink'
@@ -15,51 +11,25 @@ const NextCheckoutPaymentPage: NextPage = () => {
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { req, res, locale } = context
+  const { locale } = context
   if (!isRoutingLocale(locale)) return { notFound: true }
-
-  let shopSession: ShopSession
-  try {
-    const apolloClient = initializeApollo({ req, res })
-    shopSession = await getCurrentShopSessionServerSide({ req, res, apolloClient })
-  } catch (error) {
-    LOGGER.error(error, 'Failed to get shop session')
-    return { notFound: true }
-  }
-  const shopSessionLogger = LOGGER.child({ shopSessionId: shopSession.id })
-
-  if (shopSession.checkout.completedAt) {
-    return {
-      redirect: {
-        destination: PageLink.confirmation({ locale, shopSessionId: shopSession.id }),
-        permanent: false,
-      },
-    }
-  }
-
-  if (shopSession.checkout.paymentConnectionFlow !== PaymentConnectionFlow.AfterSign) {
-    shopSessionLogger.error(
-      `Unspported payment connection flow: ${shopSession.checkout.paymentConnectionFlow}`,
-    )
-    return { notFound: true }
-  }
 
   const redirectBaseURL = PageLink.checkoutPaymentRedirectBase({ locale })
   let redirectURL: URL
   try {
     redirectURL = new URL(redirectBaseURL)
   } catch (error) {
-    shopSessionLogger.error(error, `Invalid redirect base URL: ${redirectBaseURL}`)
+    LOGGER.error(error, `Invalid redirect base URL: ${redirectBaseURL}`)
     return { notFound: true }
   }
 
   const woPaymentURL = getWebOnboardingPaymentURL({ locale, redirectURL })
   if (!woPaymentURL) {
-    shopSessionLogger.error('Web Onboarding payment URL not configured')
+    LOGGER.error('Web Onboarding payment URL not configured')
     return { notFound: true }
   }
 
-  shopSessionLogger.info('Re-directing user to Web Onboarding for payment connection')
+  LOGGER.info('Re-directing to Web Onboarding for payment connection')
   return { redirect: { destination: woPaymentURL, permanent: false } }
 }
 


### PR DESCRIPTION
## Describe your changes

Reset cookie after successfully signing current `ShopSession`.

Remove code to fetch/validate `ShopSession` on checkout payment page.

## Justify why they are needed

A signed `ShopSession` has reached it's "end of life" so we should discard it as the "current `ShopSession`".

We will need to update the payment page code a bit when we implement "payment before sign" but for now this will do it for us.

## Jira issue(s): []

## Checklist before requesting a review

- [x] I have performed a self-review of my code
