### PR TITLE
fix: get page title from correct story field

### DIFF
--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -41,7 +41,7 @@ const NextPage: NextPageWithLayout<StoryblokPageProps> = (props: StoryblokPagePr
   return (
     <>
       <Head>
-        <title>{story.content.name}</title>
+        <title>{story.name}</title>
       </Head>
       <HeadSeoInfo story={story} />
       <StoryblokComponent blok={story.content} />


### PR DESCRIPTION
## Describe your changes

There's no `name` field inside `story.content`. Should we take it from `story.name`? 🤔 

## Justify your changes

Just faced this while working in another task.

<img width="1060" alt="Screenshot 2022-12-06 at 14 09 45" src="https://user-images.githubusercontent.com/19200662/205921445-575b3893-0c4f-46aa-9978-958bed7578eb.png">

