### PR TITLE
Implement base CurrentInsuranceField

### DIFF
--- a/apps/store/public/locales/default/purchase-form.json
+++ b/apps/store/public/locales/default/purchase-form.json
@@ -1,4 +1,5 @@
 {
   "HOUSEHOLD_SIZE_VALUE": "You + {{count}}",
-  "HOUSEHOLD_SIZE_VALUE_zero": "Just you"
+  "HOUSEHOLD_SIZE_VALUE_zero": "Just you",
+  "CURRENT_INSURANCE_FIELD_PLACEHOLDER": "Pick company..."
 }

--- a/apps/store/public/locales/sv-se/purchase-form.json
+++ b/apps/store/public/locales/sv-se/purchase-form.json
@@ -1,4 +1,5 @@
 {
   "HOUSEHOLD_SIZE_VALUE": "Du + {{count}}",
-  "HOUSEHOLD_SIZE_VALUE_zero": "Bara du"
+  "HOUSEHOLD_SIZE_VALUE_zero": "Bara du",
+  "CURRENT_INSURANCE_FIELD_PLACEHOLDER": "Välj bolag..."
 }

--- a/apps/store/src/components/InputSelect/InputSelect.tsx
+++ b/apps/store/src/components/InputSelect/InputSelect.tsx
@@ -44,7 +44,7 @@ const StyledSelect = styled.select(({ theme }) => ({
 
 type InputSelectProps = InputBaseProps & {
   name: string
-  options: Array<{ name: string; value: string }>
+  options: ReadonlyArray<{ name: string; value: string }>
   value?: string
   defaultValue?: string
   onChange?: React.ChangeEventHandler<HTMLSelectElement>

--- a/apps/store/src/components/PriceForm/CurrentInsuranceField/CurrentInsuranceField.stories.tsx
+++ b/apps/store/src/components/PriceForm/CurrentInsuranceField/CurrentInsuranceField.stories.tsx
@@ -1,0 +1,33 @@
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { CurrentInsuranceField } from './CurrentInsuranceField'
+
+export default {
+  title: 'Input / Current Insurance Field',
+  component: CurrentInsuranceField,
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'iphonese2',
+    },
+  },
+  argTypes: { onCompanyChange: { action: 'changed' } },
+} as ComponentMeta<typeof CurrentInsuranceField>
+
+const Template: ComponentStory<typeof CurrentInsuranceField> = (props) => {
+  return <CurrentInsuranceField {...props} />
+}
+export const Default = Template.bind({})
+Default.args = {
+  label: 'Are you already insured?',
+  companyOptions: [
+    {
+      name: 'Folksam',
+      value: 'se-folksam',
+    },
+    {
+      name: 'Trygg Hansa',
+      value: 'se-trygg-hansa',
+    },
+  ],
+}

--- a/apps/store/src/components/PriceForm/CurrentInsuranceField/CurrentInsuranceField.tsx
+++ b/apps/store/src/components/PriceForm/CurrentInsuranceField/CurrentInsuranceField.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from 'next-i18next'
+import { ChangeEventHandler, useState } from 'react'
+import { Space } from 'ui'
+import { InputSelect } from '@/components/InputSelect/InputSelect'
+import { InputSwitch } from '../InputSwitch'
+import { SelectOptions } from './CurrentInsuranceField.types'
+
+export type CurrentInsuranceFieldProps = {
+  label: string
+  companyOptions: SelectOptions
+  onCompanyChange: (company: string) => void
+}
+
+export const CurrentInsuranceField = (props: CurrentInsuranceFieldProps) => {
+  const { companyOptions, onCompanyChange, label } = props
+  const [hasInsurance, setHasInsurance] = useState(false)
+
+  const handleCheckedChange = (checked: boolean) => {
+    setHasInsurance(checked)
+  }
+
+  const { t } = useTranslation('purchase-form')
+
+  const handleChangeExternalInsurer: ChangeEventHandler<HTMLSelectElement> = (event) => {
+    if (event.target.value) {
+      onCompanyChange(event.target.value)
+    }
+  }
+
+  return (
+    <Space y={1}>
+      <InputSwitch label={label} checked={hasInsurance} onCheckedChange={handleCheckedChange} />
+
+      {hasInsurance && (
+        <InputSelect
+          name="externalInsurer"
+          // @TODO: remove, not part of updated designs
+          label="Current insurance company"
+          required
+          options={companyOptions}
+          placeholder={t('CURRENT_INSURANCE_FIELD_PLACEHOLDER')}
+          onChange={handleChangeExternalInsurer}
+        />
+      )}
+    </Space>
+  )
+}

--- a/apps/store/src/components/PriceForm/CurrentInsuranceField/CurrentInsuranceField.types.ts
+++ b/apps/store/src/components/PriceForm/CurrentInsuranceField/CurrentInsuranceField.types.ts
@@ -1,0 +1,1 @@
+export type SelectOptions = ReadonlyArray<{ name: string; value: string }>

--- a/apps/store/src/components/PriceForm/CurrentInsuranceField/useCurrentInsuranceFieldProps.ts
+++ b/apps/store/src/components/PriceForm/CurrentInsuranceField/useCurrentInsuranceFieldProps.ts
@@ -1,0 +1,73 @@
+import { datadogLogs } from '@datadog/browser-logs'
+import { usePriceIntentDataUpdateMutation } from '@/services/apollo/generated'
+import { SelectOptions } from './CurrentInsuranceField.types'
+
+const useCompanyOptions = (productName: string): SelectOptions => {
+  console.debug('Fetching companies for: ', productName)
+  const companyOptions = [
+    {
+      name: 'Trygg Hansa',
+      value: 'TRYGGHANSA',
+    },
+    {
+      name: 'Folksam',
+      value: 'FOLKSAM',
+    },
+    {
+      name: 'If',
+      value: 'IF',
+    },
+    {
+      name: 'Länsförsäkringar',
+      value: 'LANSFORSAKRINGAR',
+    },
+    {
+      name: 'Länsförsäkringar Stockholm',
+      value: 'LANSFORSAKRINGAR',
+    },
+    {
+      name: 'Moderna',
+      value: 'MODERNA',
+    },
+  ]
+  return companyOptions
+}
+
+const useUpdateExternalInsurer = (priceIntentId: string) => {
+  const [updateExternalInsurer] = usePriceIntentDataUpdateMutation({
+    onCompleted(data) {
+      if (data.priceIntentDataUpdate.priceIntent) {
+        console.log('Added external insurer')
+      } else {
+        datadogLogs.logger.warn('Failed to add external insurer', {
+          priceIntentId,
+        })
+      }
+    },
+    onError(error) {
+      datadogLogs.logger.warn('Error adding external insurer', {
+        priceIntentId,
+        error,
+      })
+    },
+  })
+
+  return (externalInsurerId: string) => {
+    updateExternalInsurer({ variables: { priceIntentId, data: { externalInsurerId } } })
+  }
+}
+
+type Params = {
+  productName: string
+  priceIntentId: string
+}
+
+export const useCurrentInsuranceFieldProps = ({ productName, priceIntentId }: Params) => {
+  const companyOptions = useCompanyOptions(productName)
+  const updateExternalInsurer = useUpdateExternalInsurer(priceIntentId)
+
+  return {
+    companyOptions,
+    updateExternalInsurer,
+  }
+}

--- a/apps/store/src/components/PriceForm/InputRadio.tsx
+++ b/apps/store/src/components/PriceForm/InputRadio.tsx
@@ -53,7 +53,7 @@ const Indicator = styled(RadioGroup.Indicator)(({ theme }) => ({
 
 type InputRadioProps = InputBaseProps & {
   name: string
-  options: Array<{ label: string; value: string }>
+  options: ReadonlyArray<{ label: string; value: string }>
   value?: string
   defaultValue?: string
   onValueChange?: (value: string) => void


### PR DESCRIPTION
## Describe your changes

Implement base version of `CurrentInsuranceField`.

Will allow a user to pick their current insurance company.

In the future it will also integrate with Insurely.

![Screenshot 2022-11-22 at 10.49.18.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/fd16d2a4-5dcc-4209-a918-76cdaca6e4cc/Screenshot%202022-11-22%20at%2010.49.18.png)

## Justify why they are needed

For Switching.

The API integration is just placeholder but wanted to add something that resembels what it will look like when the new endpoints are in place!

The look & feel is not according to design but I feel it is too early to implement the new versions of the inputs.

## Jira issue(s): [GRW-1812]

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1812]: https://hedvig.atlassian.net/browse/GRW-1812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ