### PR TITLE
GRW-2016/Desktop layout - Cart Entry

### DIFF
--- a/apps/store/src/components/CartInventory/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem.tsx
@@ -1,6 +1,9 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { Button, Dialog, Space, Text } from 'ui'
+import Link, { LinkProps } from 'next/link'
+import { FormEvent } from 'react'
+import { Button, Dialog, mq, Space, Text } from 'ui'
+import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { useFormatter } from '@/utils/useFormatter'
@@ -17,30 +20,80 @@ export const CartEntryItem = (props: Props) => {
   const formatter = useFormatter()
 
   return (
-    <Wrapper>
-      <Pillow size="small" {...pillow} />
-      <Space y={1}>
-        <div>
-          <Text size="md">{title}</Text>
-          <Text size="md" color="textSecondary">
-            {/* @TODO: display "automatically switches" if cancellation is requested" */}
-            {startDate
-              ? t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(startDate) })
-              : 'Starts sometime...'}
-          </Text>
-        </div>
-        <SpaceFlex space={0.25}>
-          <DetailsSheetDialog {...cartEntry}>
+    <FullscreenDialog.Root>
+      <MobileWrapper>
+        <Pillow size="small" {...pillow} />
+        <Space y={1}>
+          <div>
+            <Text size="md">{title}</Text>
+            <Text size="md" color="textSecondary">
+              {/* @TODO: display "automatically switches" if cancellation is requested" */}
+              {startDate
+                ? t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(startDate), ns: 'cart' })
+                : 'Starts sometime...'}
+            </Text>
+          </div>
+          <SpaceFlex space={0.25}>
+            <LinkButtonSecondary href="#">
+              {t('VIEW_ENTRY_DETAILS_BUTTON', { ns: 'cart' })}
+            </LinkButtonSecondary>
             <Dialog.Trigger asChild>
               <Button variant="secondary" size="small">
                 {t('VIEW_ENTRY_DETAILS_BUTTON')}
               </Button>
             </Dialog.Trigger>
-          </DetailsSheetDialog>
-          <RemoveEntryDialog cartId={cartId} {...cartEntry}>
+          </SpaceFlex>
+        </Space>
+        <Text size="md">{formatter.monthlyPrice(cost)}</Text>
+      </MobileWrapper>
+
+      <DesktopWrapper>
+        <DesktopPillowTitle>
+          <DesktopPillowFlexItem>
+            <Pillow size="small" {...pillow} />
+            <Text size="md">{title}</Text>
+          </DesktopPillowFlexItem>
+        </DesktopPillowTitle>
+        <Space y={1}>
+          <div>
+            <Text size="md" color="textSecondary">
+              Bostadsrätt Tavastgatan 39 Startar 02 dec. 2023
+            </Text>
+            <Text size="md" color="textSecondary">
+              {/* @TODO: display "automatically switches" if cancellation is requested" */}
+              {startDate
+                ? t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(startDate), ns: 'cart' })
+                : 'Starts sometime...'}
+            </Text>
+          </div>
+          <SpaceFlex space={0.25}>
+            <LinkButtonSecondary href="#">
+              {t('VIEW_ENTRY_DETAILS_BUTTON', { ns: 'cart' })}
+            </LinkButtonSecondary>
             <Dialog.Trigger asChild>
-              <Button variant="ghost" size="small">
-                {t('REMOVE_ENTRY_BUTTON')}
+              <TextButton disabled={loading}>{t('REMOVE_ENTRY_BUTTON', { ns: 'cart' })}</TextButton>
+            </Dialog.Trigger>
+          </SpaceFlex>
+        </Space>
+        <Text align="right" size="md">
+          {formatter.monthlyPrice(cost)}
+        </Text>
+      </DesktopWrapper>
+
+      <FullscreenDialog.Modal
+        Footer={
+          <>
+            <Button
+              form={REMOVE_CART_ENTRY_FORM}
+              type="submit"
+              loading={loading}
+              disabled={loading}
+            >
+              {t('REMOVE_ENTRY_MODAL_CONFIRM_BUTTON', { ns: 'cart' })}
+            </Button>
+            <FullscreenDialog.Close asChild>
+              <Button type="button" variant="ghost">
+                {t('REMOVE_ENTRY_MODAL_CANCEL_BUTTON', { ns: 'cart' })}
               </Button>
             </Dialog.Trigger>
           </RemoveEntryDialog>
@@ -51,8 +104,54 @@ export const CartEntryItem = (props: Props) => {
   )
 }
 
-const Wrapper = styled.li(({ theme }) => ({
+const MobileWrapper = styled.li(({ theme }) => ({
   display: 'grid',
   gridTemplateColumns: '3rem minmax(0, 1fr) auto',
-  gap: theme.space[3],
+  gap: theme.space.sm,
+  [mq.lg]: {
+    display: 'none',
+    gridTemplateColumns: '3fr 2fr 2fr',
+    gap: theme.space.sm,
+  },
 }))
+
+const DesktopWrapper = styled.li(({ theme }) => ({
+  display: 'none',
+  [mq.lg]: {
+    display: 'grid',
+    gridTemplateColumns: '3fr 2fr 2fr',
+    gap: theme.space.sm,
+  },
+}))
+const DesktopPillowTitle = styled.div({
+  display: 'flex',
+  alignItems: 'flex-start',
+})
+const DesktopPillowFlexItem = styled.div(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.space.sm,
+}))
+
+const SecondaryButton = styled.button(({ theme }) => ({
+  fontSize: theme.fontSizes[1],
+  paddingLeft: theme.space.md,
+  paddingRight: theme.space.md,
+  paddingTop: theme.space.xs,
+  paddingBottom: theme.space.xs,
+  borderRadius: theme.radius.xs,
+  backgroundColor: theme.colors.gray200,
+  boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.15)',
+
+  ':disabled': {
+    opacity: 0.6,
+  },
+}))
+
+const LinkButtonSecondary = styled(SecondaryButton)<LinkProps>()
+LinkButtonSecondary.defaultProps = { as: Link }
+
+const TextButton = styled(SecondaryButton)({
+  backgroundColor: 'transparent',
+  boxShadow: 'none',
+})

--- a/apps/store/src/components/CartInventory/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem.tsx
@@ -42,7 +42,7 @@ export const CartEntryItem = (props: Props) => {
             <Text size="md" color="textSecondary">
               {/* @TODO: display "automatically switches" if cancellation is requested" */}
               {startDate
-                ? t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(startDate), ns: 'cart' })
+                ? t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(startDate) })
                 : 'Starts sometime...'}
             </Text>
           </div>

--- a/apps/store/src/components/CartInventory/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem.tsx
@@ -107,8 +107,6 @@ const MobileWrapper = styled.li(({ theme }) => ({
   gap: theme.space.sm,
   [mq.lg]: {
     display: 'none',
-    gridTemplateColumns: '3fr 2fr 2fr',
-    gap: theme.space.sm,
   },
 }))
 

--- a/apps/store/src/components/CartInventory/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem.tsx
@@ -1,97 +1,60 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { FormEvent } from 'react'
 import { Button, Dialog, mq, Space, Text } from 'ui'
-import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { useFormatter } from '@/utils/useFormatter'
 import { CartEntry } from './CartInventory.types'
 import { DetailsSheetDialog } from './DetailsSheetDialog'
-import { useRemoveCartEntry } from './useRemoveCartEntry'
-
-const REMOVE_CART_ENTRY_FORM = 'remove-cart-entry-form'
+import { RemoveEntryDialog } from './RemoveEntryDialog'
 
 type Props = CartEntry & { cartId: string }
 
 export const CartEntryItem = (props: Props) => {
   const { cartId, ...cartEntry } = props
-  const { offerId, title, startDate, cost, pillow } = cartEntry
+  const { title, startDate, cost, pillow } = cartEntry
   const { t } = useTranslation('cart')
   const formatter = useFormatter()
 
-  const [removeCartEntry, { loading }] = useRemoveCartEntry({ cartId, offerId })
-
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    removeCartEntry()
-  }
-
   return (
-    <FullscreenDialog.Root>
-      <Wrapper>
+    <Wrapper>
+      <div>
+        <DesktopPillowWithTitle>
+          <Pillow size="small" {...pillow} />
+          <DesktopTitle size="md">{title}</DesktopTitle>
+        </DesktopPillowWithTitle>
+      </div>
+      <Space y={1}>
         <div>
-          <DesktopPillowWithTitle>
-            <Pillow size="small" {...pillow} />
-            <DesktopTitle size="md">{title}</DesktopTitle>
-          </DesktopPillowWithTitle>
+          <MobileTitle size="md">{title}</MobileTitle>
+          <Text size="md" color="textSecondary">
+            {/* @TODO: display "automatically switches" if cancellation is requested" */}
+            {startDate
+              ? t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(startDate) })
+              : 'Starts sometime...'}
+          </Text>
         </div>
-        <Space y={1}>
-          <div>
-            <MobileTitle size="md">{title}</MobileTitle>
-            <Text size="md" color="textSecondary">
-              {/* @TODO: display "automatically switches" if cancellation is requested" */}
-              {startDate
-                ? t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(startDate) })
-                : 'Starts sometime...'}
-            </Text>
-          </div>
-          <SpaceFlex space={0.25}>
-            <DetailsSheetDialog {...cartEntry}>
-              <Dialog.Trigger asChild>
-                <Button variant="secondary" size="small">
-                  {t('VIEW_ENTRY_DETAILS_BUTTON')}
-                </Button>
-              </Dialog.Trigger>
-            </DetailsSheetDialog>
+        <SpaceFlex space={0.25}>
+          <DetailsSheetDialog {...cartEntry}>
             <Dialog.Trigger asChild>
-              <Button variant="ghost" size="small" disabled={loading}>
+              <Button variant="secondary" size="small">
+                {t('VIEW_ENTRY_DETAILS_BUTTON')}
+              </Button>
+            </Dialog.Trigger>
+          </DetailsSheetDialog>
+          <RemoveEntryDialog cartId={cartId} {...cartEntry}>
+            <Dialog.Trigger asChild>
+              <Button variant="ghost" size="small">
                 {t('REMOVE_ENTRY_BUTTON')}
               </Button>
             </Dialog.Trigger>
-          </SpaceFlex>
-        </Space>
-        <Text align="right" size="md">
-          {formatter.monthlyPrice(cost)}
-        </Text>
-      </Wrapper>
-
-      <FullscreenDialog.Modal
-        center
-        Footer={
-          <>
-            <Button
-              form={REMOVE_CART_ENTRY_FORM}
-              type="submit"
-              loading={loading}
-              disabled={loading}
-            >
-              {t('REMOVE_ENTRY_MODAL_CONFIRM_BUTTON')}
-            </Button>
-            <FullscreenDialog.Close asChild>
-              <Button type="button" variant="ghost">
-                {t('REMOVE_ENTRY_MODAL_CANCEL_BUTTON')}
-              </Button>
-            </FullscreenDialog.Close>
-          </>
-        }
-      >
-        <form id={REMOVE_CART_ENTRY_FORM} onSubmit={handleSubmit} />
-        <Text size={{ _: 'md', lg: 'xl' }} align="center">
-          {t('REMOVE_ENTRY_MODAL_PROMPT', { name: title })}
-        </Text>
-      </FullscreenDialog.Modal>
-    </FullscreenDialog.Root>
+          </RemoveEntryDialog>
+        </SpaceFlex>
+      </Space>
+      <Text align="right" size="md">
+        {formatter.monthlyPrice(cost)}
+      </Text>
+    </Wrapper>
   )
 }
 

--- a/apps/store/src/components/CartInventory/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem.tsx
@@ -21,41 +21,16 @@ export const CartEntryItem = (props: Props) => {
 
   return (
     <FullscreenDialog.Root>
-      <MobileWrapper>
-        <Pillow size="small" {...pillow} />
-        <Space y={1}>
-          <div>
-            <Text size="md">{title}</Text>
-            <Text size="md" color="textSecondary">
-              {/* @TODO: display "automatically switches" if cancellation is requested" */}
-              {startDate
-                ? t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(startDate), ns: 'cart' })
-                : 'Starts sometime...'}
-            </Text>
-          </div>
-          <SpaceFlex space={0.25}>
-            <LinkButtonSecondary href="#">
-              {t('VIEW_ENTRY_DETAILS_BUTTON', { ns: 'cart' })}
-            </LinkButtonSecondary>
-            <Dialog.Trigger asChild>
-              <Button variant="secondary" size="small">
-                {t('VIEW_ENTRY_DETAILS_BUTTON')}
-              </Button>
-            </Dialog.Trigger>
-          </SpaceFlex>
-        </Space>
-        <Text size="md">{formatter.monthlyPrice(cost)}</Text>
-      </MobileWrapper>
-
-      <DesktopWrapper>
-        <DesktopPillowTitle>
+      <Wrapper>
+        <PillowWrapper>
           <DesktopPillowFlexItem>
             <Pillow size="small" {...pillow} />
-            <Text size="md">{title}</Text>
+            <DesktopTitle size="md">{title}</DesktopTitle>
           </DesktopPillowFlexItem>
-        </DesktopPillowTitle>
+        </PillowWrapper>
         <Space y={1}>
           <div>
+            <MobileTitle size="md">{title}</MobileTitle>
             <Text size="md" color="textSecondary">
               {/* @TODO: display "automatically switches" if cancellation is requested" */}
               {startDate
@@ -75,7 +50,7 @@ export const CartEntryItem = (props: Props) => {
         <Text align="right" size="md">
           {formatter.monthlyPrice(cost)}
         </Text>
-      </DesktopWrapper>
+      </Wrapper>
 
       <FullscreenDialog.Modal
         Footer={
@@ -101,17 +76,10 @@ export const CartEntryItem = (props: Props) => {
   )
 }
 
-const MobileWrapper = styled.li(({ theme }) => ({
+const Wrapper = styled.li(({ theme }) => ({
   display: 'grid',
   gridTemplateColumns: '3rem minmax(0, 1fr) auto',
   gap: theme.space.sm,
-  [mq.lg]: {
-    display: 'none',
-  },
-}))
-
-const DesktopWrapper = styled.li(({ theme }) => ({
-  display: 'none',
   [mq.lg]: {
     display: 'grid',
     gridTemplateColumns: '3fr 2fr 2fr',
@@ -119,9 +87,26 @@ const DesktopWrapper = styled.li(({ theme }) => ({
   },
 }))
 
-const DesktopPillowTitle = styled.div({
+const PillowWrapper = styled.div({
   display: 'flex',
   alignItems: 'flex-start',
+  [mq.lg]: {
+    display: 'flex',
+    alignItems: 'flex-start',
+  },
+})
+
+const DesktopTitle = styled(Text)({
+  display: 'none',
+  [mq.lg]: {
+    display: 'block',
+  },
+})
+
+const MobileTitle = styled(Text)({
+  [mq.lg]: {
+    display: 'none',
+  },
 })
 
 const DesktopPillowFlexItem = styled.div(({ theme }) => ({

--- a/apps/store/src/components/CartInventory/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem.tsx
@@ -57,9 +57,6 @@ export const CartEntryItem = (props: Props) => {
         <Space y={1}>
           <div>
             <Text size="md" color="textSecondary">
-              Bostadsrätt Tavastgatan 39 Startar 02 dec. 2023
-            </Text>
-            <Text size="md" color="textSecondary">
               {/* @TODO: display "automatically switches" if cancellation is requested" */}
               {startDate
                 ? t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(startDate), ns: 'cart' })

--- a/apps/store/src/components/CartInventory/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem.tsx
@@ -120,10 +120,12 @@ const DesktopWrapper = styled.li(({ theme }) => ({
     gap: theme.space.sm,
   },
 }))
+
 const DesktopPillowTitle = styled.div({
   display: 'flex',
   alignItems: 'flex-start',
 })
+
 const DesktopPillowFlexItem = styled.div(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
@@ -132,10 +134,7 @@ const DesktopPillowFlexItem = styled.div(({ theme }) => ({
 
 const SecondaryButton = styled.button(({ theme }) => ({
   fontSize: theme.fontSizes[1],
-  paddingLeft: theme.space.md,
-  paddingRight: theme.space.md,
-  paddingTop: theme.space.xs,
-  paddingBottom: theme.space.xs,
+  padding: `${theme.space.xs} ${theme.space.md}`,
   borderRadius: theme.radius.xs,
   backgroundColor: theme.colors.gray200,
   boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.15)',

--- a/apps/store/src/components/CartInventory/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem.tsx
@@ -30,12 +30,12 @@ export const CartEntryItem = (props: Props) => {
   return (
     <FullscreenDialog.Root>
       <Wrapper>
-        <PillowWrapper>
-          <DesktopPillowFlexItem>
+        <div>
+          <DesktopPillowWithTitle>
             <Pillow size="small" {...pillow} />
             <DesktopTitle size="md">{title}</DesktopTitle>
-          </DesktopPillowFlexItem>
-        </PillowWrapper>
+          </DesktopPillowWithTitle>
+        </div>
         <Space y={1}>
           <div>
             <MobileTitle size="md">{title}</MobileTitle>
@@ -100,20 +100,9 @@ const Wrapper = styled.li(({ theme }) => ({
   gridTemplateColumns: '3rem minmax(0, 1fr) auto',
   gap: theme.space.sm,
   [mq.lg]: {
-    display: 'grid',
     gridTemplateColumns: '3fr 2fr 2fr',
-    gap: theme.space.sm,
   },
 }))
-
-const PillowWrapper = styled.div({
-  display: 'flex',
-  alignItems: 'flex-start',
-  [mq.lg]: {
-    display: 'flex',
-    alignItems: 'flex-start',
-  },
-})
 
 const DesktopTitle = styled(Text)({
   display: 'none',
@@ -128,7 +117,7 @@ const MobileTitle = styled(Text)({
   },
 })
 
-const DesktopPillowFlexItem = styled.div(({ theme }) => ({
+const DesktopPillowWithTitle = styled.div(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   gap: theme.space.sm,

--- a/apps/store/src/components/CartInventory/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem.tsx
@@ -107,7 +107,7 @@ const Wrapper = styled.li(({ theme }) => ({
 const DesktopTitle = styled(Text)({
   display: 'none',
   [mq.lg]: {
-    display: 'block',
+    display: 'revert',
   },
 })
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Created a desktop layout of cart entry items. This component is seen on the /cart and /checkout pages.

Attempted to do this in several ways. Thought this was the least complicated, although I don't _love_ how the show/hide of things like the "title" (`<MobileTitle />` & `<DesktopTitle />`) are done with css. 

![checkout-entries](https://user-images.githubusercontent.com/50870173/210779802-1d4d1457-1468-487b-9f8a-d98127a82675.png)
![cart-entries](https://user-images.githubusercontent.com/50870173/210779811-b005f21b-4f3a-494e-9cb1-167778f7310c.png)


## Justify why they are needed

Matching the designs in Figma.
## Figma
<img width="709" alt="Screenshot 2023-01-05 at 15 07 31" src="https://user-images.githubusercontent.com/50870173/210799003-1a1c07b6-0d7f-472a-8f49-98e85e39ec82.png">

## Jira issue(s): [GRW-2016]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [x] I have performed a self-review of my code


[GRW-2016]: https://hedvig.atlassian.net/browse/GRW-2016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ