### PR TITLE
GRW-2054 - feat: update ImageTextBlock

### DIFF
--- a/apps/store/src/blocks/ButtonBlock.tsx
+++ b/apps/store/src/blocks/ButtonBlock.tsx
@@ -10,6 +10,7 @@ export type ButtonBlockProps = SbBaseBlockProps<{
   text: string
   link: LinkField
   variant: ComponentProps<typeof Button>['variant']
+  size: ComponentProps<typeof Button>['size']
 }>
 
 export const ButtonBlock = ({ blok }: ButtonBlockProps) => {
@@ -17,8 +18,8 @@ export const ButtonBlock = ({ blok }: ButtonBlockProps) => {
     <Wrapper {...storyblokEditable(blok)}>
       <ButtonNextLink
         href={getLinkFieldURL(blok.link, blok.text)}
-        variant={blok.variant}
-        size="large"
+        variant={blok.variant ?? 'primary'}
+        size={blok.size ?? 'medium'}
       >
         {blok.text}
       </ButtonNextLink>

--- a/apps/store/src/blocks/ButtonBlock.tsx
+++ b/apps/store/src/blocks/ButtonBlock.tsx
@@ -27,7 +27,7 @@ export const ButtonBlock = ({ blok }: ButtonBlockProps) => {
 }
 ButtonBlock.blockName = 'button'
 
-const Wrapper = styled.div(({ theme }) => ({
+export const Wrapper = styled.div(({ theme }) => ({
   display: 'flex',
   justifyContent: 'center',
   paddingLeft: theme.space[4],

--- a/apps/store/src/blocks/HeadingBlock.tsx
+++ b/apps/store/src/blocks/HeadingBlock.tsx
@@ -3,7 +3,7 @@ import { storyblokEditable } from '@storyblok/react'
 import { Heading, HeadingProps } from 'ui'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
-const Wrapper = styled.div(({ theme }) => ({
+export const Wrapper = styled.div(({ theme }) => ({
   paddingLeft: theme.space[4],
   paddingRight: theme.space[4],
 }))

--- a/apps/store/src/blocks/ImageTextBlock.tsx
+++ b/apps/store/src/blocks/ImageTextBlock.tsx
@@ -1,54 +1,92 @@
 import styled from '@emotion/styled'
-import { StoryblokComponent, storyblokEditable } from '@storyblok/react'
+import { SbBlokData, StoryblokComponent, storyblokEditable } from '@storyblok/react'
 import { default as NextImage } from 'next/image'
 import { mq } from 'ui'
-import { ButtonBlockProps } from '@/blocks/ButtonBlock'
-import { HeadingBlockProps } from '@/blocks/HeadingBlock'
-import { getSizeFromURL } from '@/blocks/ImageBlock'
-import { TextBlockProps } from '@/blocks/TextBlock'
-import { SbBaseBlockProps, ExpectedBlockType, StoryblokAsset } from '@/services/storyblok/storyblok'
+import { Wrapper as ButtonBlockWrapper } from '@/blocks/ButtonBlock'
+import { Wrapper as HeadingBlockWrapper } from '@/blocks/HeadingBlock'
+import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
+
+type Orientation = 'left' | 'right'
+
+type Alignment = 'top' | 'center' | 'bottom'
 
 type ImageTextBlockProps = SbBaseBlockProps<{
   image: StoryblokAsset
-  body?: ExpectedBlockType<HeadingBlockProps | TextBlockProps | ButtonBlockProps>
+  body?: SbBlokData[]
+  orientation?: Orientation
+  alignment?: Alignment
 }>
 
 export const ImageTextBlock = ({ blok }: ImageTextBlockProps) => {
-  const sizeProps = getSizeFromURL(blok.image.filename)
-
   return (
-    <Wrapper {...storyblokEditable(blok)}>
-      <Image src={blok.image.filename} {...sizeProps} alt={blok.image.alt} />
-      <BodyWrapper>
-        {blok.body?.map((nestedBlock) => (
-          <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} />
-        ))}
+    <Wrapper data-orientation={blok.orientation ?? 'left'} {...storyblokEditable(blok)}>
+      <ImageWrapper>
+        <Image src={blok.image.filename} alt={blok.image.alt} fill={true} />
+      </ImageWrapper>
+      <BodyWrapper data-alignment={blok.alignment ?? 'top'}>
+        <div>
+          {blok.body?.map((nestedBlock) => (
+            <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} />
+          ))}
+        </div>
       </BodyWrapper>
     </Wrapper>
   )
 }
 ImageTextBlock.blockName = 'imageText'
 
-const Wrapper = styled('div')(({ theme }) => ({
+const Wrapper = styled.div(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
   paddingInline: theme.space[2],
+  minHeight: '37.5rem',
+  [mq.md]: {
+    minHeight: 'revert',
+    "&[data-orientation='left']": {
+      flexDirection: 'row',
+    },
+    "&[data-orientation='right']": {
+      flexDirection: 'row-reverse',
+    },
+  },
   [mq.lg]: {
     paddingInline: theme.space[4],
   },
 }))
 
+const ImageWrapper = styled.div({
+  flex: 1,
+  position: 'relative',
+  aspectRatio: '1 / 1',
+})
+
 const Image = styled(NextImage)(({ theme }) => ({
-  borderRadius: theme.radius.md,
-  [mq.lg]: {
-    borderRadius: theme.radius.xl,
-  },
+  objectFit: 'cover',
+  borderRadius: theme.radius.lg,
 }))
 
 const BodyWrapper = styled.div(({ theme }) => ({
-  padding: theme.space[2],
-  [mq.lg]: {
-    padding: theme.space[4],
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  padding: `${theme.space[5]} ${theme.space[4]}`,
+  [mq.md]: {
+    padding: `${theme.space[4]} ${theme.space[6]}`,
+    "&[data-alignment='top']": {
+      justifyContent: 'flex-start',
+    },
+    "&[data-alignment='center']": {
+      justifyContent: 'center',
+    },
+    "&[data-alignment='bottom']": {
+      justifyContent: 'flex-end',
+    },
   },
-  '& > *': {
-    paddingInline: 0,
+  [`${HeadingBlockWrapper}`]: {
+    padding: 0,
+  },
+  [`${ButtonBlockWrapper}`]: {
+    display: 'inline-block',
+    padding: 0,
   },
 }))

--- a/apps/store/src/blocks/ImageTextBlock.tsx
+++ b/apps/store/src/blocks/ImageTextBlock.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { SbBlokData, StoryblokComponent, storyblokEditable } from '@storyblok/react'
 import { default as NextImage } from 'next/image'
-import { mq } from 'ui'
+import { mq, theme } from 'ui'
 import { Wrapper as ButtonBlockWrapper } from '@/blocks/ButtonBlock'
 import { Wrapper as HeadingBlockWrapper } from '@/blocks/HeadingBlock'
 import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
@@ -35,7 +35,7 @@ export const ImageTextBlock = ({ blok }: ImageTextBlockProps) => {
 }
 ImageTextBlock.blockName = 'imageText'
 
-const Wrapper = styled.div(({ theme }) => ({
+const Wrapper = styled.div({
   display: 'flex',
   flexDirection: 'column',
   paddingInline: theme.space[2],
@@ -52,7 +52,7 @@ const Wrapper = styled.div(({ theme }) => ({
   [mq.lg]: {
     paddingInline: theme.space[4],
   },
-}))
+})
 
 const ImageWrapper = styled.div({
   flex: 1,
@@ -60,12 +60,12 @@ const ImageWrapper = styled.div({
   aspectRatio: '1 / 1',
 })
 
-const Image = styled(NextImage)(({ theme }) => ({
+const Image = styled(NextImage)({
   objectFit: 'cover',
   borderRadius: theme.radius.lg,
-}))
+})
 
-const BodyWrapper = styled.div(({ theme }) => ({
+const BodyWrapper = styled.div({
   flex: 1,
   display: 'flex',
   flexDirection: 'column',
@@ -89,4 +89,4 @@ const BodyWrapper = styled.div(({ theme }) => ({
     display: 'inline-block',
     padding: 0,
   },
-}))
+})

--- a/apps/store/src/blocks/TextBlock.tsx
+++ b/apps/store/src/blocks/TextBlock.tsx
@@ -1,14 +1,26 @@
+import styled from '@emotion/styled'
 import { ISbRichtext, renderRichText, storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
-import { Space } from 'ui'
+import { Space, UIColors, getColor } from 'ui'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
-export type TextBlockProps = SbBaseBlockProps<{ body: ISbRichtext }>
+type TextColor = keyof Pick<UIColors, 'textPrimary' | 'textSecondary' | 'textTertiary'>
+
+export type TextBlockProps = SbBaseBlockProps<{ body: ISbRichtext; color?: TextColor }>
 
 export const TextBlock = ({ blok }: TextBlockProps) => {
   const contentHtml = useMemo(() => renderRichText(blok.body), [blok.body])
   return (
-    <Space {...storyblokEditable(blok)} y={1} dangerouslySetInnerHTML={{ __html: contentHtml }} />
+    <Text
+      {...storyblokEditable(blok)}
+      color={blok.color ?? 'textPrimary'}
+      y={1}
+      dangerouslySetInnerHTML={{ __html: contentHtml }}
+    />
   )
 }
 TextBlock.blockName = 'text'
+
+const Text = styled(Space)<{ color: TextColor }>(({ color }) => ({
+  color: getColor(color),
+}))

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -51,7 +51,7 @@ export type SbBaseBlockProps<T> = {
   blok: SbBlokData & T
 }
 
-export type ExpectedBlockType<T> = T extends { blok: SbBlokData }
+export type ExpectedBlockType<T> = [T] extends [{ blok: SbBlokData }]
   ? T['blok'][]
   : `ExpectedBlock expects an argument which extends SbBlockData.
      These are likely the props of the block you are looking to render`


### PR DESCRIPTION
## Describe your changes

Update `ImageTextBlock` to match the designs.

Can be tested on `en-se/insurances/car-insurance` storyblok page (overview tab)

## Jira issue(s): [GRW-2054](https://hedvig.atlassian.net/browse/GRW-2054)

---

<img width="376" alt="Screenshot 2023-01-11 at 11 23 02" src="https://user-images.githubusercontent.com/19200662/211787084-e1e51088-9c6d-4672-9232-cbe66cca3a66.png">
<img width="1904" alt="Screenshot 2023-01-11 at 11 22 35" src="https://user-images.githubusercontent.com/19200662/211787088-25622911-d72b-45e9-b33e-545a4385aef3.png">

 

[GRW-2054]: https://hedvig.atlassian.net/browse/GRW-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ