### PR TITLE
Add size settings for Video

### DIFF
--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -1,11 +1,13 @@
-import { Video } from '@/components/Video/Video'
+import { Video, VideoSize } from '@/components/Video/Video'
 import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 
-type VideoBlockProps = SbBaseBlockProps<{
-  video: StoryblokAsset
-  poster?: StoryblokAsset
-  autoplay?: boolean
-}>
+type VideoBlockProps = SbBaseBlockProps<
+  {
+    video: StoryblokAsset
+    poster?: StoryblokAsset
+    autoplay?: boolean
+  } & VideoSize
+>
 
 export const VideoBlock = ({ blok }: VideoBlockProps) => {
   return (
@@ -13,6 +15,10 @@ export const VideoBlock = ({ blok }: VideoBlockProps) => {
       sources={[{ url: blok.video.filename }]}
       poster={blok.poster?.filename}
       autoplay={blok.autoplay}
+      aspectRatioLandscape={blok.aspectRatioLandscape}
+      aspectRatioPortrait={blok.aspectRatioPortrait}
+      maxHeightLandscape={blok.maxHeightLandscape}
+      maxHeightPortrait={blok.maxHeightPortrait}
     />
   )
 }

--- a/apps/store/src/components/Video/Video.stories.tsx
+++ b/apps/store/src/components/Video/Video.stories.tsx
@@ -1,9 +1,16 @@
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { Video } from './Video'
 
 export default {
   title: 'Video',
   component: Video,
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'iphone12',
+    },
+  },
 } as ComponentMeta<typeof Video>
 
 const Template: ComponentStory<typeof Video> = (args) => <Video {...args} />
@@ -14,4 +21,16 @@ Default.args = {
   sources: [
     { url: 'https://cdn.dev.hedvigit.com/assets/videos/HEDVIG_FILM01_1x1_15sec_CLEAN.mp4' },
   ],
+}
+
+export const ProductVideo = Template.bind({})
+ProductVideo.args = {
+  autoplay: true,
+  sources: [
+    { url: 'https://cdn.dev.hedvigit.com/assets/videos/HEDVIG_FILM01_1x1_15sec_CLEAN.mp4' },
+  ],
+  aspectRatioPortrait: '4 / 6',
+  maxHeightPortrait: 80,
+  aspectRatioLandscape: '1 / 1',
+  maxHeightLandscape: 90,
 }

--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -1,19 +1,25 @@
 import styled from '@emotion/styled'
-import { PropsWithChildren } from 'react'
 import { theme } from 'ui'
 
 export type VideoSource = {
   url: string
 }
 
-export type VideoProps = PropsWithChildren & {
+export type VideoSize = {
+  aspectRatioLandscape?: '1 / 1' | '16 / 9'
+  aspectRatioPortrait?: '4 / 5' | '4 / 6'
+  maxHeightLandscape?: number
+  maxHeightPortrait?: number
+}
+
+export type VideoProps = {
   /**
    * An array of videos with different supported formats
    */
   sources: VideoSource[]
   poster?: string
   autoplay?: boolean
-}
+} & VideoSize
 
 const VideoWrapper = styled.div(({ theme }) => ({
   position: 'relative',
@@ -21,21 +27,29 @@ const VideoWrapper = styled.div(({ theme }) => ({
   paddingRight: theme.space[2],
 }))
 
-const StyledVideo = styled.video(({ poster }: Pick<VideoProps, 'poster'>) => ({
-  width: '100%',
-  background: `url(${poster}) no-repeat`,
-  backgroundSize: 'cover',
-  objectFit: 'cover',
-  borderRadius: theme.radius.xl,
-  ['@media (orientation: portrait)']: {
-    aspectRatio: '4 / 5',
-    maxHeight: '80vh',
-  },
-  ['@media (orientation: landscape)']: {
-    aspectRatio: '1 / 1',
-    maxHeight: '90vh',
-  },
-}))
+const StyledVideo = styled.video(
+  ({
+    poster,
+    aspectRatioLandscape,
+    aspectRatioPortrait,
+    maxHeightLandscape,
+    maxHeightPortrait,
+  }: Omit<VideoProps, 'sources' | 'autoplay'>) => ({
+    width: '100%',
+    background: `url(${poster}) no-repeat`,
+    backgroundSize: 'cover',
+    objectFit: 'cover',
+    borderRadius: theme.radius.xl,
+    ['@media (orientation: portrait)']: {
+      ...(maxHeightPortrait && { maxHeight: `${maxHeightPortrait}vh` }),
+      ...(aspectRatioPortrait && { aspectRatio: aspectRatioPortrait }),
+    },
+    ['@media (orientation: landscape)']: {
+      ...(aspectRatioLandscape && { aspectRatio: aspectRatioLandscape }),
+      ...(maxHeightLandscape && { maxHeight: `${maxHeightLandscape}vh` }),
+    },
+  }),
+)
 
 const autoplaySettings = {
   autoPlay: true,
@@ -43,7 +57,15 @@ const autoplaySettings = {
   loop: true,
 }
 
-export const Video = ({ sources, poster, autoplay }: VideoProps) => {
+export const Video = ({
+  sources,
+  poster,
+  autoplay,
+  aspectRatioLandscape,
+  aspectRatioPortrait,
+  maxHeightLandscape,
+  maxHeightPortrait,
+}: VideoProps) => {
   const autoplayAttributes = autoplay ? autoplaySettings : {}
   return (
     <VideoWrapper>
@@ -53,7 +75,16 @@ export const Video = ({ sources, poster, autoplay }: VideoProps) => {
     - Safari on iOS will default to autoplay videos in fullscreen unless `playsInline` is added
     Read more: https://webkit.org/blog/6784/new-video-policies-for-ios/
     */}
-      <StyledVideo {...autoplayAttributes} playsInline preload="auto" poster={poster}>
+      <StyledVideo
+        {...autoplayAttributes}
+        playsInline
+        preload="auto"
+        poster={poster}
+        aspectRatioLandscape={aspectRatioLandscape}
+        aspectRatioPortrait={aspectRatioPortrait}
+        maxHeightLandscape={maxHeightLandscape}
+        maxHeightPortrait={maxHeightPortrait}
+      >
         {sources.map((source) => (
           <source key={source.url} src={source.url} />
         ))}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add size settings for Video

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Make it possible to set aspect ratio in Storyblok for videos.
Default is displaying the video without changing size from the uploaded format.

<img width="439" alt="Screenshot 2022-12-01 at 15 56 16" src="https://user-images.githubusercontent.com/6661511/205085517-cc17449d-0a91-4fb5-a7c4-43304c5c9d42.png">

<img width="1788" alt="Screenshot 2022-12-01 at 15 38 39" src="https://user-images.githubusercontent.com/6661511/205085542-237a74a4-044c-43b0-9486-7ad502278990.png">

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
