### PR TITLE
Integrate `CancellationForm` in `OfferPresenter`

### DIFF
--- a/apps/store/src/components/ProductPage/ProductPage.constants.ts
+++ b/apps/store/src/components/ProductPage/ProductPage.constants.ts
@@ -1,4 +1,0 @@
-export enum FormElement {
-  ProductOfferId = 'productOfferId',
-  StartDate = 'startDate',
-}

--- a/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/CancellationForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/CancellationForm.tsx
@@ -10,8 +10,8 @@ type CancellationOption = { type: 'NONE' } | { type: 'IEX'; companyName: string 
 
 type Props = {
   option: CancellationOption
-  onStartDateChange: (date: Date) => void
-  onAutoSwithChange: (checked: boolean) => void
+  onStartDateChange?: (date: Date) => void
+  onAutoSwithChange?: (checked: boolean) => void
 }
 
 export const CancellationForm = ({ option, ...props }: Props) => {
@@ -39,7 +39,7 @@ const IEXCancellation = (props: IEXCancellationProps) => {
   const [checked, setChecked] = useState(false)
   const handleCheckedChange = (newValue: boolean) => {
     setChecked(newValue)
-    onAutoSwithChange(newValue)
+    onAutoSwithChange?.(newValue)
   }
 
   return (
@@ -63,7 +63,7 @@ const IEXCancellation = (props: IEXCancellationProps) => {
   )
 }
 
-type StartDateInputProps = { onChange: (date: Date) => void }
+type StartDateInputProps = { onChange?: (date: Date) => void }
 
 const StartDateInput = ({ onChange }: StartDateInputProps) => {
   const { t } = useTranslation('purchase-form')
@@ -73,7 +73,7 @@ const StartDateInput = ({ onChange }: StartDateInputProps) => {
   const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     if (event.target.valueAsDate) {
       setValue(event.target.valueAsDate)
-      onChange(event.target.valueAsDate)
+      onChange?.(event.target.valueAsDate)
     }
   }
 

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -1,19 +1,18 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { RefObject, useState } from 'react'
-import { Button, InputField } from 'ui'
-import { FormElement } from '@/components/ProductPage/ProductPage.constants'
+import { Button } from 'ui'
 import { ScrollPast } from '@/components/ProductPage/ScrollPast/ScrollPast'
 import { ScrollToButton } from '@/components/ProductPage/ScrollToButton/ScrollToButton'
-import { useHandleSubmitAddToCart } from '@/components/ProductPage/useHandleSubmitAddToCart'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { Text } from '@/components/Text/Text'
 import { ProductOfferFragment } from '@/services/apollo/generated'
 import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
-import { formatAPIDate } from '@/utils/date'
 import { useCurrencyFormatter } from '@/utils/useCurrencyFormatter'
+import { CancellationForm } from './CancellationForm/CancellationForm'
 import { TierSelector } from './TierSelector'
+import { useHandleSubmitAddToCart } from './useHandleSubmitAddToCart'
 
 type Props = {
   priceIntent: PriceIntent
@@ -66,7 +65,7 @@ export const OfferPresenter = ({
             onValueChange={setSelectedOfferId}
           />
 
-          <CancellationSettings />
+          <CancellationForm option={{ type: 'NONE' }} />
 
           <SubmitButton loading={loadingAddToCart} />
         </FormContent>
@@ -85,18 +84,6 @@ export const OfferPresenter = ({
 const FormContent = styled(SpaceFlex)({
   flex: 1,
 })
-
-// TODO: Support IEX switching
-const CancellationSettings = () => {
-  return (
-    <InputField
-      label="Start date"
-      type="date"
-      name={FormElement.StartDate}
-      defaultValue={formatAPIDate(new Date())}
-    />
-  )
-}
 
 // TODO: Localize
 const SubmitButton = ({ loading }: { loading: boolean }) => {

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.constants.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.constants.ts
@@ -1,4 +1,5 @@
 export enum FormElement {
   StartDate = 'startDate',
   AutoSwitch = 'autoSwitch',
+  ProductOfferId = 'productOfferId',
 }

--- a/apps/store/src/components/ProductPage/PurchaseForm/TierSelector.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/TierSelector.tsx
@@ -2,9 +2,9 @@ import styled from '@emotion/styled'
 import * as RadioGroup from '@radix-ui/react-radio-group'
 import { useTranslation } from 'next-i18next'
 import { Space } from 'ui'
-import { FormElement } from '@/components/ProductPage/ProductPage.constants'
 import { ProductOfferFragment } from '@/services/apollo/generated'
 import { useCurrencyFormatter } from '@/utils/useCurrencyFormatter'
+import { FormElement } from './PurchaseForm.constants'
 
 type Props = {
   offers: Array<ProductOfferFragment>

--- a/apps/store/src/components/ProductPage/PurchaseForm/useHandleSubmitAddToCart.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/useHandleSubmitAddToCart.ts
@@ -2,7 +2,7 @@ import { FormEventHandler } from 'react'
 import { useUpdateStartDate } from '@/components/ProductPage/PurchaseForm/useUpdateStartDate'
 import { useCartEntryAddMutation } from '@/services/apollo/generated'
 import { getOrThrowFormValue } from '@/utils/getOrThrowFormValue'
-import { FormElement } from './ProductPage.constants'
+import { FormElement } from './PurchaseForm.constants'
 
 type Params = {
   cartId: string


### PR DESCRIPTION
## Describe your changes

Integrate `CancellationForm` in `OfferPresenter`.

Lock to "no cancellation" option.

Move form element constants and hook under `PurchaseForm`.

## Justify why they are needed

Just added it to the `OfferPresenter`. When the API is in place we can automatically chose which cancellation option to display to the user.

## Jira issue(s): [GRW-1818]

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1818]: https://hedvig.atlassian.net/browse/GRW-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ