### PR TITLE
GRW-1985 / Feat / Ensure we do full page reload on country change

### DIFF
--- a/apps/store/src/blocks/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock.tsx
@@ -20,9 +20,10 @@ import { LocaleField, LOCALE_COOKIE_MAX_AGE, LOCALE_COOKIE_KEY } from '@/utils/l
 import {
   getLocaleOrFallback,
   toRoutingLocale,
+  translateCountryName,
   translateLanguageName,
 } from '@/utils/l10n/localeUtils'
-import { IsoLocale } from '@/utils/l10n/types'
+import { CountryLabel, IsoLocale } from '@/utils/l10n/types'
 import { useCurrentCountry } from '@/utils/l10n/useCurrentCountry'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 
@@ -76,7 +77,7 @@ export const FooterBlock = ({ blok }: FooterBlockProps) => {
   const apolloClient = useApolloClient()
 
   const countryList = Object.keys(countries).map((country) => ({
-    name: t(`COUNTRY_LABEL_${country}`, { defaultValue: country }),
+    name: translateCountryName(country as CountryLabel, t),
     value: country,
   }))
 

--- a/apps/store/src/blocks/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock.tsx
@@ -1,6 +1,8 @@
+import { useApolloClient } from '@apollo/client'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { useTranslation } from 'next-i18next'
+import { addLocale } from 'next/dist/client/add-locale'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { ChangeEvent, useRef } from 'react'
@@ -9,10 +11,11 @@ import * as Accordion from '@/components/Accordion/Accordion'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { CookiePersister } from '@/services/persister/CookiePersister'
+import { setupShopSessionServiceClientSide } from '@/services/shopSession/ShopSession.helpers'
 import { ExpectedBlockType, LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { filterByBlockType, getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
 import { countries } from '@/utils/l10n/countries'
-import { getCountryLocale } from '@/utils/l10n/countryUtils'
+import { getCountryByLocale, getCountryLocale } from '@/utils/l10n/countryUtils'
 import { LocaleField, LOCALE_COOKIE_MAX_AGE, LOCALE_COOKIE_KEY } from '@/utils/l10n/locales'
 import {
   getLocaleOrFallback,
@@ -70,6 +73,7 @@ export const FooterBlock = ({ blok }: FooterBlockProps) => {
   const currentCountry = useCurrentCountry()
   const { t } = useTranslation()
   const cookiePersister = new CookiePersister(LOCALE_COOKIE_KEY)
+  const apolloClient = useApolloClient()
 
   const countryList = Object.keys(countries).map((country) => ({
     name: t(`COUNTRY_LABEL_${country}`, { defaultValue: country }),
@@ -90,8 +94,17 @@ export const FooterBlock = ({ blok }: FooterBlockProps) => {
 
   const router = useRouter()
   const onChangeLocale = (locale: IsoLocale) => {
-    cookiePersister.save(toRoutingLocale(locale), undefined, { maxAge: LOCALE_COOKIE_MAX_AGE })
-    router.push(router.asPath, undefined, { locale: toRoutingLocale(locale) })
+    const nextLocale = toRoutingLocale(locale)
+    cookiePersister.save(nextLocale, undefined, { maxAge: LOCALE_COOKIE_MAX_AGE })
+    const nextCountry = getCountryByLocale(nextLocale)
+    if (nextCountry === currentCountry) {
+      router.push(router.asPath, undefined, { locale: nextLocale })
+    } else {
+      // Country change should be full app reload to maintain our programming assumptions
+      // We may clean any previous shop session while we're at it
+      setupShopSessionServiceClientSide(apolloClient).reset()
+      window.location.href = addLocale(router.asPath, nextLocale)
+    }
   }
   const handleSubmit = (event: ChangeEvent<HTMLFormElement>) => {
     event.preventDefault()

--- a/apps/store/src/components/CountrySelectorPage/CountrySelectorPage.tsx
+++ b/apps/store/src/components/CountrySelectorPage/CountrySelectorPage.tsx
@@ -1,15 +1,13 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import Link from 'next/link'
 import { Space, Heading, Button } from 'ui'
 import { CookiePersister } from '@/services/persister/CookiePersister'
-import { StoryblokPageProps } from '@/services/storyblok/storyblok'
 import { countries } from '@/utils/l10n/countries'
 import { LOCALE_COOKIE_MAX_AGE, LOCALE_COOKIE_KEY } from '@/utils/l10n/locales'
 import { toRoutingLocale } from '@/utils/l10n/localeUtils'
 import { IsoLocale } from '@/utils/l10n/types'
 
-export const CountrySelectorPage = (props: StoryblokPageProps) => {
+export const CountrySelectorPage = (props: { className?: string }) => {
   const { t } = useTranslation()
   const cookiePersister = new CookiePersister(LOCALE_COOKIE_KEY)
 
@@ -25,16 +23,13 @@ export const CountrySelectorPage = (props: StoryblokPageProps) => {
           </Heading>
           <Space y={0.5}>
             {Object.entries(countries).map(([country, countryData]) => (
-              <Link
+              <Button
                 key={country}
                 href={`/${toRoutingLocale(countryData.defaultLocale)}`}
-                passHref
-                legacyBehavior
+                onClick={() => onHandleClick(countryData.defaultLocale)}
               >
-                <Button onClick={() => onHandleClick(countryData.defaultLocale)}>
-                  {t(`COUNTRY_LABEL_${country}`, { defaultValue: `MISSING ${country}` })}
-                </Button>
-              </Link>
+                {t(`COUNTRY_LABEL_${country}`, { defaultValue: `MISSING ${country}` })}
+              </Button>
             ))}
           </Space>
         </Space>

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -23,6 +23,7 @@ import { contentFontClassName } from '@/utils/fonts'
 import { getCountryByLocale } from '@/utils/l10n/countryUtils'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
 import { useDebugTranslationKeys } from '@/utils/l10n/useDebugTranslationKeys'
+import { useReloadOnCountryChange } from '@/utils/useReloadOnCountryChange'
 
 // Enable API mocking
 if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
@@ -56,6 +57,8 @@ if (typeof window !== 'undefined') {
 const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
   useRemoveExperimentQueryParam()
   useDebugTranslationKeys()
+  useReloadOnCountryChange()
+
   const apolloClient = useApollo(pageProps)
   const getLayout = Component.getLayout || ((page) => page)
 

--- a/apps/store/src/pages/country-selector.tsx
+++ b/apps/store/src/pages/country-selector.tsx
@@ -1,8 +1,6 @@
-import type { GetServerSideProps, NextPageWithLayout } from 'next'
+import type { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { CountrySelectorPage } from '@/components/CountrySelectorPage/CountrySelectorPage'
-import { getGlobalStory, StoryblokPageProps } from '@/services/storyblok/storyblok'
-import { GLOBAL_STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
 import { FALLBACK_LOCALE } from '@/utils/l10n/locales'
 import { isRoutingLocale, toRoutingLocale } from '@/utils/l10n/localeUtils'
 import { RoutingLocale } from '@/utils/l10n/types'
@@ -12,21 +10,17 @@ export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   if (isRoutingLocale(locale)) routingLocale = locale
   else routingLocale = toRoutingLocale(FALLBACK_LOCALE)
 
-  const [globalStory, translations] = await Promise.all([
-    getGlobalStory({ locale: routingLocale }),
-    serverSideTranslations(routingLocale),
-  ])
+  const translations = await serverSideTranslations(routingLocale)
 
   return {
     props: {
       ...translations,
-      [GLOBAL_STORY_PROP_NAME]: globalStory,
     },
   }
 }
 
-const NextCountrySelectorPage: NextPageWithLayout<StoryblokPageProps> = (props) => {
-  return <CountrySelectorPage {...props} />
+const NextCountrySelectorPage = (props: { className?: string }) => {
+  return <CountrySelectorPage className={props?.className} />
 }
 
 export default NextCountrySelectorPage

--- a/apps/store/src/utils/l10n/localeUtils.ts
+++ b/apps/store/src/utils/l10n/localeUtils.ts
@@ -1,6 +1,13 @@
 import { TFunction } from 'next-i18next'
 import { FALLBACK_LOCALE, LocaleData, locales } from '@/utils/l10n/locales'
-import { CountryCode, IsoLocale, Language, RoutingLocale, UiLocale } from '@/utils/l10n/types'
+import {
+  CountryCode,
+  CountryLabel,
+  IsoLocale,
+  Language,
+  RoutingLocale,
+  UiLocale,
+} from '@/utils/l10n/types'
 
 const routingToIsoLocales = {} as { [key in RoutingLocale]: IsoLocale }
 const isoToRoutingLocales = {} as { [key in IsoLocale]: RoutingLocale }
@@ -46,7 +53,7 @@ export const getUrlLocale = (url: string): RoutingLocale => {
   return getLocaleOrFallback(routingLocale).routingLocale
 }
 
-export const translateCountryName = (countryCode: CountryCode, t: TFunction) => {
+export const translateCountryName = (countryCode: CountryCode | CountryLabel, t: TFunction) => {
   switch (countryCode) {
     case CountryCode.Dk:
       return t('COUNTRY_LABEL_DK')

--- a/apps/store/src/utils/l10n/localeUtils.ts
+++ b/apps/store/src/utils/l10n/localeUtils.ts
@@ -41,6 +41,11 @@ export const getLocaleOrFallback = (locale: UiLocale | string | undefined): Loca
   return locales[toIsoLocale(locale)]
 }
 
+export const getUrlLocale = (url: string): RoutingLocale => {
+  const routingLocale = url.split('/')[0]
+  return getLocaleOrFallback(routingLocale).routingLocale
+}
+
 export const translateCountryName = (countryCode: CountryCode, t: TFunction) => {
   switch (countryCode) {
     case CountryCode.Dk:

--- a/apps/store/src/utils/useReloadOnCountryChange.ts
+++ b/apps/store/src/utils/useReloadOnCountryChange.ts
@@ -1,0 +1,16 @@
+import { datadogLogs } from '@datadog/browser-logs'
+import { useEffect, useRef } from 'react'
+import { useCurrentCountry } from '@/utils/l10n/useCurrentCountry'
+
+export const useReloadOnCountryChange = () => {
+  const { countryCode } = useCurrentCountry()
+  const countryRef = useRef(countryCode)
+  useEffect(() => {
+    if (countryCode !== countryRef.current) {
+      datadogLogs.logger.warn(
+        `Country changed without page reload, this is probably an error ${countryRef.current} -> ${countryCode}`,
+      )
+      window.location.reload()
+    }
+  }, [countryCode])
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add hook to ensure we reload a page if country changes during client side navigation

Make country selector controls and page use full reload when changing country

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Ensure our assumptions about never changing country during client lifetime are satisfied, prevent bugs

This gives us simpler app model at expense of small increase in user wait time when country changes (should be rare)

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
