### PR TITLE
Recreate price intent after adding to cart

### DIFF
--- a/apps/store/src/components/PriceCalculator/AutomaticField.tsx
+++ b/apps/store/src/components/PriceCalculator/AutomaticField.tsx
@@ -30,7 +30,7 @@ export const AutomaticField = ({ field, priceIntent, onSubmit, loading, autoFocu
     case 'text':
       return (
         <TextField
-          type="text"
+          type={field.inputType ?? 'text'}
           name={field.name}
           label={translateLabel(field.label)}
           pattern={field.pattern}

--- a/apps/store/src/components/PriceCalculator/HouseholdSizeField/HouseholdSizeField.tsx
+++ b/apps/store/src/components/PriceCalculator/HouseholdSizeField/HouseholdSizeField.tsx
@@ -63,6 +63,7 @@ export const HouseholdSizeField = ({ field, autoFocus = false }: FieldProps) => 
 
         <SpaceFlex space={0.5}>
           <StyledButton
+            type="button"
             onClick={decrement}
             tabIndex={-1}
             aria-hidden={true}
@@ -71,6 +72,7 @@ export const HouseholdSizeField = ({ field, autoFocus = false }: FieldProps) => 
             <Minus />
           </StyledButton>
           <StyledButton
+            type="button"
             onClick={increment}
             tabIndex={-1}
             aria-hidden={true}

--- a/apps/store/src/services/PriceCalculator/Field.types.ts
+++ b/apps/store/src/services/PriceCalculator/Field.types.ts
@@ -14,6 +14,7 @@ export type TextField = BaseField<string> & {
   minLength?: number
   maxLength?: number
   inputMode?: 'text' | 'numeric' | 'tel' | 'email'
+  inputType?: 'text' | 'tel' | 'email'
 }
 
 export type SsnSeField = BaseField<string> & {

--- a/apps/store/src/services/PriceCalculator/formFragments.ts
+++ b/apps/store/src/services/PriceCalculator/formFragments.ts
@@ -50,7 +50,7 @@ const householdSizeField: InputField = {
 
 export const emailField: InputField = {
   type: 'text',
-  inputMode: 'email',
+  inputType: 'email',
   name: 'email',
   label: { key: 'FIELD_EMAIL_LABEL' },
   required: true,


### PR DESCRIPTION
## Describe your changes

Refresh price intent after adding an offer to the cart.

## Justify why they are needed

We used to just refresh the page but this doesn't work when we have a static page.

I exposed a `setupPriceIntent` function from the context to avoid having to repeat the code that creates price intents.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
