### PR TITLE
fix(PerilsBlock): renders heading only when it's provided

### DIFF
--- a/apps/store/src/blocks/PerilsBlock.tsx
+++ b/apps/store/src/blocks/PerilsBlock.tsx
@@ -8,7 +8,7 @@ import { useProductPageContext } from '@/components/ProductPage/ProductPageConte
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
 type PerilsBlockProps = SbBaseBlockProps<{
-  heading: string
+  heading?: string
 }>
 
 export const PerilsBlock = ({ blok }: PerilsBlockProps) => {
@@ -34,7 +34,7 @@ export const PerilsBlock = ({ blok }: PerilsBlockProps) => {
   return (
     <Wrapper {...storyblokEditable(blok)}>
       <Space y={1}>
-        <HeadingLabel>{blok.heading}</HeadingLabel>
+        {blok.heading && <HeadingLabel>{blok.heading}</HeadingLabel>}
         <Perils items={items} />
       </Space>
     </Wrapper>


### PR DESCRIPTION
## Describe your changes

* Renders `PerilsBlock` heading only it gets provided

## Justify why they are needed

`heading` is a optional field in _Storyblok_. By always rendering `PerilsBlock`'s heading we might end up with this "weird" design here only a "small blue pill" is displayed on top of the block.

![Screenshot 2023-01-10 at 10 08 50](https://user-images.githubusercontent.com/19200662/211509176-2ed34400-1104-4b0f-9782-9e66f2fc2b89.png)

---

![Screenshot 2023-01-10 at 10 13 55](https://user-images.githubusercontent.com/19200662/211510069-c5a2626a-0168-4f7f-a519-cc902ae116ee.png)




