### PR TITLE
Add gray translucent colors to theme

### DIFF
--- a/packages/ui/src/components/Text/Text.tsx
+++ b/packages/ui/src/components/Text/Text.tsx
@@ -6,7 +6,14 @@ import { FontSizeProps, getFontSize } from '../../lib/fontSizes'
 
 type TextColor = Pick<
   UIColors,
-  'textPrimary' | 'textSecondary' | 'textTertiary' | 'textDisabled' | 'textNegative'
+  | 'textPrimary'
+  | 'textSecondary'
+  | 'textTertiary'
+  | 'textDisabled'
+  | 'textNegative'
+  | 'textGreen'
+  | 'textAmber'
+  | 'textRed'
 >
 
 export type TextProps = {

--- a/packages/ui/src/lib/theme/colors/colors.stories.tsx
+++ b/packages/ui/src/lib/theme/colors/colors.stories.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { theme } from '../theme'
-import { gray, green, highlight, red, signal, yellow } from './colors'
+import { gray, grayTranslucent, green, highlight, red, signal, yellow } from './colors'
 
 export default {
   title: 'Theme / Colors',
@@ -29,6 +29,9 @@ const Palette = ({ colors, name }: Props) => (
 export const Colors = () => (
   <>
     <Palette name="Gray" colors={gray} />
+    <TranslucentWrapper>
+      <Palette name="Gray Translucent" colors={grayTranslucent} />
+    </TranslucentWrapper>
     <Palette name="Green" colors={green} />
     <Palette name="Yellow" colors={yellow} />
     <Palette name="Red" colors={red} />
@@ -70,7 +73,13 @@ const HueName = styled.p({
   fontSize: '1.125rem',
 })
 
-const HueValue = styled.p(({ theme }) => ({
+const HueValue = styled.p({
   color: theme.colors.textSecondary,
   textTransform: 'uppercase',
-}))
+})
+
+const TranslucentWrapper = styled.div({
+  padding: '1rem',
+  backgroundColor: green[50],
+  borderRadius: 16,
+})

--- a/packages/ui/src/lib/theme/colors/colors.ts
+++ b/packages/ui/src/lib/theme/colors/colors.ts
@@ -13,6 +13,21 @@ export const gray = {
   1000: 'hsl(0, 0%, 7%)',
 } as const
 
+export const grayTranslucent = {
+  25: 'hsla(0, 0%, 98%, 0.6)',
+  50: 'hsla(0, 0%, 96%, 0.6)',
+  100: 'hsla(0, 0%, 94%, 0.6)',
+  200: 'hsla(0, 0%, 92%, 0.6)',
+  300: 'hsla(0, 0%, 88%, 0.7)',
+  400: 'hsla(0, 0%, 81%, 0.7)',
+  500: 'hsla(0, 0%, 71%, 0.7)',
+  600: 'hsla(0, 0%, 59%, 0.74)',
+  700: 'hsla(0, 0%, 45%, 0.8)',
+  800: 'hsla(0, 0%, 31%, 0.84)',
+  900: 'hsla(0, 0%, 19%, 0.87)',
+  1000: 'hsla(0, 0%, 7%, 0.92)',
+} as const
+
 export const green = {
   50: 'hsl(85, 100%, 90%)',
   100: 'hsl(85, 73%, 87%)',
@@ -142,11 +157,28 @@ export const colors = {
   dark: gray[1000],
   light: gray[25],
   lavender: oldPurple[500],
+
+  // Text colors
   textPrimary: gray[1000],
   textSecondary: gray[700],
   textTertiary: gray[500],
   textDisabled: gray[400],
   textNegative: gray[25],
+  textGreen: signal.green.text,
+  textAmber: signal.amber.text,
+  textRed: signal.red.text,
+
+  // Semantic colors
+  backgroundStandard: gray[25],
+  backgroundFrostedGlass: grayTranslucent[25],
+  borderOpaque: gray[400],
+  borderTranslucent: grayTranslucent[400],
+  opaque1: gray[100],
+  translucent1: grayTranslucent[100],
+  opaque2: gray[300],
+  translucent2: grayTranslucent[300],
+  opaque3: gray[400],
+  translucent3: grayTranslucent[400],
 
   // Highlight colors
   // Used as fill on light backgrounds


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add translucent colors to the theme

Add more text colors

Add semantic gray colors based on translucent values

![Screenshot 2023-01-25 at 09.58.11.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/01600cd1-2897-4b7e-9057-1ae4a9684425/Screenshot%202023-01-25%20at%2009.58.11.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
