### PR TITLE
ci(cypress): load NEXT_PUBLIC_GRAPHQL_ENDPOINT secret

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -23,6 +23,8 @@ jobs:
       # Install NPM dependencies, cache them correctly and run all Cypress tests
       - name: Cypress run
         uses: cypress-io/github-action@v4
+        env:
+          NEXT_PUBLIC_GRAPHQL_ENDPOINT: ${{ secrets.NEXT_PUBLIC_GRAPHQL_ENDPOINT }}
         with:
           install-command: yarn install --immutable
           command: yarn e2e-onboarding:headless


### PR DESCRIPTION
## Describe your changes

Load `NEXT_PUBLIC_GRAPHQL_ENDPOINT` from Github secrets.

## Justify why they are needed

That action was [failing](https://github.com/HedvigInsurance/racoon/actions/runs/3522523785/jobs/5905600143) due the lack of `NEXT_PUBLIC_GRAPHQL_ENDPOINT` during `cypress` action execution.

Tested [here](https://github.com/HedvigInsurance/racoon/actions/runs/3522765456/jobs/5906123348)