### PR TITLE
Remove focus styles for household size field

### DIFF
--- a/apps/store/src/components/PriceCalculator/HouseholdSizeField/HouseholdSizeField.tsx
+++ b/apps/store/src/components/PriceCalculator/HouseholdSizeField/HouseholdSizeField.tsx
@@ -82,10 +82,6 @@ const Wrapper = styled(motion.div)(({ theme }) => ({
   padding: `${theme.space[3]} ${theme.space[4]}`,
   borderRadius: theme.radius.sm,
   backgroundColor: theme.colors.gray300,
-
-  '&:focus-within': {
-    outline: `1px solid ${theme.colors.gray500}`,
-  },
 }))
 
 const StyledSelect = styled.select(({ theme }) => ({


### PR DESCRIPTION
## Describe your changes

Remove focus styles for household size field.

## Justify why they are needed

The designs call for different state for inputs based on what triggered focus: keyboard or mouse.

I've been playing around with `:focus-visible` but can't get it to work as intended.

For now I think we can remove the focus styles for this field and revisit later and try a [polyfill](https://github.com/WICG/focus-visible).

## Jira issue(s): [GRW-1947]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1947]: https://hedvig.atlassian.net/browse/GRW-1947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ