### PR TITLE
Update TextField to use floating label

### DIFF
--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -45,7 +45,7 @@ const CheckoutPage = (props: CheckoutPageProps) => {
                 name={FormElement.PersonalNumber}
                 required
                 defaultValue={prefilledData.personalNumber ?? undefined}
-                placeholder="ÅÅMMDD-XXXX"
+                label="ÅÅÅÅMMDDXXXX"
               />
               <InputField
                 label="First Name"

--- a/apps/store/src/components/PersonalNumberField/PersonalNumberField.stories.tsx
+++ b/apps/store/src/components/PersonalNumberField/PersonalNumberField.stories.tsx
@@ -19,5 +19,5 @@ const Template: ComponentStory<typeof PersonalNumberField> = (props) => {
 }
 export const Default = Template.bind({})
 Default.args = {
-  placeholder: 'ÅÅMMDD-XXXX',
+  label: 'ÅÅÅÅMMDDXXXX',
 }

--- a/apps/store/src/components/PersonalNumberField/PersonalNumberField.tsx
+++ b/apps/store/src/components/PersonalNumberField/PersonalNumberField.tsx
@@ -5,14 +5,16 @@ import { TextField } from '@/components/TextField/TextField'
 type Props = Omit<
   InputHTMLAttributes<HTMLInputElement>,
   'onAnimationStart' | 'onDragStart' | 'onDragEnd' | 'onDrag'
->
+> & {
+  label: string
+}
 
 /**
  * Personal Number input field.
  * Only supports Swedish personal numbers.
  */
 export const PersonalNumberField = (props: Props) => {
-  const { value: propValue, defaultValue, ...baseProps } = props
+  const { value: propValue, defaultValue, label, ...baseProps } = props
 
   const [value, setValue] = useState(() => {
     if (typeof propValue === 'string') return propValue
@@ -36,6 +38,7 @@ export const PersonalNumberField = (props: Props) => {
       <TextField
         {...baseProps}
         defaultValue={propValue ?? defaultValue}
+        label={label}
         type="text"
         name={undefined}
         inputMode="numeric"

--- a/apps/store/src/components/PriceCalculator/AutomaticField.tsx
+++ b/apps/store/src/components/PriceCalculator/AutomaticField.tsx
@@ -32,7 +32,7 @@ export const AutomaticField = ({ field, priceIntent, onSubmit, loading, autoFocu
         <TextField
           type="text"
           name={field.name}
-          placeholder={translateLabel(field.label)}
+          label={translateLabel(field.label)}
           pattern={field.pattern}
           minLength={field.minLength}
           maxLength={field.maxLength}
@@ -48,7 +48,7 @@ export const AutomaticField = ({ field, priceIntent, onSubmit, loading, autoFocu
         <TextField
           type="number"
           name={field.name}
-          placeholder={translateLabel(field.label)}
+          label={translateLabel(field.label)}
           min={field.min}
           max={field.max}
           inputMode="numeric"

--- a/apps/store/src/components/PriceCalculator/SsnSeField.tsx
+++ b/apps/store/src/components/PriceCalculator/SsnSeField.tsx
@@ -9,5 +9,5 @@ type SsnSeFieldProps = {
 export const SsnSeField = ({ field }: SsnSeFieldProps) => {
   const translateLabel = useTranslateTextLabel({ data: {} })
 
-  return <PersonalNumberField {...field} placeholder={translateLabel(field.label)} />
+  return <PersonalNumberField {...field} label={translateLabel(field.label)} />
 }

--- a/apps/store/src/components/TextField/TextField.stories.tsx
+++ b/apps/store/src/components/TextField/TextField.stories.tsx
@@ -13,17 +13,26 @@ export default {
   },
 } as ComponentMeta<typeof TextField>
 
-const Template: ComponentStory<typeof TextField> = (props) => {
+const Template: ComponentStory<typeof TextField> = ({ defaultValue, ...props }) => {
   return (
     <>
       <TextField {...props} />
-      <div style={{ marginTop: '2rem' }}></div>
-      <TextField {...props} />
+      <div style={{ marginTop: '0.25rem' }}></div>
+      <TextField {...props} defaultValue={defaultValue} />
     </>
   )
 }
 
-export const Default = Template.bind({})
-Default.args = {
-  placeholder: 'Name',
+export const Large = Template.bind({})
+Large.args = {
+  label: 'Name',
+  variant: 'large',
+  defaultValue: 'John Sculley',
+}
+
+export const Small = Template.bind({})
+Small.args = {
+  label: 'Address',
+  variant: 'small',
+  defaultValue: '786 Franklin Ave.',
 }

--- a/apps/store/src/components/TextField/TextField.tsx
+++ b/apps/store/src/components/TextField/TextField.tsx
@@ -1,30 +1,108 @@
 import styled from '@emotion/styled'
 import { motion } from 'framer-motion'
-import { InputHTMLAttributes } from 'react'
+import { ChangeEventHandler, InputHTMLAttributes, useState } from 'react'
 import { useHighlightAnimation } from '@/utils/useHighlightAnimation'
 
-const Input = styled(motion.input)(({ theme }) => ({
-  width: '100%',
-  fontSize: theme.fontSizes[5],
-  padding: `${theme.space[3]} ${theme.space[4]}`,
-  borderRadius: theme.radius.sm,
-  backgroundColor: theme.colors.gray300,
-  color: theme.colors.gray900,
-
-  ':focus': {
-    outline: `1px solid ${theme.colors.gray500}`,
-  },
-  '::placeholder': {
-    color: theme.colors.gray600,
-  },
-}))
-
-type Props = Omit<
+type BaseInputProps = Omit<
   InputHTMLAttributes<HTMLInputElement>,
   'onAnimationStart' | 'onDragStart' | 'onDragEnd' | 'onDrag'
 >
 
-export const TextField = (props: Props) => {
-  const { highlight, animationProps } = useHighlightAnimation()
-  return <Input {...props} onKeyDown={highlight} {...animationProps} />
+type Props = BaseInputProps & {
+  label: string
+  variant?: 'small' | 'large'
 }
+
+export const TextField = ({ label, variant = 'large', ...props }: Props) => {
+  const [value, setValue] = useState(props.defaultValue || '')
+  const { highlight, animationProps } = useHighlightAnimation()
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    setValue(event.target.value)
+    props.onChange?.(event)
+  }
+
+  const inputValue = props.value || value
+
+  const [Wrapper, Label, Input] =
+    variant === 'large'
+      ? [LargeWrapper, LargeLabel, LargeInput]
+      : [SmallWrapper, SmallLabel, SmallInput]
+
+  return (
+    <Wrapper {...animationProps} active={!!inputValue}>
+      <Label htmlFor={props.id}>{label}</Label>
+      <Input {...props} onKeyDown={highlight} onChange={handleChange} />
+    </Wrapper>
+  )
+}
+
+type WrapperProps = { active: boolean }
+
+const LargeWrapper = styled(motion.div)<WrapperProps>(({ theme, active }) => ({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  borderRadius: theme.radius.sm,
+  backgroundColor: theme.colors.gray300,
+
+  height: '4rem',
+
+  [':focus-within > label']: {
+    transform: `translate(calc(${theme.space[4]} * 0.4), -0.1rem) scale(0.6)`,
+  },
+
+  ...(active && {
+    '> label': {
+      transform: `translate(calc(${theme.space[4]} * 0.4), -0.1rem) scale(0.6)`,
+    },
+  }),
+}))
+
+const LargeLabel = styled.label(({ theme }) => ({
+  position: 'absolute',
+  pointerEvents: 'none',
+  transformOrigin: 'top left',
+  transition: '200ms cubic-bezier(0, 0, 0.2, 1) 0ms',
+  transform: `translate(0, 0) scale(1)`,
+
+  fontSize: theme.fontSizes[5],
+  color: theme.colors.gray700,
+  padding: theme.space[4],
+}))
+
+const LargeInput = styled.input(({ theme }) => ({
+  width: '100%',
+  fontSize: theme.fontSizes[5],
+  padding: theme.space[4],
+  paddingTop: theme.space[5],
+
+  ':disabled': {
+    opacity: 0.6,
+    cursor: 'not-allowed',
+  },
+}))
+
+const SmallWrapper = styled(LargeWrapper)(({ theme, active }) => ({
+  height: '3.5rem',
+
+  [':focus-within > label']: {
+    transform: `translate(calc(${theme.space[4]} * 0.2), -0.4rem) scale(0.8)`,
+  },
+
+  ...(active && {
+    '> label': {
+      transform: `translate(calc(${theme.space[4]} * 0.2), -0.4rem) scale(0.8)`,
+    },
+  }),
+}))
+
+const SmallLabel = styled(LargeLabel)(({ theme }) => ({
+  fontSize: theme.fontSizes[3],
+  paddingTop: theme.space[4],
+}))
+
+const SmallInput = styled(LargeInput)(({ theme }) => ({
+  fontSize: theme.fontSizes[4],
+  paddingTop: theme.space[5],
+}))

--- a/apps/store/src/utils/useHighlightAnimation.ts
+++ b/apps/store/src/utils/useHighlightAnimation.ts
@@ -1,5 +1,5 @@
 import { useTheme } from '@emotion/react'
-import { useCallback, useState } from 'react'
+import { KeyboardEvent, useCallback, useState } from 'react'
 
 enum AnimationState {
   Idle = 'IDLE',
@@ -15,7 +15,9 @@ export const useHighlightAnimation = () => {
     [AnimationState.Idle]: { backgroundColor: theme.colors.gray300 },
   } as const
 
-  const highlight = useCallback(() => setIsInteractive(true), [])
+  const highlight = useCallback((event?: KeyboardEvent<HTMLElement>) => {
+    if (event && !EXCLUDE_SET.has(event.key)) setIsInteractive(true)
+  }, [])
 
   return {
     highlight,
@@ -27,3 +29,13 @@ export const useHighlightAnimation = () => {
     },
   } as const
 }
+
+const EXCLUDE_SET = new Set([
+  'Tab',
+  'Enter',
+  'ArrowDown',
+  'ArrowUp',
+  'ArrowRight',
+  'ArrowLeft',
+  'Shift',
+])


### PR DESCRIPTION
## Describe your changes

Update `TextField` to behave like "floating label input" from Material design.

![Screenshot 2022-12-12 at 10.54.41.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/95811199-2156-4555-9ffa-112472deede3/Screenshot%202022-12-12%20at%2010.54.41.png)

![Screenshot 2022-12-12 at 10.54.46.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/daf471af-3871-49c8-bec8-d34d4485a296/Screenshot%202022-12-12%20at%2010.54.46.png)

Make `label` prop required.

Update `useHighlightAnimation` to exclude certain key press events.

## Justify why they are needed

The input doesn't look/behave like the designs. However, I made some experiments and found that causing layout shifts isn't a very nice experience. It also causes problems when two inputs are placed next to one another and one grows but the other doesn't.

The problem with animating the label on "type" is that we need to animate the input field which also feels jarring -- so I avoided that.

## Jira issue(s): []

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
