### PR TITLE
Display animation while calculating price

### DIFF
--- a/apps/store/public/locales/default/purchase-form.json
+++ b/apps/store/public/locales/default/purchase-form.json
@@ -35,5 +35,6 @@
   "OPEN_PRICE_CALCULATOR_BUTTON": "Calculate price",
   "PRICE_CALCULATOR_SECTION_EDIT_BUTTON": "Edit",
   "INSURELY_SUCCESS_CONTINUE_BUTTON": "Continue",
-  "INSURELY_SUCCESS_PROMPT": "We found your insurance at {{company}}"
+  "INSURELY_SUCCESS_PROMPT": "We found your insurance at {{company}}",
+  "LOADING_PRICE_ANIMATION_LABEL": "Calculating your price..."
 }

--- a/apps/store/public/locales/sv-se/purchase-form.json
+++ b/apps/store/public/locales/sv-se/purchase-form.json
@@ -35,5 +35,6 @@
   "OPEN_PRICE_CALCULATOR_BUTTON": "Beräkna pris",
   "PRICE_CALCULATOR_SECTION_EDIT_BUTTON": "Ändra",
   "INSURELY_SUCCESS_CONTINUE_BUTTON": "Fortsätt",
-  "INSURELY_SUCCESS_PROMPT": "Vi hittade din försäkring hos {{company}}"
+  "INSURELY_SUCCESS_PROMPT": "Vi hittade din försäkring hos {{company}}",
+  "LOADING_PRICE_ANIMATION_LABEL": "Ditt pris beräknas..."
 }


### PR DESCRIPTION
## Describe your changes

Display animation while confirming price intent.

[Screen Recording 2022-12-21 at 09.15.51.mov](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/77cd20be-20ac-4334-87af-97a7d9804175/Screen%20Recording%202022-12-21%20at%2009.15.51.mov)

Move confirm mutation to purchase form.

Make sure to select first incomplete form section OR the last one if all are complete. Before we didn't select any section if all were complete. If all accordions were closed, user would not see the submit button.

## Justify why they are needed

We have some small issues but I prefer to show to designers first and iterate on that.

Now we first update price intent and then confirrm + show the animation. However, we should show the animation right away - this would require further refactoring so I left it for now.

We always display the animation even if you edit the price intent - this was discussed with Zak and we decided to leave it like that for now.

## Jira issue(s): [GRW-1959]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1959]: https://hedvig.atlassian.net/browse/GRW-1959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ