### PR TITLE
Update `TextField` styles

### DIFF
--- a/apps/store/src/components/TextField/TextField.stories.tsx
+++ b/apps/store/src/components/TextField/TextField.stories.tsx
@@ -19,6 +19,8 @@ const Template: ComponentStory<typeof TextField> = ({ defaultValue, ...props }) 
       <TextField {...props} />
       <div style={{ marginTop: '0.25rem' }}></div>
       <TextField {...props} defaultValue={defaultValue} />
+      <div style={{ marginTop: '0.25rem' }}></div>
+      <TextField {...props} defaultValue={defaultValue} disabled />
     </>
   )
 }

--- a/apps/store/src/components/TextField/TextField.tsx
+++ b/apps/store/src/components/TextField/TextField.tsx
@@ -28,14 +28,18 @@ export const TextField = ({ label, variant = 'large', suffix, ...props }: Props)
 
   const inputValue = props.value || value
 
-  const [Wrapper, Label, Input, Suffix] =
+  const [Wrapper, Input, Suffix, labelSize] =
     variant === 'large'
-      ? [LargeWrapper, LargeLabel, LargeInput, LargeSuffix]
-      : [SmallWrapper, SmallLabel, SmallInput, SmallSuffix]
+      ? ([LargeWrapper, LargeInput, LargeSuffix, 'xl'] as const)
+      : ([SmallWrapper, SmallInput, SmallSuffix, 'lg'] as const)
 
   return (
     <Wrapper {...animationProps} isActive={!!inputValue}>
-      <Label htmlFor={props.id}>{label}</Label>
+      <Label htmlFor={props.id}>
+        <Text as="span" size={labelSize} color={props.disabled ? 'textDisabled' : 'textPrimary'}>
+          {label}
+        </Text>
+      </Label>
       <SpaceFlex align="center" space={0}>
         <Input {...props} onKeyDown={highlight} onChange={handleChange} />
         {suffix && inputValue && <Suffix>{suffix}</Suffix>}
@@ -54,8 +58,7 @@ const LargeWrapper = styled(motion.div, {
   flexDirection: 'column',
   justifyContent: 'center',
   borderRadius: theme.radius.sm,
-  backgroundColor: theme.colors.gray300,
-
+  backgroundColor: theme.colors.gray100,
   height: '4rem',
 
   [':focus-within > label']: {
@@ -67,17 +70,18 @@ const LargeWrapper = styled(motion.div, {
       transform: `translate(calc(${theme.space.md} * 0.4), -0.5rem) scale(0.6)`,
     },
   }),
+
+  ':has(input:focus-visible)': {
+    boxShadow: `0 0 0 2px ${theme.colors.textPrimary}`,
+  },
 }))
 
-const LargeLabel = styled.label(({ theme }) => ({
+const Label = styled.label(({ theme }) => ({
   position: 'absolute',
   pointerEvents: 'none',
   transformOrigin: 'top left',
   transition: 'transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms',
   transform: `translate(0, 0) scale(1)`,
-
-  fontSize: theme.fontSizes.xl,
-  color: theme.colors.gray700,
   paddingInline: theme.space.md,
   whiteSpace: 'nowrap',
 }))
@@ -89,8 +93,12 @@ const LargeInput = styled.input(({ theme }) => ({
   paddingTop: theme.space.md,
 
   ':disabled': {
-    opacity: 0.6,
+    color: theme.colors.textDisabled,
     cursor: 'not-allowed',
+
+    // Webkit overrides
+    WebkitTextFillColor: theme.colors.textDisabled,
+    opacity: 1,
   },
 }))
 
@@ -112,7 +120,6 @@ const SmallWrapper = styled(LargeWrapper)(({ theme, isActive }) => ({
   }),
 }))
 
-const SmallLabel = styled(LargeLabel)(({ theme }) => ({ fontSize: theme.fontSizes.md }))
 const SmallInput = styled(LargeInput)(({ theme }) => ({ fontSize: theme.fontSizes.lg }))
 
 const SmallSuffix = styled(LargeSuffix)()

--- a/apps/store/src/utils/useHighlightAnimation.ts
+++ b/apps/store/src/utils/useHighlightAnimation.ts
@@ -11,8 +11,7 @@ export const useHighlightAnimation = () => {
   const [isInteractive, setIsInteractive] = useState(false)
 
   const animationVariants = {
-    [AnimationState.Active]: { backgroundColor: 'rgba(197, 236, 127, 0.6)' },
-    [AnimationState.Idle]: { backgroundColor: theme.colors.gray300 },
+    [AnimationState.Active]: { backgroundColor: theme.colors.green100 },
   } as const
 
   const highlight = useCallback((event?: KeyboardEvent<HTMLElement>) => {


### PR DESCRIPTION
## Describe your changes

Update `TextField` background color and disabled state.

![Screenshot 2023-01-03 at 16.38.40.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/90cd533d-7325-444d-acfe-90fadab914b5/Screenshot%202023-01-03%20at%2016.38.40.png)

Use Text component inside label-tag.

Add `:focus-visible` styles.

Allow highlight animation to work with any default background.

## Justify why they are needed

Keeping it up-to-date with Figma designs.

I used `:has` selector even if it has very poor browser support. Let's see what kind of focus states we will end up with in the end -- this way we can quickly show designers so they get a feel for it.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
