### PR TITLE
GRW-2145 - feat(ProductPage): added SEO data

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import { storyblokEditable, StoryblokComponent, SbBlokData } from '@storyblok/react'
+import Head from 'next/head'
 import { useState } from 'react'
 import { mq, theme } from 'ui'
 import { MENU_BAR_HEIGHT_DESKTOP } from '@/components/Header/HeaderStyles'
@@ -8,17 +9,26 @@ import { PurchaseForm } from '@/components/ProductPage/PurchaseForm/PurchaseForm
 import * as Tabs from '@/components/ProductPage/Tabs'
 import type { TabsProps } from '@/components/ProductPage/Tabs'
 import { ProductVariantSelector } from '@/components/ProductVariantSelector/ProductVariantSelector'
-import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 
 const TABLIST_HEIGHT = '2.5rem'
 
-type ProductPageBlockProps = SbBaseBlockProps<{
-  overviewLabel: string
-  coverageLabel: string
-  overview: SbBlokData[]
-  coverage: SbBlokData[]
-  body: SbBlokData[]
-}>
+type SEOData = {
+  robots: 'index' | 'noindex'
+  seoMetaTitle?: string
+  seoMetaDescription?: string
+  seoMetaOgImage?: StoryblokAsset
+}
+
+type ProductPageBlockProps = SbBaseBlockProps<
+  {
+    overviewLabel: string
+    coverageLabel: string
+    overview: SbBlokData[]
+    coverage: SbBlokData[]
+    body: SbBlokData[]
+  } & SEOData
+>
 
 export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
   const { productData } = useProductPageContext()
@@ -27,34 +37,52 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
   const shouldRenderVariantSelector = selectedTab === 'coverage' && productData.variants.length > 1
 
   return (
-    <Main {...storyblokEditable(blok)}>
-      <MobileLayout>
-        <PurchaseForm />
-        <ProducPageTabs
-          blok={blok}
-          renderVariantSelector={shouldRenderVariantSelector}
-          value={selectedTab}
-          onValueChange={setSelectedTab}
-        />
-      </MobileLayout>
-
-      <DesktopLayout>
-        <ProducPageTabs
-          blok={blok}
-          renderVariantSelector={shouldRenderVariantSelector}
-          value={selectedTab}
-          onValueChange={setSelectedTab}
-        />
-
-        <PurchaseFormWrapper>
+    <>
+      <Head>
+        <meta name="robots" content={blok.robots} />
+        {blok.seoMetaTitle && (
+          <>
+            <meta name="title" content={blok.seoMetaTitle} />
+            <meta property="og:title" content={blok.seoMetaTitle} />
+          </>
+        )}
+        {blok.seoMetaDescription && (
+          <>
+            <meta name="description" content={blok.seoMetaDescription} />
+            <meta property="og:description" content={blok.seoMetaDescription} />
+          </>
+        )}
+        {blok.seoMetaOgImage && <meta property="og:image" content={blok.seoMetaOgImage.filename} />}
+      </Head>
+      <Main {...storyblokEditable(blok)}>
+        <MobileLayout>
           <PurchaseForm />
-        </PurchaseFormWrapper>
-      </DesktopLayout>
+          <ProducPageTabs
+            blok={blok}
+            renderVariantSelector={shouldRenderVariantSelector}
+            value={selectedTab}
+            onValueChange={setSelectedTab}
+          />
+        </MobileLayout>
 
-      {blok.body.map((nestedBlock) => (
-        <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
-      ))}
-    </Main>
+        <DesktopLayout>
+          <ProducPageTabs
+            blok={blok}
+            renderVariantSelector={shouldRenderVariantSelector}
+            value={selectedTab}
+            onValueChange={setSelectedTab}
+          />
+
+          <PurchaseFormWrapper>
+            <PurchaseForm />
+          </PurchaseFormWrapper>
+        </DesktopLayout>
+
+        {blok.body.map((nestedBlock) => (
+          <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+        ))}
+      </Main>
+    </>
   )
 }
 ProductPageBlock.blockName = 'product'


### PR DESCRIPTION
## Describe your changes

* Added some SEO meta tags for `ProductPageBlock`. Observe that's not possible to configure _og:title_ and _og:description_ in _Storyblok_ since they should [assume the same value as _meta title_ and _meta description_](https://hedviginsurance.slack.com/archives/C04JND65KPH/p1675086492792989?thread_ts=1675086209.814679&cid=C04JND65KPH).

## Justify why they are needed

Requested by Peter

## Jira issue(s): [GRW-2145](https://hedvig.atlassian.net/browse/GRW-2145)

<img width="400" alt="image" src="https://user-images.githubusercontent.com/19200662/215526399-0d7e2365-d536-411f-bffa-e1352dbd2fba.png">



[GRW-2145]: https://hedvig.atlassian.net/browse/GRW-2145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ