### PR TITLE
GRW-2089 - fix(ProductPage): display product name as a 'h1'

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -139,7 +139,7 @@ const Layout = ({ children, pillowSize }: LayoutProps) => {
               {...productData.pillowImage}
             />
             <Space y={0.5}>
-              <Heading as="h2" variant="standard.24" align="center">
+              <Heading as="h1" variant="standard.24" align="center">
                 {productData.displayNameShort}
                 <CircledHSuperscript />
               </Heading>


### PR DESCRIPTION
## Describe your changes

* Displays product name as a `h1`

## Justify why they are needed

SEO reasons.

## Jira issue(s): [GRW-2089](https://hedvig.atlassian.net/browse/GRW-2089)



[GRW-2089]: https://hedvig.atlassian.net/browse/GRW-2089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ