### PR TITLE
Create more specific color types

### DIFF
--- a/packages/ui/src/lib/theme/colors/colors.ts
+++ b/packages/ui/src/lib/theme/colors/colors.ts
@@ -11,7 +11,7 @@ export const gray = {
   800: 'hsl(0, 0%, 40%)',
   900: 'hsl(0, 0%, 25%)',
   1000: 'hsl(0, 0%, 7%)',
-}
+} as const
 
 export const green = {
   50: 'hsl(85, 100%, 90%)',
@@ -24,7 +24,7 @@ export const green = {
   700: 'hsl(100, 25%, 45%)',
   800: 'hsl(100, 28%, 32%)',
   900: 'hsl(100, 40%, 18%)',
-}
+} as const
 
 export const red = {
   50: 'hsl(7, 100%, 97%)',
@@ -37,7 +37,7 @@ export const red = {
   700: 'hsl(7, 61%, 57%)',
   800: 'hsl(7, 76%, 40%)',
   900: 'hsl(7, 100%, 22%)',
-}
+} as const
 
 export const yellow = {
   50: 'hsl(55, 100%, 91%)',
@@ -50,7 +50,7 @@ export const yellow = {
   700: 'hsl(50, 30%, 49%)',
   800: 'hsl(50, 42%, 36%)',
   900: 'hsl(50, 80%, 20%)',
-}
+} as const
 
 const purple = {
   100: '#f5ebf5',
@@ -59,7 +59,7 @@ const purple = {
   700: '#ccb9df',
   800: '#bea4d5',
   900: '#8c67ad',
-}
+} as const
 
 export const colors = {
   gray25: gray[25],
@@ -116,6 +116,6 @@ export const colors = {
   textSecondary: gray[700],
   textTertiary: gray[500],
   textDisabled: gray[400],
-}
+} as const
 
 export type UIColor = keyof typeof colors


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

(Sprinkled `as const` all over the place)

Changing the types of the color tokens from `string` to `(property) gray200: "hsl(0, 0%, 92%)"`. 

![Screenshot 2022-12-19 at 15 04 10](https://user-images.githubusercontent.com/50870173/208625447-ea5a2b3d-7e4e-43e0-9ae7-35dc1f86646d.png)

![Screenshot 2022-12-19 at 15 03 59](https://user-images.githubusercontent.com/50870173/208625510-73d51324-d1ec-4894-82cf-30d50345bca3.png)

For me I like this because I can quickly see the hsl value of the token I'm working with. 

_That said_ I don't have the full context of where the design system is going so perhaps there are some forthcoming changes that Idk about.

## Justify why they are needed

More specific types


## Checklist before requesting a review

- [x] I have performed a self-review of my code
