### PR TITLE
Fix / Don't close price calculator until offer is ready

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -22,9 +22,12 @@ export const PurchaseForm = () => {
   const { priceTemplate, priceIntent, shopSession, story } = useProductPageContext()
   const currencyFormatter = useCurrencyFormatter(shopSession.currencyCode)
   const [refreshData, isLoadingData] = useRefreshData()
-  const handleCalculatePriceSuccess = () => {
-    refreshData()
-    setIsEditingPriceCalculator(false)
+  const handleCalculatePriceSuccess = async () => {
+    try {
+      await refreshData()
+    } finally {
+      setIsEditingPriceCalculator(false)
+    }
   }
 
   const scrollPastRef = useRef<HTMLDivElement | null>(null)

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -1,3 +1,4 @@
+import isPropValid from '@emotion/is-prop-valid'
 import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
@@ -16,7 +17,9 @@ const contentShow = keyframes({
   '100%': { opacity: 1, transform: 'scale(1)' },
 })
 
-const StyledOverlay = styled(DialogPrimitive.Overlay)<OverlayProps>(({ frosted }) => ({
+const StyledOverlay = styled(DialogPrimitive.Overlay, {
+  shouldForwardProp: isPropValid,
+})<OverlayProps>(({ frosted }) => ({
   backgroundColor: 'rgba(0, 0, 0, 0.6)',
   position: 'fixed',
   inset: 0,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


- Keep price calculator open until underlying page has loaded all the data
- Fix annoying React warning about frosted prop

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Prevent UI flicker when product page becomes visible and then offer is displayed after some delay

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
