### PR TITLE
Allow PriceCalculator to use full width on small screens

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -151,9 +151,7 @@ const PendingState = () => {
     <SectionWrapper>
       <Space y={0.5}>
         <Tagline />
-        <OpenModalButtonWrapper>
-          <Button disabled>{t('OPEN_PRICE_CALCULATOR_BUTTON')}</Button>
-        </OpenModalButtonWrapper>
+        <Button disabled>{t('OPEN_PRICE_CALCULATOR_BUTTON')}</Button>
       </Space>
     </SectionWrapper>
   )
@@ -172,7 +170,7 @@ const IdleState = ({ onClick }: IdleStateProps) => {
       <SectionWrapper ref={ref}>
         <Space y={0.5}>
           <Tagline />
-          <OpenModalButtonWrapper>{button}</OpenModalButtonWrapper>
+          {button}
         </Space>
       </SectionWrapper>
       <ScrollPast targetRef={ref}>
@@ -345,23 +343,14 @@ const ShowOfferState = (props: ShowOfferStateProps) => {
   )
 }
 
-const PurchaseFormTop = styled.div({
+const PurchaseFormTop = styled.div(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',
   gap: '4.5rem',
-  paddingTop: '9vh',
-  paddingBottom: '9vh',
-})
-
-const OpenModalButtonWrapper = styled.div({
-  [mq.lg]: {
-    padding: 0,
-    maxWidth: PURCHASE_FORM_MAX_WIDTH,
-    marginLeft: 'auto',
-    marginRight: 'auto',
-  },
-})
+  paddingBlock: '9vh',
+  paddingInline: theme.space.md,
+}))
 
 const StickyButtonWrapper = styled.div(({ theme }) => ({
   paddingInline: theme.space[4],
@@ -372,12 +361,16 @@ const StickyButtonWrapper = styled.div(({ theme }) => ({
 
 const SectionWrapper = styled.div({
   width: '100%',
-  maxWidth: PURCHASE_FORM_MAX_WIDTH,
-  margin: '0 auto',
+  [mq.sm]: {
+    maxWidth: PURCHASE_FORM_MAX_WIDTH,
+    margin: '0 auto',
+  },
 })
 
 const PriceCalculatorWrapper = styled.div({
   width: '100%',
-  maxWidth: PURCHASE_FORM_MAX_WIDTH,
-  margin: '0 auto',
+  [mq.sm]: {
+    maxWidth: PURCHASE_FORM_MAX_WIDTH,
+    margin: '0 auto',
+  },
 })

--- a/apps/store/src/components/TextField/TextField.stories.tsx
+++ b/apps/store/src/components/TextField/TextField.stories.tsx
@@ -19,6 +19,8 @@ const Template: ComponentStory<typeof TextField> = ({ defaultValue, ...props }) 
       <TextField {...props} />
       <div style={{ marginTop: '0.25rem' }}></div>
       <TextField {...props} defaultValue={defaultValue} />
+      <div style={{ marginTop: '0.25rem' }}></div>
+      <TextField {...props} defaultValue={defaultValue} disabled />
     </>
   )
 }

--- a/apps/store/src/components/TextField/TextField.tsx
+++ b/apps/store/src/components/TextField/TextField.tsx
@@ -28,14 +28,18 @@ export const TextField = ({ label, variant = 'large', suffix, ...props }: Props)
 
   const inputValue = props.value || value
 
-  const [Wrapper, Label, Input, Suffix] =
+  const [Wrapper, Input, Suffix, labelSize] =
     variant === 'large'
-      ? [LargeWrapper, LargeLabel, LargeInput, LargeSuffix]
-      : [SmallWrapper, SmallLabel, SmallInput, SmallSuffix]
+      ? ([LargeWrapper, LargeInput, LargeSuffix, 'xl'] as const)
+      : ([SmallWrapper, SmallInput, SmallSuffix, 'lg'] as const)
 
   return (
     <Wrapper {...animationProps} isActive={!!inputValue}>
-      <Label htmlFor={props.id}>{label}</Label>
+      <Label htmlFor={props.id}>
+        <Text as="span" size={labelSize} color={props.disabled ? 'textDisabled' : 'textPrimary'}>
+          {label}
+        </Text>
+      </Label>
       <SpaceFlex align="center" space={0}>
         <Input {...props} onKeyDown={highlight} onChange={handleChange} />
         {suffix && inputValue && <Suffix>{suffix}</Suffix>}
@@ -54,8 +58,7 @@ const LargeWrapper = styled(motion.div, {
   flexDirection: 'column',
   justifyContent: 'center',
   borderRadius: theme.radius.sm,
-  backgroundColor: theme.colors.gray300,
-
+  backgroundColor: theme.colors.gray100,
   height: '4rem',
 
   [':focus-within > label']: {
@@ -67,17 +70,18 @@ const LargeWrapper = styled(motion.div, {
       transform: `translate(calc(${theme.space.md} * 0.4), -0.5rem) scale(0.6)`,
     },
   }),
+
+  ':has(input:focus-visible)': {
+    boxShadow: `0 0 0 2px ${theme.colors.textPrimary}`,
+  },
 }))
 
-const LargeLabel = styled.label(({ theme }) => ({
+const Label = styled.label(({ theme }) => ({
   position: 'absolute',
   pointerEvents: 'none',
   transformOrigin: 'top left',
   transition: 'transform 200ms cubic-bezier(0, 0, 0.2, 1) 0ms',
   transform: `translate(0, 0) scale(1)`,
-
-  fontSize: theme.fontSizes.xl,
-  color: theme.colors.gray700,
   paddingInline: theme.space.md,
   whiteSpace: 'nowrap',
 }))
@@ -89,8 +93,12 @@ const LargeInput = styled.input(({ theme }) => ({
   paddingTop: theme.space.md,
 
   ':disabled': {
-    opacity: 0.6,
+    color: theme.colors.textDisabled,
     cursor: 'not-allowed',
+
+    // Webkit overrides
+    WebkitTextFillColor: theme.colors.textDisabled,
+    opacity: 1,
   },
 }))
 
@@ -112,7 +120,6 @@ const SmallWrapper = styled(LargeWrapper)(({ theme, isActive }) => ({
   }),
 }))
 
-const SmallLabel = styled(LargeLabel)(({ theme }) => ({ fontSize: theme.fontSizes.md }))
 const SmallInput = styled(LargeInput)(({ theme }) => ({ fontSize: theme.fontSizes.lg }))
 
 const SmallSuffix = styled(LargeSuffix)()

--- a/apps/store/src/utils/useHighlightAnimation.ts
+++ b/apps/store/src/utils/useHighlightAnimation.ts
@@ -11,8 +11,7 @@ export const useHighlightAnimation = () => {
   const [isInteractive, setIsInteractive] = useState(false)
 
   const animationVariants = {
-    [AnimationState.Active]: { backgroundColor: 'rgba(197, 236, 127, 0.6)' },
-    [AnimationState.Idle]: { backgroundColor: theme.colors.gray300 },
+    [AnimationState.Active]: { backgroundColor: theme.colors.green100 },
   } as const
 
   const highlight = useCallback((event?: KeyboardEvent<HTMLElement>) => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Just a quick refactor for small screens.

![Screenshot 2023-01-03 at 17.25.28.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/93117734-dc35-4e33-aea9-8d53a6d03b97/Screenshot%202023-01-03%20at%2017.25.28.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
