### PR TITLE
Integrate product recommendations on Cart page

### DIFF
--- a/apps/store/public/locales/en/cart.json
+++ b/apps/store/public/locales/en/cart.json
@@ -27,6 +27,7 @@
   "DISCOUNT_STATE_INDEFINITE_PERCENTAGE": "{{percentage}}% discount",
   "DISCOUNT_STATE_MONTHLY_PERCENTAGE": "{{percentage}}% discount for {{count}} mth.",
   "GO_TO_STORE_BUTTON": "Go to Store",
+  "RECOMMENDATIONS_HEADING": "Others also bought",
   "REMOVE_ENTRY_BUTTON": "Remove",
   "REMOVE_ENTRY_MODAL_CANCEL_BUTTON": "Cancel",
   "REMOVE_ENTRY_MODAL_CONFIRM_BUTTON": "Yes, remove",

--- a/apps/store/public/locales/sv-se/cart.json
+++ b/apps/store/public/locales/sv-se/cart.json
@@ -26,6 +26,7 @@
   "DISCOUNT_STATE_FREE_MONTHS": "Gratis i {{count}} mån",
   "DISCOUNT_STATE_INDEFINITE_PERCENTAGE": "{{percentage}}% rabatt",
   "DISCOUNT_STATE_MONTHLY_PERCENTAGE": "{{percentage}}% rabatt i {{count}} mån",
+  "RECOMMENDATIONS_HEADING": "Andra har köpt",
   "REMOVE_ENTRY_BUTTON": "Ta bort",
   "REMOVE_ENTRY_MODAL_CANCEL_BUTTON": "Avbryt",
   "REMOVE_ENTRY_MODAL_CONFIRM_BUTTON": "Ja, ta bort",

--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import Link from 'next/link'
 import { ReactNode, useEffect } from 'react'
-import { Heading, mq, Space, Text } from 'ui'
+import { Heading, mq, Space, Text, theme } from 'ui'
 import { CampaignCodeList } from '@/components/CartInventory/CampaignCodeList'
 import { CartEntryItem } from '@/components/CartInventory/CartEntryItem'
 import { CartEntryList } from '@/components/CartInventory/CartEntryList'
@@ -13,9 +13,10 @@ import { useTracking } from '@/services/Tracking/useTracking'
 import { PageLink } from '@/utils/PageLink'
 import { ButtonNextLink } from '../ButtonNextLink'
 import { CartPageProps } from './CartPageProps.types'
+import { RecommendationList } from './RecommendationList'
 
 export const CartPage = (props: CartPageProps) => {
-  const { cartId, entries, campaigns, cost, prevURL } = props
+  const { cartId, entries, campaigns, cost, recommendations, prevURL } = props
   const { onReady } = useShopSession()
   const { t } = useTranslation('cart')
 
@@ -33,35 +34,42 @@ export const CartPage = (props: CartPageProps) => {
     [onReady, tracking],
   )
 
-  if (entries.length === 0) {
-    return (
-      <EmptyState prevURL={prevURL}>
-        <Space y={1.5}>
-          <HorizontalLine />
-          <CampaignCodeList cartId={cartId} campaigns={campaigns} />
-          <HorizontalLine />
-          <CostSummary {...cost} campaigns={campaigns} />
-        </Space>
-      </EmptyState>
-    )
-  }
-
-  return (
-    <Wrapper y={{ base: 1, lg: 4 }}>
-      <Header prevURL={prevURL} />
+  let body = (
+    <EmptyState prevURL={prevURL}>
       <Space y={1.5}>
-        <CartEntryList>
-          {entries.map((item) => (
-            <CartEntryItem key={item.offerId} cartId={cartId} {...item} />
-          ))}
-        </CartEntryList>
         <HorizontalLine />
         <CampaignCodeList cartId={cartId} campaigns={campaigns} />
         <HorizontalLine />
         <CostSummary {...cost} campaigns={campaigns} />
-        <ButtonNextLink href={PageLink.checkout()}>{t('CHECKOUT_BUTTON')}</ButtonNextLink>
       </Space>
-    </Wrapper>
+    </EmptyState>
+  )
+
+  if (entries.length > 0) {
+    body = (
+      <Wrapper y={{ base: 1, lg: 4 }}>
+        <Header prevURL={prevURL} />
+        <Space y={1.5}>
+          <CartEntryList>
+            {entries.map((item) => (
+              <CartEntryItem key={item.offerId} cartId={cartId} {...item} />
+            ))}
+          </CartEntryList>
+          <HorizontalLine />
+          <CampaignCodeList cartId={cartId} campaigns={campaigns} />
+          <HorizontalLine />
+          <CostSummary {...cost} campaigns={campaigns} />
+          <ButtonNextLink href={PageLink.checkout()}>{t('CHECKOUT_BUTTON')}</ButtonNextLink>
+        </Space>
+      </Wrapper>
+    )
+  }
+
+  return (
+    <Space y={2}>
+      {body}
+      <RecommendationList recommendations={recommendations} />
+    </Space>
   )
 }
 
@@ -88,19 +96,18 @@ const EmptyState = ({ children, prevURL }: EmptyStateProps) => {
   )
 }
 
-const HorizontalLine = styled.hr(({ theme }) => ({
+const HorizontalLine = styled.hr({
   backgroundColor: theme.colors.gray300,
   height: 1,
-}))
+})
 
-const Wrapper = styled(Space)(({ theme }) => ({
-  paddingBottom: theme.space.xl,
+const Wrapper = styled(Space)({
   maxWidth: '40rem',
   marginLeft: 'auto',
   marginRight: 'auto',
   paddingLeft: theme.space.md,
   paddingRight: theme.space.md,
-}))
+})
 
 // Header
 
@@ -119,8 +126,9 @@ const Header = ({ prevURL }: HeaderProps) => {
   )
 }
 
-const HeaderLink = styled(Link)(({ theme }) => ({
+const HeaderLink = styled(Link)({
   backgroundColor: theme.colors.light,
+
   ':focus-visible': {
     borderRadius: theme.radius.xs,
     boxShadow: `${theme.colors.light} 0 0 0 3px, ${theme.colors.textPrimary} 0 0 0 4px`,
@@ -131,14 +139,14 @@ const HeaderLink = styled(Link)(({ theme }) => ({
     top: theme.space.md,
     right: theme.space.md,
   },
-}))
+})
 
-const HeaderHeading = styled(Heading)(({ theme }) => ({
+const HeaderHeading = styled(Heading)({
   [mq.lg]: {
     textAlign: 'center',
     fontSize: theme.fontSizes[8],
   },
-}))
+})
 
 const StyledHeader = styled(Space)({
   height: '3.5rem',

--- a/apps/store/src/components/CartPage/CartPageProps.types.ts
+++ b/apps/store/src/components/CartPage/CartPageProps.types.ts
@@ -1,4 +1,5 @@
 import { CartCost, CartCampaign, CartEntry } from '@/components/CartInventory/CartInventory.types'
+import { ProductRecommendationFragment } from '@/services/apollo/generated'
 
 export type CartPageProps = {
   // FIXME: Remove
@@ -7,5 +8,6 @@ export type CartPageProps = {
   cost: CartCost
   campaigns: Array<CartCampaign>
   entries: Array<CartEntry>
+  recommendations: Array<ProductRecommendationFragment>
   prevURL: string
 }

--- a/apps/store/src/components/CartPage/RecommendationList.tsx
+++ b/apps/store/src/components/CartPage/RecommendationList.tsx
@@ -1,0 +1,103 @@
+import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
+import Image from 'next/image'
+import Link from 'next/link'
+import { Heading, mq, Space, Text, theme } from 'ui'
+import { ProductRecommendationFragment } from '@/services/apollo/generated'
+
+type Props = {
+  recommendations: Array<ProductRecommendationFragment>
+}
+
+export const RecommendationList = ({ recommendations }: Props) => {
+  const { t } = useTranslation('cart')
+
+  return (
+    <Wrapper y={1.5}>
+      <MobileHeader>
+        <Heading as="h2" variant="standard.24">
+          {t('RECOMMENDATIONS_HEADING')}
+        </Heading>
+      </MobileHeader>
+      <DesktopHeader>
+        <Heading as="h2" variant="standard.32">
+          {t('RECOMMENDATIONS_HEADING')}
+        </Heading>
+      </DesktopHeader>
+
+      <List>
+        {recommendations.map((recommendation) => (
+          <Link key={recommendation.id} href={recommendation.pageLink}>
+            <Space y={0.5}>
+              <StyledImage
+                // TODO: Use the correct image
+                src="https://a.storyblok.com/f/165473/330x396/573a75c77d/home-low.png"
+                alt=""
+                width={330}
+                height={396}
+              />
+              <ListItemContent>
+                <Heading as="h3" variant="standard.18">
+                  {recommendation.displayNameShort}
+                </Heading>
+                <Text size="lg" color="textSecondary">
+                  {recommendation.displayNameFull}
+                </Text>
+              </ListItemContent>
+            </Space>
+          </Link>
+        ))}
+      </List>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled(Space)({
+  paddingInline: theme.space.xs,
+  paddingBottom: theme.space.xl,
+
+  maxWidth: '40rem',
+  marginInline: 'auto',
+
+  [mq.lg]: {
+    maxWidth: '100%',
+  },
+})
+
+const MobileHeader = styled.div({
+  paddingInline: theme.space.xs,
+
+  [mq.lg]: {
+    display: 'none',
+  },
+})
+
+const DesktopHeader = styled.div({
+  display: 'none',
+
+  [mq.lg]: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+})
+
+const List = styled.div({
+  display: 'grid',
+  gridGap: theme.space.md,
+
+  [mq.sm]: {
+    gridTemplateColumns: 'repeat(auto-fit, 19rem)',
+  },
+
+  [mq.lg]: {
+    justifyContent: 'center',
+  },
+})
+
+const ListItemContent = styled.div({
+  paddingInline: theme.space.xs,
+
+  [mq.lg]: { paddingInline: 0 },
+})
+
+const StyledImage = styled(Image)({ width: '100%' })

--- a/apps/store/src/graphql/ProductRecommendationFragment.graphql
+++ b/apps/store/src/graphql/ProductRecommendationFragment.graphql
@@ -1,0 +1,6 @@
+fragment ProductRecommendation on Product {
+  id
+  displayNameFull
+  displayNameShort
+  pageLink
+}

--- a/apps/store/src/graphql/ShopSessionFragment.graphql
+++ b/apps/store/src/graphql/ShopSessionFragment.graphql
@@ -11,4 +11,9 @@ fragment ShopSession on ShopSession {
   cart {
     ...CartFragment
   }
+  recommendations {
+    product {
+      ...ProductRecommendation
+    }
+  }
 }

--- a/apps/store/src/pages/cart.tsx
+++ b/apps/store/src/pages/cart.tsx
@@ -55,12 +55,15 @@ const NextCartPage: NextPageWithLayout<Props> = (props) => {
     crossOut: getCrossOut(shopSession),
   }
 
+  const productRecommendations = shopSession.recommendations.map((item) => item.product)
+
   return (
     <CartPage
       cartId={shopSession.cart.id}
       entries={entries}
       campaigns={campaigns}
       cost={{ ...cost }}
+      recommendations={productRecommendations}
       {...props}
     />
   )


### PR DESCRIPTION
## Describe your changes

Integrate list of product recommendations on Cart page.

Add recommendations when fetching `ShopSession`.

Refactor Cart page to not use dynamic theme.

![Screenshot 2023-01-18 at 13.20.15.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/fd1cddbe-ff2f-4ee1-9392-8ea4aea69acd/Screenshot%202023-01-18%20at%2013.20.15.png)

![Screenshot 2023-01-18 at 13.19.56.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/9980df20-ae71-43db-b6e0-307e59c27d33/Screenshot%202023-01-18%20at%2013.19.56.png)

## Justify why they are needed

We should probably consider only fetching recommendations on the Cart page and not with every shop session request but don't want to optimize too early.

The API is not 100% working so that's why I didn't include photos.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
