### PR TITLE
Make open price calculator button sticky

### DIFF
--- a/apps/store/src/blocks/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock.tsx
@@ -138,6 +138,7 @@ export const Wrapper = styled(Space)(({ theme }) => ({
   width: '100%',
   backgroundColor: theme.colors.gray200,
   padding: `${theme.space[6]} ${theme.space[4]}`,
+  paddingBottom: theme.space[9],
 }))
 
 export const Flex = styled.div({ flex: 1 })

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -2,7 +2,7 @@ import { useApolloClient } from '@apollo/client'
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { ReactNode, useRef, useState } from 'react'
-import { Button, Heading, Space, useBreakpoint } from 'ui'
+import { Button, Heading, mq, Space, useBreakpoint } from 'ui'
 import { CartToast, CartToastAttributes } from '@/components/CartNotification/CartToast'
 import { ProductItemProps } from '@/components/CartNotification/ProductItem'
 import { Pillow } from '@/components/Pillow/Pillow'
@@ -17,6 +17,7 @@ import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { useFormatter } from '@/utils/useFormatter'
 import useRouterRefresh from '@/utils/useRouterRefresh'
+import { ScrollPast } from '../ScrollPast/ScrollPast'
 import { usePriceIntent } from '../usePriceIntent'
 import { CircledHSuperscript } from './CircledHSuperscript'
 import { OfferPresenter } from './OfferPresenter'
@@ -81,7 +82,7 @@ const Layout = ({ children, pillowSize }: LayoutProps) => {
   return (
     <>
       <PurchaseFormTop>
-        <OfferPresenterWrapper>
+        <SectionWrapper>
           <SpaceFlex space={1} align="center" direction="vertical">
             <Pillow
               size={pillowSize === 'large' ? 'xlarge' : 'large'}
@@ -97,7 +98,7 @@ const Layout = ({ children, pillowSize }: LayoutProps) => {
               </Text>
             </Space>
           </SpaceFlex>
-        </OfferPresenterWrapper>
+        </SectionWrapper>
 
         {children(notifyProductAdded)}
       </PurchaseFormTop>
@@ -110,29 +111,37 @@ const PendingState = () => {
   const { t } = useTranslation('purchase-form')
 
   return (
-    <OfferPresenterWrapper>
-      <ButtonWrapper>
+    <SectionWrapper>
+      <OpenModalButtonWrapper>
         <Button disabled fullWidth>
           {t('OPEN_PRICE_CALCULATOR_BUTTON')}
         </Button>
-      </ButtonWrapper>
-    </OfferPresenterWrapper>
+      </OpenModalButtonWrapper>
+    </SectionWrapper>
   )
 }
 
 type IdleStateProps = { onClick: () => void }
 
 const IdleState = ({ onClick }: IdleStateProps) => {
+  const ref = useRef<HTMLDivElement>(null)
   const { t } = useTranslation('purchase-form')
 
+  const button = (
+    <Button onClick={onClick} fullWidth>
+      {t('OPEN_PRICE_CALCULATOR_BUTTON')}
+    </Button>
+  )
+
   return (
-    <OfferPresenterWrapper>
-      <ButtonWrapper>
-        <Button onClick={onClick} fullWidth>
-          {t('OPEN_PRICE_CALCULATOR_BUTTON')}
-        </Button>
-      </ButtonWrapper>
-    </OfferPresenterWrapper>
+    <>
+      <SectionWrapper ref={ref}>
+        <OpenModalButtonWrapper>{button}</OpenModalButtonWrapper>
+      </SectionWrapper>
+      <ScrollPast targetRef={ref}>
+        <StickyButtonWrapper>{button}</StickyButtonWrapper>
+      </ScrollPast>
+    </>
   )
 }
 
@@ -202,14 +211,14 @@ const ShowOfferState = (props: ShowOfferStateProps) => {
   }
 
   return (
-    <OfferPresenterWrapper>
+    <SectionWrapper ref={scrollPastRef}>
       <OfferPresenter
         priceIntent={priceIntent}
         shopSession={shopSession}
         scrollPastRef={scrollPastRef}
         onAddedToCart={handleAddedToCart}
       />
-    </OfferPresenterWrapper>
+    </SectionWrapper>
   )
 }
 
@@ -222,16 +231,23 @@ const PurchaseFormTop = styled.div({
   paddingBottom: '9vh',
 })
 
-const ButtonWrapper = styled.div({
-  maxWidth: '21rem',
-  marginLeft: 'auto',
-  marginRight: 'auto',
+const OpenModalButtonWrapper = styled.div({
+  [mq.lg]: {
+    padding: 0,
+    maxWidth: '21rem',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+  },
 })
 
-const OfferPresenterWrapper = styled.div({
-  paddingLeft: '1rem',
-  paddingRight: '1rem',
+const StickyButtonWrapper = styled.div(({ theme }) => ({
+  paddingInline: theme.space[4],
+  [mq.lg]: {
+    display: 'none',
+  },
+}))
 
+const SectionWrapper = styled.div({
   width: '100%',
   maxWidth: '21rem',
   margin: '0 auto',

--- a/apps/store/src/components/ProductPage/ScrollPast/ScrollPast.tsx
+++ b/apps/store/src/components/ProductPage/ScrollPast/ScrollPast.tsx
@@ -13,7 +13,7 @@ export const ScrollPast = ({ targetRef, children }: ScrollPastProps) => {
 
   const [hasScrolledPassed, setHasScrolledPassed] = useState(false)
   useEffect(() => {
-    return scrollY.onChange((latest) => {
+    return scrollY.on('change', (latest) => {
       if (targetRef.current) {
         const elementEnd = targetRef.current.offsetTop + targetRef.current.clientHeight
         setHasScrolledPassed(latest > elementEnd)
@@ -37,7 +37,7 @@ export const ScrollPast = ({ targetRef, children }: ScrollPastProps) => {
 
 const StyledWrapper = styled(motion.div)(({ theme }) => ({
   position: 'fixed',
-  bottom: theme.space[8],
+  bottom: theme.space[4],
   left: 0,
   right: 0,
   zIndex: zIndexes.scrollPast,


### PR DESCRIPTION
## Describe your changes

Make open price calculator button sticky after you scroll down on the product page.

Fix "add to cart" button so it's also sticky (pass ref).

Clear possible floating elements by adding padding to the bottom of footer.

## Justify why they are needed

It's unclear how this looks on desktop so for now I just hide the element on desktop.

## Jira issue(s): [GRW-1940]

## Checklist before requesting a review

- [x] I have performed a self-review of my code


[GRW-1940]: https://hedvig.atlassian.net/browse/GRW-1940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ