### PR TITLE
Fix scroll to bottom on iOS in Price Calculator

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/PriceCalculatorDialog.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PriceCalculatorDialog.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { CrossIcon, Space, Dialog } from 'ui'
+import { CrossIcon, Space, Dialog, theme } from 'ui'
 
 type Props = {
   header?: React.ReactNode
@@ -11,35 +11,32 @@ type Props = {
 export const PriceCalculatorDialog = ({ children, header, isOpen, toggleDialog }: Props) => {
   return (
     <Dialog.Root open={isOpen} onOpenChange={toggleDialog}>
-      <Dialog.Content frostedOverlay>
-        <ContentWrapper>
-          <Dialog.Close asChild>
-            <IconButton>
-              <CrossIcon size="1.25rem" />
-            </IconButton>
-          </Dialog.Close>
-          <Space y={4}>
-            <HeaderWrapper>{header}</HeaderWrapper>
-            {children}
-          </Space>
-        </ContentWrapper>
-      </Dialog.Content>
+      <DialogContent frostedOverlay>
+        <Dialog.Close asChild>
+          <IconButton>
+            <CrossIcon size="1.25rem" />
+          </IconButton>
+        </Dialog.Close>
+        <Space y={4}>
+          <HeaderWrapper>{header}</HeaderWrapper>
+          {children}
+        </Space>
+      </DialogContent>
     </Dialog.Root>
   )
 }
 
-const HeaderWrapper = styled.div(({ theme }) => ({
-  paddingTop: theme.space[8],
-}))
+const HeaderWrapper = styled.div({
+  paddingTop: theme.space.xxxl,
+})
 
-const ContentWrapper = styled(Dialog.Window)(({ theme }) => ({
+const DialogContent = styled(Dialog.Content)({
   position: 'relative',
-  width: '100vw',
-  height: '100vh',
+  height: '100%',
   overflow: 'auto',
-  padding: theme.space[4],
+  padding: theme.space.md,
   backgroundColor: 'transparent',
-}))
+})
 
 export const IconButton = styled.button({
   position: 'absolute',

--- a/apps/store/src/components/TextField/TextField.tsx
+++ b/apps/store/src/components/TextField/TextField.tsx
@@ -61,10 +61,6 @@ const LargeWrapper = styled(motion.div)({
       overflow: 'visible',
     },
   },
-
-  ':has(input:focus-visible)': {
-    boxShadow: `0 0 0 1px ${theme.colors.textPrimary}`,
-  },
 })
 
 const Label = styled.label(({ theme }) => ({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix issue in price calculator where you can't scroll to the bottom on iOS.

![Screenshot 2023-01-24 at 14.01.46.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/14b14111-bded-4796-8863-d7438bd2baa3/Screenshot%202023-01-24%20at%2014.01.46.png)

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
