### PR TITLE
GRW-1911 - feat(ContentBlock): addded alignment and heading fields

### DIFF
--- a/apps/store/src/blocks/ContentBlock.tsx
+++ b/apps/store/src/blocks/ContentBlock.tsx
@@ -1,25 +1,41 @@
 import styled from '@emotion/styled'
 import { ISbRichtext, renderRichText, storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
-import { Space } from 'ui'
+import { Space, HeadingLabel, mq } from 'ui'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+
+type Alignment = 'left' | 'center' | 'right' | 'justify'
 
 export type Props = SbBaseBlockProps<{
   body: ISbRichtext
+  heading?: string
+  alignment?: Alignment
 }>
 
 export const ContentBlock = ({ blok }: Props) => {
   const contentHtml = useMemo(() => renderRichText(blok.body), [blok.body])
+
   return (
-    <Wrapper {...storyblokEditable(blok)}>
-      <Space y={1} dangerouslySetInnerHTML={{ __html: contentHtml }} />
+    <Wrapper {...storyblokEditable(blok)} y={1}>
+      {blok.heading && <HeadingLabel>{blok.heading}</HeadingLabel>}
+      <TextWrapper alignment={blok.alignment ?? 'left'}>
+        <Space y={1} dangerouslySetInnerHTML={{ __html: contentHtml }} />
+      </TextWrapper>
     </Wrapper>
   )
 }
 ContentBlock.blockName = 'content'
 
-const Wrapper = styled.div(({ theme }) => ({
+const Wrapper = styled(Space)(({ theme }) => ({
   paddingLeft: theme.space[4],
   paddingRight: theme.space[4],
-  textAlign: 'center',
+}))
+
+const TextWrapper = styled.div<{ alignment: Alignment }>(({ theme, alignment }) => ({
+  fontSize: theme.fontSizes.xl,
+  textAlign: alignment,
+
+  [mq.md]: {
+    fontSize: theme.fontSizes.xxl,
+  },
 }))


### PR DESCRIPTION
## Describe your changes

Updated `ContentBlock` so we can use it to display _product description_.

## Jira issue(s): [GRW-1911](https://hedvig.atlassian.net/browse/GRW-1911)

<img width="379" alt="image" src="https://user-images.githubusercontent.com/19200662/210375017-8221feed-301e-4270-ac57-1c38c70610d9.png">