### PR TITLE
Refactor Cart + Checkout layout

### DIFF
--- a/apps/store/src/components/CartInventory/CartEntryList.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryList.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { ReactNode } from 'react'
-import { mq, Separate } from 'ui'
+import { Separate } from 'ui'
 
 type Props = { children: ReactNode }
 
@@ -10,14 +10,11 @@ export const CartEntryList = ({ children }: Props) => {
   )
 }
 
-const StyledCartEntryList = styled(Separate)(({ theme }) => ({
+const StyledCartEntryList = styled(Separate)({
   padding: 0,
   listStyleType: 'none',
   width: '100%',
-  [mq.lg]: {
-    paddingTop: theme.space.xxxl,
-  },
-}))
+})
 StyledCartEntryList.defaultProps = { as: 'ul' }
 
 const HorizontalLineWithSpace = styled.hr(({ theme }) => ({

--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -58,23 +58,21 @@ export const CartPage = (props: CartPageProps) => {
 
   return (
     <Wrapper y={{ base: 1, lg: 4 }}>
-      <Section>
-        <Space y={1.5}>
-          <Header prevURL={prevURL} />
-          <CartEntryList>
-            {entries.map((item) => (
-              <CartEntryItem key={item.offerId} cartId={cartId} {...item} />
-            ))}
-          </CartEntryList>
-          <HorizontalLine />
-          <CampaignCodeList cartId={cartId} campaigns={campaigns} />
-          <HorizontalLine />
-          <CostSummary {...cost} campaigns={campaigns} />
-          <Button onClick={() => startCheckout()} disabled={loadingStartCheckout}>
-            {t('CHECKOUT_BUTTON')}
-          </Button>
-        </Space>
-      </Section>
+      <Header prevURL={prevURL} />
+      <Space y={1.5}>
+        <CartEntryList>
+          {entries.map((item) => (
+            <CartEntryItem key={item.offerId} cartId={cartId} {...item} />
+          ))}
+        </CartEntryList>
+        <HorizontalLine />
+        <CampaignCodeList cartId={cartId} campaigns={campaigns} />
+        <HorizontalLine />
+        <CostSummary {...cost} campaigns={campaigns} />
+        <Button onClick={() => startCheckout()} disabled={loadingStartCheckout}>
+          {t('CHECKOUT_BUTTON')}
+        </Button>
+      </Space>
     </Wrapper>
   )
 }
@@ -85,22 +83,19 @@ const EmptyState = ({ children, prevURL }: EmptyStateProps) => {
   const { t } = useTranslation('cart')
 
   return (
-    <Wrapper>
-      <Space y={5}>
-        <Header prevURL={prevURL} />
-
-        <Space y={2}>
-          <Space y={1}>
-            <Text align="center">¯\_(ツ)_/¯</Text>
-            <Text align="center" color="textSecondary">
-              {t('CART_EMPTY_SUMMARY')}
-            </Text>
-          </Space>
-
-          <ButtonNextLink href={PageLink.store()}>{t('GO_TO_STORE_BUTTON')}</ButtonNextLink>
+    <Wrapper y={4}>
+      <Header prevURL={prevURL} />
+      <Space y={2}>
+        <Space y={1}>
+          <Text align="center">¯\_(ツ)_/¯</Text>
+          <Text align="center" color="textSecondary">
+            {t('CART_EMPTY_SUMMARY')}
+          </Text>
         </Space>
-        {children}
+
+        <ButtonNextLink href={PageLink.store()}>{t('GO_TO_STORE_BUTTON')}</ButtonNextLink>
       </Space>
+      {children}
     </Wrapper>
   )
 }
@@ -115,9 +110,6 @@ const Wrapper = styled(Space)(({ theme }) => ({
   maxWidth: '40rem',
   marginLeft: 'auto',
   marginRight: 'auto',
-}))
-
-const Section = styled(Space)(({ theme }) => ({
   paddingLeft: theme.space.md,
   paddingRight: theme.space.md,
 }))


### PR DESCRIPTION
## Describe your changes

Refactor Cart + Checkout page layout to match design.

![Screenshot 2023-01-05 at 14.11.02.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/c6476e71-b089-47bf-b4e2-e86076647420/Screenshot%202023-01-05%20at%2014.11.02.png)

Move padding from shared `CartInventory` to Cart page.

![Screenshot 2023-01-05 at 14.12.31.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/066421fc-c313-45b6-b7e2-dd712cf5fd43/Screenshot%202023-01-05%20at%2014.12.31.png)

## Justify why they are needed

Layout should be decided by the component that implements it, not by the child component. Therefore it's better to use e.g. `Space` in the parent component rather than pushing content with padding in the child component.

In this case, the added padding in `CartEntryList` didn't work on the Checkout page.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
