### PR TITLE
Refactor Switching Assitant page to avoid SSR issues

### DIFF
--- a/apps/store/src/pages/checkout/switching-assistant.tsx
+++ b/apps/store/src/pages/checkout/switching-assistant.tsx
@@ -1,22 +1,22 @@
 import type { GetServerSideProps, NextPage } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { SwitchingAssistantPage } from '@/components/SwitchingAssistantPage/SwitchingAssistantPage'
+import {
+  SwitchingAssistantPage,
+  SwitchingAssistantPageProps,
+} from '@/components/SwitchingAssistantPage/SwitchingAssistantPage'
 import { addApolloState, initializeApollo } from '@/services/apollo/client'
+import { ExternalInsuranceCancellationOption } from '@/services/apollo/generated'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
 import { getCurrentShopSessionServerSide } from '@/services/shopSession/ShopSession.helpers'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+import { PageLink } from '@/utils/PageLink'
 
-type NextPageProps = {
+type NextPageProps = SwitchingAssistantPageProps & {
   [SHOP_SESSION_PROP_NAME]: string
 }
 
-const NextSwitchingAssistantPage: NextPage<NextPageProps> = () => {
-  const { shopSession } = useShopSession()
-
-  if (!shopSession) return null
-
-  return <SwitchingAssistantPage shopSession={shopSession} />
+const NextSwitchingAssistantPage: NextPage<NextPageProps> = (props) => {
+  return <SwitchingAssistantPage {...props} />
 }
 
 export const getServerSideProps: GetServerSideProps<NextPageProps> = async (context) => {
@@ -31,9 +31,42 @@ export const getServerSideProps: GetServerSideProps<NextPageProps> = async (cont
 
   // TODO: check if user is authenticated
 
+  const entriesToCancel = shopSession.cart.entries.filter(
+    (item) => item.cancellation.option === ExternalInsuranceCancellationOption.Banksignering,
+  )
+
+  const entries: SwitchingAssistantPageProps['entries'] = []
+  entriesToCancel.forEach((item) => {
+    const company = item.cancellation.externalInsurer?.displayName
+    if (!company) {
+      console.warn('Missing company name for Banksignering cancellation', {
+        entryId: item.id,
+      })
+      return
+    }
+
+    entries.push({
+      key: item.id,
+      name: item.variant.product.displayNameFull,
+      company,
+      url: '/',
+      date: new Date().toJSON(),
+    })
+  })
+
+  if (entries.length === 0) {
+    return {
+      redirect: {
+        destination: PageLink.confirmation({ locale, shopSessionId: shopSession.id }),
+        permanent: false,
+      },
+    }
+  }
+
   const pageProps = {
     ...translations,
     [SHOP_SESSION_PROP_NAME]: shopSession.id,
+    entries,
   } satisfies NextPageProps
 
   return addApolloState(apolloClient, { props: pageProps })

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -54,6 +54,6 @@ export const PageLink = {
 } as const
 
 const CUSTOMER_SERVICE_URL: Partial<Record<RoutingLocale, string>> = {
-  'sv-se': '/se/hjalp/kundservice',
+  se: '/se/hjalp/kundservice',
   'en-se': '/se-en/help/customer-service',
 }


### PR DESCRIPTION
## Describe your changes

Move data transforms server-side and pass down to React for switching assistant page.

## Justify why they are needed

There was a bug when we were trying to log with datadog from the server.

We only render this page once so we don't need to do any client-side refresh => transform data on the server!

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
