### PR TITLE
Update country-selector page styles

### DIFF
--- a/apps/store/src/components/CountrySelectorPage/CountrySelectorPage.tsx
+++ b/apps/store/src/components/CountrySelectorPage/CountrySelectorPage.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { Space, Heading, Button } from 'ui'
+import { Space, Heading, Button, theme, mq } from 'ui'
 import { CookiePersister } from '@/services/persister/CookiePersister'
 import { countries } from '@/utils/l10n/countries'
 import { LOCALE_COOKIE_MAX_AGE, LOCALE_COOKIE_KEY } from '@/utils/l10n/locales'
@@ -34,10 +34,12 @@ export const CountrySelectorPage = (props: { className?: string }) => {
   )
 }
 
-const Wrapper = styled(Space)(({ theme }) => ({
-  maxWidth: '40rem',
-  minHeight: '100vh',
-  marginLeft: 'auto',
-  marginRight: 'auto',
-  padding: `${theme.space.xxl} ${theme.space.md} `,
-}))
+const Wrapper = styled(Space)({
+  paddingInline: theme.space.md,
+
+  [mq.sm]: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(28rem, 33%)',
+    justifyContent: 'center',
+  },
+})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Added the wrapper from pages like the cart/confirmation page to the country-selector page. Seems like these should all have the same or similar widths.

![Screenshot 2023-01-24 at 10 31 45](https://user-images.githubusercontent.com/50870173/214256792-45bfe6a5-d42a-4481-8460-5d88eabf098c.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Consistant  styles across the app. 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
