### PR TITLE
Skip downloading en-* locales from Lokalise

### DIFF
--- a/apps/store/scripts/download-translations.sh
+++ b/apps/store/scripts/download-translations.sh
@@ -39,15 +39,12 @@ lokalise2 \
   --plural-format i18next \
   --include-tags hedvig-com \
   --indentation 2sp \
-  --filter-langs 'en,da_DK,en_DK,sv_SE,en_SE,nb_NO,en_NO' \
+  --filter-langs 'en,da_DK,sv_SE,nb_NO' \
   --language-mapping '[
     {"original_language_iso": "en","custom_language_iso": "en"},
     {"original_language_iso": "da_DK","custom_language_iso": "dk"},
-    {"original_language_iso": "en_DK","custom_language_iso": "en-dk"},
     {"original_language_iso": "sv_SE","custom_language_iso": "sv-se"},
-    {"original_language_iso": "en_SE","custom_language_iso": "en-se"},
-    {"original_language_iso": "nb_NO","custom_language_iso": "no"},
-    {"original_language_iso": "en_NO","custom_language_iso": "en-no"}
+    {"original_language_iso": "nb_NO","custom_language_iso": "no"}
   ]'
 
 # Convert plural forms to i18next v4 format (https://www.i18next.com/misc/json-format)


### PR DESCRIPTION
## Describe your changes

Skip en-* locales when downloading from Lokalise (in "store")

## Justify why they are needed

We rely on falling back to the "en" locale across all countries.

We can easily add them back into the script if we see a need for it.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
