### PR TITLE
Implement login endpoint for Swedish BankID method

### DIFF
--- a/apps/store/src/pages/api/auth/login/se.ts
+++ b/apps/store/src/pages/api/auth/login/se.ts
@@ -1,0 +1,26 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import * as Auth from '@/services/Auth/Auth'
+import { memberLoginSE } from '@/utils/auth'
+import { ORIGIN_URL, PageLink } from '@/utils/PageLink'
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  console.info('Logging in with BankID')
+
+  const ssn = req.body.ssn
+  if (typeof ssn !== 'string') throw new Error('No ssn provided')
+
+  const accessToken = await memberLoginSE(ssn)
+  console.debug('Login successful')
+
+  Auth.save(accessToken, { req, res })
+
+  const nextQueryParam = req.query['next']
+  const url = typeof nextQueryParam === 'string' ? nextQueryParam : PageLink.home({ locale: 'se' })
+  const nextURL = new URL(url, ORIGIN_URL)
+
+  const destination = nextURL.toString()
+  console.debug(`Re-directing to destination: ${destination}`)
+  return res.redirect(destination)
+}
+
+export default handler

--- a/apps/store/src/services/Auth/Auth.ts
+++ b/apps/store/src/services/Auth/Auth.ts
@@ -1,5 +1,6 @@
 import { getCookie, setCookie, deleteCookie } from 'cookies-next'
 import { OptionsType } from 'cookies-next/lib/types'
+import { PageLink } from '@/utils/PageLink'
 
 const COOKIE_KEY = '_hvsession'
 const ACCESS_TOKEN_SESSION_FIELD = 'token'
@@ -13,8 +14,8 @@ const OPTIONS: OptionsType = {
   }),
 }
 
-export const save = (accessToken: string) => {
-  setCookie(COOKIE_KEY, serialize(accessToken), OPTIONS)
+export const save = (accessToken: string, { req, res }: CookieParams = {}) => {
+  setCookie(COOKIE_KEY, serialize(accessToken), { req, res, ...OPTIONS })
 }
 
 export type CookieParams = Pick<OptionsType, 'req' | 'res'>
@@ -47,5 +48,19 @@ const deserialize = (value: string) => {
   } catch (error) {
     console.warn('Unable to deserialize session')
     return undefined
+  }
+}
+
+type LoginSEOptions = Partial<{ nextUrl: string }>
+
+export const loginSE = async (ssn: string, { nextUrl }: LoginSEOptions = {}) => {
+  const response = await fetch(PageLink.apiLoginSe(), {
+    method: 'POST',
+    body: JSON.stringify({ ssn, nextUrl }),
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+  if (!response.ok) {
+    throw new Error('Unable to login')
   }
 }

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -37,4 +37,6 @@ export const PageLink = {
 
   apiPaymentAdyenCallback: ({ locale, shopSessionId }: AdyenCallbackRoute) =>
     `/api/payment/adyen-callback/${shopSessionId}/${locale}`,
+
+  apiLoginSe: () => `/api/auth/login/se`,
 } as const

--- a/apps/store/src/utils/auth.ts
+++ b/apps/store/src/utils/auth.ts
@@ -1,30 +1,114 @@
 import { CookieParams, getAuthHeader } from '@/services/Auth/Auth'
 
+enum MemberLoginMethod {
+  SE_BANKID = 'SE_BANKID',
+}
+
+const BASE_URL = process.env.NEXT_PUBLIC_AUTH_ENDPOINT
+const Endpoint = {
+  TOKEN: `${BASE_URL}/oauth/token`,
+  MEMBER_AUTH_CODES: `${BASE_URL}/member-authorization-codes`,
+  MEMBER_LOGIN: `${BASE_URL}/member-login`,
+  LOGIN_STATUS: (statusUrl: string) => `${BASE_URL}${statusUrl}`,
+} as const
+
+type TokenResponse = { access_token?: string }
+
 export const exchangeAuthorizationCode = async (authorizationCode: string): Promise<string> => {
-  const url = `${process.env.NEXT_PUBLIC_AUTH_ENDPOINT}/oauth/token`
-  const data = await fetchJson<{ access_token: string }>(url, {
+  const { access_token: accessToken } = await fetchJson<TokenResponse>(Endpoint.TOKEN, {
     method: 'POST',
     body: JSON.stringify({
       grant_type: 'authorization_code',
       authorization_code: authorizationCode,
     }),
   })
-  const accessToken = data.access_token
   if (!accessToken) {
     throw new Error('No access_token field in response')
   }
   return accessToken
 }
 
+type MemberAuthCodeResponse = { authorizationCode: string }
+
 export const createAuthorizationCode = async (params?: CookieParams) => {
-  const url = `${process.env.NEXT_PUBLIC_AUTH_ENDPOINT}/member-authorization-codes`
-  const data = await fetchJson<{ authorizationCode: string }>(url, {
+  const data = await fetchJson<MemberAuthCodeResponse>(Endpoint.MEMBER_AUTH_CODES, {
     method: 'POST',
-    headers: {
-      ...getAuthHeader(params),
-    },
+    headers: getAuthHeader(params),
   })
   return data.authorizationCode
+}
+
+type MemberLoginResponseSuccess = {
+  result: 'success'
+  id: string
+  method: MemberLoginMethod
+  statusUrl: string
+
+  seBankIdProperties: {
+    orderRef: string
+    autoStartToken: string
+  }
+}
+
+type MemberLoginResponseError = {
+  result: 'error'
+  reason: string
+}
+
+type MemberLoginResponse = MemberLoginResponseSuccess | MemberLoginResponseError
+
+const memberLoginCreateSE = async (personalNumber: string) => {
+  const data = await fetchJson<MemberLoginResponse>(Endpoint.MEMBER_LOGIN, {
+    method: 'POST',
+    body: JSON.stringify({
+      method: MemberLoginMethod.SE_BANKID,
+      personalNumber,
+    }),
+  })
+
+  if (data.result === 'error') {
+    throw new Error('Failed to login: ' + data.reason)
+  }
+
+  return data
+}
+
+type MemberLoginStatusResponse =
+  | {
+      status: 'PENDING' | 'FAILED'
+      statusText: string
+    }
+  | {
+      status: 'COMPLETED'
+      authorizationCode: string
+    }
+
+const memberLoginStatus = async (statusUrl: string) => {
+  return await fetchJson<MemberLoginStatusResponse>(statusUrl)
+}
+
+const memberLoginStatusPoll = async (statusUrl: string): Promise<string> => {
+  const result = await memberLoginStatus(statusUrl)
+
+  if (result.status === 'COMPLETED') {
+    return result.authorizationCode
+  }
+
+  if (result.status === 'FAILED') {
+    throw new Error('Login failed: ' + result.statusText)
+  }
+
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(memberLoginStatusPoll(statusUrl))
+    }, 1000)
+  })
+}
+
+export const memberLoginSE = async (ssn: string) => {
+  const { statusUrl } = await memberLoginCreateSE(ssn)
+  const authorizationCode = await memberLoginStatusPoll(Endpoint.LOGIN_STATUS(statusUrl))
+  return await exchangeAuthorizationCode(authorizationCode)
 }
 
 const fetchJson = async <T extends object>(


### PR DESCRIPTION
## Describe your changes

Integrate the auth service to be able to use the "member login" endpoint.

Add a new API route to make the request to auth service.

This new API route accepts an SSN + optional "next" parameter to redirect the user after successful login. It also sets the auth session cookie.

## Justify why they are needed

This will be useful in the future but more so if we want to handle existing members in the checkout. The idea is to make them login before going through the checkout.

I added an API route beacuse CORS blocks us from calling auth service directly from client.

We don't know what the UX will look like so this PR doesn't contain any UI stuff.

I want to co-locate all auth stuff in the same "service" module -- will do in separate PR.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
