### PR TITLE
Use API product data in `ProductPage`

### DIFF
--- a/apps/store/src/components/Pillow/Pillow.tsx
+++ b/apps/store/src/components/Pillow/Pillow.tsx
@@ -5,15 +5,15 @@ const PLACEHOLDER = 'https://a.storyblok.com/f/165473/512x512/7996914970/se-apar
 
 type PillowProps = {
   size?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'
+  src?: string
+  alt?: string | null
 }
 
-export const Pillow = (props: PillowProps) => (
-  <StyledImage alt="" src={PLACEHOLDER} {...props} width={80} height={80} />
+export const Pillow = ({ alt, src = PLACEHOLDER, ...props }: PillowProps) => (
+  <StyledImage {...props} src={src} alt={alt ?? ''} width={80} height={80} />
 )
 
-const StyledImage = styled(Image)<PillowProps>(({ size = 'medium' }) => ({
-  ...getSize(size),
-}))
+const StyledImage = styled(Image)<PillowProps>(({ size = 'medium' }) => getSize(size))
 
 const getSize = (size: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge') => {
   switch (size) {

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -1,13 +1,14 @@
 import { useApolloClient } from '@apollo/client'
 import styled from '@emotion/styled'
 import { ReactNode, useRef, useState } from 'react'
-import { Button, Heading, useBreakpoint } from 'ui'
+import { Button, Heading, Space, useBreakpoint } from 'ui'
 import { CartToast, CartToastAttributes } from '@/components/CartNotification/CartToast'
 import { ProductItemProps } from '@/components/CartNotification/ProductItem'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { PriceCalculator } from '@/components/PriceCalculator/PriceCalculator'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
+import { Text } from '@/components/Text/Text'
 import { ProductOfferFragment } from '@/services/apollo/generated'
 import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntent.helpers'
 import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
@@ -23,12 +24,12 @@ import { PriceCalculatorDialog } from './PriceCalculatorDialog'
 export const PurchaseForm = () => {
   const [isEditingPriceCalculator, setIsEditingPriceCalculator] = useState(false)
 
-  const { priceTemplate, story } = useProductPageContext()
+  const { priceTemplate, productData } = useProductPageContext()
   const { shopSession } = useShopSession()
   const { data: { priceIntent } = {} } = usePriceIntent({
     shopSession,
     priceTemplate: priceTemplate,
-    productName: story.content.productId,
+    productName: productData.name,
   })
 
   return (
@@ -69,7 +70,7 @@ type LayoutProps = {
 
 const Layout = ({ children, pillowSize }: LayoutProps) => {
   const toastRef = useRef<CartToastAttributes | null>(null)
-  const { story } = useProductPageContext()
+  const { productData } = useProductPageContext()
 
   const notifyProductAdded = (item: ProductItemProps) => {
     toastRef.current?.publish(item)
@@ -80,11 +81,19 @@ const Layout = ({ children, pillowSize }: LayoutProps) => {
       <PurchaseFormTop>
         <OfferPresenterWrapper>
           <SpaceFlex space={1} align="center" direction="vertical">
-            <Pillow size={pillowSize === 'large' ? 'xlarge' : 'large'} />
-            <Heading as="h2" variant="standard.24">
-              {story.content.name}
-              <CircledHSuperscript />
-            </Heading>
+            <Pillow
+              size={pillowSize === 'large' ? 'xlarge' : 'large'}
+              {...productData.pillowImage}
+            />
+            <Space y={0.5}>
+              <Heading as="h2" variant="standard.24" textAlignment="center">
+                {productData.displayNameShort}
+                <CircledHSuperscript />
+              </Heading>
+              <Text size="s" color="secondaryText" align="center">
+                {productData.displayNameFull}
+              </Text>
+            </Space>
           </SpaceFlex>
         </OfferPresenterWrapper>
 
@@ -129,7 +138,7 @@ type EditingStateProps = {
 
 const EditingState = (props: EditingStateProps) => {
   const { onToggleDialog, priceIntent, onSuccess } = props
-  const { priceTemplate, story } = useProductPageContext()
+  const { priceTemplate, productData } = useProductPageContext()
   const isLarge = useBreakpoint('lg')
 
   const priceCalculator = (
@@ -150,9 +159,9 @@ const EditingState = (props: EditingStateProps) => {
       toggleDialog={onToggleDialog}
       header={
         <SpaceFlex direction="vertical" align="center" space={0.5}>
-          <Pillow size="large" />
+          <Pillow size="large" {...productData.pillowImage} />
           <Heading as="h2" variant="standard.18">
-            {story.content.name}
+            {productData.displayNameShort}
             <CircledHSuperscript />
           </Heading>
         </SpaceFlex>

--- a/apps/store/src/graphql/ProductData.graphql
+++ b/apps/store/src/graphql/ProductData.graphql
@@ -1,6 +1,15 @@
 query ProductData($productName: String!) {
   product(productName: $productName) {
     id
+    name
+    displayNameFull
+    displayNameShort
+    tagline
+    pillowImage {
+      id
+      alt
+      src
+    }
     variants {
       typeOfContract
       perils {

--- a/apps/store/src/services/apollo/client.ts
+++ b/apps/store/src/services/apollo/client.ts
@@ -32,8 +32,8 @@ const authLink = setContext((_, { headers = {}, context }) => {
   }
 })
 
-const languageLink = setContext((operation, { headers = {}, ...context }) => {
-  const locale = operation.variables?.locale ?? getLocaleOrFallback(i18n?.language).locale
+const languageLink = setContext((_, { headers = {}, ...context }) => {
+  const locale = getLocaleOrFallback(i18n?.language).locale
   return {
     headers: {
       ...headers,


### PR DESCRIPTION
## Describe your changes

Integrate product date from API on `ProductPage`.

![Screenshot 2022-12-15 at 11.52.18.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/ca0512b3-1b3a-4755-87f0-408da25a1255/Screenshot%202022-12-15%20at%2011.52.18.png)

Update `Pillow` component to accept image props.

Update Apollo client language link to not consider "locale" variables.

## Justify why they are needed

We will move away from passing "locale" variables in the API.

## Jira issue(s): [GRW-1925]

## Checklist before requesting a review

- [x] I have performed a self-review of my code


[GRW-1925]: https://hedvig.atlassian.net/browse/GRW-1925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ