### PR TITLE
fix: coverage dialog style

### DIFF
--- a/apps/onboarding/src/components/LandingPage/CoverageDialog.tsx
+++ b/apps/onboarding/src/components/LandingPage/CoverageDialog.tsx
@@ -39,6 +39,7 @@ export const CoverageDialog = ({ open, onOpenChange, title, perils }: CoverageDi
 const DialogContent = styled(Dialog.Content)({
   display: 'grid',
   placeItems: 'center',
+  height: '100%',
 })
 
 const Wrapper = styled.div(({ theme }) => ({


### PR DESCRIPTION
## Describe your changes

Fix `CoverageDialog` styles

## Justify why they are needed

## Before
<img width="1262" alt="Screenshot 2022-12-14 at 13 17 02" src="https://user-images.githubusercontent.com/19200662/207593512-fc861107-fe41-4209-8c34-3e0ab6e20a98.png">

## After
<img width="1262" alt="Screenshot 2022-12-14 at 13 17 23" src="https://user-images.githubusercontent.com/19200662/207593524-61489b65-13d7-40a7-bcdf-42ebdd840091.png">
