### PR TITLE
GRW-2090 - refact(ProductPage): displays Overview+Coverage tab on desktop layout

### DIFF
--- a/apps/store/src/components/Header/Header.tsx
+++ b/apps/store/src/components/Header/Header.tsx
@@ -11,7 +11,6 @@ export const Wrapper = styled.header(({ theme }) => ({
   width: '100%',
   height: MENU_BAR_HEIGHT_MOBILE,
   padding: theme.space[4],
-  position: 'sticky',
   zIndex: zIndexes.header,
 
   [mq.md]: {

--- a/apps/store/src/components/ProductPage/Tabs.tsx
+++ b/apps/store/src/components/ProductPage/Tabs.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled'
 import * as RadixTabs from '@radix-ui/react-tabs'
 import { zIndexes } from '@/utils/zIndex'
 
+export type { TabsProps } from '@radix-ui/react-tabs'
+
 export const Tabs = styled(RadixTabs.Root)({
   position: 'relative',
   display: 'flex',

--- a/apps/store/src/components/ProductPage/Tabs.tsx
+++ b/apps/store/src/components/ProductPage/Tabs.tsx
@@ -37,8 +37,6 @@ export const TabsTrigger = styled(RadixTabs.Trigger)(({ theme }) => ({
   borderRadius: theme.radius.sm,
   cursor: 'pointer',
 
-  '&:hover': { color: theme.colors.purple900 },
-
   '&[data-state=active]': {
     paddingInline: '3.75rem',
     color: theme.colors.dark,


### PR DESCRIPTION
## Describe your changes

* Remove one unused CSS declaration from `Header` component
* Update `ProductPageBlock` so it better matches the designs:
  * Also display _Overview+Coverage_ tabs on mobile
  * Scroll to top when active tab changes

I guess the easiest way to test is running this branch locally and load this [page](http://localhost:8040/se/forsakringar/hemforsakring/hyresratt) and compare it with the proposed [design](https://www.figma.com/file/8SfzuQEJ4LJ6uKL0l7WKoE/Hedvig.com-%C2%B7-Final-Design?node-id=1544%3A6150&t=TCUeMFR0Eb98ROcl-0)

## Justify why they are needed

Requested by design.

## Jira issue(s): [GRW-2090](https://hedvig.atlassian.net/browse/GRW-2090)

[GRW-2090]: https://hedvig.atlassian.net/browse/GRW-2090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ