### PR TITLE
GRW-2159 - fix content navigation for desktop layout

### DIFF
--- a/packages/ui/src/lib/globalStyles.ts
+++ b/packages/ui/src/lib/globalStyles.ts
@@ -22,6 +22,15 @@ export const globalStyles = css`
     box-sizing: border-box;
   }
 
+  html {
+    scroll-behavior: smooth;
+  }
+  @media screen and (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+  }
+
   /* Set default font rules and color on body */
   body {
     color: ${getColor('textPrimary')};

--- a/packages/ui/src/lib/theme/colors/colors.ts
+++ b/packages/ui/src/lib/theme/colors/colors.ts
@@ -170,6 +170,7 @@ export const colors = {
   grayTranslucent100: grayTranslucent[100],
   grayTranslucent200: grayTranslucent[200],
   grayTranslucent300: grayTranslucent[300],
+  grayTranslucent400: grayTranslucent[400],
   grayTranslucent500: grayTranslucent[500],
   grayTranslucent600: grayTranslucent[600],
   grayTranslucent700: grayTranslucent[700],


### PR DESCRIPTION
## Describe your changes

* Updates _Overview/Coverage_ navigation controls work based on layout applied: Mobile or Desktop

## Justify why they are needed

_Overview/Coverage_ navigation should behave differently based on the layout applied:

* Mobile: they should work as tabs where only the content related with the active tab should be displayed;
* Desktop: all of the content should be displayed and the navigation control should behave like internal links to page content sections.

### Before

As it can be seen in the attached video below content for product page were being segmented in a tab format the same way mobile layout does; which is wrong:

https://user-images.githubusercontent.com/19200662/215842283-ea3545ba-18eb-47b2-9222-a8bc2fb8cc69.mov

### After

As it can be seen in the attached video below the whole product page content is now being displayed for the Desktop layout and _Overview/Coverage_ navigation are used as internal links:

https://user-images.githubusercontent.com/19200662/215842368-3c548f00-5324-4454-9dac-a4f786d5d2e7.mov


## Jira issue(s): [GRW-2159](https://hedvig.atlassian.net/browse/GRW-2159)




[GRW-2159]: https://hedvig.atlassian.net/browse/GRW-2159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ