### PR TITLE
Setup Storyblok to be used on the confirmation page

### DIFF
--- a/apps/store/src/blocks/ConfirmationPageBlock.tsx
+++ b/apps/store/src/blocks/ConfirmationPageBlock.tsx
@@ -1,0 +1,18 @@
+import { storyblokEditable, StoryblokComponent, SbBlokData } from '@storyblok/react'
+import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+
+type ConfirmationPageBlockProps = SbBaseBlockProps<{
+  body: SbBlokData[]
+}>
+
+export const ConfirmationPageBlock = ({ blok }: ConfirmationPageBlockProps) => {
+  return (
+    <div {...storyblokEditable(blok)}>
+      {blok.body.map((nestedBlock) => (
+        <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+      ))}
+    </div>
+  )
+}
+
+ConfirmationPageBlock.blockName = 'confirmation'

--- a/apps/store/src/blocks/ConfirmationPageBlock.tsx
+++ b/apps/store/src/blocks/ConfirmationPageBlock.tsx
@@ -15,4 +15,4 @@ export const ConfirmationPageBlock = ({ blok }: ConfirmationPageBlockProps) => {
   )
 }
 
-ConfirmationPageBlock.blockName = 'confirmation'
+ConfirmationPageBlock.blockName = 'confirmationPage'

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -4,13 +4,22 @@ import { Heading, mq, Space, Text, theme } from 'ui'
 import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
 import { CartInventory } from '@/components/CartInventory/CartInventory'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
-import { appStoreLinks } from '@/utils/appStoreLinks'
+import { ConfirmationStory } from '@/services/storyblok/storyblok'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { AppStoreBadge } from '../AppStoreBadge/AppStoreBadge'
 import { CheckList, CheckListItem } from './CheckList'
 import { ConfirmationPageProps } from './ConfirmationPage.types'
 
-export const ConfirmationPage = (props: ConfirmationPageProps) => {
+const appStoreLinks = {
+  apple: 'https://apps.apple.com/se/app/id1303668531?l=en',
+  google: 'https://play.google.com/store/apps/details?id=com.hedvig.app',
+} as const
+
+type Props = ConfirmationPageProps & {
+  story: ConfirmationStory
+}
+
+export const ConfirmationPage = (props: Props) => {
   const { locale } = useCurrentLocale()
   const { platform, cart, story } = props
 

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -5,15 +5,11 @@ import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
 import { CartInventory } from '@/components/CartInventory/CartInventory'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { ConfirmationStory } from '@/services/storyblok/storyblok'
+import { appStoreLinks } from '@/utils/appStoreLinks'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { AppStoreBadge } from '../AppStoreBadge/AppStoreBadge'
 import { CheckList, CheckListItem } from './CheckList'
 import { ConfirmationPageProps } from './ConfirmationPage.types'
-
-const appStoreLinks = {
-  apple: 'https://apps.apple.com/se/app/id1303668531?l=en',
-  google: 'https://play.google.com/store/apps/details?id=com.hedvig.app',
-} as const
 
 type Props = ConfirmationPageProps & {
   story: ConfirmationStory

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import Link from 'next/link'
 import { Heading, mq, Space, Text, theme } from 'ui'
+import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
 import { CartInventory } from '@/components/CartInventory/CartInventory'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { appStoreLinks } from '@/utils/appStoreLinks'
@@ -11,7 +12,7 @@ import { ConfirmationPageProps } from './ConfirmationPage.types'
 
 export const ConfirmationPage = (props: ConfirmationPageProps) => {
   const { locale } = useCurrentLocale()
-  const { platform, cart } = props
+  const { platform, cart, story } = props
 
   return (
     <Wrapper>
@@ -66,6 +67,7 @@ export const ConfirmationPage = (props: ConfirmationPageProps) => {
           </Space>
         </main>
       </Space>
+      <ConfirmationPageBlock blok={story.content} />
     </Wrapper>
   )
 }

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
@@ -1,8 +1,9 @@
 import { CartFragmentFragment } from '@/services/apollo/generated'
-import { StoryblokPageProps } from '@/services/storyblok/storyblok'
+import { ConfirmationStory, StoryblokPageProps } from '@/services/storyblok/storyblok'
 
-export type ConfirmationPageProps = Pick<StoryblokPageProps, 'globalStory'> & {
+export type ConfirmationPageProps = StoryblokPageProps & {
   currency: string
   platform: 'apple' | 'google' | null
   cart: CartFragmentFragment
+  story: ConfirmationStory
 }

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
@@ -1,9 +1,8 @@
 import { CartFragmentFragment } from '@/services/apollo/generated'
-import { ConfirmationStory, StoryblokPageProps } from '@/services/storyblok/storyblok'
+import { StoryblokPageProps } from '@/services/storyblok/storyblok'
 
-export type ConfirmationPageProps = StoryblokPageProps & {
+export type ConfirmationPageProps = Pick<StoryblokPageProps, 'globalStory'> & {
   currency: string
   platform: 'apple' | 'google' | null
   cart: CartFragmentFragment
-  story: ConfirmationStory
 }

--- a/apps/store/src/pages/confirmation/[shopSessionId].tsx
+++ b/apps/store/src/pages/confirmation/[shopSessionId].tsx
@@ -6,7 +6,7 @@ import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
 import { addApolloState, initializeApollo } from '@/services/apollo/client'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
-import { getGlobalStory, getStoryBySlug } from '@/services/storyblok/storyblok'
+import { ConfirmationStory, getGlobalStory, getStoryBySlug } from '@/services/storyblok/storyblok'
 import { GLOBAL_STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
 import { getMobilePlatform } from '@/utils/getMobilePlatform'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
@@ -52,9 +52,9 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
   })
 }
 
-const CheckoutConfirmationPage: NextPageWithLayout<ConfirmationPageProps> = (props) => (
-  <ConfirmationPage {...props} />
-)
+const CheckoutConfirmationPage: NextPageWithLayout<
+  ConfirmationPageProps & { story: ConfirmationStory }
+> = (props) => <ConfirmationPage {...props} />
 
 CheckoutConfirmationPage.getLayout = (children) => <LayoutWithMenu>{children}</LayoutWithMenu>
 

--- a/apps/store/src/pages/confirmation/[shopSessionId].tsx
+++ b/apps/store/src/pages/confirmation/[shopSessionId].tsx
@@ -3,14 +3,15 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { ConfirmationPage } from '@/components/ConfirmationPage/ConfirmationPage'
 import { ConfirmationPageProps } from '@/components/ConfirmationPage/ConfirmationPage.types'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
-// import { PageLink } from '@/lib/PageLink'
 import { addApolloState, initializeApollo } from '@/services/apollo/client'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
-import { getGlobalStory } from '@/services/storyblok/storyblok'
+import { getGlobalStory, getStoryBySlug } from '@/services/storyblok/storyblok'
 import { GLOBAL_STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
 import { getMobilePlatform } from '@/utils/getMobilePlatform'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+
+const CONFIRMATION_PAGE_SLUG = 'confirmation'
 
 type Params = { shopSessionId: string }
 
@@ -18,6 +19,7 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
   context,
 ) => {
   const { req, res, locale, params } = context
+
   if (!isRoutingLocale(locale)) return { notFound: true }
 
   const shopSessionId = params?.shopSessionId
@@ -25,10 +27,11 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
 
   const apolloClient = initializeApollo({ req, res })
   const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
-  const [shopSession, globalStory, translations] = await Promise.all([
+  const [shopSession, translations, globalStory, story] = await Promise.all([
     shopSessionService.fetchById(shopSessionId),
-    getGlobalStory({ locale }),
     serverSideTranslations(locale),
+    getGlobalStory({ locale }),
+    getStoryBySlug(CONFIRMATION_PAGE_SLUG, { locale }),
   ])
 
   // @TODO: uncomment after implementing signing
@@ -44,13 +47,14 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
       cart: shopSession.cart,
       currency: shopSession.currencyCode,
       platform: getMobilePlatform(req.headers['user-agent'] ?? ''),
+      story,
     },
   })
 }
 
-const CheckoutConfirmationPage: NextPageWithLayout<ConfirmationPageProps> = (props) => {
-  return <ConfirmationPage {...props} />
-}
+const CheckoutConfirmationPage: NextPageWithLayout<ConfirmationPageProps> = (props) => (
+  <ConfirmationPage {...props} />
+)
 
 CheckoutConfirmationPage.getLayout = (children) => <LayoutWithMenu>{children}</LayoutWithMenu>
 

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -124,7 +124,6 @@ export type GlobalStory = ISbStoryData & {
 export type ReusableStory = ISbStoryData & {
   content: ISbStoryData['content'] & {
     body: Array<SbBlokData>
-    global: Array<SbBlokData>
   }
 }
 

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -10,6 +10,7 @@ import { AccordionItemBlock } from '@/blocks/AccordionItemBlock'
 import { BannerBlock } from '@/blocks/BannerBlock'
 import { ButtonBlock } from '@/blocks/ButtonBlock'
 import { CheckListBlock } from '@/blocks/CheckListBlock'
+import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
 import { ContactSupportBlock } from '@/blocks/ContactSupportBlock'
 import { ContentBlock } from '@/blocks/ContentBlock'
 import { FooterBlock, FooterBlockProps, FooterLink, FooterSection } from '@/blocks/FooterBlock'
@@ -123,6 +124,13 @@ export type GlobalStory = ISbStoryData & {
 export type ReusableStory = ISbStoryData & {
   content: ISbStoryData['content'] & {
     body: Array<SbBlokData>
+    global: Array<SbBlokData>
+  }
+}
+
+export type ConfirmationStory = ISbStoryData & {
+  content: ISbStoryData['content'] & {
+    body: Array<SbBlokData>
   }
 }
 
@@ -150,6 +158,7 @@ export const initStoryblok = () => {
     CheckListBlock,
     ContactSupportBlock,
     ContentBlock,
+    ConfirmationPageBlock,
     FooterBlock,
     FooterLink,
     FooterSection,


### PR DESCRIPTION
## Describe your changes

Looking to create a page where some of the content is hardcoded and the other is managed in Storyblok. 

- Creating a `confirmation` component in Storyblok and in code.

## Justify why they are needed

Designers want the ability to changes things around on parts of the confirmation page, these changes would be a step to allowing that to happen.

## Jira issue(s): []

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
