### PR TITLE
Don't capitalize 'today' label in date input

### DIFF
--- a/apps/store/public/locales/sv-se/cart.json
+++ b/apps/store/public/locales/sv-se/cart.json
@@ -29,6 +29,7 @@
   "DISCOUNT_STATE_INDEFINITE_PERCENTAGE": "{{percentage}}% rabatt",
   "DISCOUNT_STATE_MONTHLY_PERCENTAGE_one": "{{percentage}}% rabatt i {{count}} månad",
   "DISCOUNT_STATE_MONTHLY_PERCENTAGE_other": "{{percentage}}% rabatt i {{count}} månader",
+  "GO_TO_STORE_BUTTON": "Handla försäkringar",
   "RECOMMENDATIONS_HEADING": "Andra har köpt",
   "REMOVE_ENTRY_BUTTON": "Ta bort",
   "REMOVE_ENTRY_MODAL_CANCEL_BUTTON": "Avbryt",

--- a/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/DateInput.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/DateInput.tsx
@@ -103,7 +103,6 @@ const Floating = styled.div({
   right: 0,
   pointerEvents: 'none',
   cursor: 'pointer',
-  textTransform: 'capitalize',
 })
 
 const IconWrapper = styled.div({

--- a/apps/store/src/components/ToggleCard/Switch.tsx
+++ b/apps/store/src/components/ToggleCard/Switch.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import * as RadixSwitch from '@radix-ui/react-switch'
+import { theme } from 'ui'
 
 export type SwitchProps = RadixSwitch.SwitchProps
 
@@ -11,7 +12,7 @@ export const Switch = (props: SwitchProps) => {
   )
 }
 
-const SwitchWrapper = styled(RadixSwitch.Root)(({ theme }) => ({
+const SwitchWrapper = styled(RadixSwitch.Root)({
   boxSizing: 'border-box',
   width: '1.75rem',
   borderRadius: 9999,
@@ -19,24 +20,24 @@ const SwitchWrapper = styled(RadixSwitch.Root)(({ theme }) => ({
   alignItems: 'center',
   justifyContent: 'flex-start',
 
-  backgroundColor: theme.colors.gray500,
+  backgroundColor: theme.colors.opaque3,
   borderWidth: 1,
   borderStyle: 'solid',
   borderColor: 'transparent',
 
-  ':focus': {
-    borderColor: theme.colors.gray900,
+  ':focus-visible': {
+    borderColor: theme.colors.gray1000,
   },
 
   '&[data-state=checked]': {
-    backgroundColor: '#23CD61',
+    backgroundColor: theme.colors.greenElement,
     justifyContent: 'flex-end',
   },
-}))
+})
 
-const SwitchHandle = styled(RadixSwitch.Thumb)(({ theme }) => ({
+const SwitchHandle = styled(RadixSwitch.Thumb)({
   width: '1rem',
   height: '1rem',
   borderRadius: '100%',
-  backgroundColor: theme.colors.white,
-}))
+  backgroundColor: theme.colors.textNegative,
+})

--- a/apps/store/src/components/ToggleCard/ToggleCard.tsx
+++ b/apps/store/src/components/ToggleCard/ToggleCard.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { motion } from 'framer-motion'
 import { useId } from 'react'
-import { Space } from 'ui'
+import { Space, theme } from 'ui'
 import { useHighlightAnimation } from '@/utils/useHighlightAnimation'
 import { Switch, SwitchProps } from './Switch'
 
@@ -32,24 +32,24 @@ export const ToggleCard = ({ id, label, children, onCheckedChange, ...checkboxPr
   )
 }
 
-const InputWrapper = styled(motion.div)(({ theme }) => ({
-  backgroundColor: theme.colors.gray300,
-  padding: theme.space[4],
+const InputWrapper = styled(motion.div)({
+  backgroundColor: theme.colors.opaque1,
+  padding: theme.space.md,
   borderRadius: theme.radius.sm,
-}))
+})
 
-const CheckboxHeader = styled.div(({ theme }) => ({
+const CheckboxHeader = styled.div({
   display: 'flex',
-  gap: theme.space[3],
+  gap: theme.space.sm,
   justifyContent: 'space-between',
   alignItems: 'center',
-}))
+})
 
-const StyledLabel = styled.label(({ theme }) => ({
+const StyledLabel = styled.label({
   fontFamily: theme.fonts.body,
-  fontSize: theme.fontSizes[3],
+  fontSize: theme.fontSizes.md,
 
   overflow: 'hidden',
   whiteSpace: 'nowrap',
   textOverflow: 'ellipsis',
-}))
+})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Avoid capitalizing "today" when using `fromNow` formatted.

![Screenshot 2023-01-28 at 11.38.45.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/2e191a2f-9ecd-46ae-a66e-3b441e3c6578/Screenshot%202023-01-28%20at%2011.38.45.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Messes up copy in the UI.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
