### PR TITLE
feat(RichtTextContent): added support for links and line breaks

### DIFF
--- a/apps/store/src/blocks/AccordionItemBlock.tsx
+++ b/apps/store/src/blocks/AccordionItemBlock.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled'
 import { storyblokEditable, renderRichText, ISbRichtext } from '@storyblok/react'
 import { useId } from 'react'
 import { Text } from 'ui'
@@ -18,10 +19,14 @@ export const AccordionItemBlock = ({ blok }: AccordionItemBlockProps) => {
       <Accordion.HeaderWithTrigger>
         <Text size={{ _: 'md', md: 'xl' }}>{blok.title}</Text>
       </Accordion.HeaderWithTrigger>
-      <Accordion.Content asChild>
+      <Content asChild>
         <RichTextContent dangerouslySetInnerHTML={{ __html: contentHtml }} />
-      </Accordion.Content>
+      </Content>
     </Accordion.Item>
   )
 }
 AccordionItemBlock.blockName = 'accordionItem'
+
+const Content = styled(Accordion.Content)({
+  paddingTop: 0,
+})

--- a/apps/store/src/components/RichTextContent/RichTextContent.tsx
+++ b/apps/store/src/components/RichTextContent/RichTextContent.tsx
@@ -2,6 +2,9 @@ import styled from '@emotion/styled'
 import { theme } from 'ui'
 
 export const RichTextContent = styled.div({
+  '& > p': {
+    marginBlock: theme.space.md,
+  },
   '& b': {
     fontWeight: 'bold',
   },
@@ -23,5 +26,16 @@ export const RichTextContent = styled.div({
   },
   '& ol': {
     listStyle: 'decimal',
+  },
+  '& a': {
+    cursor: 'pointer',
+    color: theme.colors.black,
+
+    // apply hover styles only when the device supports them
+    '@media (hover: hover) and (pointer: fine)': {
+      ':hover': {
+        textDecoration: 'underline',
+      },
+    },
   },
 })


### PR DESCRIPTION
## Describe your changes

* Added support for links and line breaks on `RichTextContent` component

## Justify why they are needed

Requested for used on AccordionBlock

<img width="1037" alt="Screenshot 2023-01-30 at 15 57 41" src="https://user-images.githubusercontent.com/19200662/215513860-02842c26-350b-4b4b-9818-5ceaa56f933e.png">


