### PR TITLE
GRW-2054 - feat(ButtonBlock): enable size configuration

### DIFF
--- a/apps/store/src/blocks/ButtonBlock.tsx
+++ b/apps/store/src/blocks/ButtonBlock.tsx
@@ -10,6 +10,7 @@ export type ButtonBlockProps = SbBaseBlockProps<{
   text: string
   link: LinkField
   variant: ComponentProps<typeof Button>['variant']
+  size: ComponentProps<typeof Button>['size']
 }>
 
 export const ButtonBlock = ({ blok }: ButtonBlockProps) => {
@@ -17,8 +18,8 @@ export const ButtonBlock = ({ blok }: ButtonBlockProps) => {
     <Wrapper {...storyblokEditable(blok)}>
       <ButtonNextLink
         href={getLinkFieldURL(blok.link, blok.text)}
-        variant={blok.variant}
-        size="large"
+        variant={blok.variant ?? 'primary'}
+        size={blok.size ?? 'medium'}
       >
         {blok.text}
       </ButtonNextLink>


### PR DESCRIPTION
## Describe your changes

* Updated `ButtonBlock` so we can take in `size` from Storyblok

## Justify why they are needed

So we can support some of the design requirements, like the one for `ImageTextBock`

<img width="855" alt="Screenshot 2023-01-12 at 09 31 09" src="https://user-images.githubusercontent.com/19200662/212017004-7b06fa85-802b-40f9-b0ec-fada859673f8.png">


## Jira issue(s): [GRW-2054](https://hedvig.atlassian.net/browse/GRW-2054)

[GRW-2054]: https://hedvig.atlassian.net/browse/GRW-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ