### PR TITLE
Add theme switcher to Storybook and add text colors

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -90,7 +90,7 @@ const Layout = ({ children, pillowSize }: LayoutProps) => {
                 {productData.displayNameShort}
                 <CircledHSuperscript />
               </Heading>
-              <Text size="s" color="secondaryText" align="center">
+              <Text size="s" color="textSecondary" align="center">
                 {productData.displayNameFull}
               </Text>
             </Space>

--- a/packages/ui/.storybook/preview.js
+++ b/packages/ui/.storybook/preview.js
@@ -1,4 +1,4 @@
-import { theme, ThemeProvider } from '../src'
+import { legacyTheme, theme as defaultTheme, ThemeProvider } from '../src'
 import { Global } from '@emotion/react'
 import { storybookFontStyles } from '../src/lib/storybookFontStyles'
 
@@ -13,20 +13,44 @@ export const parameters = {
   backgrounds: {
     default: 'Light',
     values: [
-      { name: 'Dark', value: theme.colors.gray900 },
-      { name: 'Light', value: theme.colors.gray100 },
+      { name: 'Dark', value: defaultTheme.colors.gray900 },
+      { name: 'Light', value: defaultTheme.colors.gray100 },
     ],
   },
   layout: 'centered',
 }
 
-export const decorators = [
-  (Story) => (
+export const withTheme = (Story, context) => {
+  // Get values from story parameter first
+  const theme = context.parameters.theme || context.globals.theme
+  const storyTheme = theme === 'legacy' ? legacyTheme : defaultTheme
+  return (
     <>
       <Global styles={storybookFontStyles} />
-      <ThemeProvider>
+      <ThemeProvider theme={storyTheme}>
         <Story />
       </ThemeProvider>
     </>
-  ),
-]
+  )
+}
+
+export const globalTypes = {
+  theme: {
+    name: 'Theme',
+    description: 'Global theme for components',
+    defaultValue: 'default',
+    toolbar: {
+      // The icon for the toolbar item
+      icon: 'circlehollow',
+      // Array of options
+      items: [
+        { value: 'default', icon: 'circlehollow', title: 'Default theme' },
+        { value: 'legacy', icon: 'circle', title: 'Legacy theme' },
+      ],
+      // Property that specifies if the name of the item will be displayed
+      showName: true,
+    },
+  },
+}
+
+export const decorators = [withTheme]

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -80,15 +80,15 @@ const ButtonElement = styled(UnstyledButton)<ButtonProps>(
       borderRadius: size === 'lg' ? '0.5rem' : '0.375rem',
     }),
     ...(variant === 'filled' && {
-      backgroundColor: color === 'lavender' ? theme.colors.purple500 : theme.colors.gray900,
-      color: color === 'lavender' ? theme.colors.gray900 : theme.colors.gray100,
-      borderColor: color === 'lavender' ? theme.colors.purple500 : theme.colors.gray900,
+      backgroundColor: color === 'lavender' ? theme.colors.purple500 : theme.colors.dark,
+      color: color === 'lavender' ? theme.colors.dark : theme.colors.light,
+      borderColor: color === 'lavender' ? theme.colors.purple500 : theme.colors.dark,
 
       ':hover, :focus': {
         backgroundColor: color === 'lavender' ? theme.colors.purple800 : theme.colors.gray800,
       },
       ':disabled': {
-        color: theme.colors.gray500,
+        color: theme.colors.textDisabled,
         backgroundColor: theme.colors.gray300,
         borderColor: theme.colors.gray300,
       },
@@ -96,14 +96,14 @@ const ButtonElement = styled(UnstyledButton)<ButtonProps>(
 
     ...(variant === 'outlined' && {
       backgroundColor: 'transparent',
-      color: color ? getColor(color) : theme.colors.gray900,
-      borderColor: color ? getColor(color) : theme.colors.gray900,
+      color: color ? getColor(color) : theme.colors.dark,
+      borderColor: color ? getColor(color) : theme.colors.dark,
       ':hover, :focus': {
         color: color ? getColor(color) : theme.colors.gray700,
         borderColor: color ? getColor(color) : theme.colors.gray700,
       },
       ':disabled': {
-        color: theme.colors.gray500,
+        color: theme.colors.textDisabled,
         borderColor: theme.colors.gray500,
       },
     }),
@@ -113,7 +113,7 @@ const ButtonElement = styled(UnstyledButton)<ButtonProps>(
       color: color ? getColor(color) : 'currentcolor',
       border: 'none',
       ':disabled': {
-        color: theme.colors.gray500,
+        color: theme.colors.textDisabled,
       },
     }),
 

--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -40,7 +40,7 @@ const ControlLabel = styled.label<{ disabled?: boolean }>(
   },
   (props) => ({
     fontFamily: props.theme.fonts.body,
-    color: props.disabled ? props.theme.colors.gray500 : props.theme.colors.gray900,
+    color: props.disabled ? props.theme.colors.gray500 : props.theme.colors.textPrimary,
   }),
 )
 
@@ -71,14 +71,14 @@ const StyledCheckboxElement = styled.div<CheckboxProps>(({ theme, circle }) => (
   transition: 'all 150ms',
   // checked/unchecked backgorund
   [`${HiddenInput}:checked + &`]: {
-    background: theme.colors.gray900,
+    background: theme.colors.dark,
   },
   [`${HiddenInput}:disabled + &`]: {
     background: theme.colors.gray300,
   },
   // hover/focus-visible
   [`${HiddenInput}:enabled:hover + &, ${HiddenInput}:focus-visible + &`]: {
-    border: `2px solid ${theme.colors.gray900}`,
+    border: `2px solid ${theme.colors.dark}`,
   },
   // checked/disabled icons
   [`${HiddenInput}:enabled${HiddenInput}:checked + & > ${Icon}`]: {

--- a/packages/ui/src/components/InputBase.tsx
+++ b/packages/ui/src/components/InputBase.tsx
@@ -4,7 +4,7 @@ import { Space } from './Space'
 
 const Label = styled.label(({ theme }) => ({
   fontFamily: theme.fonts.body,
-  color: theme.colors.gray900,
+  color: theme.colors.textPrimary,
   fontSize: '0.875rem',
   lineHeight: '1.375rem',
 }))
@@ -29,7 +29,7 @@ const ErrorMessage = styled.span(({ theme }) => ({
 
 const InfoMessage = styled.span(({ theme }) => ({
   fontFamily: theme.fonts.body,
-  color: theme.colors.gray700,
+  color: theme.colors.textSecondary,
   fontSize: '0.75rem',
   lineHeight: '1rem',
 }))

--- a/packages/ui/src/components/InputField/InputField.tsx
+++ b/packages/ui/src/components/InputField/InputField.tsx
@@ -19,7 +19,7 @@ const Wrapper = styled.div(({ $suffix }: StyleProps) => ({
 
 const StyledInput = styled.input<StyleProps>(({ theme, $error }) => ({
   backgroundColor: theme.colors.white,
-  color: theme.colors.gray900,
+  color: theme.colors.textPrimary,
   fontSize: '1.125rem',
   lineHeight: '1.75rem',
   padding: '0 1rem',
@@ -32,7 +32,7 @@ const StyledInput = styled.input<StyleProps>(({ theme, $error }) => ({
   height: '3.5rem',
 
   '::placeholder': {
-    color: theme.colors.gray500,
+    color: theme.colors.textTertiary,
   },
 
   ':focus, :hover': {
@@ -44,7 +44,7 @@ const StyledInput = styled.input<StyleProps>(({ theme, $error }) => ({
   ':disabled': {
     backgroundColor: theme.colors.gray300,
     borderColor: theme.colors.gray300,
-    color: theme.colors.gray500,
+    color: theme.colors.textDisabled,
     cursor: 'not-allowed',
   },
 

--- a/packages/ui/src/components/InputStepper/InputStepper.tsx
+++ b/packages/ui/src/components/InputStepper/InputStepper.tsx
@@ -27,7 +27,7 @@ const Wrapper = styled.div<ErrorProps>(({ theme, $error }) => ({
   ':disabled': {
     backgroundColor: theme.colors.gray300,
     borderColor: theme.colors.gray300,
-    color: theme.colors.gray500,
+    color: theme.colors.textDisabled,
     cursor: 'not-allowed',
   },
 
@@ -59,7 +59,7 @@ const StepButtonRight = styled(StepButton)({
 })
 
 const StyledInput = styled.input(({ theme }) => ({
-  color: theme.colors.gray900,
+  color: theme.colors.textPrimary,
   fontSize: '1.125rem',
   lineHeight: '1.75rem',
   textAlign: 'center',
@@ -67,7 +67,7 @@ const StyledInput = styled.input(({ theme }) => ({
   border: 0,
 
   '::placeholder': {
-    color: theme.colors.gray500,
+    color: theme.colors.textTertiary,
   },
 }))
 

--- a/packages/ui/src/lib/theme/colors.ts
+++ b/packages/ui/src/lib/theme/colors.ts
@@ -53,7 +53,10 @@ export const colors = {
   dark: gray[1000],
   light: gray[25],
   lavender: purple[500],
-  secondaryText: gray[500],
+  textPrimary: gray[1000],
+  textSecondary: gray[700],
+  textTertiary: gray[500],
+  textDisabled: gray[400],
 }
 
 export type UIColor = keyof typeof colors

--- a/packages/ui/src/lib/theme/legacy/legacyColors.ts
+++ b/packages/ui/src/lib/theme/legacy/legacyColors.ts
@@ -46,6 +46,10 @@ export const legacyColors = {
   dark: gray[900],
   light: gray[100],
   lavender: purple[500],
+  textPrimary: purple[900],
+  textSecondary: gray[700],
+  textTertiary: gray[500],
+  textDisabled: gray[500],
 }
 
 export type LegacyUIColor = keyof typeof legacyColors


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add theme switcher to Storybook. This way we can see that shared components (as long as we still have them) look good.
- Add semantic colors for text to use in themes. Updated use in UI library 

(just an example where I set `textPrimary` to purple)
https://user-images.githubusercontent.com/6661511/207643727-8e8d8f44-fbb9-45b5-8663-7d8f40724839.mov

## Justify why they are needed
Start using semantic colors from theme

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
