### PR TITLE
GRW-2095 - fix(AccordionBlock): desktop layout

### DIFF
--- a/apps/store/src/blocks/AccordionBlock.tsx
+++ b/apps/store/src/blocks/AccordionBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
-import { Heading, Text, theme } from 'ui'
+import { Heading, Text, theme, mq } from 'ui'
 import { AccordionItemBlock, AccordionItemBlockProps } from '@/blocks/AccordionItemBlock'
 import * as Accordion from '@/components/Accordion/Accordion'
 import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
@@ -18,12 +18,12 @@ export const AccordionBlock = ({ blok }: Props) => {
     <Wrapper {...storyblokEditable(blok)}>
       <TitleDescriptionWrapper>
         {blok.title && (
-          <Heading as="h2" variant={{ _: 'standard.20', md: 'standard.24' }}>
+          <Heading as="h2" variant={{ _: 'standard.24', md: 'standard.32' }}>
             {blok.title}
           </Heading>
         )}
         {blok.description && (
-          <Text color="textSecondary" size={{ _: 'lg', md: 'xl' }}>
+          <Text color="textSecondary" size={{ _: 'xl', md: 'xxl' }}>
             {blok.description}
           </Text>
         )}
@@ -49,10 +49,13 @@ const Wrapper = styled.div({
 
 const TitleDescriptionWrapper = styled.div({
   flex: 1,
-  minWidth: '23.75rem',
+  minWidth: 'min(23.75rem, 100%)',
 })
 
 const StyledAccordion = styled(Accordion.Root)({
   flex: 1,
-  minWidth: '28.125rem',
+  minWidth: 'min(28.125rem, 100%)',
+  [mq.md]: {
+    gap: theme.space.xs,
+  },
 })

--- a/apps/store/src/blocks/AccordionBlock.tsx
+++ b/apps/store/src/blocks/AccordionBlock.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
-import { Heading, Space } from 'ui'
+import { storyblokEditable } from '@storyblok/react'
+import { Heading, Text, theme } from 'ui'
 import { AccordionItemBlock, AccordionItemBlockProps } from '@/blocks/AccordionItemBlock'
 import * as Accordion from '@/components/Accordion/Accordion'
 import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
@@ -7,34 +8,51 @@ import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 
 type Props = SbBaseBlockProps<{
   title?: string
+  description?: string
   items: ExpectedBlockType<AccordionItemBlockProps>
 }>
 
 export const AccordionBlock = ({ blok }: Props) => {
   const accordionItems = filterByBlockType(blok.items, AccordionItemBlock.blockName)
   return (
-    <Wrapper>
-      <Space y={1}>
+    <Wrapper {...storyblokEditable(blok)}>
+      <TitleDescriptionWrapper>
         {blok.title && (
-          <StyledHeading as="h2" variant="standard.20">
+          <Heading as="h2" variant={{ _: 'standard.20', md: 'standard.24' }}>
             {blok.title}
-          </StyledHeading>
+          </Heading>
         )}
-        <Accordion.Root type="multiple">
-          {accordionItems.map((nestedBlock) => (
-            <AccordionItemBlock key={nestedBlock._uid} blok={nestedBlock} />
-          ))}
-        </Accordion.Root>
-      </Space>
+        {blok.description && (
+          <Text color="textSecondary" size={{ _: 'lg', md: 'xl' }}>
+            {blok.description}
+          </Text>
+        )}
+      </TitleDescriptionWrapper>
+      <StyledAccordion type="multiple">
+        {accordionItems.map((nestedBlock) => (
+          <AccordionItemBlock key={nestedBlock._uid} blok={nestedBlock} />
+        ))}
+      </StyledAccordion>
     </Wrapper>
   )
 }
 AccordionBlock.blockName = 'accordion'
 
-const Wrapper = styled.div(({ theme }) => ({
-  padding: theme.space[4],
-}))
+const Wrapper = styled.div({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: theme.space.lg,
+  paddingInline: theme.space.md,
+  marginInline: 'auto',
+  maxWidth: '90rem',
+})
 
-const StyledHeading = styled(Heading)({
-  textAlign: 'center',
+const TitleDescriptionWrapper = styled.div({
+  flex: 1,
+  minWidth: '23.75rem',
+})
+
+const StyledAccordion = styled(Accordion.Root)({
+  flex: 1,
+  minWidth: '28.125rem',
 })

--- a/apps/store/src/blocks/AccordionBlock.tsx
+++ b/apps/store/src/blocks/AccordionBlock.tsx
@@ -14,20 +14,23 @@ type Props = SbBaseBlockProps<{
 
 export const AccordionBlock = ({ blok }: Props) => {
   const accordionItems = filterByBlockType(blok.items, AccordionItemBlock.blockName)
+  const displayTitleDescriptionSection = blok.title || blok.description
   return (
     <Wrapper {...storyblokEditable(blok)}>
-      <TitleDescriptionWrapper>
-        {blok.title && (
-          <Heading as="h2" variant={{ _: 'standard.24', md: 'standard.32' }}>
-            {blok.title}
-          </Heading>
-        )}
-        {blok.description && (
-          <Text color="textSecondary" size={{ _: 'xl', md: 'xxl' }}>
-            {blok.description}
-          </Text>
-        )}
-      </TitleDescriptionWrapper>
+      {displayTitleDescriptionSection && (
+        <TitleDescriptionWrapper>
+          {blok.title && (
+            <Heading as="h2" variant={{ _: 'standard.24', md: 'standard.32' }}>
+              {blok.title}
+            </Heading>
+          )}
+          {blok.description && (
+            <Text color="textSecondary" size={{ _: 'xl', md: 'xxl' }}>
+              {blok.description}
+            </Text>
+          )}
+        </TitleDescriptionWrapper>
+      )}
       <StyledAccordion type="multiple">
         {accordionItems.map((nestedBlock) => (
           <AccordionItemBlock key={nestedBlock._uid} blok={nestedBlock} />

--- a/apps/store/src/blocks/AccordionItemBlock.tsx
+++ b/apps/store/src/blocks/AccordionItemBlock.tsx
@@ -1,5 +1,6 @@
 import { storyblokEditable, renderRichText, ISbRichtext } from '@storyblok/react'
 import { useId } from 'react'
+import { Text } from 'ui'
 import * as Accordion from '@/components/Accordion/Accordion'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
@@ -13,7 +14,9 @@ export const AccordionItemBlock = ({ blok }: AccordionItemBlockProps) => {
   const contentHtml = renderRichText(blok.body)
   return (
     <Accordion.Item value={blok._uid || defaultId} {...storyblokEditable(blok)}>
-      <Accordion.HeaderWithTrigger>{blok.title}</Accordion.HeaderWithTrigger>
+      <Accordion.HeaderWithTrigger>
+        <Text size={{ _: 'md', md: 'xl' }}>{blok.title}</Text>
+      </Accordion.HeaderWithTrigger>
       <Accordion.Content>
         <div dangerouslySetInnerHTML={{ __html: contentHtml }} />
       </Accordion.Content>

--- a/apps/store/src/components/Accordion/Accordion.tsx
+++ b/apps/store/src/components/Accordion/Accordion.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import * as AccordionPrimitives from '@radix-ui/react-accordion'
 import { PropsWithChildren, ReactElement } from 'react'
+import { mq } from 'ui'
 import { PlusIcon } from '@/components/Perils/PlusIcon'
 
 export const Root = styled(AccordionPrimitives.Root)(({ theme }) => ({
@@ -12,9 +13,10 @@ export const Root = styled(AccordionPrimitives.Root)(({ theme }) => ({
 export const Item = styled(AccordionPrimitives.Item)(({ theme }) => ({
   backgroundColor: theme.colors.gray200,
   borderRadius: theme.radius.xs,
-  padding: theme.space[3],
-  paddingLeft: theme.space[4],
-  paddingRight: theme.space[4],
+  padding: `${theme.space[3]} ${theme.space[4]}`,
+  [mq.md]: {
+    padding: `${theme.space[4]} ${theme.space[5]}`,
+  },
 }))
 
 const Header = AccordionPrimitives.Header
@@ -23,7 +25,7 @@ const Trigger = styled(AccordionPrimitives.Trigger)(({ theme }) => ({
   width: '100%',
   cursor: 'pointer',
   display: 'flex',
-  alignItems: 'flex-start',
+  alignItems: 'center',
   justifyContent: 'space-between',
   fontSize: theme.fontSizes[3],
   lineHeight: '1.375rem',
@@ -53,5 +55,6 @@ const TriggerIcon = styled(PlusIcon)({
 })
 
 export const Content = styled(AccordionPrimitives.Content)(({ theme }) => ({
-  paddingTop: theme.space[2],
+  paddingTop: theme.space[4],
+  color: theme.colors.gray700,
 }))

--- a/apps/store/src/components/Perils/Perils.tsx
+++ b/apps/store/src/components/Perils/Perils.tsx
@@ -72,5 +72,4 @@ const ContentWrapper = styled.div(({ theme }) => ({
   paddingLeft: theme.space[6],
   paddingBottom: theme.space[4],
   fontSize: theme.fontSizes[1],
-  color: theme.colors.gray700,
 }))


### PR DESCRIPTION
## Describe your changes

* Update `AccordionBlock` so desktop layout matches the proposed design.

## Jira issue(s): [GRW-2095](https://hedvig.atlassian.net/browse/GRW-2095)

---

<img width="711" alt="Screenshot 2023-01-17 at 15 34 29" src="https://user-images.githubusercontent.com/19200662/212929356-e03ad154-9970-485a-b2b3-7e4a790fbde6.png">
<img width="1230" alt="Screenshot 2023-01-17 at 15 34 23" src="https://user-images.githubusercontent.com/19200662/212929364-75d286ca-e570-44c0-9927-5935d648a950.png">




[GRW-2095]: https://hedvig.atlassian.net/browse/GRW-2095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ