### PR TITLE
Allow product display name to be overridden from CMS

### DIFF
--- a/apps/store/public/locales/default/purchase-form.json
+++ b/apps/store/public/locales/default/purchase-form.json
@@ -31,5 +31,6 @@
   "PRICE_MATCH_BUBBLE_FAIL_TITLE": "We could not match your price",
   "PRICE_MATCH_BUBBLE_EXPIRY_LABEL": "Expires on {{date}}",
   "AUTO_SWITCH_RENEWAL_DATE_LABEL": "End date {{company}}",
-  "AUTO_SWITCH_INVALID_START_DATE_MESSAGE": "Because your insurance at {{company}} expires soon, you have to manually cancel it. Don't worry, we will email instructions."
+  "AUTO_SWITCH_INVALID_START_DATE_MESSAGE": "Because your insurance at {{company}} expires soon, you have to manually cancel it. Don't worry, we will email instructions.",
+  "OPEN_PRICE_CALCULATOR_BUTTON": "Calculate price"
 }

--- a/apps/store/public/locales/sv-se/purchase-form.json
+++ b/apps/store/public/locales/sv-se/purchase-form.json
@@ -31,5 +31,6 @@
   "PRICE_MATCH_BUBBLE_FAIL_TITLE": "Vi kunde inte matcha ditt pris",
   "PRICE_MATCH_BUBBLE_EXPIRY_LABEL": "Går ut {{date}}",
   "AUTO_SWITCH_RENEWAL_DATE_LABEL": "Startdatum {{company}}",
-  "AUTO_SWITCH_INVALID_START_DATE_MESSAGE": "Eftersom din försäkring hos {{company}} går ut ganska snart behöver du själv säga upp den. Oroa dig inte, vi mejlar instruktioner till dig."
+  "AUTO_SWITCH_INVALID_START_DATE_MESSAGE": "Eftersom din försäkring hos {{company}} går ut ganska snart behöver du själv säga upp den. Oroa dig inte, vi mejlar instruktioner till dig.",
+  "OPEN_PRICE_CALCULATOR_BUTTON": "Beräkna pris"
 }

--- a/apps/store/src/blocks/ProductSummaryBlock.tsx
+++ b/apps/store/src/blocks/ProductSummaryBlock.tsx
@@ -14,12 +14,11 @@ type Props = SbBaseBlockProps<{
 }>
 
 export const ProductSummaryBlock = (props: Props) => {
-  const { story } = useProductPageContext()
-  const blockTitle = props.blok.title || story.content.name
+  const { productData } = useProductPageContext()
 
   return (
     <Wrapper {...storyblokEditable}>
-      <ProductSummary title={blockTitle}>{props.blok.description}</ProductSummary>
+      <ProductSummary title={productData.displayNameShort}>{props.blok.description}</ProductSummary>
     </Wrapper>
   )
 }

--- a/apps/store/src/components/ProductPage/ProductPageContext.tsx
+++ b/apps/store/src/components/ProductPage/ProductPageContext.tsx
@@ -24,6 +24,11 @@ export const ProductPageContextProvider = (props: Props) => {
       ...rest,
       selectedVariant,
       selectedVariantUpdate: setSelectedVariant,
+      productData: {
+        ...rest.productData,
+        displayNameShort: rest.story.content.name || rest.productData.displayNameShort,
+        displayNameFull: rest.story.content.description || rest.productData.displayNameFull,
+      },
     }),
     [rest, selectedVariant],
   )

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -1,5 +1,6 @@
 import { useApolloClient } from '@apollo/client'
 import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
 import { ReactNode, useRef, useState } from 'react'
 import { Button, Heading, Space, useBreakpoint } from 'ui'
 import { CartToast, CartToastAttributes } from '@/components/CartNotification/CartToast'
@@ -25,6 +26,7 @@ export const PurchaseForm = () => {
   const [isEditingPriceCalculator, setIsEditingPriceCalculator] = useState(false)
 
   const { priceTemplate, productData } = useProductPageContext()
+
   const { shopSession } = useShopSession()
   const { data: { priceIntent } = {} } = usePriceIntent({
     shopSession,
@@ -105,11 +107,13 @@ const Layout = ({ children, pillowSize }: LayoutProps) => {
 }
 
 const PendingState = () => {
+  const { t } = useTranslation('purchase-form')
+
   return (
     <OfferPresenterWrapper>
       <ButtonWrapper>
         <Button disabled fullWidth>
-          Calculate price
+          {t('OPEN_PRICE_CALCULATOR_BUTTON')}
         </Button>
       </ButtonWrapper>
     </OfferPresenterWrapper>
@@ -119,11 +123,13 @@ const PendingState = () => {
 type IdleStateProps = { onClick: () => void }
 
 const IdleState = ({ onClick }: IdleStateProps) => {
+  const { t } = useTranslation('purchase-form')
+
   return (
     <OfferPresenterWrapper>
       <ButtonWrapper>
         <Button onClick={onClick} fullWidth>
-          Calculate price
+          {t('OPEN_PRICE_CALCULATOR_BUTTON')}
         </Button>
       </ButtonWrapper>
     </OfferPresenterWrapper>
@@ -180,7 +186,7 @@ type ShowOfferStateProps = {
 
 const ShowOfferState = (props: ShowOfferStateProps) => {
   const { shopSession, priceIntent, onAddedToCart } = props
-  const { priceTemplate, story } = useProductPageContext()
+  const { priceTemplate, productData } = useProductPageContext()
   const scrollPastRef = useRef<HTMLDivElement | null>(null)
 
   const refresh = useRouterRefresh()
@@ -188,7 +194,7 @@ const ShowOfferState = (props: ShowOfferStateProps) => {
   const formatter = useFormatter()
   const handleAddedToCart = (addedProdutOffer: ProductOfferFragment) => {
     onAddedToCart({
-      name: story.content.name,
+      name: productData.displayNameFull,
       price: formatter.money(addedProdutOffer.price),
     })
     priceIntentServiceInitClientSide({ apolloClient, shopSession }).clear(priceTemplate.name)

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -95,7 +95,8 @@ export type LinkField = {
 
 export type ProductStory = StoryData & {
   content: StoryData['content'] & {
-    name: string
+    name?: string
+    description?: string
     productId: string
     priceFormTemplateId: string
     body: Array<SbBlokData>


### PR DESCRIPTION
## Describe your changes

Allow product display names to be overridden from the CMS.

![Screenshot 2022-12-19 at 15.25.44.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/5937057c-40ab-4f43-aa52-60b2a9c51ca1/Screenshot%202022-12-19%20at%2015.25.44.png)

Translate the button that opens the price calculator.

## Justify why they are needed

Decided to do this inside the product page context to keep things DRY - let's see how it scales.

## Jira issue(s): [GRW-1939]

## Checklist before requesting a review

- [x] I have performed a self-review of my code


[GRW-1939]: https://hedvig.atlassian.net/browse/GRW-1939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ