### PR TITLE
Remove test command from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,6 +2,5 @@
 . "$(dirname "$0")/_/husky.sh"
 
 yarn typecheck
-yarn test
 
 npx lint-staged


### PR DESCRIPTION
## Describe your changes

Remove test command from Husky pre-commit hook.

## Justify why they are needed

As discussed, we should trust our CI to run this before merge instead.

It will also speed up making commits.

## Jira issue(s): []

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
