### PR TITLE
Integrate API for campaign codes in Cart page

### DIFF
--- a/apps/store/src/components/CartInventory/CartInventory.stories.tsx
+++ b/apps/store/src/components/CartInventory/CartInventory.stories.tsx
@@ -31,7 +31,9 @@ const MOCK_CART: CartFragmentFragment = {
   cost: {
     gross: { amount: 178, currencyCode: CurrencyCode.Sek },
     net: { amount: 178, currencyCode: CurrencyCode.Sek },
+    discount: { amount: 0, currencyCode: CurrencyCode.Sek },
   },
+  redeemedCampaigns: [],
   entries: [
     {
       id: 'a98c1fe0-a216-412d-8664-fe130daec0f8',

--- a/apps/store/src/components/CartPage/CartPageProps.types.ts
+++ b/apps/store/src/components/CartPage/CartPageProps.types.ts
@@ -1,10 +1,12 @@
 import { StoryblokPageProps } from '@/services/storyblok/storyblok'
 
 export type ProductData = { id: string; name: string; cost: number; currency: string }
+type CampaignData = { id: string; displayName: string }
 type CostData = { crossOut?: number; net: number; gross: number }
 
 export type CartPageProps = Pick<StoryblokPageProps, 'globalStory'> & {
   cartId: string
   products: Array<ProductData>
   cost: CostData
+  campaigns: Array<CampaignData>
 }

--- a/apps/store/src/components/CartPage/useCampaign.ts
+++ b/apps/store/src/components/CartPage/useCampaign.ts
@@ -1,0 +1,28 @@
+import { useRedeemCampaignMutation, useUnredeemCampaignMutation } from '@/services/apollo/generated'
+
+type Params = {
+  cartId: string
+}
+
+export const useRedeemCampaign = ({ cartId }: Params) => {
+  const [redeemCampaign, result] = useRedeemCampaignMutation()
+
+  const redeem = async (code: string) => {
+    await redeemCampaign({ variables: { cartId, code } })
+  }
+
+  const userErrors = result.data?.cartRedeemCampaign.userErrors
+  const userError = userErrors?.[0]?.message
+
+  return [redeem, { ...result, userError }] as const
+}
+
+export const useUnredeemCampaign = ({ cartId }: Params) => {
+  const [unredeemCampaign, result] = useUnredeemCampaignMutation()
+
+  const unredeem = async (campaignId: string) => {
+    await unredeemCampaign({ variables: { cartId, campaignId } })
+  }
+
+  return [unredeem, result] as const
+}

--- a/apps/store/src/graphql/CartFragment.graphql
+++ b/apps/store/src/graphql/CartFragment.graphql
@@ -9,6 +9,14 @@ fragment CartFragment on Cart {
       amount
       currencyCode
     }
+    discount {
+      amount
+      currencyCode
+    }
+  }
+  redeemedCampaigns {
+    id
+    code
   }
   entries {
     ...ProductOffer

--- a/apps/store/src/graphql/CartRedeemCampaign.graphql
+++ b/apps/store/src/graphql/CartRedeemCampaign.graphql
@@ -1,0 +1,12 @@
+mutation RedeemCampaign($cartId: ID!, $code: String!) {
+  cartRedeemCampaign(input: { cartId: $cartId, code: $code }) {
+    cart {
+      ...CartFragment
+    }
+    userErrors {
+      code
+      field
+      message
+    }
+  }
+}

--- a/apps/store/src/graphql/CartUnredeemCampaign.graphql
+++ b/apps/store/src/graphql/CartUnredeemCampaign.graphql
@@ -1,0 +1,5 @@
+mutation UnredeemCampaign($cartId: ID!, $campaignId: String!) {
+  cartUnredeemCampaign(input: { cartId: $cartId, campaignId: $campaignId }) {
+    ...CartFragment
+  }
+}

--- a/apps/store/src/pages/cart.tsx
+++ b/apps/store/src/pages/cart.tsx
@@ -36,6 +36,13 @@ const NextCartPage: NextPageWithLayout<Props> = ({ shopSessionId, ...props }) =>
     }
   })
 
+  const campaigns: CartPageProps['campaigns'] = data.shopSession.cart.redeemedCampaigns.map(
+    (item) => ({
+      id: item.id,
+      displayName: item.code,
+    }),
+  )
+
   const cartCost = data.shopSession.cart.cost
   const grossAmount = cartCost.gross.amount
   const netAmount = cartCost.net.amount
@@ -45,6 +52,7 @@ const NextCartPage: NextPageWithLayout<Props> = ({ shopSessionId, ...props }) =>
     <CartPage
       cartId={data.shopSession.cart.id}
       products={products}
+      campaigns={campaigns}
       cost={{ net: grossAmount, gross: netAmount, crossOut }}
       {...props}
     />


### PR DESCRIPTION
## Describe your changes

Integrate API for campaign codes on Cart page.

- Redeem campaign
- Unredeem campaign
- List redeemed campaigns

![Screenshot 2022-11-28 at 13.14.19.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/952cd170-40e6-43e3-8721-72a6a77abb90/Screenshot%202022-11-28%20at%2013.14.19.png)

## Justify why they are needed

I haven't paid much attention to the UI - this is only about API integration.

## Jira issue(s): [GRW-1844]

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1844]: https://hedvig.atlassian.net/browse/GRW-1844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ