### PR TITLE
Implement option to share a link to a specific shop session

### DIFF
--- a/apps/store/README.md
+++ b/apps/store/README.md
@@ -25,3 +25,15 @@ the debug mode you can suffix the url with `?debug=none`.
 Requirements:
 
 - Add `APOLLO_KEY` to `.env.local` (see Vercel)
+
+## Sharing Shop Session
+
+It can be useful to share a shop session with someone. Perhaps you've got into a strange state and want to share the session with a colleague so you can debug together.
+
+You do this by sending them a link:
+
+```html
+https://www.store.dev.hedvigit.com/{LOCALE}/session/{SHOP_SESSION_ID}?next={REDIRECT_URL}
+```
+
+You can optionally provide a `?next=/se/cart` query parameter with the relative link to route to redirect the user. By default, the user is redirected to the home page.

--- a/apps/store/src/pages/session/[shopSessionId].tsx
+++ b/apps/store/src/pages/session/[shopSessionId].tsx
@@ -1,0 +1,51 @@
+import type { GetServerSideProps, NextPage } from 'next'
+import { initializeApollo } from '@/services/apollo/client'
+import logger from '@/services/logger/server'
+import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
+import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+import { ORIGIN_URL, PageLink } from '@/utils/PageLink'
+
+const LOGGER = logger.child({ module: 'pages/session' })
+
+type Props = Record<string, unknown>
+type Params = { shopSessionId: string }
+
+const NextSessionPage: NextPage = () => {
+  return null
+}
+
+export const getServerSideProps: GetServerSideProps<Props, Params> = async (context) => {
+  const { locale, params, req, res, query } = context
+
+  const fallbackRedirect = { redirect: { destination: PageLink.home(), permanent: false } }
+  if (!isRoutingLocale(locale)) return fallbackRedirect
+
+  const shopSessionId = params?.shopSessionId
+  if (!shopSessionId) {
+    logger.error('No shop session in URL')
+    return fallbackRedirect
+  }
+
+  try {
+    const apolloClient = initializeApollo({ req, res })
+    const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
+    shopSessionService.save(await shopSessionService.fetchById(shopSessionId))
+  } catch (error) {
+    logger.error(error, `Unable to fetch ShopSession: ${shopSessionId}`)
+    return fallbackRedirect
+  }
+
+  const nextURL = new URL(ORIGIN_URL)
+  nextURL.pathname = PageLink.home({ locale })
+
+  const nextQueryParam = query['next']
+  if (typeof nextQueryParam === 'string') {
+    nextURL.pathname = nextQueryParam
+  }
+
+  const destination = nextURL.toString()
+  LOGGER.info(`Re-directing to destination: ${destination}`)
+  return { redirect: { destination, permanent: false } }
+}
+
+export default NextSessionPage

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -19,6 +19,7 @@ type ConfirmationPage = BaseParams & { shopSessionId: string }
 const localePrefix = (locale?: RoutingLocale) => (locale ? `/${locale}` : '')
 
 export const PageLink = {
+  home: ({ locale }: BaseParams = {}) => `${localePrefix(locale)}`,
   store: ({ locale }: BaseParams = {}) => `${localePrefix(locale)}/store`,
   product: ({ locale, slug }: ProductPage) => `${localePrefix(locale)}/products/${slug}`,
   cart: ({ locale }: BaseParams = {}) => `${localePrefix(locale)}/cart`,


### PR DESCRIPTION
## Describe your changes

Add route that can be used to share a shop session using a link.

```url
/se/session/2i1oj3oij12oij12iojwio2j?next=/se/cart
```

## Justify why they are needed

This can be very helpful to share shop session with other people to debug. For example in test sessions.

We should probably build a feature that automatically generates the link.

I considered adding this feature to the middleware but I think this will be much easier to maintain.

## Jira issue(s): [GRW-1852]

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1852]: https://hedvig.atlassian.net/browse/GRW-1852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ