### PR TITLE
Add frosted overlay to Dialog

### DIFF
--- a/apps/store/src/components/ProductPage/PriceFormModal/PriceFormModal.tsx
+++ b/apps/store/src/components/ProductPage/PriceFormModal/PriceFormModal.tsx
@@ -12,7 +12,7 @@ type Props = {
 export const PriceFormModal = ({ children, header, isOpen, toggleDialog }: Props) => {
   return (
     <Dialog.Root open={isOpen} onOpenChange={toggleDialog}>
-      <Dialog.Content>
+      <Dialog.Content frostedOverlay>
         <PriceFormWrapper>
           <Dialog.Close asChild>
             <IconButton>
@@ -40,7 +40,7 @@ const PriceFormWrapper = styled(Dialog.Window)(({ theme }) => ({
   overflow: 'auto',
   paddingLeft: theme.space[4],
   paddingRight: theme.space[4],
-  backgroundColor: theme.colors.light,
+  backgroundColor: 'transparent',
 }))
 
 export const IconButton = styled.button({

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -2,6 +2,10 @@ import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 
+type OverlayProps = {
+  frosted?: boolean
+}
+
 const overlayShow = keyframes({
   '0%': { opacity: 0 },
   '100%': { opacity: 1 },
@@ -12,14 +16,19 @@ const contentShow = keyframes({
   '100%': { opacity: 1, transform: 'scale(1)' },
 })
 
-const StyledOverlay = styled(DialogPrimitive.Overlay)({
+const StyledOverlay = styled(DialogPrimitive.Overlay)<OverlayProps>(({ frosted }) => ({
   backgroundColor: 'rgba(0, 0, 0, 0.6)',
   position: 'fixed',
   inset: 0,
   '@media (prefers-reduced-motion: no-preference)': {
     animation: `${overlayShow} 150ms cubic-bezier(0.16, 1, 0.3, 1) forwards`,
   },
-})
+
+  ...(frosted && {
+    backgroundColor: 'rgba(250, 250, 250, 0.6)',
+    backdropFilter: 'blur(64px)',
+  }),
+}))
 
 export const Window = styled.div(({ theme }) => ({
   backgroundColor: theme.colors.white,
@@ -38,14 +47,15 @@ type ContentProps = {
   children: React.ReactNode
   onClose?: () => void
   className?: string
+  frostedOverlay?: boolean
 }
 
-export const Content = ({ children, onClose, className }: ContentProps) => {
+export const Content = ({ children, onClose, className, frostedOverlay }: ContentProps) => {
   const handleClose = () => onClose?.()
 
   return (
     <DialogPrimitive.Portal>
-      <StyledOverlay />
+      <StyledOverlay frosted={frostedOverlay} />
       <StyledContentWrapper className={className}>
         <DialogPrimitive.Content onEscapeKeyDown={handleClose} onInteractOutside={handleClose}>
           {children}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add frosted overlay to PriceCalculator Dialog
I added a prop to `Dialog.Content`. We could export the `Overlay` component as well but that would make composition a bit more complex. But happy to hear your thoughts on that!
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
[Final design](https://www.figma.com/file/8SfzuQEJ4LJ6uKL0l7WKoE/Hedvig.com-%C2%B7-Final-Design?node-id=1048%3A3883&t=RcCopTqckRsg7kKk-1)

https://user-images.githubusercontent.com/6661511/203031394-fafd9033-03af-4caa-b806-275e2f365518.mov


## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
