### PR TITLE
Only initialize Storyblok bridge when inside iframe

### DIFF
--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -187,6 +187,9 @@ export const initStoryblok = () => {
     ...blockAliases,
   }
 
+  // https://github.com/storyblok/storyblok-react/issues/156#issuecomment-1197764828
+  const shouldUseBridge =
+    typeof window !== 'undefined' ? window.location !== window.parent.location : false
   storyblokInit({
     accessToken: process.env.NEXT_PUBLIC_STORYBLOK_ACCESS_TOKEN,
     apiOptions: {
@@ -197,6 +200,7 @@ export const initStoryblok = () => {
       },
     },
     use: [apiPlugin],
+    bridge: shouldUseBridge,
     components,
   })
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Prevent "You are not in Draft Mode or in the Visual Editor" warning by only enabling Storyblok bridge in iframe

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

One step closer to zero warnings

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
