### PR TITLE
Tweak inputs to use same design as `TextField`

### DIFF
--- a/apps/store/src/components/InputSelect/InputSelect.tsx
+++ b/apps/store/src/components/InputSelect/InputSelect.tsx
@@ -16,24 +16,24 @@ const StyledChevronIcon = styled(ChevronIcon)(() => ({
 }))
 
 const StyledSelect = styled(motion.select)(({ theme }) => ({
-  backgroundColor: theme.colors.gray300,
-  color: theme.colors.gray900,
-  fontSize: theme.fontSizes[5],
+  backgroundColor: theme.colors.gray100,
+  color: theme.colors.textPrimary,
+  fontSize: theme.fontSizes.xl,
   width: '100%',
   borderRadius: theme.radius.sm,
-  padding: `${theme.space[2]} ${theme.space[7]} ${theme.space[2]} ${theme.space[4]}`,
+  padding: `${theme.space.xs} ${theme.space.xxl} ${theme.space.xs} ${theme.space.md}`,
 
   '&:hover': {
     cursor: 'pointer',
   },
 
   '&:focus-visible': {
-    boxShadow: `0 0 0 2px ${theme.colors.textPrimary}`,
+    boxShadow: `0 0 0 1px ${theme.colors.textPrimary}`,
   },
 }))
 
 const Placeholder = styled.option(({ theme }) => ({
-  color: theme.colors.gray500,
+  color: theme.colors.textSecondary,
 }))
 
 type InputSelectProps = InputBaseProps & {

--- a/apps/store/src/components/PriceCalculator/InputRadio.tsx
+++ b/apps/store/src/components/PriceCalculator/InputRadio.tsx
@@ -38,7 +38,7 @@ export const Root = ({ children, label, onValueChange, ...props }: RootProps) =>
 const Card = styled(motion(Space))(({ theme }) => ({
   padding: `${theme.space.sm} ${theme.space.md}`,
   borderRadius: theme.radius.sm,
-  backgroundColor: theme.colors.gray300,
+  backgroundColor: theme.colors.gray100,
 }))
 
 type ItemProps = {
@@ -65,22 +65,22 @@ const StyledItem = styled(RadioGroup.Item)(({ theme }) => ({
   width: '1.375rem',
   height: '1.375rem',
 
+  cursor: 'pointer',
   border: `1px solid ${theme.colors.gray500}`,
   borderRadius: '50%',
 
   '&[data-state=checked]': {
-    borderColor: theme.colors.gray900,
+    borderColor: theme.colors.gray1000,
   },
 
-  '&:focus': {
-    // @TODO: pending design
-    boxShadow: '0 0 0 2px rgba(0, 0, 0, 0.4)',
+  '&:focus-visible': {
+    boxShadow: `0 0 0 2px ${theme.colors.gray500}`,
   },
 }))
 
 const StyledIndicator = styled(RadioGroup.Indicator)(({ theme }) => ({
   display: 'block',
-  backgroundColor: theme.colors.gray900,
+  backgroundColor: theme.colors.gray1000,
   borderRadius: '50%',
   width: '100%',
   height: '100%',


### PR DESCRIPTION
## Describe your changes

Update background and other small fixes to align `Input` and `Select` fields with other inputs.

![Screenshot 2023-01-05 at 15.11.35.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/dfe8b342-140e-4414-b5a8-75a1e9d22f0b/Screenshot%202023-01-05%20at%2015.11.35.png)

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
