### PR TITLE
Switching Assistant: show external insurer display name

### DIFF
--- a/apps/store/src/graphql/ProductOfferFragment.graphql
+++ b/apps/store/src/graphql/ProductOfferFragment.graphql
@@ -29,6 +29,10 @@ fragment ProductOffer on ProductOffer {
   cancellation {
     option
     requested
+    externalInsurer {
+      id
+      displayName
+    }
   }
   priceMatch {
     externalInsurer {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

See title.

## Justify why they are needed

The API doesn't guarantee that we have an external insurer but it shouldn't happen. That's why I added the datadog logging.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
