### PR TITLE
Replace lint-staged with linting across all workspaces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,0 @@
-module.exports = {
-  root: true,
-  extends: ['custom'],
-  settings: {
-    next: {
-      rootDir: 'apps/*/',
-    },
-  },
-}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,6 @@
 
 yarn typecheck
 
+yarn lint:fix
+
 yarn lint-staged

--- a/apps/onboarding/package.json
+++ b/apps/onboarding/package.json
@@ -10,6 +10,7 @@
     "e2e": "start-server-and-test 'yarn start --port 3001' http://localhost:3001 cypress",
     "e2e:headless": "start-server-and-test 'yarn start --port 3001' http://localhost:3001 cypress:headless",
     "lint": "next lint --ignore-path .gitignore",
+    "lint:fix": "yarn lint --fix",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf .next",
     "download-translations": "./scripts/download-translations.sh",
     "codegen": "graphql-codegen",

--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "test": "jest --passWithNoTests --coverage",
     "lint": "next lint",
+    "lint:fix": "yarn lint --fix",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf .next",
     "typecheck": "tsc --noEmit",
     "storybook": "start-storybook -p 6008 --no-open",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "codegen:ci": "turbo run codegen --force",
     "dev": "turbo run dev --parallel --continue",
     "lint": "turbo run lint",
+    "lint:fix": "turbo run lint:fix",
     "test": "turbo run test",
     "e2e-onboarding": "turbo run e2e --filter=onboarding",
     "e2e-onboarding:headless": "turbo run e2e:headless --filter=onboarding",
@@ -28,8 +29,7 @@
       "prettier --ignore-unknown --write"
     ],
     "*.{js,jsx,ts,tsx}": [
-      "prettier --ignore-unknown --write",
-      "eslint --fix"
+      "prettier --ignore-unknown --write"
     ]
   },
   "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "test": "jest --passWithNoTests",
     "lint": "eslint --cache --cache-location node_modules/.cache/eslint src",
+    "lint:fix": "yarn lint --fix",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook --quiet -o dist",
     "typecheck": "tsc --noEmit"

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,7 @@
       "outputs": [],
       "cache": false
     },
+    "lint:fix": { "cache": false },
     "typecheck": {
       "dependsOn": ["codegen"],
       "outputs": []

--- a/yarn.lock
+++ b/yarn.lock
@@ -7792,9 +7792,9 @@ __metadata:
   linkType: hard
 
 "ansi-styles@npm:^6.0.0":
-  version: 6.1.0
-  resolution: "ansi-styles@npm:6.1.0"
-  checksum: 7a7f8528c07a9d20c3a92bccd2b6bc3bb4d26e5cb775c02826921477377bd495d615d61f710d56216344b6238d1d11ef2b0348e146c5b128715578bfb3217229
+  version: 6.2.1
+  resolution: "ansi-styles@npm:6.2.1"
+  checksum: ef940f2f0ced1a6347398da88a91da7930c33ecac3c77b72c5905f8b8fe402c52e6fde304ff5347f616e27a742da3f1dc76de98f6866c69251ad0b07a66776d9
   languageName: node
   linkType: hard
 
@@ -9927,7 +9927,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^9.4.1, commander@npm:~9.4.1":
+"commander@npm:^9.4.1":
+  version: 9.5.0
+  resolution: "commander@npm:9.5.0"
+  checksum: c7a3e27aa59e913b54a1bafd366b88650bc41d6651f0cbe258d4ff09d43d6a7394232a4dadd0bf518b3e696fdf595db1028a0d82c785b88bd61f8a440cecfade
+  languageName: node
+  linkType: hard
+
+"commander@npm:~9.4.1":
   version: 9.4.1
   resolution: "commander@npm:9.4.1"
   checksum: bfb18e325a5bdf772763c2213d5c7d9e77144d944124e988bcd8e5e65fb6d45d5d4e86b09155d0f2556c9a59c31e428720e57968bcd050b2306e910a0bf3cf13
@@ -16581,15 +16588,15 @@ __metadata:
   linkType: hard
 
 "listr2@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "listr2@npm:5.0.5"
+  version: 5.0.7
+  resolution: "listr2@npm:5.0.7"
   dependencies:
     cli-truncate: ^2.1.0
     colorette: ^2.0.19
     log-update: ^4.0.0
     p-map: ^4.0.0
     rfdc: ^1.3.0
-    rxjs: ^7.5.6
+    rxjs: ^7.8.0
     through: ^2.3.8
     wrap-ansi: ^7.0.0
   peerDependencies:
@@ -16597,7 +16604,7 @@ __metadata:
   peerDependenciesMeta:
     enquirer:
       optional: true
-  checksum: 71c44eb648405d2725f248747ef8d5e192dd16938ec81df854c4a7e74ff1b3f4c3149461b1cff31c761bfbdf110f7f2603c9957c908294a1c6db299c9168608c
+  checksum: 5c2cb6ba3f7a5cfd548f89405febe73dc937acb6060227198c05da0ed5d5285a8107c61fcc4e33884e3bbdd447411aff7580af396bd22b6a11047ceab4950fab
   languageName: node
   linkType: hard
 
@@ -20596,12 +20603,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.5.6":
-  version: 7.5.7
-  resolution: "rxjs@npm:7.5.7"
+"rxjs@npm:^7.8.0":
+  version: 7.8.0
+  resolution: "rxjs@npm:7.8.0"
   dependencies:
     tslib: ^2.1.0
-  checksum: edabcdb73b0f7e0f5f6e05c2077aff8c52222ac939069729704357d6406438acca831c24210db320aba269e86dbe1a400f3769c89101791885121a342fb15d9c
+  checksum: 61b4d4fd323c1043d8d6ceb91f24183b28bcf5def4f01ca111511d5c6b66755bc5578587fe714ef5d67cf4c9f2e26f4490d4e1d8cabf9bd5967687835e9866a2
   languageName: node
   linkType: hard
 
@@ -24337,9 +24344,9 @@ __metadata:
   linkType: hard
 
 "yaml@npm:^2.1.3":
-  version: 2.1.3
-  resolution: "yaml@npm:2.1.3"
-  checksum: 91316062324a93f9cb547469092392e7d004ff8f70c40fecb420f042a4870b2181557350da56c92f07bd44b8f7a252b0be26e6ade1f548e1f4351bdd01c9d3c7
+  version: 2.2.1
+  resolution: "yaml@npm:2.2.1"
+  checksum: 84f68cbe462d5da4e7ded4a8bded949ffa912bc264472e5a684c3d45b22d8f73a3019963a32164023bdf3d83cfb6f5b58ff7b2b10ef5b717c630f40bd6369a23
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes

Replace `lint-staged` with just running `eslint --fix` for each workspace in the pre-commit hook.

Setup new turbo pipeline.

## Justify why they are needed

I've been struggling with the ESLint setup over the last couple of days.

I've tried a bunch of different settings but nothing seems to work and I don't understand why.

Essentially the problem is that `eslint` run from ROOT behaves differently from when it's run from the workspace. This is the case with `lint-staged`. It might have something to do with `eslint + typescript` and how it resolves the `tsconfig.json` file.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
