### PR TITLE
Remove focus styles for text field

### DIFF
--- a/apps/store/src/components/TextField/TextField.tsx
+++ b/apps/store/src/components/TextField/TextField.tsx
@@ -61,10 +61,6 @@ const LargeWrapper = styled(motion.div)({
       overflow: 'visible',
     },
   },
-
-  ':has(input:focus-visible)': {
-    boxShadow: `0 0 0 1px ${theme.colors.textPrimary}`,
-  },
 })
 
 const Label = styled.label(({ theme }) => ({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Remove focus styles for `TextField`

## Justify why they are needed

Not correct, remove now until we have a better solution that only shows up when you use keyboard.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
