### PR TITLE
Move Checkout data transforms client-side

### DIFF
--- a/apps/store/src/services/apollo/client.ts
+++ b/apps/store/src/services/apollo/client.ts
@@ -50,7 +50,17 @@ const createApolloClient = (headers?: Record<string, string>) => {
     name: 'Web:Racoon:Store',
     ssrMode: typeof window === 'undefined',
     link: from([errorLink, authLink, languageLink, httpLink]),
-    cache: new InMemoryCache(),
+    cache: new InMemoryCache({
+      typePolicies: {
+        Cart: {
+          fields: {
+            redeemedCampaigns: {
+              merge: (_, incoming) => incoming,
+            },
+          },
+        },
+      },
+    }),
     headers,
     connectToDevTools: process.env.NODE_ENV === 'development',
   })


### PR DESCRIPTION
## Describe your changes

`CheckoutPage`: transform API data client side

Fix merge issue when removing campaign codes.

## Justify why they are needed

Since we rely on Apollo cache for updating UI data we need to transform it client-side rather than server-side. We could consider memoizing it.

Got a merge issue in the console and this is the recommended solution: https://medium.com/@dexiouz/fix-cache-data-may-be-lost-when-replacing-the-getallposts-field-of-a-query-object-in-apollo-client-7973a87a1b43

## Jira issue(s): [GRW-1927]

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1927]: https://hedvig.atlassian.net/browse/GRW-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ