### PR TITLE
fix: Swedish landing page loading issue

### DIFF
--- a/apps/onboarding/src/pages/new-member/index.tsx
+++ b/apps/onboarding/src/pages/new-member/index.tsx
@@ -73,8 +73,10 @@ export const getServerSideProps: GetServerSideProps<
       }
     }
 
+    const marketLabel = getMarketLabelFromLocaleLabel(locale)
     if (
-      Features.getFeature(Feature.TRAVEL_ACCIDENT_STANDALONE, getMarketLabelFromLocaleLabel(locale))
+      marketLabel === MarketLabel.SE ||
+      Features.getFeature(Feature.TRAVEL_ACCIDENT_STANDALONE, marketLabel)
     ) {
       return {
         props: {


### PR DESCRIPTION
## Describe your changes

* Fix `getServerSideProps` for Swedish Landing page.

## Justify why they are needed

I've recently changed that code to support travel/accident standalone, with that a bug was inserted related with getting the correct props for Swedish Landing Page