### PR TITLE
Fix / Report experiment_impression properly

### DIFF
--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -14,6 +14,7 @@ import { initStoryblok } from '@/services/storyblok/storyblok'
 import {
   handleNewSiteExperimentQueryParam,
   trackNewSiteExperimentImpression,
+  useRemoveExperimentQueryParam,
 } from '@/services/Tracking/newSiteExperimentTracking'
 import { Tracking } from '@/services/Tracking/Tracking'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
@@ -48,6 +49,8 @@ if (typeof window !== 'undefined') {
 initStoryblok()
 
 const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
+  useRemoveExperimentQueryParam()
+
   const apolloClient = useApollo(pageProps)
 
   const getLayout = Component.getLayout || ((page) => page)

--- a/apps/store/src/services/Tracking/newSiteExperimentTracking.ts
+++ b/apps/store/src/services/Tracking/newSiteExperimentTracking.ts
@@ -1,6 +1,7 @@
 // Track experiment impression based on local cookie set by router
 import { getCookie, setCookie } from 'cookies-next'
-import router from 'next/router'
+import router, { useRouter } from 'next/router'
+import { useEffect } from 'react'
 import { Tracking } from '@/services/Tracking/Tracking'
 import { newSiteAbTest } from '../../newSiteAbTest'
 
@@ -12,15 +13,23 @@ export const trackNewSiteExperimentImpression = (tracking: Tracking) => {
 
 export const handleNewSiteExperimentQueryParam = () => {
   router.ready(() => {
-    const { query, replace, pathname } = router
-    const variantId = query[newSiteAbTest.experimentQueryParam]
-    if (typeof variantId !== 'string') return
+    const url = new URL(window.location.href)
+    const variantId = url.searchParams.get(newSiteAbTest.experimentQueryParam)
+    if (!variantId) return
     setCookie(newSiteAbTest.cookies.variant.name, variantId, {
       maxAge: newSiteAbTest.cookies.variant.maxAge,
     })
-    const target = { pathname, query: { ...query } }
-    delete target.query[newSiteAbTest.experimentQueryParam]
     console.debug('Record experiment variantId from query parameter')
-    replace(target, undefined, { shallow: true })
   })
+}
+
+export const useRemoveExperimentQueryParam = () => {
+  const router = useRouter()
+  useEffect(() => {
+    if (router.query[newSiteAbTest.experimentQueryParam]) {
+      const target = { pathname: router.pathname, query: { ...router.query } }
+      delete target.query[newSiteAbTest.experimentQueryParam]
+      router.replace(target, undefined, { shallow: true })
+    }
+  }, [router])
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Stop using router properties outside of Next

Handle experiment variant param outside next and remove it from URL inside next

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

When next/router default export it used, it behaves differently depending on whether Next has already initialied

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
