### PR TITLE
GRW-2135 - fix(AccordionItem): enable rich text formatting

### DIFF
--- a/apps/store/src/blocks/AccordionItemBlock.tsx
+++ b/apps/store/src/blocks/AccordionItemBlock.tsx
@@ -1,8 +1,8 @@
-import styled from '@emotion/styled'
 import { storyblokEditable, renderRichText, ISbRichtext } from '@storyblok/react'
 import { useId } from 'react'
-import { Text, theme } from 'ui'
+import { Text } from 'ui'
 import * as Accordion from '@/components/Accordion/Accordion'
+import { RichTextContent } from '@/components/RichTextContent/RichTextContent'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
 export type AccordionItemBlockProps = SbBaseBlockProps<{
@@ -25,28 +25,3 @@ export const AccordionItemBlock = ({ blok }: AccordionItemBlockProps) => {
   )
 }
 AccordionItemBlock.blockName = 'accordionItem'
-
-const RichTextContent = styled.div({
-  '& b': {
-    fontWeight: 'bold',
-  },
-  '& i': {
-    fontStyle: 'italic',
-  },
-  '& strike': {
-    textDecoration: 'line-through',
-  },
-  '& u': {
-    textDecoration: 'underline',
-  },
-  '& :where(ul, ol)': {
-    paddingLeft: theme.space.xl,
-    marginBlock: theme.space.md,
-  },
-  '& ul': {
-    listStyle: 'disc',
-  },
-  '& ol': {
-    listStyle: 'decimal',
-  },
-})

--- a/apps/store/src/blocks/AccordionItemBlock.tsx
+++ b/apps/store/src/blocks/AccordionItemBlock.tsx
@@ -1,6 +1,7 @@
+import styled from '@emotion/styled'
 import { storyblokEditable, renderRichText, ISbRichtext } from '@storyblok/react'
 import { useId } from 'react'
-import { Text } from 'ui'
+import { Text, theme } from 'ui'
 import * as Accordion from '@/components/Accordion/Accordion'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
@@ -17,10 +18,35 @@ export const AccordionItemBlock = ({ blok }: AccordionItemBlockProps) => {
       <Accordion.HeaderWithTrigger>
         <Text size={{ _: 'md', md: 'xl' }}>{blok.title}</Text>
       </Accordion.HeaderWithTrigger>
-      <Accordion.Content>
-        <div dangerouslySetInnerHTML={{ __html: contentHtml }} />
+      <Accordion.Content asChild>
+        <RichTextContent dangerouslySetInnerHTML={{ __html: contentHtml }} />
       </Accordion.Content>
     </Accordion.Item>
   )
 }
 AccordionItemBlock.blockName = 'accordionItem'
+
+const RichTextContent = styled.div({
+  '& b': {
+    fontWeight: 'bold',
+  },
+  '& i': {
+    fontStyle: 'italic',
+  },
+  '& strike': {
+    textDecoration: 'line-through',
+  },
+  '& u': {
+    textDecoration: 'underline',
+  },
+  '& :where(ul, ol)': {
+    paddingLeft: theme.space.xl,
+    marginBlock: theme.space.md,
+  },
+  '& ul': {
+    listStyle: 'disc',
+  },
+  '& ol': {
+    listStyle: 'decimal',
+  },
+})

--- a/apps/store/src/components/RichTextContent/RichTextContent.tsx
+++ b/apps/store/src/components/RichTextContent/RichTextContent.tsx
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled'
+import { theme } from 'ui'
+
+export const RichTextContent = styled.div({
+  '& b': {
+    fontWeight: 'bold',
+  },
+  '& i': {
+    fontStyle: 'italic',
+  },
+  '& strike': {
+    textDecoration: 'line-through',
+  },
+  '& u': {
+    textDecoration: 'underline',
+  },
+  '& :where(ul, ol)': {
+    paddingLeft: theme.space.xl,
+    marginBlock: theme.space.md,
+  },
+  '& ul': {
+    listStyle: 'disc',
+  },
+  '& ol': {
+    listStyle: 'decimal',
+  },
+})


### PR DESCRIPTION
## Describe your changes

* Re-apply styles for text formatting HTML tags (`<b>`, `<i>`, etc). We get the correct HTML from _Storyblok_ but the issue is that we have a CSS reset that remove all of their styles:

<img width="1655" alt="Screenshot 2023-01-25 at 11 27 41" src="https://user-images.githubusercontent.com/19200662/214596445-c6403954-a80f-44ca-8f91-16851b2e3d1c.png">
<img width="1783" alt="Screenshot 2023-01-25 at 15 39 56" src="https://user-images.githubusercontent.com/19200662/214596436-06e9f587-fe5b-4f20-a828-4111f7a5c27e.png">

So I've thought was to keep the CSS reset as it is and re-apply some of the `initial` styles for RTF based content. In that way we can change how they should look later (if some changes become necessary).

At the moment, I'm just applying those changes for `AccordionItem`. But maybe we should consider on having a `RichTextField` shared component responsible to handle styles whenever we use _Storyblok_'s Rich Text Field. Let me know what you guys think.
 
## Justify your changes

Despite being possible to formatting the text with _Storyblok_'s Rich Text Field, the real content wasn't being displayed properly which blocks us to achieve the following proposed design:

<img width="549" alt="Screenshot 2023-01-25 at 15 35 48" src="https://user-images.githubusercontent.com/19200662/214596419-cdf5f54e-fc94-4e32-bbc4-b8165cc55ad4.png">

---

## Screenshot(s)

<img width="1149" alt="Screenshot 2023-01-25 at 15 37 12" src="https://user-images.githubusercontent.com/19200662/214596427-6a333f18-409d-4ee4-997e-90efed72683d.png">


## Jira issue(s): [GRW-2135](https://hedvig.atlassian.net/browse/GRW-2135)


[GRW-2135]: https://hedvig.atlassian.net/browse/GRW-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ