### PR TITLE
Remove layout from CartPage

### DIFF
--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'next-i18next'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { ReactNode } from 'react'
-import { Button, Heading, LinkButton, Space } from 'ui'
+import { Button, CrossIcon, Heading, LinkButton, Space } from 'ui'
 import { CampaignCodeList } from '@/components/CartInventory/CampaignCodeList'
 import { CartEntryItem } from '@/components/CartInventory/CartEntryItem'
 import { CartEntryList } from '@/components/CartInventory/CartEntryList'
@@ -15,7 +15,7 @@ import { CartPageProps } from './CartPageProps.types'
 import { useStartCheckout } from './useStartCheckout'
 
 export const CartPage = (props: CartPageProps) => {
-  const { shopSessionId, cartId, entries, campaigns, cost } = props
+  const { shopSessionId, cartId, entries, campaigns, cost, prevURL } = props
   const { t } = useTranslation()
 
   const router = useRouter()
@@ -28,7 +28,7 @@ export const CartPage = (props: CartPageProps) => {
 
   if (entries.length === 0) {
     return (
-      <EmptyState>
+      <EmptyState prevURL={prevURL}>
         <Space y={1.5}>
           <HorizontalLine />
           <CampaignCodeList cartId={cartId} campaigns={campaigns} />
@@ -42,7 +42,7 @@ export const CartPage = (props: CartPageProps) => {
   return (
     <Wrapper>
       <Space y={1.5}>
-        <Header />
+        <Header prevURL={prevURL} />
 
         <CartEntryList>
           {entries.map((item) => (
@@ -62,16 +62,16 @@ export const CartPage = (props: CartPageProps) => {
   )
 }
 
-type EmptyStateProps = { children: ReactNode }
+type EmptyStateProps = { children: ReactNode; prevURL: string }
 
-const EmptyState = ({ children }: EmptyStateProps) => {
+const EmptyState = ({ children, prevURL }: EmptyStateProps) => {
   const { t } = useTranslation('cart')
   const { routingLocale } = useCurrentLocale()
 
   return (
     <Wrapper>
       <Space y={5}>
-        <Header />
+        <Header prevURL={prevURL} />
 
         <Space y={2}>
           <Space y={1}>
@@ -90,7 +90,9 @@ const EmptyState = ({ children }: EmptyStateProps) => {
   )
 }
 
-const Header = () => {
+type HeaderProps = { prevURL: string }
+
+const Header = ({ prevURL }: HeaderProps) => {
   const { t } = useTranslation('cart')
 
   return (
@@ -98,6 +100,10 @@ const Header = () => {
       <Heading as="h1" variant="standard.24">
         {t('CART_PAGE_HEADING')}
       </Heading>
+
+      <Link href={prevURL}>
+        <CrossIcon size="1.5rem" />
+      </Link>
     </StyledHeader>
   )
 }

--- a/apps/store/src/components/CartPage/CartPageProps.types.ts
+++ b/apps/store/src/components/CartPage/CartPageProps.types.ts
@@ -1,5 +1,4 @@
 import { CartCost, CartCampaign } from '@/components/CartInventory/CartInventory.types'
-import { StoryblokPageProps } from '@/services/storyblok/storyblok'
 import { Money } from '@/utils/formatter'
 
 export type CartEntry = {
@@ -9,10 +8,11 @@ export type CartEntry = {
   startDate?: Date
 }
 
-export type CartPageProps = Pick<StoryblokPageProps, 'globalStory'> & {
+export type CartPageProps = {
   shopSessionId: string
   cartId: string
   cost: CartCost
   campaigns: Array<CartCampaign>
   entries: Array<CartEntry>
+  prevURL: string
 }

--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -45,17 +45,15 @@ const CheckoutPage = (props: CheckoutPageProps) => {
 
   return (
     <Wrapper y={1}>
-      <div>
-        <Header>
-          <Heading as="h1" variant="standard.24">
-            {t('CHECKOUT_PAGE_HEADING')}
-          </Heading>
+      <Header>
+        <Heading as="h1" variant="standard.24">
+          {t('CHECKOUT_PAGE_HEADING')}
+        </Heading>
 
-          <Link href={PageLink.cart()}>
-            <CrossIcon size="1.5rem" />
-          </Link>
-        </Header>
-      </div>
+        <Link href={PageLink.cart()}>
+          <CrossIcon size="1.5rem" />
+        </Link>
+      </Header>
 
       <Section>
         <CartCollapsible


### PR DESCRIPTION
## Describe your changes

Remove layout + menu from `CartPage`.

![Screenshot 2022-12-15 at 15.42.28.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/49ce5153-51b0-41ad-898d-86f60325baa0/Screenshot%202022-12-15%20at%2015.42.28.png)

Handle closing cart by navigating back to previous route (or store).

## Justify why they are needed

I'm always scared to rely on "history.back" since it doesn't always behave predictably. Like if the history has changes because of "#" updates...

The current solution might be a bit overengineered but I think it's okey.

Probably in the future we should just have a dialog instead of treating it as a separate page.

## Jira issue(s): []

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
