### PR TITLE
Update ProductPage to be statically rendered

### DIFF
--- a/apps/store/src/components/ProductPage/ProductPage.tsx
+++ b/apps/store/src/components/ProductPage/ProductPage.tsx
@@ -1,10 +1,8 @@
-import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
+import { StoryblokComponent } from '@storyblok/react'
 import { ProductPageProps } from './ProductPage.types'
 import { ProductPageContextProvider } from './ProductPageContext'
 
-export const ProductPage = ({ story: initalStory, ...props }: ProductPageProps) => {
-  const story = useStoryblokState(initalStory)
-
+export const ProductPage = ({ story, ...props }: ProductPageProps) => {
   return (
     <ProductPageContextProvider {...props} story={story}>
       <StoryblokComponent blok={story.content} />

--- a/apps/store/src/components/ProductPage/usePriceIntent.ts
+++ b/apps/store/src/components/ProductPage/usePriceIntent.ts
@@ -1,0 +1,88 @@
+import { datadogLogs } from '@datadog/browser-logs'
+import { useEffect, useMemo } from 'react'
+import {
+  usePriceIntentCreateMutation,
+  usePriceIntentDataUpdateMutation,
+  usePriceIntentQuery,
+} from '@/services/apollo/generated'
+import { Template } from '@/services/PriceCalculator/PriceCalculator.types'
+import { getStoredPriceIntentId, savePriceIntent } from '@/services/priceIntent/PriceIntent.helpers'
+import { ShopSession } from '@/services/shopSession/ShopSession.types'
+import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+
+type Params = {
+  shopSession?: ShopSession
+  priceTemplate: Template
+  productName: string
+}
+
+export const usePriceIntent = ({ shopSession, priceTemplate, productName }: Params) => {
+  const storedPriceIntentId = shopSession && getStoredPriceIntentId({ shopSession, priceTemplate })
+  const { locale } = useCurrentLocale()
+
+  const [updatePriceIntentData] = usePriceIntentDataUpdateMutation({
+    onError(error) {
+      datadogLogs.logger.error('Failed to update PriceIntent with initial data', { error })
+    },
+  })
+
+  const variables = useMemo(
+    () => (shopSession ? { shopSessionId: shopSession.id, productName, locale } : null),
+    [shopSession, productName, locale],
+  )
+
+  const [createPriceIntent, createResult] = usePriceIntentCreateMutation({
+    onCompleted: ({ priceIntentCreate }) => {
+      if (shopSession) {
+        savePriceIntent({ shopSession, priceTemplate, priceIntent: priceIntentCreate })
+      } else {
+        datadogLogs.logger.error('ShopSession missing when saving price intent', {
+          priceIntentId: priceIntentCreate.id,
+        })
+      }
+
+      if (priceTemplate.initialData) {
+        updatePriceIntentData({
+          variables: {
+            priceIntentId: priceIntentCreate.id,
+            data: priceTemplate.initialData,
+            locale,
+          },
+        })
+      }
+    },
+    onError(error) {
+      datadogLogs.logger.error('Failed to create PriceIntent', { ...variables, error })
+    },
+  })
+
+  const result = usePriceIntentQuery({
+    skip: !storedPriceIntentId,
+    variables: storedPriceIntentId ? { priceIntentId: storedPriceIntentId, locale } : undefined,
+    ssr: typeof window === 'undefined',
+    onError: (error) => {
+      datadogLogs.logger.warn('PriceIntent not found', {
+        priceIntentId: storedPriceIntentId,
+        error,
+      })
+      if (variables) {
+        createPriceIntent({ variables })
+      } else {
+        datadogLogs.logger.error('ShopSession missing when creating price intent (error)')
+      }
+    },
+  })
+
+  // @TODO: make sure this doesn't run more than once
+  useEffect(() => {
+    if (!storedPriceIntentId && !createResult.loading) {
+      if (variables) {
+        createPriceIntent({ variables })
+      } else {
+        datadogLogs.logger.error('ShopSession missing when creating price intent (init)')
+      }
+    }
+  }, [storedPriceIntentId, createResult.loading, createPriceIntent, variables])
+
+  return result
+}

--- a/apps/store/src/services/priceIntent/PriceIntent.helpers.ts
+++ b/apps/store/src/services/priceIntent/PriceIntent.helpers.ts
@@ -1,4 +1,5 @@
 import { ApolloClient } from '@apollo/client'
+import { getCookie, setCookie } from 'cookies-next'
 import { GetServerSidePropsContext } from 'next'
 import {
   PriceIntentCreateDocument,
@@ -10,10 +11,13 @@ import {
 } from '@/services/apollo/generated'
 import { CookiePersister } from '@/services/persister/CookiePersister'
 import { ServerCookiePersister } from '@/services/persister/ServerCookiePersister'
+import { Template } from '@/services/PriceCalculator/PriceCalculator.types'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { COOKIE_KEY_PRICE_INTENT } from './priceIntent.constants'
+import { PriceIntent } from './priceIntent.types'
 import { PriceIntentService } from './PriceIntentService'
 
+// @TODO: remove, no longer used
 export const priceIntentServiceInitServerSide = ({
   apolloClient,
   req,
@@ -85,4 +89,21 @@ export const createPriceIntent = async (params: CreatePriceIntentParams) => {
   if (!priceIntent) throw new Error('Could not create price intent')
 
   return priceIntent
+}
+
+type GetStoredPriceIntentIdParams = { shopSession: ShopSession; priceTemplate: Template }
+
+export const getStoredPriceIntentId = (params: GetStoredPriceIntentIdParams) => {
+  const { shopSession, priceTemplate } = params
+  const cookieKey = `HEDVIG_${shopSession.id}_${priceTemplate.name}`
+  const value = getCookie(cookieKey)
+  if (typeof value === 'string') return value
+}
+
+type SavePriceIntentParams = GetStoredPriceIntentIdParams & { priceIntent: PriceIntent }
+
+export const savePriceIntent = (params: SavePriceIntentParams) => {
+  const { shopSession, priceTemplate, priceIntent } = params
+  const cookieKey = `HEDVIG_${shopSession.id}_${priceTemplate.name}`
+  setCookie(cookieKey, priceIntent.id, { path: '/' })
 }

--- a/apps/store/src/services/priceIntent/PriceIntentService.ts
+++ b/apps/store/src/services/priceIntent/PriceIntentService.ts
@@ -59,7 +59,7 @@ export class PriceIntentService {
   }
 
   public async fetch({ locale, productName, priceTemplate }: FetchParams) {
-    const priceIntentId = this.persister.fetch(this.getPriceIntentKey(priceTemplate.name))
+    const priceIntentId = this.getStoredId(priceTemplate.name)
 
     if (priceIntentId) {
       const priceIntent = await this.get(priceIntentId, locale)
@@ -72,6 +72,14 @@ export class PriceIntentService {
 
   private getPriceIntentKey(templateName: string) {
     return `HEDVIG_${this.shopSession.id}_${templateName}`
+  }
+
+  public getStoredId(templateName: string) {
+    return this.persister.fetch(this.getPriceIntentKey(templateName))
+  }
+
+  public save(templateName: string, priceIntentId: string) {
+    this.persister.save(priceIntentId, this.getPriceIntentKey(templateName))
   }
 
   public clear(templateName: string) {

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -241,6 +241,11 @@ export const getGlobalStory = async (options: StoryOptions) => {
   return story as GlobalStory
 }
 
+export const getFilteredProductLinks = async () => {
+  const allLinks = await getPageLinks()
+  return allLinks.filter(({ slugParts }) => slugParts[0] === PRODUCTS_SLUG)
+}
+
 export const getProductStory = async (slug: string, options: StoryOptions) => {
   const story = await getStoryBySlug(`/products/${slug}`, options)
   return story as ProductStory


### PR DESCRIPTION
## Describe your changes

This is a big one -- make product page statically rendered.

Move management of `PriceIntent` and `ShopSession` client-side.

## Justify why they are needed

We want to be able to show the product page no matter the status of the API.

We want to be able to mix and match product pages anywhere in the URL structure.

## Jira issue(s): []

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
