### PR TITLE
Render different layout for mobile and desktop.

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import { storyblokEditable, StoryblokComponent, SbBlokData } from '@storyblok/react'
+import { useBreakpoint } from 'ui'
 import { PurchaseForm } from '@/components/ProductPage/PurchaseForm/PurchaseForm'
 import * as Tabs from '@/components/ProductPage/Tabs'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
@@ -11,29 +12,53 @@ type ProductPageBlockProps = SbBaseBlockProps<{
 }>
 
 export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
+  const isDesktop = useBreakpoint('lg')
   return (
     <Main {...storyblokEditable(blok)}>
-      <PurchaseForm />
+      {!isDesktop && (
+        <>
+          <PurchaseForm />
+          <Tabs.Tabs defaultValue="overview">
+            <Tabs.TabsList>
+              {/* TODO: Get tab labels from Storyblok */}
+              <Tabs.TabsTrigger value="overview">Overview</Tabs.TabsTrigger>
+              <Tabs.TabsTrigger value="coverage">Coverage</Tabs.TabsTrigger>
+            </Tabs.TabsList>
 
-      <Tabs.Tabs defaultValue="overview">
-        <Tabs.TabsList>
-          {/* TODO: Get tab labels from Storyblok */}
-          <Tabs.TabsTrigger value="overview">Overview</Tabs.TabsTrigger>
-          <Tabs.TabsTrigger value="coverage">Coverage</Tabs.TabsTrigger>
-        </Tabs.TabsList>
+            <Tabs.TabsContent value="overview">
+              {blok.overview?.map((nestedBlock) => (
+                <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+              ))}
+            </Tabs.TabsContent>
 
-        <Tabs.TabsContent value="overview">
-          {blok.overview?.map((nestedBlock) => (
-            <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
-          ))}
-        </Tabs.TabsContent>
+            <Tabs.TabsContent value="coverage">
+              {blok.coverage?.map((nestedBlock) => (
+                <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+              ))}
+            </Tabs.TabsContent>
+          </Tabs.Tabs>
+        </>
+      )}
 
-        <Tabs.TabsContent value="coverage">
+      {isDesktop && (
+        <>
+          <ProductUpper>
+            <div>
+              {blok.overview?.map((nestedBlock) => (
+                <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+              ))}
+            </div>
+
+            <PurchaseFormWrapper>
+              <PurchaseForm />
+            </PurchaseFormWrapper>
+          </ProductUpper>
+
           {blok.coverage?.map((nestedBlock) => (
             <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
           ))}
-        </Tabs.TabsContent>
-      </Tabs.Tabs>
+        </>
+      )}
 
       {blok.body.map((nestedBlock) => (
         <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
@@ -46,4 +71,15 @@ ProductPageBlock.blockName = 'product'
 
 const Main = styled.main({
   width: '100%',
+})
+
+const ProductUpper = styled.div({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, 1fr)',
+  alignItems: 'flex-start',
+})
+
+const PurchaseFormWrapper = styled.div({
+  position: 'sticky',
+  top: 0,
 })

--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -6,6 +6,8 @@ import * as Tabs from '@/components/ProductPage/Tabs'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
 type ProductPageBlockProps = SbBaseBlockProps<{
+  overviewLabel: string
+  coverageLabel: string
   overview: SbBlokData[]
   coverage: SbBlokData[]
   body: SbBlokData[]
@@ -20,9 +22,8 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
           <PurchaseForm />
           <Tabs.Tabs defaultValue="overview">
             <Tabs.TabsList>
-              {/* TODO: Get tab labels from Storyblok */}
-              <Tabs.TabsTrigger value="overview">Overview</Tabs.TabsTrigger>
-              <Tabs.TabsTrigger value="coverage">Coverage</Tabs.TabsTrigger>
+              <Tabs.TabsTrigger value="overview">{blok.overviewLabel}</Tabs.TabsTrigger>
+              <Tabs.TabsTrigger value="coverage">{blok.coverageLabel}</Tabs.TabsTrigger>
             </Tabs.TabsList>
 
             <Tabs.TabsContent value="overview">

--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import { storyblokEditable, StoryblokComponent, SbBlokData } from '@storyblok/react'
 import { PurchaseForm } from '@/components/ProductPage/PurchaseForm/PurchaseForm'
+import * as Tabs from '@/components/ProductPage/Tabs'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
 type ProductPageBlockProps = SbBaseBlockProps<{
@@ -13,12 +14,27 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
   return (
     <Main {...storyblokEditable(blok)}>
       <PurchaseForm />
-      {blok.overview?.map((nestedBlock) => (
-        <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
-      ))}
-      {blok.coverage?.map((nestedBlock) => (
-        <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
-      ))}
+
+      <Tabs.Tabs defaultValue="overview">
+        <Tabs.TabsList>
+          {/* TODO: Get tab labels from Storyblok */}
+          <Tabs.TabsTrigger value="overview">Overview</Tabs.TabsTrigger>
+          <Tabs.TabsTrigger value="coverage">Coverage</Tabs.TabsTrigger>
+        </Tabs.TabsList>
+
+        <Tabs.TabsContent value="overview">
+          {blok.overview?.map((nestedBlock) => (
+            <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+          ))}
+        </Tabs.TabsContent>
+
+        <Tabs.TabsContent value="coverage">
+          {blok.coverage?.map((nestedBlock) => (
+            <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+          ))}
+        </Tabs.TabsContent>
+      </Tabs.Tabs>
+
       {blok.body.map((nestedBlock) => (
         <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
       ))}

--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { storyblokEditable, StoryblokComponent, SbBlokData } from '@storyblok/react'
-import { useBreakpoint } from 'ui'
+import { mq } from 'ui'
 import { PurchaseForm } from '@/components/ProductPage/PurchaseForm/PurchaseForm'
 import * as Tabs from '@/components/ProductPage/Tabs'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
@@ -14,34 +14,31 @@ type ProductPageBlockProps = SbBaseBlockProps<{
 }>
 
 export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
-  const isDesktop = useBreakpoint('lg')
   return (
     <Main {...storyblokEditable(blok)}>
-      {!isDesktop && (
-        <>
-          <PurchaseForm />
-          <Tabs.Tabs defaultValue="overview">
-            <Tabs.TabsList>
-              <Tabs.TabsTrigger value="overview">{blok.overviewLabel}</Tabs.TabsTrigger>
-              <Tabs.TabsTrigger value="coverage">{blok.coverageLabel}</Tabs.TabsTrigger>
-            </Tabs.TabsList>
+      <MobileLayout>
+        <PurchaseForm />
+        <Tabs.Tabs defaultValue="overview">
+          <Tabs.TabsList>
+            <Tabs.TabsTrigger value="overview">{blok.overviewLabel}</Tabs.TabsTrigger>
+            <Tabs.TabsTrigger value="coverage">{blok.coverageLabel}</Tabs.TabsTrigger>
+          </Tabs.TabsList>
 
-            <Tabs.TabsContent value="overview">
-              {blok.overview?.map((nestedBlock) => (
-                <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
-              ))}
-            </Tabs.TabsContent>
+          <Tabs.TabsContent value="overview">
+            {blok.overview?.map((nestedBlock) => (
+              <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+            ))}
+          </Tabs.TabsContent>
 
-            <Tabs.TabsContent value="coverage">
-              {blok.coverage?.map((nestedBlock) => (
-                <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
-              ))}
-            </Tabs.TabsContent>
-          </Tabs.Tabs>
-        </>
-      )}
+          <Tabs.TabsContent value="coverage">
+            {blok.coverage?.map((nestedBlock) => (
+              <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+            ))}
+          </Tabs.TabsContent>
+        </Tabs.Tabs>
+      </MobileLayout>
 
-      {isDesktop && (
+      <DesktopLayout>
         <>
           <ProductUpper>
             <div>
@@ -59,7 +56,7 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
             <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
           ))}
         </>
-      )}
+      </DesktopLayout>
 
       {blok.body.map((nestedBlock) => (
         <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
@@ -83,4 +80,17 @@ const ProductUpper = styled.div({
 const PurchaseFormWrapper = styled.div({
   position: 'sticky',
   top: 0,
+})
+
+const MobileLayout = styled.div({
+  [mq.lg]: {
+    display: 'none',
+  },
+})
+
+const DesktopLayout = styled.div({
+  display: 'none',
+  [mq.lg]: {
+    display: 'block',
+  },
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Render different layout for mobile and desktop.
Since there's no straight forward way to "destroy" the tabs we will render different markup on different viewports.
Either we do it by js breakpoints or css breakpoints. Currently we get hydration warnings when doing it with js breakpoints. 
What do we prefer? I kind of favour hiding it with css if it doesn't come with drawbacks rendering more to the DOM

Next steps:
- Possibly break this out in to another component
- Get tab labels from CMS
- Add scroll to links for desktop, but as I understood design might be revised

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

### Desktop

https://user-images.githubusercontent.com/6661511/203760710-2c4756fb-00df-4e67-bfc7-3f3ad77d0ada.mov


### Mobile


https://user-images.githubusercontent.com/6661511/203760780-39f0eec1-ba13-4dce-a661-05f214782740.mov



## Justify why they are needed
Update layout for desktop

### TODO

- [x] Render section in tabs for mobile
- [x] Render sections on page with scroll to links for desktop

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
