### PR TITLE
Add endpoint to set default campaign code

### DIFF
--- a/apps/store/README.md
+++ b/apps/store/README.md
@@ -62,6 +62,16 @@ Optional query parameters:
 > **Note**
 > This endpoint only supports Sweden for now.
 
+## Attach a campaign code
+
+You can attach a campaign code to the current (or new) shop session by using the following URL:
+
+```html
+/api/campaign/{CAMPAIGN_CODE}?next={REDIRECT_URL}
+```
+
+The `next` query parameter is required. When creating a new shop session, we base the country code on the locale from the `next` URL.
+
 ## Feature Flags
 
 Feature flags are used to enable/disable features in the app. They are stored in `/src/services/Flags`. Currenyly, we define all flags in code. In the future, we might want to move them to a 3rd party service.

--- a/apps/store/README.md
+++ b/apps/store/README.md
@@ -26,19 +26,18 @@ Requirements:
 
 - Add `APOLLO_KEY` to `.env.local` (see Vercel)
 
-## Sharing Shop Session
+## Share / Resume a Shop Session
 
 It can be useful to share a shop session with someone. Perhaps you've got into a strange state and want to share the session with a colleague so you can debug together.
 
-You do this by sending them a link:
+You do this by sending them a link: `/{LOCALE}/session/{SHOP_SESSION_ID}`
 
-```html
-https://www.store.dev.hedvigit.com/{LOCALE}/session/{SHOP_SESSION_ID}?next={REDIRECT_URL}
-```
+Optional query parameters:
 
-You can optionally provide a `?next=/se/cart` query parameter with the relative link to route to redirect the user. By default, the user is redirected to the home page.
+- `?next={REDIRECT_URL}`: Relative URL to redirect to (default: home page)
+- `?code={CAMPAIGN_CODE}`: Set a campaign code for the session
 
-## Resetting current Shop Session
+## Reset current Shop Session
 
 If you want to reset the current shop session, you can do so by visiting the following URL:
 

--- a/apps/store/src/pages/api/campaign/[code].ts
+++ b/apps/store/src/pages/api/campaign/[code].ts
@@ -1,0 +1,74 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { initializeApollo } from '@/services/apollo/client'
+import {
+  RedeemCampaignDocument,
+  RedeemCampaignMutation,
+  RedeemCampaignMutationVariables,
+} from '@/services/apollo/generated'
+import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
+import { ShopSession } from '@/services/shopSession/ShopSession.types'
+import { getCountryByLocale } from '@/utils/l10n/countryUtils'
+import { getUrlLocale } from '@/utils/l10n/localeUtils'
+import { ORIGIN_URL, PageLink } from '@/utils/PageLink'
+
+/**
+ * Get or create a ShopSession, redeem a campaign code, and navigate to the next page.
+ */
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { query, url } = req
+  const fallbackRedirect: [number, string] = [307, PageLink.home()]
+
+  const nextURL = new URL(ORIGIN_URL)
+  const nextQueryParam = query['next']
+  if (typeof nextQueryParam !== 'string') {
+    console.error('Missing next query parameter: ', url)
+    return res.redirect(...fallbackRedirect)
+  }
+  nextURL.pathname = nextQueryParam
+
+  const locale = getUrlLocale(nextURL.toString())
+  fallbackRedirect[1] = PageLink.home({ locale })
+
+  const { countryCode } = getCountryByLocale(locale)
+
+  const apolloClient = initializeApollo({ req, res })
+  const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
+
+  let shopSession: ShopSession
+  try {
+    shopSession = await shopSessionService.getOrCreate({ countryCode })
+  } catch (error) {
+    console.error('Error creating shop session', error)
+    return res.redirect(...fallbackRedirect)
+  }
+
+  const campaignCode = query['code']
+  if (typeof campaignCode !== 'string') {
+    console.error('Missing campaign code query parameter: ', url)
+    return res.redirect(...fallbackRedirect)
+  }
+
+  try {
+    const response = await apolloClient.mutate<
+      RedeemCampaignMutation,
+      RedeemCampaignMutationVariables
+    >({
+      mutation: RedeemCampaignDocument,
+      variables: { cartId: shopSession.cart.id, code: campaignCode },
+    })
+    if (!response.data?.cartRedeemCampaign.cart) {
+      const message = `Invalid campaign code: ${campaignCode}`
+      console.warn(message, response.data?.cartRedeemCampaign.userError?.message)
+      return res.redirect(...fallbackRedirect)
+    }
+  } catch (error) {
+    console.error(`Unable to redeem campaign: ${campaignCode}`, error)
+    return res.redirect(...fallbackRedirect)
+  }
+
+  const destination = nextURL.toString()
+  console.log(`Re-directing to destination: ${destination}`)
+  return res.redirect(307, destination)
+}
+
+export default handler


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add a new endpoint to be able to attatch a campaign code to the current or new shop session.

## Justify why they are needed

This will be used in marketting.

We discussed that limiting it to a given endpoint will help us to maintain it rather than supporting a query parameter anywhere on the site. This was okeyed by Simon and Sonny.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
