### PR TITLE
GRW-1904 - fix(ProductDocuments): only show documents of the selected product variant

### DIFF
--- a/apps/store/src/blocks/ProductDocumentsBlock.tsx
+++ b/apps/store/src/blocks/ProductDocumentsBlock.tsx
@@ -7,13 +7,17 @@ type Props = SbBaseBlockProps<{
   heading: string
 }>
 
-// TODO: Also use variant context and show docs from selected variant only
 export const ProductDocumentsBlock = ({ blok }: Props) => {
-  const { productData } = useProductPageContext()
+  const { productData, selectedVariant } = useProductPageContext()
   const { heading } = blok
-  return (
-    <ProductDocuments heading={heading} productData={productData} {...storyblokEditable(blok)} />
-  )
+
+  const docs = selectedVariant?.documents ?? productData.variants[0].documents
+  if (docs.length < 1) {
+    console.warn('No documents to show; hiding productDocuments')
+    return null
+  }
+
+  return <ProductDocuments heading={heading} docs={docs} {...storyblokEditable(blok)} />
 }
 
 ProductDocumentsBlock.blockName = 'productDocuments'

--- a/apps/store/src/components/ProductPage/ProductDocuments.tsx
+++ b/apps/store/src/components/ProductPage/ProductDocuments.tsx
@@ -1,28 +1,21 @@
 import styled from '@emotion/styled'
 import { Card, CardContent } from 'ui/src/components/Card/Card'
 import { getColor, HeadingLabel, Space, Text } from 'ui'
-import { ProductData } from '@/components/ProductPage/ProductPage.types'
 import { InsuranceDocument } from '@/services/apollo/generated'
 
 type Props = {
   heading: string
-  productData: ProductData
+  docs: Array<InsuranceDocument>
 }
 
-export const ProductDocuments = ({ heading, productData }: Props) => {
-  if (productData.variants.length < 1) {
-    console.warn('No product variants, hiding productDocuments')
-    return null
-  }
+export const ProductDocuments = ({ heading, docs }: Props) => {
   return (
     <ProductDocumentsWrapper>
       <Space y={1}>
         <HeadingLabel>{heading}</HeadingLabel>
-        {productData.variants.flatMap((variant) =>
-          variant.documents.map((doc, i) => (
-            <ProductDocument key={`${variant.typeOfContract}_${i}`} doc={doc} />
-          )),
-        )}
+        {docs.map((doc, index) => (
+          <ProductDocument key={index} doc={doc} />
+        ))}
       </Space>
     </ProductDocumentsWrapper>
   )

--- a/apps/store/src/components/ProductVariantSelector/ProductVariantSelector.tsx
+++ b/apps/store/src/components/ProductVariantSelector/ProductVariantSelector.tsx
@@ -26,12 +26,15 @@ export const ProductVariantSelector = ({ className }: Props) => {
     }
   }
 
+  const defaultValue = productData.variants[0].typeOfContract
+
   return (
     <InputSelect
       className={className}
       name="product-variant-select"
       options={variantOptions}
       onChange={handleChange}
+      defaultValue={defaultValue}
     />
   )
 }


### PR DESCRIPTION
## Describe your changes

* Update `ProductDocumentsBlock` so it displays only the documents for the selected variant

## Jira issue(s): [GRW-1904](https://hedvig.atlassian.net/browse/GRW-1904)

