### PR TITLE
`TextField`: add warning state and message

### DIFF
--- a/apps/store/src/components/TextField/TextField.stories.tsx
+++ b/apps/store/src/components/TextField/TextField.stories.tsx
@@ -21,6 +21,8 @@ const Template: ComponentStory<typeof TextField> = ({ defaultValue, ...props }) 
       <TextField {...props} defaultValue={defaultValue} />
       <div style={{ marginTop: '0.25rem' }}></div>
       <TextField {...props} defaultValue={defaultValue} disabled />
+      <div style={{ marginTop: '0.25rem' }}></div>
+      <TextField {...props} defaultValue={defaultValue} warning message="Wrong input, try again" />
     </>
   )
 }

--- a/apps/store/src/components/TextField/TextField.tsx
+++ b/apps/store/src/components/TextField/TextField.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { motion } from 'framer-motion'
 import { ChangeEventHandler, InputHTMLAttributes, useState } from 'react'
-import { Text, theme } from 'ui'
+import { Space, Text, theme } from 'ui'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { useHighlightAnimation } from '@/utils/useHighlightAnimation'
 
@@ -14,18 +14,21 @@ type Props = BaseInputProps & {
   label: string
   variant?: 'small' | 'large'
   suffix?: string
+  warning?: boolean
+  message?: string
 }
 
-export const TextField = ({ label, variant = 'large', suffix, ...props }: Props) => {
+export const TextField = (props: Props) => {
+  const { label, variant = 'large', suffix, warning = false, message, ...inputProps } = props
   const [value, setValue] = useState(props.defaultValue || '')
   const { highlight, animationProps } = useHighlightAnimation()
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     setValue(event.target.value)
-    props.onChange?.(event)
+    inputProps.onChange?.(event)
   }
 
-  const inputValue = props.value || value
+  const inputValue = inputProps.value || value
 
   const [Wrapper, Input, Suffix] =
     variant === 'large'
@@ -33,15 +36,18 @@ export const TextField = ({ label, variant = 'large', suffix, ...props }: Props)
       : ([SmallWrapper, SmallInput, SmallSuffix] as const)
 
   return (
-    <Wrapper {...animationProps} data-active={!!inputValue}>
-      <Label htmlFor={props.id} data-disabled={props.disabled} data-variant={variant}>
-        {label}
-      </Label>
-      <SpaceFlex align="center" space={0}>
-        <Input {...props} onKeyDown={highlight} onChange={handleChange} />
-        {suffix && inputValue && <Suffix>{suffix}</Suffix>}
-      </SpaceFlex>
-    </Wrapper>
+    <Space y={0.25}>
+      <Wrapper {...animationProps} data-active={!!inputValue} data-warning={warning}>
+        <Label htmlFor={inputProps.id} data-disabled={inputProps.disabled} data-variant={variant}>
+          {label}
+        </Label>
+        <SpaceFlex align="center" space={0}>
+          <Input {...inputProps} onKeyDown={highlight} onChange={handleChange} />
+          {suffix && inputValue && <Suffix>{suffix}</Suffix>}
+        </SpaceFlex>
+      </Wrapper>
+      {message && <MessageText size="sm">{message}</MessageText>}
+    </Space>
   )
 }
 
@@ -60,6 +66,13 @@ const LargeWrapper = styled(motion.div)({
       transform: `translate(calc(${theme.space.md} * 0.4), -0.5rem) scale(0.6)`,
       overflow: 'visible',
     },
+  },
+
+  '&[data-warning=true]': {
+    // TODO: use theme color: amber fill 1
+    backgroundColor: '#FBEDC5',
+    // TODO: use theme color: amber fill 3
+    border: '1px solid #F5E0A3',
   },
 })
 
@@ -85,6 +98,11 @@ const Label = styled.label(({ theme }) => ({
   '&[data-disabled=true]': {
     color: theme.colors.textDisabled,
   },
+
+  '[data-warning=true] &': {
+    // TODO: use theme color: amber text
+    color: '#8A4C0F',
+  },
 }))
 
 const LargeInput = styled.input({
@@ -101,10 +119,24 @@ const LargeInput = styled.input({
     WebkitTextFillColor: theme.colors.textDisabled,
     opacity: 1,
   },
+
+  '[data-warning=true] &': {
+    // TODO: use theme color: amber text
+    color: '#8A4C0F',
+  },
 })
 
 type BaseProps = { children: React.ReactNode }
-const StyledLargeSuffix = styled(Text)({ paddingRight: theme.space.md })
+
+const StyledLargeSuffix = styled(Text)({
+  paddingRight: theme.space.md,
+
+  '[data-warning=true] &': {
+    // TODO: use theme color: amber text
+    color: '#8A4C0F',
+  },
+})
+
 const LargeSuffix = (props: BaseProps) => (
   <StyledLargeSuffix as="span" size="xl" color="textSecondary" {...props} />
 )
@@ -125,3 +157,11 @@ const StyledSmallSuffix = styled(StyledLargeSuffix)()
 const SmallSuffix = (props: BaseProps) => (
   <StyledSmallSuffix as="span" size="lg" color="textSecondary" {...props} />
 )
+
+const MessageText = styled(Text)({
+  paddingLeft: theme.space.md,
+  '[data-warning=true] ~ &': {
+    // TODO: use theme color: amber text
+    color: '#8A4C0F',
+  },
+})


### PR DESCRIPTION
## Describe your changes

Add warning state to `TextField`

Add optional message prop to `TextField`

![Screenshot 2023-01-24 at 17.02.02.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/6377f3da-77ef-49c9-8f8f-ef5e7f8ffc0a/Screenshot%202023-01-24%20at%2017.02.02.png)

## Justify why they are needed

New from UI kit.

Implemented as `data-warning` property to handle all styling in CSS.

Not sure what to do with `:invalid` state - if it should inherit these styles...

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
