### PR TITLE
GRW-2006 / Feature / Track view_item when offer becomes visible

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -1,7 +1,8 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
+import { useInView } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
-import { RefObject, useEffect, useMemo, useState } from 'react'
+import { RefObject, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Space, Text } from 'ui'
 import { useUpdateCancellation } from '@/components/ProductPage/PurchaseForm/useUpdateCancellation'
 import { useUpdateStartDate } from '@/components/ProductPage/PurchaseForm/useUpdateStartDate'
@@ -49,13 +50,14 @@ export const OfferPresenter = (props: Props) => {
     setSelectedOffer(offer)
   }
 
-  // TODO: Deal with duplicate tracking from purchase form responisve layout
-  //   Perhaps only track when offer becomes visible via intersectionObserver?
+  const offerRef = useRef(null)
   const tracking = useTracking()
-  useEffect(
-    () => selectedOffer && tracking.reportViewItem(selectedOffer),
-    [selectedOffer, tracking],
-  )
+  const isInView = useInView(offerRef, { once: true })
+  useEffect(() => {
+    if (isInView) {
+      tracking.reportViewItem(selectedOffer)
+    }
+  }, [selectedOffer, tracking, isInView])
 
   const [updateStartDate, updateStartDateInfo] = useUpdateStartDate({ priceIntent })
 
@@ -104,7 +106,7 @@ export const OfferPresenter = (props: Props) => {
 
   return (
     <>
-      <form onSubmit={handleSubmitAddToCart}>
+      <form ref={offerRef} onSubmit={handleSubmitAddToCart}>
         <Space y={2}>
           <Space y={0.5}>
             <Text as="p" align="center" size="xxl">


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Use intersection observer util from framer-motion to track view_item event when selectedOffer first becomes visible

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Solves double event from responsive rendering of OfferPresenter
- Solves race condition with progress bar and event timing
- Useful example of tracking something being visible, we'll likely need to track more such things in the future

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
