### PR TITLE
Improve Icon story design 

### DIFF
--- a/packages/ui/src/icons/Icons.stories.tsx
+++ b/packages/ui/src/icons/Icons.stories.tsx
@@ -73,13 +73,11 @@ const IconName = styled.div({
   paddingTop: '1rem',
 })
 
-const updateClipboard = (newClip: string) => {
-  navigator.clipboard.writeText(newClip).then(
-    () => {
-      console.log(`Copied <${newClip} /> to clipboard`)
-    },
-    () => {
-      console.log(`Failed to write ${newClip} to clipboard`)
-    },
-  )
+const updateClipboard = async (newClip: string) => {
+  try {
+    await navigator.clipboard.writeText(newClip).catch((e) => console.warn(e))
+    console.log(`Copied ${newClip} to clipboard`)
+  } catch (error) {
+    console.warn(error)
+  }
 }

--- a/packages/ui/src/icons/Icons.stories.tsx
+++ b/packages/ui/src/icons/Icons.stories.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { Heading } from '../components/Heading/Heading'
+import { Space } from '../components/Space'
 import * as AllIcons from './index'
-
-const AllIconNames = Object.keys(AllIcons)
 
 type IconProps = {
   icon: string
@@ -12,30 +12,74 @@ const Icon = ({ icon }: IconProps) => {
   return <Component />
 }
 
-const IconWrapper = styled.div({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flexDirection: 'column',
-  paddingBottom: '1rem',
-})
-
-const Template: ComponentStory<typeof Icon> = () => {
-  return (
-    <>
-      {AllIconNames.map((icon) => (
-        <IconWrapper>
-          <div>{icon}</div>
-          <Icon icon={icon} />
-        </IconWrapper>
-      ))}
-    </>
-  )
-}
-
-export const Default = Template.bind({})
-
 export default {
   title: 'Icons',
   component: Icon,
 } as ComponentMeta<typeof Icon>
+
+const AllIconNames = Object.keys(AllIcons)
+
+const Template: ComponentStory<typeof Icon> = () => {
+  return (
+    <Page>
+      <Space y={1}>
+        <Heading as="h1">Icons</Heading>
+        <IconGrid>
+          {AllIconNames.map((icon) => (
+            <IconWrapper onClick={() => updateClipboard(icon)}>
+              <Icon icon={icon} />
+              <IconName>{icon}</IconName>
+            </IconWrapper>
+          ))}
+        </IconGrid>
+      </Space>
+    </Page>
+  )
+}
+
+export const Icons = Template.bind({})
+
+const Page = styled.div({
+  height: '100vh',
+})
+
+const IconWrapper = styled.div(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexDirection: 'column',
+  width: 216,
+  height: 150,
+  padding: '1rem',
+  overflow: 'hidden',
+  backgroundColor: theme.colors.white,
+  borderRadius: theme.radius.md,
+  boxShadow: 'rgb(0 0 0 / 10%) 0px 1px 2px',
+  border: '1px solid hsla(0, 0%, 0%, 0.1)',
+  ':hover': {
+    cursor: 'pointer',
+  },
+  ':active': { backgroundColor: theme.colors.green50 },
+}))
+
+const IconGrid = styled.div({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '2rem 1rem',
+  marginBottom: '3rem',
+})
+
+const IconName = styled.div({
+  paddingTop: '1rem',
+})
+
+const updateClipboard = (newClip: string) => {
+  navigator.clipboard.writeText(newClip).then(
+    () => {
+      console.log(`Copied <${newClip} /> to clipboard`)
+    },
+    () => {
+      console.log(`Failed to write ${newClip} to clipboard`)
+    },
+  )
+}

--- a/packages/ui/src/lib/theme/colors/colors.stories.tsx
+++ b/packages/ui/src/lib/theme/colors/colors.stories.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { theme } from '../theme'
 import { gray, green, red, yellow } from './colors'
 
 export default {
@@ -52,7 +53,7 @@ const ColorSwatch = styled.div<{ hue: string }>(({ hue }) => ({
   backgroundColor: hue,
   overflow: 'hidden',
   border: '1px solid hsla(0, 0%, 0%, 0.1)',
-  borderRadius: 16,
+  borderRadius: theme.radius.md,
 }))
 
 const HueName = styled.p({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Changed the design of the icon page.
- Added the ability to click on the icon and have it's name copied to your clipboard.

Stole a bunch of ideas and code from @gustaveen 's Color story to make this happen. 

_“good artists borrow, great artists steal.”_ - [Pablo Picasso](https://media4.giphy.com/media/l2JhyuVn311Y1RWqA/200.gif) (maybe?? maybe not?? )

<img width="646" alt="Screenshot 2023-01-04 at 12 06 46" src="https://user-images.githubusercontent.com/50870173/210543292-0b115363-b3ed-4b0d-a7c1-a184ed454ce3.png">

_Would be cool to have a little toast show up when you've copied something to your clipboard but I did not want to add it to the project._

## Justify why they are needed

Not really needed. Just nice to have.

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
