### PR TITLE
Add API route to reset current session

### DIFF
--- a/apps/store/README.md
+++ b/apps/store/README.md
@@ -37,3 +37,11 @@ https://www.store.dev.hedvigit.com/{LOCALE}/session/{SHOP_SESSION_ID}?next={REDI
 ```
 
 You can optionally provide a `?next=/se/cart` query parameter with the relative link to route to redirect the user. By default, the user is redirected to the home page.
+
+## Resetting current Shop Session
+
+If you want to reset the current shop session, you can do so by visiting the following URL:
+
+```html
+/api/session/reset?next={REDIRECT_URL}
+```

--- a/apps/store/src/pages/api/session/reset.ts
+++ b/apps/store/src/pages/api/session/reset.ts
@@ -1,0 +1,44 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { initializeApollo } from '@/services/apollo/client'
+import logger from '@/services/logger/server'
+import { priceIntentServiceInitServerSide } from '@/services/priceIntent/PriceIntentService'
+import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
+import { ORIGIN_URL, PageLink } from '@/utils/PageLink'
+
+/**
+ * Reset current ShopSession and navigate to the next page.
+ */
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { query } = req
+
+  const nextURL = new URL(ORIGIN_URL)
+  nextURL.pathname = PageLink.home()
+
+  const nextQueryParam = query['next']
+  if (typeof nextQueryParam === 'string') {
+    nextURL.pathname = nextQueryParam
+  }
+
+  try {
+    const apolloClient = initializeApollo({ req, res })
+    const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
+    const priceIntentService = priceIntentServiceInitServerSide({ apolloClient, req, res })
+    const shopSessionId = shopSessionService.shopSessionId()
+
+    if (shopSessionId) {
+      logger.debug({ shopSessionId }, 'Resetting shop session')
+      shopSessionService.reset()
+
+      logger.info({ shopSessionId }, 'Deleting price intent cookies')
+      priceIntentService.clearAll(shopSessionId)
+    }
+  } catch (error) {
+    logger.error(error, 'Unable to reset ShopSession')
+  }
+
+  const destination = nextURL.toString()
+  logger.info(`Re-directing to destination: ${destination}`)
+  return res.redirect(destination)
+}
+
+export default handler

--- a/apps/store/src/services/persister/CookiePersister.ts
+++ b/apps/store/src/services/persister/CookiePersister.ts
@@ -1,4 +1,4 @@
-import { setCookie, getCookie, deleteCookie } from 'cookies-next'
+import { setCookie, getCookie, deleteCookie, getCookies } from 'cookies-next'
 import { OptionsType } from 'cookies-next/lib/types'
 import { SimplePersister } from './Persister.types'
 
@@ -21,5 +21,9 @@ export class CookiePersister implements SimplePersister {
 
   private defaultOptions() {
     return { path: '/' }
+  }
+
+  public getAll() {
+    return getCookies(this.defaultOptions())
   }
 }

--- a/apps/store/src/services/persister/Persister.types.ts
+++ b/apps/store/src/services/persister/Persister.types.ts
@@ -1,4 +1,4 @@
-import { OptionsType } from 'cookies-next/lib/types'
+import { OptionsType, TmpCookiesObj } from 'cookies-next/lib/types'
 
 export interface SimplePersister {
   save(value: string, key?: string, options?: OptionsType): void
@@ -6,4 +6,6 @@ export interface SimplePersister {
   fetch(key?: string): string | null
 
   reset(key?: string): void
+
+  getAll(): TmpCookiesObj
 }

--- a/apps/store/src/services/persister/ServerCookiePersister.ts
+++ b/apps/store/src/services/persister/ServerCookiePersister.ts
@@ -1,4 +1,4 @@
-import { deleteCookie, getCookie, setCookie } from 'cookies-next'
+import { deleteCookie, getCookie, getCookies, setCookie } from 'cookies-next'
 import { OptionsType } from 'cookies-next/lib/types'
 import { GetServerSidePropsContext } from 'next'
 import { SimplePersister } from './Persister.types'
@@ -28,5 +28,9 @@ export class ServerCookiePersister implements SimplePersister {
 
   private defaultOptions() {
     return { path: '/', req: this.request, res: this.response }
+  }
+
+  public getAll() {
+    return getCookies(this.defaultOptions())
   }
 }


### PR DESCRIPTION
## Describe your changes

Add API route `/api/session/reset` to allow us to quickly reset the current session by removing relevant cookies.

Add a way to setup price intent service server side.

Expose a couple new methods from price intent service and cookie persister.

## Justify why they are needed

Very common use case when doing development. We could build more tool on top of this but even this will help out!

## Jira issue(s): [GRW-2001]

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-2001]: https://hedvig.atlassian.net/browse/GRW-2001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ