### PR TITLE
PriceCalculator: Always move to next section after submit

### DIFF
--- a/apps/store/src/components/PriceCalculator/PriceCalculatorAccordion.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorAccordion.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { ReactNode, useEffect, useRef, useState } from 'react'
+import { ReactNode } from 'react'
 import { Heading } from 'ui'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { Form, FormSection } from '@/services/PriceCalculator/PriceCalculator.types'
@@ -12,12 +12,14 @@ import { useTranslateFieldLabel } from './useTranslateFieldLabel'
 type Props = {
   form: Form
   children(section: FormSection, index: number): ReactNode
+  activeSectionId?: string
+  onActiveSectionChange(sectionId: string): void
 }
 
-export const PriceCalculatorAccordion = ({ form, children }: Props) => {
+export const PriceCalculatorAccordion = (props: Props) => {
+  const { form, children, activeSectionId, onActiveSectionChange } = props
   const { t } = useTranslation('purchase-form')
   const translateLabel = useTranslateFieldLabel()
-  const [activeSectionId, onActiveSectionChange] = useActiveFormSection(form)
 
   return (
     <Accordion.Root
@@ -53,29 +55,6 @@ export const PriceCalculatorAccordion = ({ form, children }: Props) => {
       })}
     </Accordion.Root>
   )
-}
-
-const useActiveFormSection = (form: Form) => {
-  const [activeSectionId, setActiveSectionId] = useState(
-    () => form.sections.find(({ state }) => state !== 'valid')?.id,
-  )
-  const prevActiveSectionRef = useRef<string>()
-
-  const currentSectionIsValid =
-    form.sections.find((section) => section.id === activeSectionId)?.state === 'valid'
-
-  useEffect(() => {
-    if (currentSectionIsValid && activeSectionId === prevActiveSectionRef.current) {
-      const nextSectionId = form.sections.find(({ state }) => state !== 'valid')?.id
-      if (nextSectionId) setActiveSectionId(nextSectionId)
-    }
-  }, [activeSectionId, currentSectionIsValid, form.sections])
-
-  useEffect(() => {
-    prevActiveSectionRef.current = activeSectionId
-  }, [activeSectionId])
-
-  return [activeSectionId, setActiveSectionId] as const
 }
 
 type StyledHeadingProps = { muted: boolean }


### PR DESCRIPTION
## Describe your changes

Change behaviour of `PriceCalculator` to always move to the next section after successfully submitting a section form.

Move active section state out to `PriceCalculator`.

## Justify why they are needed

Before we selected the first section that wasn't already "valid". However, we should only to that the first time you open the price calculator. After that we should always move to the next section after successfully submitting a section form.

I moved the state out to `PriceCalculator` since this is where we can respond to successfully submitted forms. Event handlers should be as close to the source as possible.

This also gets rid of the need for `useEffect` + ref logic we had before 🙌 - always a good sign!

## Jira issue(s): [GRW-1946]

## Checklist before requesting a review

- [x] I have performed a self-review of my code


[GRW-1946]: https://hedvig.atlassian.net/browse/GRW-1946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ