### PR TITLE
Implement presentational `CancellationForm` component

### DIFF
--- a/apps/store/public/locales/default/purchase-form.json
+++ b/apps/store/public/locales/default/purchase-form.json
@@ -1,5 +1,9 @@
 {
   "HOUSEHOLD_SIZE_VALUE": "You + {{count}}",
   "HOUSEHOLD_SIZE_VALUE_zero": "Just you",
-  "CURRENT_INSURANCE_FIELD_PLACEHOLDER": "Pick company..."
+  "CURRENT_INSURANCE_FIELD_PLACEHOLDER": "Pick company...",
+  "START_DATE_FIELD_LABEL": "Start date",
+  "START_DATE_FIELD_TODAY": "Today",
+  "AUTO_SWITCH_FIELD_LABEL": "Switch automatically",
+  "AUTO_SWITCH_FIELD_MESSAGE": "We cancel your insurance at {{COMPANY}}. Hedvig is activated when it expires."
 }

--- a/apps/store/public/locales/sv-se/purchase-form.json
+++ b/apps/store/public/locales/sv-se/purchase-form.json
@@ -1,5 +1,9 @@
 {
   "HOUSEHOLD_SIZE_VALUE": "Du + {{count}}",
   "HOUSEHOLD_SIZE_VALUE_zero": "Bara du",
-  "CURRENT_INSURANCE_FIELD_PLACEHOLDER": "Välj bolag..."
+  "CURRENT_INSURANCE_FIELD_PLACEHOLDER": "Välj bolag...",
+  "START_DATE_FIELD_LABEL": "Startdatum",
+  "START_DATE_FIELD_TODAY": "Idag",
+  "AUTO_SWITCH_FIELD_LABEL": "Byt automatiskt",
+  "AUTO_SWITCH_FIELD_MESSAGE": "Vi avslutar din försäkring hos {{COMPANY}} åt dig. Hedvig aktiveras när den går ut."
 }

--- a/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/CancellationForm.stories.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/CancellationForm.stories.tsx
@@ -1,0 +1,28 @@
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+import { ComponentMeta, ComponentStoryFn } from '@storybook/react'
+import { CancellationForm } from './CancellationForm'
+
+export default {
+  title: 'Product Page / Cancellation Form',
+  component: CancellationForm,
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'iphonese2',
+    },
+  },
+  argTypes: {
+    onStartDateChange: { action: 'change start date' },
+    onAutoSwithChange: { action: 'change auto switch' },
+  },
+} as ComponentMeta<typeof CancellationForm>
+
+const Template: ComponentStoryFn<typeof CancellationForm> = (props) => {
+  return <CancellationForm {...props} />
+}
+
+export const NoCancellation = Template.bind({})
+NoCancellation.args = { option: { type: 'NONE' } }
+
+export const IEX = Template.bind({})
+IEX.args = { option: { type: 'IEX', companyName: 'Folksam' } }

--- a/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/CancellationForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/CancellationForm.tsx
@@ -1,0 +1,96 @@
+import { useTranslation } from 'next-i18next'
+import { ChangeEventHandler, useState } from 'react'
+import { InputField, Space } from 'ui'
+import { InputSwitch } from '@/components/PriceCalculator/InputSwitch'
+import { Text } from '@/components/Text/Text'
+import { formatInputDateValue } from '@/utils/date'
+import { FormElement } from '../PurchaseForm.constants'
+
+type CancellationOption = { type: 'NONE' } | { type: 'IEX'; companyName: string }
+
+type Props = {
+  option: CancellationOption
+  onStartDateChange: (date: Date) => void
+  onAutoSwithChange: (checked: boolean) => void
+}
+
+export const CancellationForm = ({ option, ...props }: Props) => {
+  switch (option.type) {
+    case 'IEX':
+      return <IEXCancellation {...props} companyName={option.companyName} />
+    case 'NONE':
+      return <NoCancellation {...props} />
+  }
+}
+
+type NoCancellationProps = Pick<Props, 'onStartDateChange'>
+
+const NoCancellation = ({ onStartDateChange }: NoCancellationProps) => {
+  return <StartDateInput onChange={onStartDateChange} />
+}
+
+type IEXCancellationProps = Pick<Props, 'onStartDateChange' | 'onAutoSwithChange'> & {
+  companyName: string
+}
+
+const IEXCancellation = (props: IEXCancellationProps) => {
+  const { onStartDateChange, onAutoSwithChange, companyName } = props
+  const { t } = useTranslation('purchase-form')
+  const [checked, setChecked] = useState(false)
+  const handleCheckedChange = (newValue: boolean) => {
+    setChecked(newValue)
+    onAutoSwithChange(newValue)
+  }
+
+  return (
+    <Space y={0.5}>
+      <Space y={0.5}>
+        <InputSwitch
+          name={FormElement.AutoSwitch}
+          label={t('AUTO_SWITCH_FIELD_LABEL')}
+          checked={checked}
+          onCheckedChange={handleCheckedChange}
+        />
+        {checked && (
+          <Text as="p" size="s">
+            {t('AUTO_SWITCH_FIELD_MESSAGE', { COMPANY: companyName })}
+          </Text>
+        )}
+      </Space>
+
+      {!checked && <StartDateInput onChange={onStartDateChange} />}
+    </Space>
+  )
+}
+
+type StartDateInputProps = { onChange: (date: Date) => void }
+
+const StartDateInput = ({ onChange }: StartDateInputProps) => {
+  const { t } = useTranslation('purchase-form')
+  const dateToday = new Date()
+  const [value, setValue] = useState(dateToday)
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    if (event.target.valueAsDate) {
+      setValue(event.target.valueAsDate)
+      onChange(event.target.valueAsDate)
+    }
+  }
+
+  const inputValue = formatInputDateValue(value)
+  const inputValueToday = formatInputDateValue(dateToday)
+  const isToday = inputValue === inputValueToday
+
+  return (
+    <InputField
+      type="date"
+      name={FormElement.StartDate}
+      label={t('START_DATE_FIELD_LABEL')}
+      required={true}
+      value={inputValue}
+      min={inputValueToday}
+      onChange={handleChange}
+      infoMessage={isToday ? t('START_DATE_FIELD_TODAY') : undefined}
+    />
+  )
+}

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.constants.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.constants.ts
@@ -1,0 +1,4 @@
+export enum FormElement {
+  StartDate = 'startDate',
+  AutoSwitch = 'autoSwitch',
+}

--- a/apps/store/src/utils/date.ts
+++ b/apps/store/src/utils/date.ts
@@ -9,5 +9,7 @@ export const convertToDate = (value: unknown) => {
 }
 
 export const formatAPIDate = (date: Date) => {
-  return date.toISOString().substring(0, 10)
+  return date.toISOString().split('T')[0]
 }
+
+export const formatInputDateValue = formatAPIDate


### PR DESCRIPTION
## Describe your changes

Create a presentational component for `CancellationForm`.

Support two cancellation options: `NONE` and `IEX`.

Add to Storybook.

NONE:

![Screenshot 2022-11-25 at 11.20.30.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/3849974c-8e70-4066-89dc-e6d2d49e10be/Screenshot%202022-11-25%20at%2011.20.30.png)

IEX:

![Screenshot 2022-11-25 at 11.20.36.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/28ec4ff2-e6f2-44d8-b5e3-948e11410381/Screenshot%202022-11-25%20at%2011.20.36.png)

![Screenshot 2022-11-25 at 11.20.41.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/84243d2b-467d-4df1-8abb-31467f132933/Screenshot%202022-11-25%20at%2011.20.41.png)

## Justify why they are needed

I will open another PR to integrate with the API and in the `OfferSelector`.

## Jira issue(s): [GRW-1818]

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1818]: https://hedvig.atlassian.net/browse/GRW-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ