### PR TITLE
Add option to skip prerendering in preview environments

### DIFF
--- a/apps/store/.env.local.example
+++ b/apps/store/.env.local.example
@@ -33,3 +33,8 @@ APOLLO_KEY=
 
 # This can be unique for yourself, for example VERCEL_URL=localhost-my-computer
 VERCEL_URL=localhost
+
+# Vercel
+
+# When this is true, don't prerender any static pages
+SKIP_BUILD_STATIC_GENERATION=<true>

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -4,6 +4,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Head from 'next/head'
 import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
+import logger from '@/services/logger/server'
 import {
   getGlobalStory,
   getStoryBySlug,
@@ -81,6 +82,15 @@ export const getStaticProps: GetStaticProps<
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
+  // When this is true (preview env) don't prerender any static pages
+  if (process.env.SKIP_BUILD_STATIC_GENERATION === 'true') {
+    logger.info('Skipping static generation...')
+    return {
+      paths: [],
+      fallback: 'blocking',
+    }
+  }
+
   const pageLinks = await getFilteredPageLinks()
   const paths: RoutingPath[] = pageLinks.map(({ locale, slugParts }) => {
     return { params: { slug: slugParts }, locale }


### PR DESCRIPTION
## Describe your changes

Add option through env variables to skip static generation.

This should be enabled only for preview deployments.

## Justify why they are needed

This will get us faster builds for preview deployments!

The pages will instead be rendered on demand in preview env.

Got the idea from here: https://twitter.com/leeerob/status/1550617876188520452?s=61&t=GPLGqmqmeZRr5jaJeUEe1w

## Jira issue(s): []

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
