### PR TITLE
Fix / Fix ShopSessionContext memozing stale value

### DIFF
--- a/apps/store/src/pages/cart.tsx
+++ b/apps/store/src/pages/cart.tsx
@@ -84,7 +84,6 @@ export const getServerSideProps: GetServerSideProps<Props> = async (context) => 
 const getPrevURL = (context: GetServerSidePropsContext, locale: RoutingLocale) => {
   const storeURL = PageLink.store({ locale })
 
-  console.log(context.req.headers.referer)
   if (!context.req.headers.referer) return storeURL
 
   const url = new URL(context.req.headers.referer)

--- a/apps/store/src/services/shopSession/ShopSessionContext.tsx
+++ b/apps/store/src/services/shopSession/ShopSessionContext.tsx
@@ -1,6 +1,7 @@
 import { useApolloClient } from '@apollo/client'
-import { createContext, PropsWithChildren, useContext, useEffect, useMemo } from 'react'
-import { ShopSessionQueryResult, useShopSessionQuery } from '@/services/apollo/generated'
+import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useRef } from 'react'
+import { ShopSessionQueryResult, useShopSessionLazyQuery } from '@/services/apollo/generated'
+import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { isBrowser } from '@/utils/env'
 import { useCurrentCountry } from '@/utils/l10n/useCurrentCountry'
 import { setupShopSessionServiceClientSide } from './ShopSession.helpers'
@@ -14,7 +15,9 @@ export const ShopSessionProvider = ({ children, shopSessionId: initialShopSessio
   return <ShopSessionContext.Provider value={contextValue}>{children}</ShopSessionContext.Provider>
 }
 
-export const useShopSession = () => {
+type ShopSessionResult = ShopSessionQueryResult & { shopSession?: ShopSession }
+
+export const useShopSession = (): ShopSessionResult => {
   const { countryCode } = useCurrentCountry()
 
   const queryResult = useContext(ShopSessionContext)
@@ -24,37 +27,45 @@ export const useShopSession = () => {
     )
   }
 
-  return useMemo(() => {
-    const shopSession = queryResult.data?.shopSession
-    return {
-      ...queryResult,
-      // Ignore session from different country.
-      // This probably means old session was fetched and new one is being created
-      shopSession: shopSession?.countryCode === countryCode ? shopSession : undefined,
-    }
-  }, [queryResult, countryCode])
+  // Make sure result object is stable
+  const result = useRef<ShopSessionResult>({} as ShopSessionResult)
+  Object.assign(result.current, queryResult)
+
+  // Ignore session from different country.
+  // This probably means old session was fetched and new one is being created
+  const shopSession = queryResult.data?.shopSession
+  result.current.shopSession = shopSession?.countryCode === countryCode ? shopSession : undefined
+
+  return result.current
 }
 
 const useShopSessionContextValue = (initialShopSessionId?: string) => {
   const { countryCode } = useCurrentCountry()
   const apolloClient = useApolloClient()
   // Only used client-side
-  const shopSessionService = useMemo(
+  const shopSessionServiceClientSide = useMemo(
     () => setupShopSessionServiceClientSide(apolloClient),
     [apolloClient],
   )
-  const shopSessionId = shopSessionService.shopSessionId() ?? initialShopSessionId
 
-  const queryResult = useShopSessionQuery({
-    variables: shopSessionId ? { shopSessionId } : undefined,
-    skip: !shopSessionId,
+  const [fetchSession, queryResult] = useShopSessionLazyQuery({
+    // Prevent network requests and ensure we trigger an error on cache miss, which should never happen
+    fetchPolicy: 'cache-only',
   })
 
+  // Fetch client-side, service ensures it only happens once
   useEffect(() => {
     if (isBrowser()) {
-      shopSessionService.getOrCreate({ countryCode })
+      shopSessionServiceClientSide.getOrCreate({ countryCode }).then((shopSession) => {
+        fetchSession({ variables: { shopSessionId: shopSession.id } })
+      })
     }
-  }, [countryCode, shopSessionService])
+  }, [shopSessionServiceClientSide, countryCode, fetchSession])
+
+  // Fetch once during SSR
+  if (!isBrowser() && initialShopSessionId && !queryResult.called) {
+    fetchSession({ variables: { shopSessionId: initialShopSessionId } })
+  }
 
   return queryResult
 }

--- a/apps/store/src/services/shopSession/ShopSessionContext.tsx
+++ b/apps/store/src/services/shopSession/ShopSessionContext.tsx
@@ -29,7 +29,6 @@ export const useShopSession = (): ShopSessionResult => {
 
   // Make sure result object is stable
   const result = useRef<ShopSessionResult>({} as ShopSessionResult)
-  Object.assign(result.current, queryResult)
 
   // Ignore session from different country.
   // This probably means old session was fetched and new one is being created
@@ -57,7 +56,9 @@ const useShopSessionContextValue = (initialShopSessionId?: string) => {
   useEffect(() => {
     if (isBrowser()) {
       shopSessionServiceClientSide.getOrCreate({ countryCode }).then((shopSession) => {
-        fetchSession({ variables: { shopSessionId: shopSession.id } })
+        fetchSession({
+          variables: { shopSessionId: shopSession.id },
+        })
       })
     }
   }, [shopSessionServiceClientSide, countryCode, fetchSession])

--- a/apps/store/src/services/shopSession/ShopSessionService.ts
+++ b/apps/store/src/services/shopSession/ShopSessionService.ts
@@ -75,6 +75,17 @@ export class ShopSessionService {
     >({
       mutation: ShopSessionCreateDocument,
       variables,
+      // TODO: Investigate if we can do it by returning shopSession recond on top instead of shopSessionCreate
+      update: (cache, result) => {
+        const shopSession = result.data?.shopSessionCreate
+        if (shopSession) {
+          cache.writeQuery({
+            query: ShopSessionDocument,
+            data: { shopSession },
+            variables: { shopSessionId: shopSession.id },
+          })
+        }
+      },
     })
 
     const shopSession = result.data?.shopSessionCreate


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Replace useMemo with ref in ShopSessionContext to avoid returning stale values

Reduce number of renders by utilizing lazy query which we run after we populate Apollo cache from outside React

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Stepping stone to fixing double run of priceIntent mutations

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
