### PR TITLE
GRW-1918 - styles: split perils into columns

### DIFF
--- a/apps/store/src/blocks/PerilsBlock.tsx
+++ b/apps/store/src/blocks/PerilsBlock.tsx
@@ -1,11 +1,17 @@
 import styled from '@emotion/styled'
-import { SbBlokData, storyblokEditable } from '@storyblok/react'
+import { storyblokEditable } from '@storyblok/react'
 import Image from 'next/image'
 import { useMemo } from 'react'
+import { HeadingLabel, Space } from 'ui'
 import { Perils } from '@/components/Perils/Perils'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
+import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
-export const PerilsBlock = (blok: SbBlokData) => {
+type PerilsBlockProps = SbBaseBlockProps<{
+  heading: string
+}>
+
+export const PerilsBlock = ({ blok }: PerilsBlockProps) => {
   const { productData, selectedVariant } = useProductPageContext()
 
   const items = useMemo(() => {
@@ -27,7 +33,10 @@ export const PerilsBlock = (blok: SbBlokData) => {
 
   return (
     <Wrapper {...storyblokEditable(blok)}>
-      <Perils items={items} />
+      <Space y={1}>
+        <HeadingLabel>{blok.heading}</HeadingLabel>
+        <Perils items={items} />
+      </Space>
     </Wrapper>
   )
 }
@@ -35,6 +44,5 @@ export const PerilsBlock = (blok: SbBlokData) => {
 PerilsBlock.blockName = 'perils'
 
 const Wrapper = styled.div(({ theme }) => ({
-  paddingLeft: theme.space[4],
-  paddingRight: theme.space[4],
+  paddingInline: theme.space[4],
 }))

--- a/apps/store/src/components/Perils/Perils.stories.tsx
+++ b/apps/store/src/components/Perils/Perils.stories.tsx
@@ -3,6 +3,89 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { Perils } from './Perils'
 import { ShieldIcon } from './ShieldIcon'
 
+const mockedPerils = [
+  {
+    id: 'waterLeaks',
+    icon: <ShieldIcon size="22px" />,
+    name: 'Water leaks',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
+    covered: [
+      'Lorem ipsum dolor sit amet',
+      'Sed fermentum tempus',
+      'Morbi at egestas tortor',
+      'Quisque venenatis lacus dolor',
+    ],
+    notCovered: ['Morbi vitae elit sapien', 'Duis sed viverra nibh'],
+  },
+  {
+    id: 'fire',
+    icon: <ShieldIcon size="22px" />,
+    name: 'Fire',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
+    covered: ['Lorem ipsum dolor sit amet', 'Sed fermentum tempus'],
+    notCovered: [
+      'Morbi at egestas tortor',
+      'Morbi vitae elit sapien',
+      'Duis sed viverra nibh',
+      'Quisque venenatis lacus dolor',
+    ],
+  },
+  {
+    id: 'storms',
+    icon: <ShieldIcon size="22px" />,
+    name: 'Storms',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
+    covered: [
+      'Lorem ipsum dolor sit amet',
+      'Sed fermentum tempus',
+      'Quisque venenatis lacus dolor',
+    ],
+    notCovered: ['Morbi vitae elit sapien'],
+  },
+  {
+    id: 'assault',
+    icon: <ShieldIcon size="22px" />,
+    name: 'Assault',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
+    covered: [
+      'Lorem ipsum dolor sit amet',
+      'Sed fermentum tempus',
+      'Quisque venenatis lacus dolor',
+    ],
+    notCovered: ['Morbi vitae elit sapien'],
+  },
+  {
+    id: 'white-goods',
+    icon: <ShieldIcon size="22px" />,
+    name: 'White Goods',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
+    covered: [
+      'Lorem ipsum dolor sit amet',
+      'Sed fermentum tempus',
+      'Quisque venenatis lacus dolor',
+    ],
+    notCovered: ['Morbi vitae elit sapien'],
+  },
+  {
+    id: 'criminal-damage',
+    icon: <ShieldIcon size="22px" />,
+    name: 'Criminal Damage',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
+    covered: [
+      'Lorem ipsum dolor sit amet',
+      'Sed fermentum tempus',
+      'Quisque venenatis lacus dolor',
+    ],
+    notCovered: ['Morbi vitae elit sapien'],
+  },
+]
+
 export default {
   title: 'Perils',
   component: Perils,
@@ -16,49 +99,12 @@ export default {
 
 const Template: ComponentStory<typeof Perils> = (props) => <Perils {...props} />
 
-export const Default = Template.bind({})
-Default.args = {
-  items: [
-    {
-      id: 'waterLeaks',
-      icon: <ShieldIcon size="22px" />,
-      name: 'Water leaks',
-      description:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
-      covered: [
-        'Lorem ipsum dolor sit amet',
-        'Sed fermentum tempus',
-        'Morbi at egestas tortor',
-        'Quisque venenatis lacus dolor',
-      ],
-      notCovered: ['Morbi vitae elit sapien', 'Duis sed viverra nibh'],
-    },
-    {
-      id: 'fire',
-      icon: <ShieldIcon size="22px" />,
-      name: 'Fire',
-      description:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
-      covered: ['Lorem ipsum dolor sit amet', 'Sed fermentum tempus'],
-      notCovered: [
-        'Morbi at egestas tortor',
-        'Morbi vitae elit sapien',
-        'Duis sed viverra nibh',
-        'Quisque venenatis lacus dolor',
-      ],
-    },
-    {
-      id: 'storms',
-      icon: <ShieldIcon size="22px" />,
-      name: 'Storms',
-      description:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent at dictum urna. Pellentesque gravida, sapien ut maximus cursus, dui ligula sodales nisl, sed placerat felis metus quis dolor.',
-      covered: [
-        'Lorem ipsum dolor sit amet',
-        'Sed fermentum tempus',
-        'Quisque venenatis lacus dolor',
-      ],
-      notCovered: ['Morbi vitae elit sapien'],
-    },
-  ],
+export const FourItemsOrMore = Template.bind({})
+FourItemsOrMore.args = {
+  items: mockedPerils,
+}
+
+export const LessThanFourItems = Template.bind({})
+LessThanFourItems.args = {
+  items: mockedPerils.slice(0, 2),
 }

--- a/apps/store/src/components/Perils/Perils.tsx
+++ b/apps/store/src/components/Perils/Perils.tsx
@@ -1,15 +1,38 @@
 import styled from '@emotion/styled'
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, ReactNode } from 'react'
+import { mq } from 'ui'
 import * as Accordion from '@/components/Accordion/Accordion'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { CoverageList } from './CoverageList'
 import { Peril } from './Perils.types'
+
+const MAX_COLS = 4
 
 type Props = {
   items: Array<Peril>
 }
 
 export const Perils = ({ items }: Props) => {
+  const numberOfItemsPerColumn = Math.ceil(items.length / MAX_COLS)
+  const accordions: Array<ReactNode> = []
+  for (let i = 0; i < items.length; i += numberOfItemsPerColumn) {
+    const perils = items.slice(i, i + numberOfItemsPerColumn)
+    accordions.push(<PerilsAccordion key={i} perils={perils} />)
+  }
+
+  return <PerilsAccordionGrid fixedCols={items.length < 4}>{accordions}</PerilsAccordionGrid>
+}
+
+const PerilsAccordionGrid = styled.div(({ fixedCols = false }: { fixedCols?: boolean }) => ({
+  display: 'grid',
+  gap: '0.25rem',
+  [mq.md]: {
+    gridTemplateColumns: `repeat(auto-fit, ${fixedCols ? '20.75rem' : 'minmax(20.75rem, 1fr)'})`,
+    gap: '1rem',
+  },
+}))
+
+const PerilsAccordion = ({ perils }: { perils: Array<Peril> }) => {
   const [openedItems, setOpenedItems] = useState<Array<string>>()
 
   const handleValueChange = useCallback((value: Array<string>) => {
@@ -18,7 +41,7 @@ export const Perils = ({ items }: Props) => {
 
   return (
     <Accordion.Root type="multiple" value={openedItems} onValueChange={handleValueChange}>
-      {items.map(({ id, icon, name, description, covered, notCovered }) => {
+      {perils.map(({ id, icon, name, description, covered, notCovered }) => {
         return (
           <Accordion.Item key={id} value={name}>
             <Accordion.HeaderWithTrigger>


### PR DESCRIPTION
## Describe your changes

* UI changes: split PerilsBlock content into columns

## Justify why they are needed

Requested by design

<img width="661" alt="Screenshot 2022-12-19 at 11 18 39" src="https://user-images.githubusercontent.com/19200662/208403646-84a4dccb-0230-4e76-9317-517a0e02ceab.png">
<img width="1542" alt="Screenshot 2022-12-19 at 11 18 21" src="https://user-images.githubusercontent.com/19200662/208403667-05d99de2-6ff0-4713-a3a6-79c9d701b72c.png">



## Jira issue(s): [GRW-1918](https://hedvig.atlassian.net/browse/GRW-1918)
