### PR TITLE
Define explicit ShopSession for Checkout/Payment step

### DIFF
--- a/apps/store/src/components/CheckoutPaymentPage/CheckoutPaymentPageAdyen.tsx
+++ b/apps/store/src/components/CheckoutPaymentPage/CheckoutPaymentPageAdyen.tsx
@@ -48,7 +48,11 @@ export const CheckoutPaymentPageAdyen = ({
             </Text>
           </p>
         </Space>
-        <AdyenCheckout paymentMethodsResponse={paymentMethodsResponse} onSuccess={() => {}} />
+        <AdyenCheckout
+          shopSessionId={shopSessionId}
+          paymentMethodsResponse={paymentMethodsResponse}
+          onSuccess={() => {}}
+        />
         <Space y={0.5}>
           <Button onClick={startSign} disabled={isCompleteButtonDisabled} fullWidth>
             Complete purchase

--- a/apps/store/src/pages/api/payment/adyen-callback/[shopSessionId]/[locale].ts
+++ b/apps/store/src/pages/api/payment/adyen-callback/[shopSessionId]/[locale].ts
@@ -5,10 +5,11 @@ import { PageLink } from '@/utils/PageLink'
 
 export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { MD: md, PaRes: pares } = req.body
+  const { locale, shopSessionId } = req.query
 
-  if (!isRoutingLocale(req.query.locale)) return res.status(400).json({ message: 'Invalid locale' })
-
-  const locale = req.query.locale
+  if (!isRoutingLocale(locale)) return res.status(400).json({ message: 'Invalid locale' })
+  if (typeof shopSessionId !== 'string')
+    return res.status(400).json({ message: 'Missing ShopSession ID' })
 
   if (typeof md !== 'string')
     return res.status(400).json({ message: 'MD parameter not found in body' })
@@ -20,6 +21,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   return res.redirect(
     PageLink.checkoutPayment({
       locale,
+      shopSessionId,
       authStatus: AuthStatus.Success,
     }),
   )

--- a/apps/store/src/pages/checkout/[shopSessionId]/payment/index.tsx
+++ b/apps/store/src/pages/checkout/[shopSessionId]/payment/index.tsx
@@ -1,20 +1,37 @@
 import type { GetServerSideProps, NextPage } from 'next'
+import { initializeApollo } from '@/services/apollo/client'
 import logger from '@/services/logger/server'
+import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { getWebOnboardingPaymentURL } from '@/services/WebOnboarding/WebOnboarding.helpers'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { PageLink } from '@/utils/PageLink'
 
-const LOGGER = logger.child({ module: 'pages/checkout/payment' })
+const LOGGER = logger.child({ module: 'pages/checkout/[shopSessionId]/payment' })
+
+type Props = Record<string, unknown>
+type Params = { shopSessionId: string }
 
 const NextCheckoutPaymentPage: NextPage = () => {
   return null
 }
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { locale } = context
+export const getServerSideProps: GetServerSideProps<Props, Params> = async (context) => {
+  const { locale, params, req, res } = context
   if (!isRoutingLocale(locale)) return { notFound: true }
 
-  const redirectBaseURL = PageLink.checkoutPaymentRedirectBase({ locale })
+  const shopSessionId = params?.shopSessionId
+  if (!shopSessionId) return { notFound: true }
+
+  try {
+    const apolloClient = initializeApollo({ req, res })
+    await setupShopSessionServiceServerSide({ apolloClient, req, res }).fetchById(shopSessionId)
+    // TODO: validate ShopSession
+  } catch (error) {
+    logger.error(error, `Unable to fetch ShopSession: ${shopSessionId}`)
+    return { notFound: true }
+  }
+
+  const redirectBaseURL = PageLink.checkoutPaymentRedirectBase({ locale, shopSessionId })
   let redirectURL: URL
   try {
     redirectURL = new URL(redirectBaseURL)

--- a/apps/store/src/pages/checkout/index.tsx
+++ b/apps/store/src/pages/checkout/index.tsx
@@ -22,10 +22,11 @@ type NextPageProps = Omit<CheckoutPageProps, 'loading' | 'userErrors'> & {
   cartId: string
   checkoutId: string
   checkoutSigningId: string | null
+  shopSessionId: string
 }
 
 const NextCheckoutPage: NextPage<NextPageProps> = (props) => {
-  const { cartId, products, checkoutId, checkoutSigningId, ...pageProps } = props
+  const { cartId, products, checkoutId, checkoutSigningId, shopSessionId, ...pageProps } = props
   const router = useRouter()
 
   const apolloClient = useApolloClient()
@@ -37,7 +38,7 @@ const NextCheckoutPage: NextPage<NextPageProps> = (props) => {
     onSuccess(accessToken) {
       setupShopSessionServiceClientSide(apolloClient).reset()
       Auth.save(accessToken)
-      router.push(PageLink.checkoutPayment())
+      router.push(PageLink.checkoutPayment({ shopSessionId }))
     },
   })
 

--- a/apps/store/src/services/adyen/AdyenCheckout.tsx
+++ b/apps/store/src/services/adyen/AdyenCheckout.tsx
@@ -9,13 +9,14 @@ import { localeToAdyenLocale, usePaymentMethodConfiguration } from './Adyen.help
 import { AdyenDropinStyles } from './DropinStyles'
 
 type Props = {
+  shopSessionId: string
   paymentMethodsResponse: PaymentMethodsResponseObject
   onSuccess: (paymentConnection: unknown) => void
 }
 
-export const AdyenCheckout = ({ onSuccess, paymentMethodsResponse }: Props) => {
+export const AdyenCheckout = ({ shopSessionId, onSuccess, paymentMethodsResponse }: Props) => {
   const paymentContainer = useRef<HTMLDivElement>(null)
-  const configuration = useAdyenConfiguration()
+  const configuration = useAdyenConfiguration({ shopSessionId })
 
   useEffect(() => {
     const createCheckout = async () => {
@@ -50,7 +51,9 @@ export const AdyenCheckout = ({ onSuccess, paymentMethodsResponse }: Props) => {
   )
 }
 
-const useAdyenConfiguration = () => {
+type AdyenConfigurationParams = { shopSessionId: string }
+
+const useAdyenConfiguration = ({ shopSessionId }: AdyenConfigurationParams) => {
   const { locale, routingLocale } = useCurrentLocale()
   const { t } = useTranslation()
   const paymentMethodConfiguration = usePaymentMethodConfiguration()
@@ -77,10 +80,10 @@ const useAdyenConfiguration = () => {
         'da-DK': { payButton: payButtonText },
         'en-US': { payButton: payButtonText },
       },
-      returnUrl: PageLink.apiPaymentAdyenCallback({ locale: routingLocale }),
+      returnUrl: PageLink.apiPaymentAdyenCallback({ locale: routingLocale, shopSessionId }),
 
       paymentMethodConfiguration,
     }),
-    [locale, routingLocale, payButtonText, paymentMethodConfiguration],
+    [locale, routingLocale, payButtonText, paymentMethodConfiguration, shopSessionId],
   )
 }

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -10,7 +10,9 @@ export const ORIGIN_URL =
 type BaseParams = { locale?: RoutingLocale }
 
 type ProductPage = BaseParams & { slug: string }
-type CheckoutPaymentPage = BaseParams & { authStatus?: AuthStatus }
+type CheckoutPaymentPage = BaseParams & { shopSessionId: string; authStatus?: AuthStatus }
+type CheckoutPaymentRedirectBasePage = Required<BaseParams> & { shopSessionId: string }
+type AdyenCallbackRoute = Required<BaseParams> & { shopSessionId: string }
 type ConfirmationPage = BaseParams & { shopSessionId: string }
 
 // We need explicit locale when doing server-side redirects.  On client side NextJs adds it automatically
@@ -21,17 +23,17 @@ export const PageLink = {
   product: ({ locale, slug }: ProductPage) => `${localePrefix(locale)}/products/${slug}`,
   cart: ({ locale }: BaseParams = {}) => `${localePrefix(locale)}/cart`,
   checkout: ({ locale }: BaseParams = {}) => `${localePrefix(locale)}/checkout`,
-  checkoutPayment: ({ locale, authStatus }: CheckoutPaymentPage = {}) => {
+  checkoutPayment: ({ locale, authStatus, shopSessionId }: CheckoutPaymentPage) => {
     const authStatusQueryParam = authStatus ? `authStatus=${authStatus}` : null
     const queryString = authStatusQueryParam ? `?${authStatusQueryParam}` : ''
-    return `${localePrefix(locale)}/checkout/payment${queryString}`
+    return `${localePrefix(locale)}/checkout/${shopSessionId}/payment${queryString}`
   },
-  checkoutPaymentRedirectBase: ({ locale }: Required<BaseParams>) =>
-    `${ORIGIN_URL}/${locale}/checkout/payment`,
+  checkoutPaymentRedirectBase: ({ locale, shopSessionId }: CheckoutPaymentRedirectBasePage) =>
+    `${ORIGIN_URL}/${locale}/checkout/${shopSessionId}/payment`,
   checkoutSign: ({ locale }: BaseParams = {}) => `${localePrefix(locale)}/checkout/sign`,
   confirmation: ({ locale, shopSessionId }: ConfirmationPage) =>
     `${localePrefix(locale)}/confirmation/${shopSessionId}`,
 
-  apiPaymentAdyenCallback: ({ locale }: Required<BaseParams>) =>
-    `/api/payment/adyen-callback/${locale}`,
+  apiPaymentAdyenCallback: ({ locale, shopSessionId }: AdyenCallbackRoute) =>
+    `/api/payment/adyen-callback/${shopSessionId}/${locale}`,
 } as const


### PR DESCRIPTION
## Describe your changes

Explicitly define a ShopSession in Checkout for all steps after signing (payment + confirmation).

Use this ShopSession when creating the redirect URL back from Web Onboarding.

Update Adyen implementation just to keep it in line. We should revisit this later tho.

## Justify why they are needed

After signing, the life of the shop session is over. However, we don't have any other resource to handle data we need for later steps. Instead I define the ShopSession explicitly in the URL.

## Jira issue(s): []

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
