### PR TITLE
Allow user to edit after seeing price and confirm again

### DIFF
--- a/apps/store/src/components/CartInventory/CartInventory.stories.tsx
+++ b/apps/store/src/components/CartInventory/CartInventory.stories.tsx
@@ -73,6 +73,7 @@ const MOCK_CART: CartFragmentFragment = {
       id: 'e01f57f9-37f8-4554-946b-e509233632ff',
       variant: {
         typeOfContract: 'SE_ACCIDENT',
+        displayName: 'Accident Insurance',
         product: {
           displayNameFull: 'Accident Insurance',
           pillowImage: {
@@ -101,6 +102,7 @@ const MOCK_CART: CartFragmentFragment = {
       id: '078f43ab-19fa-4007-bf64-714202bfb430',
       variant: {
         typeOfContract: 'SE_APARTMENT_RENT',
+        displayName: 'Home Insurance Rental',
         product: {
           displayNameFull: 'Home Insurance Rental',
           pillowImage: {
@@ -129,6 +131,7 @@ const MOCK_CART: CartFragmentFragment = {
       id: 'f13c5d6f-52ba-41db-adf3-9df196818dec',
       variant: {
         typeOfContract: 'SE_APARTMENT_RENT',
+        displayName: 'Home Insurance Rental',
         product: {
           displayNameFull: 'Home Insurance Rental',
           pillowImage: {

--- a/apps/store/src/components/PriceCalculator/CarMileageField.tsx
+++ b/apps/store/src/components/PriceCalculator/CarMileageField.tsx
@@ -21,8 +21,7 @@ export const CarMileageField = ({ field, autoFocus }: Props) => {
   return (
     <InputSelect
       name={field.name}
-      // @ts-expect-error dynamic text (not type-safe)
-      label={t(field.label.key)}
+      placeholder={t(field.label.key, { defaultValue: t('FIELD_MILEAGE_LABEL') })}
       required={field.required}
       defaultValue={field.defaultValue}
       options={options.map((option) => ({

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -1,3 +1,4 @@
+import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { RefObject, useMemo, useState } from 'react'
@@ -33,8 +34,19 @@ export const OfferPresenter = (props: Props) => {
   const { priceIntent, shopSession, scrollPastRef, onAddedToCart, onClickEdit } = props
   const { t } = useTranslation('purchase-form')
   const formatter = useFormatter()
-  const [selectedOfferId, setSelectedOfferId] = useState(priceIntent.offers[0].id)
-  const selectedOffer = priceIntent.offers.find((offer) => offer.id === selectedOfferId)!
+  const [selectedOffer, setSelectedOffer] = useState(priceIntent.offers[0])
+  const selectedOfferId = selectedOffer.id
+
+  const handleTierSelectorValueChange = (offerId: string) => {
+    const offer = priceIntent.offers.find((offer) => offer.id === offerId)
+
+    if (offer === undefined) {
+      datadogLogs.logger.error(`Unknown offer selected: ${offerId}`)
+      return
+    }
+
+    setSelectedOffer(offer)
+  }
 
   const [updateStartDate, updateStartDateInfo] = useUpdateStartDate({ priceIntent })
 
@@ -102,7 +114,7 @@ export const OfferPresenter = (props: Props) => {
             <TierSelector
               offers={priceIntent.offers}
               selectedOfferId={selectedOfferId}
-              onValueChange={setSelectedOfferId}
+              onValueChange={handleTierSelectorValueChange}
               currencyCode={shopSession.currencyCode}
             />
 
@@ -128,7 +140,7 @@ export const OfferPresenter = (props: Props) => {
   )
 }
 
-const FullWidthButton = styled.button({ width: '100%' })
+const FullWidthButton = styled.button({ width: '100%', cursor: 'pointer' })
 
 // TODO: Localize
 const SubmitButton = ({ loading }: { loading: boolean }) => {

--- a/apps/store/src/components/TierSelector/TierSelector.stories.tsx
+++ b/apps/store/src/components/TierSelector/TierSelector.stories.tsx
@@ -18,6 +18,7 @@ const MockedOffers: TierSelectorProps['offers'] = [
     id: '0',
     variant: {
       typeOfContract: 'Traffic',
+      displayName: 'Traffic',
       product: {
         displayNameFull: 'Bilförsäkring',
         pillowImage: {
@@ -37,6 +38,7 @@ const MockedOffers: TierSelectorProps['offers'] = [
     id: '1',
     variant: {
       typeOfContract: 'Halvförsäkring',
+      displayName: 'Halvförsäkring',
       product: {
         displayNameFull: 'Bilförsäkring',
         pillowImage: {
@@ -56,6 +58,7 @@ const MockedOffers: TierSelectorProps['offers'] = [
     id: '2',
     variant: {
       typeOfContract: 'Driving',
+      displayName: 'Driving',
       product: {
         displayNameFull: 'Bilförsäkring',
         pillowImage: {

--- a/apps/store/src/components/TierSelector/TierSelector.tsx
+++ b/apps/store/src/components/TierSelector/TierSelector.tsx
@@ -1,6 +1,5 @@
 import * as AccordionPrimitives from '@radix-ui/react-accordion'
 import { useTranslation } from 'next-i18next'
-import { Dispatch, SetStateAction } from 'react'
 import { ProductOfferFragment } from '@/services/apollo/generated'
 import { useFormatter } from '@/utils/useFormatter'
 import { FormElement } from '../ProductPage/PurchaseForm/PurchaseForm.constants'
@@ -33,7 +32,7 @@ const TierItem = ({
   price,
   description,
   isSelected = false,
-  suggestedText = '',
+  suggestedText,
   handleClick,
 }: TierItemProps) => (
   <TierItemWrapper isSelected={isSelected} onClick={handleClick}>
@@ -56,7 +55,7 @@ export type TierSelectorProps = {
   offers: Array<ProductOfferFragment>
   selectedOfferId: string
   currencyCode: string
-  onValueChange: Dispatch<SetStateAction<string>>
+  onValueChange: (offerId: string) => void
 }
 export const TierSelector = ({ offers, selectedOfferId, onValueChange }: TierSelectorProps) => {
   const { t } = useTranslation('purchase-form')
@@ -65,7 +64,7 @@ export const TierSelector = ({ offers, selectedOfferId, onValueChange }: TierSel
   const selectedOffer = offers.find((offer) => offer.id === selectedOfferId)
 
   const handleClick = (id: string) => {
-    onValueChange?.(id)
+    onValueChange(id)
   }
 
   if (offers.length === 1) {
@@ -81,13 +80,13 @@ export const TierSelector = ({ offers, selectedOfferId, onValueChange }: TierSel
         value={selectedOfferId}
         name={FormElement.ProductOfferId}
       />
-      <Root type="multiple">
+      <Root type="multiple" defaultValue={[tierSelectorValue]}>
         <Item value={tierSelectorValue}>
           <HeaderWithTrigger>
             {selectedOffer ? (
               <>
                 <div>{t('TIER_SELECTOR_SELECTED_LABEL', { ns: 'purchase-form' })}</div>
-                <div>{selectedOffer.variant.typeOfContract}</div>
+                <div>{selectedOffer.variant.displayName}</div>
               </>
             ) : (
               <div>{t('TIER_SELECTOR_DEFAULT_LABEL', { ns: 'purchase-form' })}</div>
@@ -98,12 +97,11 @@ export const TierSelector = ({ offers, selectedOfferId, onValueChange }: TierSel
               <TierItem
                 key={offer.id}
                 value={offer.id}
-                title={offer.variant.typeOfContract}
+                title={offer.variant.displayName}
                 description="Description here"
                 price={formatter.monthlyPrice(offer.price)}
                 isSelected={selectedOffer?.id === offer.id}
                 handleClick={() => handleClick(offer.id)}
-                suggestedText={'Suggested'}
               />
             ))}
           </Content>

--- a/apps/store/src/components/TierSelector/TierSelectorStyles.tsx
+++ b/apps/store/src/components/TierSelector/TierSelectorStyles.tsx
@@ -85,6 +85,10 @@ export const TierItemWrapper = styled.div<{ isSelected: boolean }>(({ theme }) =
   padding: theme.space[2],
   backgroundColor: theme.colors.gray200,
 
+  ':not(:first-of-type)': {
+    paddingTop: 0,
+  },
+
   '&:first-of-type': {
     borderTop: `1px solid ${theme.colors.gray300}`,
   },

--- a/apps/store/src/graphql/ProductOfferFragment.graphql
+++ b/apps/store/src/graphql/ProductOfferFragment.graphql
@@ -2,6 +2,7 @@ fragment ProductOffer on ProductOffer {
   id
   variant {
     typeOfContract
+    displayName
     product {
       displayNameFull
       pillowImage {


### PR DESCRIPTION
## Describe your changes

Fix a bunch of small bugs related to editing a price intent that already is confirmed.

Keep selected product offer in state rather than deriving it from the ID.

Update `ProductOffer` fragment to fetch and use `displayName` for product variants.

Update `CarMileageField` to use placeholder instead of label.

## Justify why they are needed

Bug that didn't allow us to edit a confirmed price intent.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
