### PR TITLE
Grw-2042/fix cart heading spacing

### DIFF
--- a/apps/store/src/components/CartInventory/CartEntryList.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryList.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { ReactNode } from 'react'
-import { Separate } from 'ui'
+import { mq, Separate } from 'ui'
 
 type Props = { children: ReactNode }
 
@@ -10,16 +10,19 @@ export const CartEntryList = ({ children }: Props) => {
   )
 }
 
-const StyledCartEntryList = styled(Separate)({
+const StyledCartEntryList = styled(Separate)(({ theme }) => ({
   padding: 0,
   listStyleType: 'none',
   width: '100%',
-})
+  [mq.lg]: {
+    paddingTop: theme.space.xxxl,
+  },
+}))
 StyledCartEntryList.defaultProps = { as: 'ul' }
 
 const HorizontalLineWithSpace = styled.hr(({ theme }) => ({
   backgroundColor: theme.colors.gray300,
   height: 1,
-  marginTop: theme.space[5],
-  marginBottom: theme.space[5],
+  marginTop: theme.space.lg,
+  marginBottom: theme.space.lg,
 }))

--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -59,15 +59,13 @@ export const CartPage = (props: CartPageProps) => {
   return (
     <Wrapper y={{ base: 1, lg: 4 }}>
       <Section>
-        <Space y={2}>
-          <Space y={4}>
-            <Header prevURL={prevURL} />
-            <CartEntryList>
-              {entries.map((item) => (
-                <CartEntryItem key={item.offerId} cartId={cartId} {...item} />
-              ))}
-            </CartEntryList>
-          </Space>
+        <Space y={1.5}>
+          <Header prevURL={prevURL} />
+          <CartEntryList>
+            {entries.map((item) => (
+              <CartEntryItem key={item.offerId} cartId={cartId} {...item} />
+            ))}
+          </CartEntryList>
           <HorizontalLine />
           <CampaignCodeList cartId={cartId} campaigns={campaigns} />
           <HorizontalLine />

--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -59,13 +59,15 @@ export const CartPage = (props: CartPageProps) => {
   return (
     <Wrapper y={{ base: 1, lg: 4 }}>
       <Section>
-        <Space y={1.5}>
-          <Header prevURL={prevURL} />
-          <CartEntryList>
-            {entries.map((item) => (
-              <CartEntryItem key={item.offerId} cartId={cartId} {...item} />
-            ))}
-          </CartEntryList>
+        <Space y={2}>
+          <Space y={4}>
+            <Header prevURL={prevURL} />
+            <CartEntryList>
+              {entries.map((item) => (
+                <CartEntryItem key={item.offerId} cartId={cartId} {...item} />
+              ))}
+            </CartEntryList>
+          </Space>
           <HorizontalLine />
           <CampaignCodeList cartId={cartId} campaigns={campaigns} />
           <HorizontalLine />

--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -159,7 +159,7 @@ const HeaderHeading = styled(Heading)(({ theme }) => ({
   },
 }))
 
-const StyledHeader = styled(Section)({
+const StyledHeader = styled(Space)({
   height: '3.5rem',
   display: 'flex',
   alignItems: 'center',


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Small ui fixes on the cart page to better match the designs. 
- heading padding left/right
- heading padding with the content on the page

_Should all look very much like the /checkout page._ 

![localhost_8040_en-se_cart(iPhone XR)](https://user-images.githubusercontent.com/50870173/210751864-5510542f-c575-46d7-8480-107fa6b8ee06.png)
![localhost_8040_en-se_cart](https://user-images.githubusercontent.com/50870173/210751868-b1990c6d-3c6d-4219-83b0-f6786b6bc505.png)


## Justify why they are needed

## Jira issue(s): [GRW-2042]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [x] I have performed a self-review of my code


[GRW-2042]: https://hedvig.atlassian.net/browse/GRW-2042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ