### PR TITLE
Maintenance Day - Swap to theme imports

### DIFF
--- a/apps/onboarding/src/components/Button/Button.tsx
+++ b/apps/onboarding/src/components/Button/Button.tsx
@@ -4,7 +4,7 @@ import { ElementType, forwardRef } from 'react'
 import { ReactNode } from 'react'
 import { getMargins, Margins } from 'ui/src/lib/margins'
 import { getPaddings, Paddings } from 'ui/src/lib/paddings'
-import { getColor } from 'ui'
+import { getColor, theme } from 'ui'
 
 export type ButtonVariant = 'filled' | 'outlined' | 'text'
 export type ButtonSize = 'sm' | 'lg'
@@ -57,7 +57,7 @@ const paddingsForSize: Record<ButtonSize, string> = {
 }
 
 const ButtonElement = styled(UnstyledButton)<ButtonProps>(
-  ({ theme, variant = 'filled', fullWidth, color, size = 'lg', ...props }) => ({
+  ({ variant = 'filled', fullWidth, color, size = 'lg', ...props }) => ({
     width: fullWidth ? '100%' : 'auto',
     padding: paddingsForSize[size],
     lineHeight: size === 'lg' ? '1.5rem' : '1rem',

--- a/apps/onboarding/src/components/DebuggerPage/DebuggerPage.tsx
+++ b/apps/onboarding/src/components/DebuggerPage/DebuggerPage.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import React, { useState } from 'react'
-import { Space } from 'ui'
+import { Space, theme } from 'ui'
 import { Button } from '@/components/Button/Button'
 import { FixedFooter } from '@/components/FixedFooter'
 import { useForm } from '@/hooks/useForm'
@@ -10,10 +10,10 @@ import { FORMS_PER_MARKET, MARKETS, PageInput, PAGE_WIDTH } from './DebuggerPage
 import { DynamicInput } from './DynamicInput'
 import { InputSelect } from './InputSelect'
 
-const PageWrapper = styled.div(({ theme }) => ({
+const PageWrapper = styled.div({
   backgroundColor: theme.colors.gray200,
   minHeight: '100vh',
-}))
+})
 
 const Content = styled.div(() => ({
   maxWidth: PAGE_WIDTH,
@@ -22,16 +22,16 @@ const Content = styled.div(() => ({
   paddingBottom: `calc(${FixedFooter.HEIGHT} + 1rem)`,
 }))
 
-const InputGroup = styled.div(({ theme }) => ({
+const InputGroup = styled.div({
   backgroundColor: theme.colors.gray100,
   boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.1)',
   padding: '1rem',
   borderRadius: '0.75rem',
-}))
+})
 
-const ErrorText = styled.p(({ theme }) => ({
+const ErrorText = styled.p({
   color: theme.colors.red600,
-}))
+})
 
 export const DebuggerPage = () => {
   const pageForm = useForm({ action: PageLink.debuggerFormApi() })

--- a/apps/onboarding/src/components/ForeverPage/ForeverCodeReadyPage.tsx
+++ b/apps/onboarding/src/components/ForeverPage/ForeverCodeReadyPage.tsx
@@ -1,7 +1,7 @@
 import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { Space } from 'ui'
+import { Space, theme } from 'ui'
 import { LinkButton } from '@/components/Button/Button'
 import { useCurrentLocale } from '@/lib/l10n'
 import { PageLink } from '@/lib/PageLink'
@@ -25,10 +25,10 @@ const Wrapper = styled(Space)({
   alignItems: 'center',
 })
 
-const Paragraph = styled.p(({ theme }) => ({
+const Paragraph = styled.p({
   textAlign: 'center',
   color: theme.colors.gray700,
-}))
+})
 
 export const ForeverCodeReadyPage = () => {
   const { t } = useTranslation()

--- a/apps/onboarding/src/components/ForeverPage/PageLayout.tsx
+++ b/apps/onboarding/src/components/ForeverPage/PageLayout.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import Head from 'next/head'
-import { HedvigLogo, Space, mq } from 'ui'
+import { HedvigLogo, Space, mq, theme } from 'ui'
 import { LanguageSwitcher } from '@/components/language-switcher'
 
-const Wrapper = styled.div(({ theme }) => ({
+const Wrapper = styled.div({
   display: 'flex',
   flexDirection: 'column',
   padding: '2rem',
@@ -14,7 +14,7 @@ const Wrapper = styled.div(({ theme }) => ({
   [mq.lg]: {
     padding: '2.5rem 3.5rem',
   },
-}))
+})
 
 const Header = styled.header({
   display: 'flex',
@@ -26,13 +26,13 @@ const Header = styled.header({
   },
 })
 
-const SiteLink = styled.a(({ theme }) => ({
+const SiteLink = styled.a({
   color: theme.colors.gray900,
 
   '&:hover': {
     color: theme.colors.purple900,
   },
-}))
+})
 
 const Main = styled(Space)({
   flex: '1 1 0%',
@@ -49,7 +49,7 @@ const Footer = styled(Space)({
   alignItems: 'center',
 })
 
-const Paragraph = styled.div(({ theme }) => ({
+const Paragraph = styled.div({
   fontSize: '0.75rem',
   color: theme.colors.gray700,
   textAlign: 'center',
@@ -63,7 +63,7 @@ const Paragraph = styled.div(({ theme }) => ({
     color: theme.colors.purple900,
     textDecoration: 'underline',
   },
-}))
+})
 
 const Content = styled.div({
   flex: '1 1 0%',

--- a/apps/onboarding/src/components/Heading/Heading.tsx
+++ b/apps/onboarding/src/components/Heading/Heading.tsx
@@ -1,6 +1,6 @@
 import styled, { StyledComponent } from '@emotion/styled'
 import React from 'react'
-import { mq } from 'ui/src/lib/media-query'
+import { mq, theme } from 'ui'
 
 export type HeadingProps = {
   variant: 'xl' | 'l' | 'm' | 's' | 'xs' | 'overline'
@@ -15,7 +15,7 @@ type StyleProps = {
   as: HeadingProps['headingLevel']
 } & ColorProp
 
-const HeadingBase = styled.span<ColorProp>(({ theme, colorVariant }) => ({
+const HeadingBase = styled.span<ColorProp>(({ colorVariant }) => ({
   color: colorVariant === 'light' ? theme.colors.gray100 : theme.colors.gray900,
   margin: 0,
   padding: 0,

--- a/apps/onboarding/src/components/language-switcher.tsx
+++ b/apps/onboarding/src/components/language-switcher.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { Separate } from 'ui'
+import { Separate, theme } from 'ui'
 import { useCurrentMarket } from '@/lib/l10n'
 
 const FALLBACK_PATH = '/'
@@ -32,15 +32,15 @@ const Wrapper = styled(Separate)({
   height: '1.5rem',
 })
 
-const Separator = styled.div(({ theme }) => ({
+const Separator = styled.div({
   width: 1,
   height: '100%',
   backgroundColor: theme.colors.gray700,
   marginLeft: '0.5rem',
   marginRight: '0.5rem',
-}))
+})
 
-const StyledLink = styled(Link)<{ active: boolean }>(({ active, theme }) => ({
+const StyledLink = styled(Link)<{ active: boolean }>(({ active }) => ({
   textDecoration: 'none',
   '&:hover': {
     color: theme.colors.gray900,

--- a/apps/onboarding/src/components/page-header-layout.tsx
+++ b/apps/onboarding/src/components/page-header-layout.tsx
@@ -1,14 +1,14 @@
 import styled from '@emotion/styled'
-import { HedvigLogo, mq } from 'ui'
+import { HedvigLogo, mq, theme } from 'ui'
 
-const Container = styled.div(({ theme }) => ({
+const Container = styled.div({
   display: 'flex',
   flexDirection: 'column',
   backgroundColor: theme.colors.gray100,
   height: '100vh',
-}))
+})
 
-const Header = styled.header<{ variant: HeaderVariant }>(({ theme, variant }) => ({
+const Header = styled.header<{ variant: HeaderVariant }>(({ variant }) => ({
   position: 'absolute',
   display: 'flex',
   width: '100%',
@@ -22,7 +22,7 @@ const Header = styled.header<{ variant: HeaderVariant }>(({ theme, variant }) =>
   },
 }))
 
-const SiteLink = styled.a<{ variant: HeaderVariant }>(({ theme, variant }) => ({
+const SiteLink = styled.a<{ variant: HeaderVariant }>(({ variant }) => ({
   color: 'inherit',
 
   '&:hover': {

--- a/apps/store/src/blocks/BannerBlock.tsx
+++ b/apps/store/src/blocks/BannerBlock.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { default as NextImage } from 'next/image'
-import { Heading, Text, mq } from 'ui'
+import { Heading, Text, mq, theme } from 'ui'
 import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 
 type ImageSize = {
@@ -46,32 +46,30 @@ export const BannerBlock = ({ blok }: BannerBlockProps) => {
 }
 BannerBlock.blockName = 'banner'
 
-const Wrapper = styled('div')<ImageSize>(
-  ({ theme, aspectRatioLandscape, aspectRatioPortrait }) => ({
-    position: 'relative',
-    marginInline: theme.space.xs,
-    borderRadius: theme.radius.md,
-    overflow: 'hidden',
+const Wrapper = styled('div')<ImageSize>(({ aspectRatioLandscape, aspectRatioPortrait }) => ({
+  position: 'relative',
+  marginInline: theme.space.xs,
+  borderRadius: theme.radius.md,
+  overflow: 'hidden',
 
-    [mq.md]: {
-      marginInline: theme.space.md,
-      borderRadius: theme.radius.lg,
-    },
+  [mq.md]: {
+    marginInline: theme.space.md,
+    borderRadius: theme.radius.lg,
+  },
 
-    ['@media (orientation: portrait)']: {
-      ...(aspectRatioPortrait && { aspectRatio: aspectRatioPortrait }),
-    },
-    ['@media (orientation: landscape)']: {
-      ...(aspectRatioLandscape && { aspectRatio: aspectRatioLandscape }),
-    },
-  }),
-)
+  ['@media (orientation: portrait)']: {
+    ...(aspectRatioPortrait && { aspectRatio: aspectRatioPortrait }),
+  },
+  ['@media (orientation: landscape)']: {
+    ...(aspectRatioLandscape && { aspectRatio: aspectRatioLandscape }),
+  },
+}))
 
 const Image = styled(NextImage)({
   objectFit: 'cover',
 })
 
-const BodyWrapper = styled.div(({ theme }) => ({
+const BodyWrapper = styled.div({
   position: 'absolute',
   inset: 0,
   display: 'grid',
@@ -86,16 +84,16 @@ const BodyWrapper = styled.div(({ theme }) => ({
   [mq.md]: {
     padding: theme.space.xl,
   },
-}))
+})
 
-const Title = styled(Heading)(({ theme }) => ({
+const Title = styled(Heading)({
   gridArea: 'title',
   fontSize: theme.fontSizes[6],
 
   [mq.md]: {
     fontSize: theme.fontSizes[10],
   },
-}))
+})
 
 const Description = styled(Text)({
   gridArea: 'content',

--- a/apps/store/src/blocks/ButtonBlock.tsx
+++ b/apps/store/src/blocks/ButtonBlock.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { ComponentProps } from 'react'
-import { Button } from 'ui'
+import { Button, theme } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
@@ -28,9 +28,9 @@ export const ButtonBlock = ({ blok }: ButtonBlockProps) => {
 }
 ButtonBlock.blockName = 'button'
 
-export const Wrapper = styled.div(({ theme }) => ({
+export const Wrapper = styled.div({
   display: 'flex',
   justifyContent: 'center',
   paddingLeft: theme.space[4],
   paddingRight: theme.space[4],
-}))
+})

--- a/apps/store/src/blocks/CheckListBlock.tsx
+++ b/apps/store/src/blocks/CheckListBlock.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import { SbBlokData, storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
+import { theme } from 'ui'
 import { TextBlock, TextBlockProps } from '@/blocks/TextBlock'
 import * as CheckList from '@/components/CheckList/CheckList'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
@@ -31,7 +32,7 @@ const isTextBlock = (blok: SbBlokData): blok is TextBlockProps['blok'] => {
   return blok.component === TextBlock.blockName
 }
 
-const Wrapper = styled.div(({ theme }) => ({
+const Wrapper = styled.div({
   paddingLeft: theme.space[4],
   paddingRight: theme.space[4],
-}))
+})

--- a/apps/store/src/blocks/ContentBlock.tsx
+++ b/apps/store/src/blocks/ContentBlock.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { ISbRichtext, renderRichText, storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
-import { Space, HeadingLabel, mq } from 'ui'
+import { Space, HeadingLabel, mq, theme } from 'ui'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
 type Alignment = 'left' | 'center' | 'right' | 'justify'
@@ -26,13 +26,13 @@ export const ContentBlock = ({ blok }: Props) => {
 }
 ContentBlock.blockName = 'content'
 
-const Wrapper = styled(Space)(({ theme }) => ({
+const Wrapper = styled(Space)({
   maxWidth: '37.5rem',
   paddingLeft: theme.space[4],
   paddingRight: theme.space[4],
-}))
+})
 
-const TextWrapper = styled.div<{ alignment: Alignment }>(({ theme, alignment }) => ({
+const TextWrapper = styled.div<{ alignment: Alignment }>(({ alignment }) => ({
   fontSize: theme.fontSizes.xl,
   textAlign: alignment,
 

--- a/apps/store/src/blocks/HeadingBlock.tsx
+++ b/apps/store/src/blocks/HeadingBlock.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
-import { Heading, HeadingProps, PossibleHeadingVariant } from 'ui'
+import { Heading, HeadingProps, PossibleHeadingVariant, theme } from 'ui'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
-export const Wrapper = styled.div(({ theme }) => ({
+export const Wrapper = styled.div({
   paddingLeft: theme.space[4],
   paddingRight: theme.space[4],
-}))
+})
 
 export type HeadingBlockProps = SbBaseBlockProps<{
   text: string

--- a/apps/store/src/blocks/HeroBlock.tsx
+++ b/apps/store/src/blocks/HeroBlock.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import Image from 'next/image'
+import { theme } from 'ui'
 import { ButtonBlock, ButtonBlockProps } from '@/blocks/ButtonBlock'
 import { HeadingBlock, HeadingBlockProps } from '@/blocks/HeadingBlock'
 import { ExpectedBlockType, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
@@ -44,7 +45,7 @@ export const HeroBlock = ({ blok }: HeroBlockProps) => {
 }
 HeroBlock.blockName = 'hero'
 
-const HeroSection = styled.section(({ theme }) => ({
+const HeroSection = styled.section({
   position: 'relative',
   display: 'flex',
   flexDirection: 'column',
@@ -52,7 +53,7 @@ const HeroSection = styled.section(({ theme }) => ({
   minHeight: '80vh',
   paddingTop: theme.space[9],
   paddingBottom: theme.space[9],
-}))
+})
 
 const HeroImageWrapper = styled.div({
   zIndex: '-1',

--- a/apps/store/src/blocks/InsurableLimitsBlock.tsx
+++ b/apps/store/src/blocks/InsurableLimitsBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
-import { HeadingLabel } from 'ui'
+import { HeadingLabel, theme } from 'ui'
 import { InsurableLimits } from '@/components/InsurableLimits/InsurableLimits'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import * as Statistic from '@/components/Statistic/Statistic'
@@ -31,6 +31,6 @@ export const InsurableLimitsBlock = ({ blok }: InsurableLimitsBlockProps) => {
 }
 InsurableLimitsBlock.blockName = 'insurableLimits'
 
-const StyledInsurableLimits = styled(InsurableLimits)(({ theme }) => ({
+const StyledInsurableLimits = styled(InsurableLimits)({
   padding: theme.space[4],
-}))
+})

--- a/apps/store/src/blocks/ProductSlideshowBlock.tsx
+++ b/apps/store/src/blocks/ProductSlideshowBlock.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
+import { theme } from 'ui'
 import { Slideshow } from '@/components/Slideshow/Slideshow'
 import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
@@ -25,7 +26,7 @@ export const ProductSlideshowBlock = ({ blok }: ProductSlideshowBlockProps) => {
 }
 ProductSlideshowBlock.blockName = 'productSlideshow'
 
-const Wrapper = styled.div(({ theme }) => ({
+const Wrapper = styled.div({
   paddingLeft: theme.space[3],
   paddingRight: theme.space[3],
-}))
+})

--- a/apps/store/src/blocks/SpacerBlock.tsx
+++ b/apps/store/src/blocks/SpacerBlock.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
+import { theme } from 'ui'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
 type Props = {
@@ -13,6 +14,6 @@ export const SpacerBlock = ({ blok }: SpacerBlockProps) => {
 }
 SpacerBlock.blockName = 'spacer'
 
-const Spacer = styled.div<Props>(({ theme, size }) => ({
+const Spacer = styled.div<Props>(({ size }) => ({
   height: theme.space[size as keyof typeof theme.space] ?? size,
 }))

--- a/apps/store/src/blocks/TimelineItemBlock.tsx
+++ b/apps/store/src/blocks/TimelineItemBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { ISbRichtext, renderRichText } from '@storyblok/react'
-import { Heading } from 'ui'
+import { Heading, theme } from 'ui'
 import * as Timeline from '@/components/Timeline/Timeline'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
@@ -32,7 +32,7 @@ export const TimelineItemBlock = ({ blok, isFirst, isLast }: TimelineItemBlockPr
 }
 TimelineItemBlock.blockName = 'timelineItem'
 
-const StyledBody = styled.div(({ theme }) => ({
+const StyledBody = styled.div({
   color: theme.colors.gray600,
-  marginTop: theme.space[2],
-}))
+  marginTop: theme.space.xs,
+})

--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { mq } from 'ui'
+import { mq, theme } from 'ui'
 import { Video, VideoProps } from '@/components/Video/Video'
 import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 
@@ -36,9 +36,9 @@ export const VideoBlock = ({ className, blok }: VideoBlockProps) => {
 }
 VideoBlock.blockName = 'videoBlock'
 
-const Wrapper = styled.div(({ theme }) => ({
+const Wrapper = styled.div({
   paddingInline: theme.space[2],
   [mq.lg]: {
     paddingInline: theme.space[4],
   },
-}))
+})

--- a/apps/store/src/components/CartInventory/CartEntryList.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryList.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { ReactNode } from 'react'
-import { Separate } from 'ui'
+import { Separate, theme } from 'ui'
 
 type Props = { children: ReactNode }
 
@@ -18,9 +18,9 @@ const StyledCartEntryList = styled(Separate)({
   width: '100%',
 })
 
-const HorizontalLineWithSpace = styled.hr(({ theme }) => ({
+const HorizontalLineWithSpace = styled.hr({
   backgroundColor: theme.colors.gray300,
   height: 1,
   marginTop: theme.space.lg,
   marginBottom: theme.space.lg,
-}))
+})

--- a/apps/store/src/components/CartInventory/InventoryItem.tsx
+++ b/apps/store/src/components/CartInventory/InventoryItem.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
+import { theme } from 'ui'
 
-export const Root = styled.div(({ theme }) => ({
+export const Root = styled.div({
   display: 'grid',
   columnGap: theme.space[4],
   rowGap: theme.space[1],
@@ -11,13 +12,13 @@ export const Root = styled.div(({ theme }) => ({
     'left  main'
     'empty bottom'
   `,
-}))
+})
 
 export const Left = styled.div({
   gridArea: 'left',
 })
 
-export const Main = styled.div(({ theme }) => ({
+export const Main = styled.div({
   gridArea: 'main',
 
   display: 'grid',
@@ -29,7 +30,7 @@ export const Main = styled.div(({ theme }) => ({
     'main-left   main-right'
     'main-bottom main-bottom'
   `,
-}))
+})
 
 export const MainLeft = styled.div({
   gridArea: 'main-left',

--- a/apps/store/src/components/CartNotification/CartToast.tsx
+++ b/apps/store/src/components/CartNotification/CartToast.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { forwardRef, useImperativeHandle, useState } from 'react'
-import { Heading, Space, Dialog, CrossIcon, theme } from 'ui'
+import { Space, Dialog, mq, theme } from 'ui'
 import { MENU_BAR_HEIGHT_DESKTOP, MENU_BAR_HEIGHT_MOBILE } from '@/components/Header/HeaderStyles'
 import { PageLink } from '@/utils/PageLink'
 import { ButtonNextLink } from '../ButtonNextLink'
@@ -74,18 +74,8 @@ const DialogContentWrapper = styled.div({
   paddingTop: theme.space.lg,
   paddingBottom: theme.space.xs,
 
-  borderRadius: theme.radius.sm,
-  backgroundColor: theme.colors.light,
-  boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.15)',
-})
   borderBottomLeftRadius: theme.radius.md,
   borderBottomRightRadius: theme.radius.md,
-
-const TopRightCloseButton = styled(Dialog.Close)({
-  position: 'absolute',
-  top: theme.space.md,
-  right: theme.space.md,
-  cursor: 'pointer',
 
   backgroundColor: theme.colors.light,
   boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.15)',

--- a/apps/store/src/components/CartNotification/CartToast.tsx
+++ b/apps/store/src/components/CartNotification/CartToast.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { forwardRef, useImperativeHandle, useState } from 'react'
-import { Space, Dialog, mq } from 'ui'
+import { Heading, Space, Dialog, CrossIcon, theme } from 'ui'
 import { MENU_BAR_HEIGHT_DESKTOP, MENU_BAR_HEIGHT_MOBILE } from '@/components/Header/HeaderStyles'
 import { PageLink } from '@/utils/PageLink'
 import { ButtonNextLink } from '../ButtonNextLink'
@@ -64,7 +64,7 @@ const DialogContent = styled(Dialog.Content)({
   },
 })
 
-const DialogContentWrapper = styled.div(({ theme }) => ({
+const DialogContentWrapper = styled.div({
   position: 'relative',
   display: 'flex',
   flexDirection: 'column',
@@ -74,8 +74,18 @@ const DialogContentWrapper = styled.div(({ theme }) => ({
   paddingTop: theme.space.lg,
   paddingBottom: theme.space.xs,
 
+  borderRadius: theme.radius.sm,
+  backgroundColor: theme.colors.light,
+  boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.15)',
+})
   borderBottomLeftRadius: theme.radius.md,
   borderBottomRightRadius: theme.radius.md,
+
+const TopRightCloseButton = styled(Dialog.Close)({
+  position: 'absolute',
+  top: theme.space.md,
+  right: theme.space.md,
+  cursor: 'pointer',
 
   backgroundColor: theme.colors.light,
   boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.15)',
@@ -84,4 +94,4 @@ const DialogContentWrapper = styled.div(({ theme }) => ({
     borderRadius: theme.radius.md,
     maxWidth: '28rem',
   },
-}))
+})

--- a/apps/store/src/components/CheckList/CheckList.tsx
+++ b/apps/store/src/components/CheckList/CheckList.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { PropsWithChildren } from 'react'
-import { CheckIcon } from 'ui'
+import { CheckIcon, theme } from 'ui'
 
 export const Root = styled.ul({
   padding: 0,
@@ -17,11 +17,11 @@ export const Item = ({ children }: PropsWithChildren<unknown>) => {
   )
 }
 
-const StyledItem = styled.li(({ theme }) => ({
+const StyledItem = styled.li({
   display: 'flex',
   alignItems: 'center',
-  gap: theme.space[2],
-}))
+  gap: theme.space.xs,
+})
 
 const IconWrapper = styled.div({ flexShrink: 0 })
 const Content = styled.div({ flex: 1 })

--- a/apps/store/src/components/CheckoutPaymentPage/CheckoutPaymentPage.tsx
+++ b/apps/store/src/components/CheckoutPaymentPage/CheckoutPaymentPage.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Heading, Space } from 'ui'
+import { Heading, Space, theme } from 'ui'
 
 type Props = {
   children: React.ReactNode
@@ -24,17 +24,17 @@ export const CheckoutPaymentPage = ({ children, Header }: Props) => {
   )
 }
 
-const HeaderWrapper = styled.header(({ theme }) => ({
+const HeaderWrapper = styled.header({
   padding: theme.space[3],
-}))
+})
 
-const PageHeader = styled.header(({ theme }) => ({
+const PageHeader = styled.header({
   display: 'flex',
   justifyContent: 'center',
   paddingLeft: theme.space[3],
   paddingRight: theme.space[3],
-}))
+})
 
-const Main = styled.main(({ theme }) => ({
+const Main = styled.main({
   padding: theme.space[3],
-}))
+})

--- a/apps/store/src/components/ContactSupport/ContactSupport.tsx
+++ b/apps/store/src/components/ContactSupport/ContactSupport.tsx
@@ -63,12 +63,12 @@ export const ContactSupport = ({
   )
 }
 
-const Main = styled.main(({ theme }) => ({
+const Main = styled.main({
   padding: theme.space[4],
   paddingTop: theme.space[5],
   paddingBottom: theme.space[5],
   textAlign: 'center',
-}))
+})
 
 const CardWrapper = styled.div({
   display: 'grid',

--- a/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
+++ b/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { CrossIcon, Dialog, mq } from 'ui'
+import { CrossIcon, Dialog, mq, theme } from 'ui'
 
 type Props = {
   children: React.ReactNode
@@ -35,7 +35,7 @@ const Content = styled(Dialog.Content)({
 })
 
 const HEADER_HEIGHT = '3.5rem'
-const Header = styled.header(({ theme }) => ({
+const Header = styled.header({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'flex-end',
@@ -49,7 +49,7 @@ const Header = styled.header(({ theme }) => ({
   [mq.lg]: {
     paddingInline: theme.space.xl,
   },
-}))
+})
 
 const CloseButton = styled(Dialog.Close)({ cursor: 'pointer' })
 
@@ -57,26 +57,26 @@ const Main = styled.main({
   height: '100%',
 })
 
-const CenteredMain = styled(Main)(({ theme }) => ({
+const CenteredMain = styled(Main)({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   paddingInline: theme.space.md,
-}))
+})
 
 const ClearHeader = styled.div({
   height: HEADER_HEIGHT,
 })
 
 const BUTTON_HEIGHT = '3.25rem'
-const ClearFooter = styled.div(({ theme }) => ({
+const ClearFooter = styled.div({
   height: `calc(${BUTTON_HEIGHT} + ${theme.space.md} * 2)`,
   [mq.lg]: {
     height: `calc(${BUTTON_HEIGHT} + ${theme.space.xxl} * 2)`,
   },
-}))
+})
 
-const FooterWrapper = styled.footer(({ theme }) => ({
+const FooterWrapper = styled.footer({
   position: 'fixed',
   bottom: 0,
   left: 0,
@@ -92,7 +92,7 @@ const FooterWrapper = styled.footer(({ theme }) => ({
   [mq.lg]: {
     paddingBottom: theme.space.xxl,
   },
-}))
+})
 
 export const Root = Dialog.Root
 export const Close = Dialog.Close

--- a/apps/store/src/components/Header/Header.stories.tsx
+++ b/apps/store/src/components/Header/Header.stories.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import { ComponentMeta, Story } from '@storybook/react'
 import Link from 'next/link'
+import { theme } from 'ui'
 import { PageLink } from '@/utils/PageLink'
 import { Header, Wrapper as MockedHeaderWrapper } from './Header'
 import {
@@ -25,12 +26,12 @@ const ShoppingCartMenuItemWrapper = styled.div({
   lineHeight: 0,
 })
 
-const StyledLink = styled(Link)(({ theme }) => ({
+const StyledLink = styled(Link)({
   display: 'inline-block',
   '&:focus-visible': {
     outline: `2px solid ${theme.colors.gray900}`,
   },
-}))
+})
 
 export const MockedShoppingCartMenuItem = ({ count = 0 }) => {
   return (

--- a/apps/store/src/components/Header/NavigationLink.tsx
+++ b/apps/store/src/components/Header/NavigationLink.tsx
@@ -12,7 +12,7 @@ const StyledSecondaryNavigationLink = styled(NavigationMenuPrimitive.Link)({
   ...focusableStyles,
 })
 
-const ProductNavigationLinkCard = styled(Space)(({ theme }) => ({
+const ProductNavigationLinkCard = styled(Space)({
   ...focusableStyles,
   display: 'flex',
   placeItems: 'center',
@@ -28,7 +28,7 @@ const ProductNavigationLinkCard = styled(Space)(({ theme }) => ({
       },
     },
   },
-}))
+})
 
 const StyledPillow = styled(Pillow)({
   height: '6rem',

--- a/apps/store/src/components/Header/ShoppingCartMenuItem.tsx
+++ b/apps/store/src/components/Header/ShoppingCartMenuItem.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import Link from 'next/link'
+import { theme } from 'ui'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { PageLink } from '@/utils/PageLink'
 import { ShoppingBagIcon } from './ShoppingBagIcon'
@@ -22,9 +23,9 @@ const Wrapper = styled.div({
   lineHeight: 0,
 })
 
-const StyledLink = styled(Link)(({ theme }) => ({
+const StyledLink = styled(Link)({
   display: 'inline-block',
   '&:focus-visible': {
     outline: `2px solid ${theme.colors.gray900}`,
   },
-}))
+})

--- a/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
+++ b/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
@@ -24,21 +24,21 @@ export const DialogClose = styled(DialogPrimitive.DialogClose)({
   ...triggerStyles,
 })
 
-const ButtonWrapper = styled(Space)(({ theme }) => ({
+const ButtonWrapper = styled(Space)({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'center',
   paddingTop: theme.space.xxl,
-}))
+})
 
-const StyledAppleIcon = styled(AppleIcon)(({ theme }) => ({
+const StyledAppleIcon = styled(AppleIcon)({
   marginRight: theme.space.xs,
-}))
+})
 
-const StyledAndroidIcon = styled(AndroidIcon)(({ theme }) => ({
+const StyledAndroidIcon = styled(AndroidIcon)({
   marginRight: theme.space.xs,
-}))
+})
 
 export type TopMenuMobileProps = {
   isOpen?: boolean

--- a/apps/store/src/components/InputSelect/InputSelect.tsx
+++ b/apps/store/src/components/InputSelect/InputSelect.tsx
@@ -17,7 +17,7 @@ const StyledChevronIcon = styled(ChevronIcon)(() => ({
   transform: 'translateY(-50%)',
 }))
 
-const StyledSelect = styled.select(({ theme }) => ({
+const StyledSelect = styled.select({
   color: theme.colors.textPrimary,
   fontSize: theme.fontSizes.xl,
   borderRadius: theme.radius.sm,
@@ -31,11 +31,11 @@ const StyledSelect = styled.select(({ theme }) => ({
   '&:focus-visible': {
     boxShadow: `0 0 0 1px ${theme.colors.textPrimary}`,
   },
-}))
+})
 
-const Placeholder = styled.option(({ theme }) => ({
+const Placeholder = styled.option({
   color: theme.colors.textSecondary,
-}))
+})
 
 type InputSelectProps = InputBaseProps & {
   name: string

--- a/apps/store/src/components/InsurableLimits/InsurableLimits.tsx
+++ b/apps/store/src/components/InsurableLimits/InsurableLimits.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import React from 'react'
-import { mq } from 'ui'
+import { mq, theme } from 'ui'
 
 type InsurableLimitsProps = {
   children: React.ReactNode
@@ -17,7 +17,7 @@ export const InsurableLimits = ({ children, className }: InsurableLimitsProps) =
   )
 }
 
-const Wrapper = styled.div(({ theme }) => ({
+const Wrapper = styled.div({
   display: 'flex',
   gap: theme.space[2],
   scrollSnapType: 'x mandatory',
@@ -26,7 +26,7 @@ const Wrapper = styled.div(({ theme }) => ({
   [mq.lg]: {
     gap: theme.space[4],
   },
-}))
+})
 
 const ScrollableItem = styled.div({
   scrollSnapAlign: 'center',

--- a/apps/store/src/components/PriceBreakdown/PriceBreakdown.tsx
+++ b/apps/store/src/components/PriceBreakdown/PriceBreakdown.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as RadixCollapsible from '@radix-ui/react-collapsible'
-import { ChevronIcon, Space, Text } from 'ui'
+import { ChevronIcon, Space, Text, theme } from 'ui'
 import { useFormatter } from '@/utils/useFormatter'
 import { CheckoutPaymentPageProps } from '../CheckoutPaymentPage/CheckoutPaymentPage.types'
 
@@ -68,15 +68,15 @@ const DataRowStyles = css({
 
 const DataRow = styled.div(() => ({}), DataRowStyles)
 
-const CollapsibleHeader = styled(RadixCollapsible.Trigger)(DataRowStyles, ({ theme }) => ({
+const CollapsibleHeader = styled(RadixCollapsible.Trigger)(DataRowStyles, {
   paddingRight: theme.space[1],
   width: '100%',
-}))
+})
 
-const CrossOutText = styled.p(({ theme }) => ({
+const CrossOutText = styled.p({
   color: theme.colors.gray500,
   textDecoration: 'line-through',
-}))
+})
 
 const SpaceFlex = styled(Space)(() => ({
   display: 'flex',
@@ -90,14 +90,14 @@ const TriggerIcon = styled(ChevronIcon)({
 
 const CollapsibleContent = styled(RadixCollapsible.Content)(() => ({}))
 
-const CollapsibleDivider = styled.div(({ theme }) => ({
+const CollapsibleDivider = styled.div({
   borderTop: `1px solid ${theme.colors.gray300}`,
   height: theme.space[2],
   marginTop: '0.75rem',
   marginBottom: theme.space[3],
-}))
+})
 
-const Price = styled.p(({ theme }) => ({
+const Price = styled.p({
   fontSize: theme.fontSizes[1],
   color: theme.colors.gray600,
-}))
+})

--- a/apps/store/src/components/PriceCalculator/Accordion.tsx
+++ b/apps/store/src/components/PriceCalculator/Accordion.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import * as Accordion from '@radix-ui/react-accordion'
 import { ReactNode } from 'react'
+import { theme } from 'ui'
 
 export const Header = styled(Accordion.Header)(() => ({
   display: 'flex',
@@ -8,18 +9,18 @@ export const Header = styled(Accordion.Header)(() => ({
   justifyContent: 'space-between',
 }))
 
-export const Content = styled(Accordion.Content)(({ theme }) => ({
+export const Content = styled(Accordion.Content)({
   paddingTop: theme.space[3],
-}))
+})
 
 export const Root = Accordion.Root
-export const Item = styled(Accordion.Item)(({ theme }) => ({
+export const Item = styled(Accordion.Item)({
   paddingTop: theme.space[3],
   '&:not(:last-child)': {
     borderBottom: '1px solid hsla(0, 0%, 7%, 0.15)',
     paddingBottom: theme.space[3],
   },
-}))
+})
 
 type TriggerProps = { children: ReactNode }
 
@@ -27,11 +28,11 @@ export const Trigger = ({ children }: TriggerProps) => {
   return <StyledTrigger>{children}</StyledTrigger>
 }
 
-const StyledTrigger = styled(Accordion.Trigger)(({ theme }) => ({
+const StyledTrigger = styled(Accordion.Trigger)({
   cursor: 'pointer',
 
   '&:focus-visible': {
     outline: `2px solid ${theme.colors.gray900}`,
     outlineOffset: 2,
   },
-}))
+})

--- a/apps/store/src/components/PriceCalculator/CurrentInsuranceField/CurrentInsuranceField.tsx
+++ b/apps/store/src/components/PriceCalculator/CurrentInsuranceField/CurrentInsuranceField.tsx
@@ -2,7 +2,7 @@ import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { useCallback, useState } from 'react'
-import { Button, Dialog, Heading, Space } from 'ui'
+import { Button, Dialog, Heading, Space, theme } from 'ui'
 import { PURCHASE_FORM_MAX_WIDTH } from '@/components/ProductPage/PurchaseForm/PurchaseForm.constants'
 import {
   useExternalInsurersQuery,
@@ -221,26 +221,26 @@ const useUpdateExternalInsurer = (params: UseUpdateExternalInsurerParams) => {
   }
 }
 
-const StyledDialogContent = styled(Dialog.Content)(({ theme }) => ({
+const StyledDialogContent = styled(Dialog.Content)({
   height: '100%',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   padding: theme.space[2],
-}))
+})
 
-const DialogIframeWindow = styled(Dialog.Window)(({ theme }) => ({
+const DialogIframeWindow = styled(Dialog.Window)({
   width: '100%',
   maxWidth: INSURELY_IFRAME_MAX_WIDTH,
   height: '100%',
   maxHeight: INSURELY_IFRAME_MAX_HEIGHT,
   overflowY: 'auto',
   borderRadius: theme.radius.xs,
-}))
+})
 
-const DialogSuccessWindow = styled(Dialog.Window)(({ theme }) => ({
+const DialogSuccessWindow = styled(Dialog.Window)({
   padding: theme.space[4],
   borderRadius: theme.radius.xs,
   width: '100%',
   maxWidth: `calc(${PURCHASE_FORM_MAX_WIDTH} + 1rem)`,
-}))
+})

--- a/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
+++ b/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { FormEventHandler, useState } from 'react'
-import { Button, Heading, Space, Dialog, Text } from 'ui'
+import { Button, Heading, Space, Dialog, Text, theme } from 'ui'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { TextField } from '@/components/TextField/TextField'
@@ -174,28 +174,28 @@ const convertExtraBuilding = (data: Record<string, FormDataEntryValue>): ExtraBu
   }
 }
 
-const Card = styled(Space)(({ theme }) => ({
+const Card = styled(Space)({
   padding: `${theme.space[3]} ${theme.space[4]}`,
   borderRadius: theme.radius.sm,
   backgroundColor: theme.colors.gray300,
-}))
+})
 
-const DialogContent = styled(Dialog.Content)(({ theme }) => ({
+const DialogContent = styled(Dialog.Content)({
   height: '100%',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   padding: theme.space[2],
-}))
+})
 
-const DialogContentWrapper = styled(Dialog.Window)(({ theme }) => ({
+const DialogContentWrapper = styled(Dialog.Window)({
   marginRight: theme.space[3],
   marginLeft: theme.space[3],
   padding: theme.space[4],
   borderRadius: 8,
   width: '100%',
   maxWidth: '32rem',
-}))
+})
 
 const Preview = styled.li({
   display: 'flex',

--- a/apps/store/src/components/PriceCalculator/FormGrid.tsx
+++ b/apps/store/src/components/PriceCalculator/FormGrid.tsx
@@ -1,13 +1,14 @@
 import styled from '@emotion/styled'
 import { ReactNode } from 'react'
+import { theme } from 'ui'
 import { InputField } from '@/services/PriceCalculator/Field.types'
 import { SectionItem } from '@/services/PriceCalculator/PriceCalculator.types'
 
-const Grid = styled.div(({ theme }) => ({
+const Grid = styled.div({
   display: 'grid',
   gridTemplateColumns: 'repeat(6, 1fr)',
   gap: theme.space[1],
-}))
+})
 
 type GridItemProps = { columnSpan: number }
 

--- a/apps/store/src/components/PriceCalculator/HouseholdSizeField/HouseholdSizeField.tsx
+++ b/apps/store/src/components/PriceCalculator/HouseholdSizeField/HouseholdSizeField.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import { motion } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
 import { ChangeEventHandler, MouseEventHandler, useState } from 'react'
+import { theme } from 'ui'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { HouseholdSizeField as HouseholdSizeFieldType } from '@/services/PriceCalculator/Field.types'
 import { useHighlightAnimation } from '@/utils/useHighlightAnimation'
@@ -86,7 +87,7 @@ export const HouseholdSizeField = ({ field, autoFocus = false }: FieldProps) => 
   )
 }
 
-const Wrapper = styled(motion.div)(({ theme }) => ({
+const Wrapper = styled(motion.div)({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'space-between',
@@ -96,18 +97,18 @@ const Wrapper = styled(motion.div)(({ theme }) => ({
   padding: `${theme.space.sm} ${theme.space.md}`,
   borderRadius: theme.radius.sm,
   backgroundColor: theme.colors.gray100,
-}))
+})
 
-const StyledSelect = styled.select(({ theme }) => ({
+const StyledSelect = styled.select({
   fontSize: theme.fontSizes.xl,
   color: theme.colors.textPrimary,
-}))
+})
 
-const Minus = styled.div(({ theme }) => ({
+const Minus = styled.div({
   width: '1.25rem',
   height: '0.0625rem', // 1px
   backgroundColor: theme.colors.textPrimary,
-}))
+})
 
 const Plus = () => {
   return (
@@ -118,12 +119,12 @@ const Plus = () => {
   )
 }
 
-const PlusVerticalLine = styled.div(({ theme }) => ({
+const PlusVerticalLine = styled.div({
   height: '1.25rem',
   width: '0.0625rem', // 1px
   backgroundColor: theme.colors.textPrimary,
   position: 'absolute',
-}))
+})
 
 const PlusWrapper = styled.div({
   position: 'relative',
@@ -132,7 +133,7 @@ const PlusWrapper = styled.div({
   justifyContent: 'center',
 })
 
-const StyledButton = styled.button(({ theme }) => ({
+const StyledButton = styled.button({
   cursor: 'pointer',
   height: '1.5rem',
   width: '1.5rem',
@@ -143,4 +144,4 @@ const StyledButton = styled.button(({ theme }) => ({
   '&[disabled] div': {
     backgroundColor: theme.colors.textDisabled,
   },
-}))
+})

--- a/apps/store/src/components/PriceCalculator/InputRadio.tsx
+++ b/apps/store/src/components/PriceCalculator/InputRadio.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import * as RadioGroup from '@radix-ui/react-radio-group'
 import { motion } from 'framer-motion'
-import { Space, Text } from 'ui'
+import { Space, Text, theme } from 'ui'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { useHighlightAnimation } from '@/utils/useHighlightAnimation'
 
@@ -35,11 +35,11 @@ export const Root = ({ children, label, onValueChange, ...props }: RootProps) =>
   )
 }
 
-const Card = styled(motion(Space))(({ theme }) => ({
+const Card = styled(motion(Space))({
   padding: `${theme.space.sm} ${theme.space.md}`,
   borderRadius: theme.radius.sm,
   backgroundColor: theme.colors.gray100,
-}))
+})
 
 type ItemProps = {
   label: string
@@ -61,7 +61,7 @@ export const Item = ({ value, label, id, autoFocus }: ItemProps) => {
   )
 }
 
-const StyledItem = styled(RadioGroup.Item)(({ theme }) => ({
+const StyledItem = styled(RadioGroup.Item)({
   width: '1.375rem',
   height: '1.375rem',
 
@@ -76,12 +76,12 @@ const StyledItem = styled(RadioGroup.Item)(({ theme }) => ({
   '&:focus-visible': {
     boxShadow: `0 0 0 2px ${theme.colors.gray500}`,
   },
-}))
+})
 
-const StyledIndicator = styled(RadioGroup.Indicator)(({ theme }) => ({
+const StyledIndicator = styled(RadioGroup.Indicator)({
   display: 'block',
   backgroundColor: theme.colors.gray1000,
   borderRadius: '50%',
   width: '100%',
   height: '100%',
-}))
+})

--- a/apps/store/src/components/PriceCalculator/StepIcon.tsx
+++ b/apps/store/src/components/PriceCalculator/StepIcon.tsx
@@ -1,5 +1,6 @@
 import isValidProp from '@emotion/is-prop-valid'
 import styled from '@emotion/styled'
+import { theme } from 'ui'
 
 type Props = {
   state: 'outline' | 'filled' | 'valid'
@@ -10,7 +11,7 @@ const checkProps = { shouldForwardProp: isValidProp }
 export const StepIcon = styled(
   'div',
   checkProps,
-)<Props>(({ theme, state }) => ({
+)<Props>(({ state }) => ({
   width: '1rem',
   height: '1rem',
   borderRadius: '50%',

--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -73,14 +73,14 @@ const ContentWrapper = styled.div({
   marginInline: theme.space.xs,
 })
 
-const Title = styled.p(({ theme }) => ({
+const Title = styled.p({
   fontSize: theme.fontSizes.md,
-}))
+})
 
-const Subtitle = styled.p(({ theme }) => ({
+const Subtitle = styled.p({
   fontSize: theme.fontSizes.md,
   color: theme.colors.gray600,
-}))
+})
 
 const CallToAction = styled.div({
   display: 'flex',

--- a/apps/store/src/components/ProductGrid/ProductGrid.tsx
+++ b/apps/store/src/components/ProductGrid/ProductGrid.tsx
@@ -29,12 +29,12 @@ const Wrapper = styled(Space)({
   height: '100%',
 })
 
-const Title = styled.p(({ theme }) => ({
+const Title = styled.p({
   fontSize: theme.fontSizes[2],
   color: theme.colors.gray600,
   textTransform: 'uppercase',
   textAlign: 'center',
-}))
+})
 
 const Grid = styled.div({
   display: 'grid',

--- a/apps/store/src/components/ProductPage/ProductDocuments.tsx
+++ b/apps/store/src/components/ProductPage/ProductDocuments.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { Card, CardContent } from 'ui/src/components/Card/Card'
-import { getColor, HeadingLabel, mq, Space, Text } from 'ui'
+import { getColor, HeadingLabel, mq, Space, Text, theme } from 'ui'
 import { InsuranceDocument } from '@/services/apollo/generated'
 
 type Props = {
@@ -36,14 +36,14 @@ const ProductDocument = ({ doc }: { doc: InsuranceDocument }) => {
   )
 }
 
-const ProductDocumentsWrapper = styled.div(({ theme }) => ({
+const ProductDocumentsWrapper = styled.div({
   paddingInline: theme.space[4],
   marginBlock: theme.space[4],
 
   [mq.lg]: {
     maxWidth: '32rem',
   },
-}))
+})
 
 // TODO: Add hover style to Card or LinkCard component
 // TODO: Provide default card background in app theme

--- a/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/DateInput.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/DateInput.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { motion } from 'framer-motion'
 import { ChangeEventHandler, FocusEventHandler, InputHTMLAttributes, useId, useState } from 'react'
-import { ChevronIcon, Space, Text } from 'ui'
+import { ChevronIcon, Space, Text, theme } from 'ui'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { convertToDate } from '@/utils/date'
 import { useFormatter } from '@/utils/useFormatter'
@@ -76,20 +76,20 @@ export const DateInput = (props: Props) => {
   )
 }
 
-const InputWrapper = styled(motion(Space))(({ theme }) => ({
+const InputWrapper = styled(motion(Space))({
   backgroundColor: theme.colors.gray100,
   padding: theme.space.md,
   borderRadius: theme.radius.sm,
   width: '100%',
-}))
+})
 
-const CheckboxHeader = styled.div(({ theme }) => ({
+const CheckboxHeader = styled.div({
   position: 'relative',
   display: 'flex',
   gap: theme.space.sm,
   justifyContent: 'space-between',
   alignItems: 'center',
-}))
+})
 
 const StyledLabel = styled.label({
   overflow: 'hidden',
@@ -113,7 +113,7 @@ const IconWrapper = styled.div({
   justifyContent: 'center',
 })
 
-const StyledInput = styled.input(({ theme }) => ({
+const StyledInput = styled.input({
   fontFamily: theme.fonts.body,
   fontSize: theme.fontSizes.md,
   cursor: 'pointer',
@@ -128,4 +128,4 @@ const StyledInput = styled.input(({ theme }) => ({
     textAlign: 'right',
     paddingRight: theme.space.xxs,
   },
-}))
+})

--- a/apps/store/src/components/ProductPage/PurchaseForm/ComparisonTable/ComparisonTable.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ComparisonTable/ComparisonTable.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
-import { Text, CheckIcon as PerilsCheckIcon, MinusIcon } from 'ui'
+import { Text, CheckIcon as PerilsCheckIcon, MinusIcon, theme } from 'ui'
 
 export const Root = styled.table({
   width: '100%',
@@ -10,7 +10,7 @@ export const Root = styled.table({
 export const Head = styled.thead({})
 export const Body = styled.tbody({})
 
-export const Row = styled.tr(({ theme }) => ({
+export const Row = styled.tr({
   ':not(:last-child)': {
     borderBottom: `1px solid ${theme.colors.gray300}`,
   },
@@ -21,7 +21,7 @@ export const Row = styled.tr(({ theme }) => ({
       borderBottomRightRadius: theme.radius.xs,
     },
   },
-}))
+})
 
 type HeaderProps = { children?: React.ReactNode; className?: string; active?: boolean }
 
@@ -38,15 +38,15 @@ export const Header = ({ children, active, ...props }: HeaderProps) => {
   )
 }
 
-const TableHeader = styled.th(({ theme }) => ({
+const TableHeader = styled.th({
   paddingBlock: theme.space.xxs,
-}))
+})
 
-const ActiveTableHeader = styled(TableHeader)(({ theme }) => ({
+const ActiveTableHeader = styled(TableHeader)({
   backgroundColor: theme.colors.green100,
   borderTopLeftRadius: theme.radius.xs,
   borderTopRightRadius: theme.radius.xs,
-}))
+})
 
 type TitleDataCellProps = { children: React.ReactNode; className?: string }
 
@@ -69,15 +69,15 @@ export const DataCell = ({ children, active, ...props }: DataCellProps) => {
   )
 }
 
-const TableDataCell = styled.td(({ theme }) => ({
+const TableDataCell = styled.td({
   paddingBlock: theme.space.xs,
   verticalAlign: 'middle',
   minWidth: '2.5rem',
-}))
+})
 
-const ActiveTableDataCell = styled(TableDataCell)(({ theme }) => ({
+const ActiveTableDataCell = styled(TableDataCell)({
   backgroundColor: theme.colors.green100,
-}))
+})
 
 const Centered = styled.div({
   display: 'flex',

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 import { useInView } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
 import { RefObject, useEffect, useMemo, useRef, useState } from 'react'
-import { Button, CrossIcon, Space, Text } from 'ui'
+import { Button, CrossIcon, Space, Text, theme } from 'ui'
 import { useUpdateCancellation } from '@/components/ProductPage/PurchaseForm/useUpdateCancellation'
 import { useUpdateStartDate } from '@/components/ProductPage/PurchaseForm/useUpdateStartDate'
 import { ScrollPast } from '@/components/ProductPage/ScrollPast/ScrollPast'
@@ -258,7 +258,7 @@ const Centered = styled.div({
   justifyContent: 'center',
 })
 
-const TextButton = styled.button(({ theme }) => ({
+const TextButton = styled.button({
   cursor: 'pointer',
 
   backgroundColor: theme.colors.light,
@@ -266,7 +266,7 @@ const TextButton = styled.button(({ theme }) => ({
     borderRadius: theme.radius.xs,
     boxShadow: `${theme.colors.light} 0 0 0 3px, ${theme.colors.textPrimary} 0 0 0 4px`,
   },
-}))
+})
 
 const SubmitButton = ({ loading }: { loading: boolean }) => {
   const { t } = useTranslation('purchase-form')
@@ -280,16 +280,16 @@ const SubmitButton = ({ loading }: { loading: boolean }) => {
   )
 }
 
-const Separator = styled.div(({ theme }) => ({
+const Separator = styled.div({
   width: 1,
   backgroundColor: theme.colors.gray600,
   margin: `0 ${theme.space[3]}`,
   alignSelf: 'stretch',
-}))
+})
 
-const StyledCrossIcon = styled(CrossIcon)(({ theme }) => ({
+const StyledCrossIcon = styled(CrossIcon)({
   marginRight: theme.space[1],
-}))
+})
 
 type GetCancellationOptionParams = {
   priceIntent: PriceIntent

--- a/apps/store/src/components/ProductPage/PurchaseForm/PriceMatchBubble/PriceMatchBubble.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PriceMatchBubble/PriceMatchBubble.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Text } from 'ui'
+import { Text, theme } from 'ui'
 
 type Props = {
   title: string
@@ -32,12 +32,12 @@ const Root = styled.div({
   position: 'relative',
 })
 
-const Bubble = styled.div(({ theme }) => ({
+const Bubble = styled.div({
   backgroundColor: LIGHT_BLUE,
   paddingBlock: theme.space[3],
   paddingInline: theme.space[4],
   borderRadius: theme.radius.sm,
-}))
+})
 
 const Tip = styled.div({
   position: 'absolute',

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled'
 import { motion, Variants } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
 import { ReactNode, useRef, useState } from 'react'
-import { Button, Heading, mq, Space, Text, useBreakpoint } from 'ui'
+import { Button, Heading, mq, Space, Text, theme, useBreakpoint } from 'ui'
 import { CartToast, CartToastAttributes } from '@/components/CartNotification/CartToast'
 import { ProductItemProps } from '@/components/CartNotification/ProductItem'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
@@ -351,23 +351,23 @@ const PriceLoader = () => {
   )
 }
 
-const PriceLoaderWrapper = styled.div(({ theme }) => ({
+const PriceLoaderWrapper = styled.div({
   paddingTop: theme.space[7],
-}))
+})
 
-const Bar = styled.div(({ theme }) => ({
+const Bar = styled.div({
   height: theme.space[1],
   maxWidth: '16rem',
   marginInline: 'auto',
   backgroundColor: theme.colors.gray500,
   borderRadius: theme.radius.xs,
-}))
+})
 
-const ProgressBar = styled(motion.div)(({ theme }) => ({
+const ProgressBar = styled(motion.div)({
   height: '100%',
   backgroundColor: theme.colors.gray1000,
   borderRadius: theme.radius.xs,
-}))
+})
 
 type ShowOfferStateProps = {
   priceIntent: PriceIntent
@@ -393,21 +393,21 @@ const ShowOfferState = (props: ShowOfferStateProps) => {
   )
 }
 
-const PurchaseFormTop = styled.div(({ theme }) => ({
+const PurchaseFormTop = styled.div({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',
   gap: '4.5rem',
   paddingBlock: '9vh',
   paddingInline: theme.space.md,
-}))
+})
 
-const StickyButtonWrapper = styled.div(({ theme }) => ({
+const StickyButtonWrapper = styled.div({
   paddingInline: theme.space[4],
   [mq.lg]: {
     display: 'none',
   },
-}))
+})
 
 const SectionWrapper = styled.div({
   width: '100%',

--- a/apps/store/src/components/ProductPage/PurchaseForm/TierSelector.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/TierSelector.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import * as RadioGroup from '@radix-ui/react-radio-group'
-import { Space } from 'ui'
+import { Space, theme } from 'ui'
 import { ProductOfferFragment } from '@/services/apollo/generated'
 import { useFormatter } from '@/utils/useFormatter'
 import { FormElement } from './PurchaseForm.constants'
@@ -43,16 +43,16 @@ export const TierSelector = ({ offers, selectedOfferId, onValueChange }: Props) 
   )
 }
 
-const StyledRadioGroup = styled(RadioGroup.Root)(({ theme }) => ({
+const StyledRadioGroup = styled(RadioGroup.Root)({
   display: 'flex',
   gap: theme.space[2],
   paddingLeft: theme.space[4],
   paddingRight: theme.space[4],
   scrollSnapType: 'x mandatory',
   overflowX: 'auto',
-}))
+})
 
-const OfferItem = styled(RadioGroup.Item)(({ theme }) => ({
+const OfferItem = styled(RadioGroup.Item)({
   scrollSnapAlign: 'center',
   flex: '0 0 85%',
 
@@ -70,13 +70,13 @@ const OfferItem = styled(RadioGroup.Item)(({ theme }) => ({
   '&[data-state=checked]': {
     borderColor: theme.colors.gray900,
   },
-}))
+})
 
 const IndicatorBox = styled.div({
   gridArea: '1 / 1 / 3 / 2',
 })
 
-const IndicatorWrapper = styled.div(({ theme }) => ({
+const IndicatorWrapper = styled.div({
   borderWidth: 2,
   borderStyle: 'solid',
   borderColor: theme.colors.gray900,
@@ -86,14 +86,14 @@ const IndicatorWrapper = styled.div(({ theme }) => ({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-}))
-const Indicator = styled(RadioGroup.Indicator)(({ theme }) => ({
+})
+const Indicator = styled(RadioGroup.Indicator)({
   display: 'block',
   width: '0.625rem',
   height: '0.625rem',
   borderRadius: '0.3125rem',
   backgroundColor: theme.colors.gray900,
-}))
+})
 
 const TitleBox = styled.div({
   gridArea: '1 / 2 / 2 / 3',

--- a/apps/store/src/components/ProductPage/ScrollPast/ScrollPast.stories.tsx
+++ b/apps/store/src/components/ProductPage/ScrollPast/ScrollPast.stories.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { ComponentMeta, Story } from '@storybook/react'
 import { useRef } from 'react'
-import { Button } from 'ui'
+import { Button, theme } from 'ui'
 import { ScrollPast, ScrollPastProps } from './ScrollPast'
 
 export default {
@@ -132,7 +132,7 @@ const Template: Story<ScrollPastProps> = (props) => {
   )
 }
 
-const FixedFooter = styled.div(({ theme }) => ({
+const FixedFooter = styled.div({
   position: 'fixed',
   bottom: 0,
   right: 0,
@@ -140,7 +140,7 @@ const FixedFooter = styled.div(({ theme }) => ({
   padding: theme.space[4],
   display: 'flex',
   justifyContent: 'center',
-}))
+})
 
 export const Default = Template.bind({})
 Default.args = {}

--- a/apps/store/src/components/ProductPage/ScrollPast/ScrollPast.tsx
+++ b/apps/store/src/components/ProductPage/ScrollPast/ScrollPast.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import { motion, useScroll } from 'framer-motion'
 import { useEffect, useState } from 'react'
+import { theme } from 'ui'
 import { zIndexes } from '@/utils/zIndex'
 
 export type ScrollPastProps = {
@@ -35,10 +36,10 @@ export const ScrollPast = ({ targetRef, children }: ScrollPastProps) => {
   )
 }
 
-const StyledWrapper = styled(motion.div)(({ theme }) => ({
+const StyledWrapper = styled(motion.div)({
   position: 'fixed',
   bottom: theme.space[4],
   left: 0,
   right: 0,
   zIndex: zIndexes.scrollPast,
-}))
+})

--- a/apps/store/src/components/ProductPage/ScrollToButton/ScrollToButton.tsx
+++ b/apps/store/src/components/ProductPage/ScrollToButton/ScrollToButton.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { ReactNode } from 'react'
-import { Button, mq } from 'ui'
+import { Button, mq, theme } from 'ui'
 
 export type ScrollToButtonProps = {
   type: 'button' | 'submit'
@@ -20,9 +20,9 @@ export const ScrollToButton = ({ children, type, targetRef }: ScrollToButtonProp
   )
 }
 
-const Wrappper = styled.div(({ theme }) => ({
+const Wrappper = styled.div({
   paddingInline: theme.space[4],
   width: '100%',
 
   [mq.lg]: { display: 'none' },
-}))
+})

--- a/apps/store/src/components/ProductPage/Tabs.tsx
+++ b/apps/store/src/components/ProductPage/Tabs.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import * as RadixTabs from '@radix-ui/react-tabs'
+import { theme } from 'ui'
 import { zIndexes } from '@/utils/zIndex'
 
 export type { TabsProps } from '@radix-ui/react-tabs'
@@ -11,16 +12,16 @@ export const Tabs = styled(RadixTabs.Root)({
   isolation: 'isolate',
 })
 
-export const TabsList = styled(RadixTabs.TabsList)(({ theme }) => ({
+export const TabsList = styled(RadixTabs.TabsList)({
   display: 'grid',
   gap: theme.space[2],
   position: 'sticky',
   top: theme.space[3],
   paddingInline: theme.space[4],
   zIndex: zIndexes.tabs,
-}))
+})
 
-export const TabsTrigger = styled(RadixTabs.Trigger)(({ theme }) => ({
+export const TabsTrigger = styled(RadixTabs.Trigger)({
   display: 'flex',
   alignItems: 'flex-end',
   justifyContent: 'center',
@@ -46,6 +47,6 @@ export const TabsTrigger = styled(RadixTabs.Trigger)(({ theme }) => ({
   '&:focus-visible': {
     boxShadow: `0 0 0 2px ${theme.colors.purple500}`,
   },
-}))
+})
 
 export const TabsContent = styled(RadixTabs.Content)({})

--- a/apps/store/src/components/Slideshow/Slideshow.tsx
+++ b/apps/store/src/components/Slideshow/Slideshow.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import React from 'react'
-import { mq, Space } from 'ui'
+import { mq, Space, theme } from 'ui'
 
 type Alignment = 'left' | 'center' | 'right'
 
@@ -23,14 +23,14 @@ export const Slideshow = ({ children, title, alignment = 'left' }: SlideshowProp
   )
 }
 
-const Title = styled.h2(({ theme }) => ({
+const Title = styled.h2({
   fontSize: theme.fontSizes[2],
   color: theme.colors.gray600,
   textTransform: 'uppercase',
   textAlign: 'center',
-}))
+})
 
-const ScollableContainer = styled.div<{ alignment: Alignment }>(({ theme, alignment }) => ({
+const ScollableContainer = styled.div<{ alignment: Alignment }>(({ alignment }) => ({
   display: 'flex',
   gap: theme.space[2],
   paddingInline: theme.space[2],
@@ -47,8 +47,8 @@ const ScrollableItem = styled.div({
   scrollSnapAlign: 'center',
 })
 
-const getAligmentStyles = (aligment: Alignment) => {
-  switch (aligment) {
+const getAligmentStyles = (alignment: Alignment) => {
+  switch (alignment) {
     case 'left':
       return {
         justifyContent: 'flex-start',

--- a/apps/store/src/components/Statistic/Statistic.tsx
+++ b/apps/store/src/components/Statistic/Statistic.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { theme } from 'ui'
 
 const HEIGHT = '20rem'
 
@@ -8,7 +9,7 @@ export type StatisticProps = {
   label: string
 }
 
-export const Root = styled.div(({ theme }) => ({
+export const Root = styled.div({
   padding: theme.space[5],
   borderRadius: theme.radius.lg,
   backgroundColor: theme.colors.gray200,
@@ -23,18 +24,18 @@ export const Root = styled.div(({ theme }) => ({
     'description'
     'value'
   `,
-}))
+})
 
-export const Description = styled.p(({ theme }) => ({
+export const Description = styled.p({
   gridArea: 'description',
 
   fontSize: theme.fontSizes[3],
-}))
+})
 
-export const Value = styled.p(({ theme }) => ({
+export const Value = styled.p({
   gridArea: 'value',
   alignSelf: 'flex-end',
 
   color: theme.colors.black,
   fontSize: theme.fontSizes[6],
-}))
+})

--- a/apps/store/src/components/Table/Table.tsx
+++ b/apps/store/src/components/Table/Table.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { theme } from 'ui'
 
 type TableProps = { layout?: 'fixed' | 'auto' }
 
@@ -16,7 +17,7 @@ export const Row = styled.tr({})
 
 type CellProps = { align?: 'left' | 'right' | 'center' }
 
-export const Cell = styled.td<CellProps>(({ theme, align = 'left' }) => ({
+export const Cell = styled.td<CellProps>(({ align = 'left' }) => ({
   padding: theme.space[2],
   border: `1px solid ${theme.colors.gray500}`,
 

--- a/apps/store/src/components/TextField/TextField.tsx
+++ b/apps/store/src/components/TextField/TextField.tsx
@@ -76,7 +76,7 @@ const LargeWrapper = styled(motion.div)({
   },
 })
 
-const Label = styled.label(({ theme }) => ({
+const Label = styled.label({
   position: 'absolute',
   left: 0,
   right: 0,
@@ -103,7 +103,7 @@ const Label = styled.label(({ theme }) => ({
     // TODO: use theme color: amber text
     color: '#8A4C0F',
   },
-}))
+})
 
 const LargeInput = styled.input({
   width: '100%',

--- a/apps/store/src/components/TierSelector/TierSelectorStyles.tsx
+++ b/apps/store/src/components/TierSelector/TierSelectorStyles.tsx
@@ -1,14 +1,14 @@
 import styled from '@emotion/styled'
 import * as AccordionPrimitives from '@radix-ui/react-accordion'
 import { PropsWithChildren, ReactElement } from 'react'
-import { ChevronIcon } from 'ui'
+import { ChevronIcon, theme } from 'ui'
 
 export const Root = AccordionPrimitives.Root
 export const Content = AccordionPrimitives.Content
 export const Item = AccordionPrimitives.Item
 const Header = AccordionPrimitives.Header
 
-const Trigger = styled(AccordionPrimitives.Trigger)(({ theme }) => ({
+const Trigger = styled(AccordionPrimitives.Trigger)({
   height: theme.space[7],
   width: '100%',
   cursor: 'pointer',
@@ -23,7 +23,7 @@ const Trigger = styled(AccordionPrimitives.Trigger)(({ theme }) => ({
   '[data-state=open] &': {
     borderRadius: `${theme.radius.xs}px ${theme.radius.xs}px 0 0`,
   },
-}))
+})
 
 const CenteredHeader = styled.div({
   width: '100%',
@@ -56,18 +56,18 @@ export const HeaderWithTrigger = ({
   )
 }
 
-const RecommendedContainer = styled.div(({ theme }) => ({
+const RecommendedContainer = styled.div({
   paddingTop: theme.space[2],
-}))
+})
 
-const SuggestedDot = styled.span(({ theme }) => ({
+const SuggestedDot = styled.span({
   display: 'inline-block',
   height: theme.radius.sm,
   width: theme.radius.sm,
   backgroundColor: theme.colors.black,
   borderRadius: '50%',
   marginRight: '.5rem',
-}))
+})
 
 type SuggestedItemProps = {
   children: React.ReactNode
@@ -80,7 +80,7 @@ export const SuggestedItem = ({ children }: SuggestedItemProps) => (
   </RecommendedContainer>
 )
 
-export const TierItemWrapper = styled.div<{ isSelected: boolean }>(({ theme }) => ({
+export const TierItemWrapper = styled.div<{ isSelected: boolean }>({
   cursor: 'pointer',
   padding: theme.space[2],
   backgroundColor: theme.colors.gray200,
@@ -95,37 +95,35 @@ export const TierItemWrapper = styled.div<{ isSelected: boolean }>(({ theme }) =
   '&:last-of-type': {
     borderRadius: `0 0 ${theme.radius.xs}px ${theme.radius.xs}px`,
   },
+})
+
+export const TierItemContainer = styled.div<{ isSelected: boolean }>(({ isSelected = false }) => ({
+  cursor: 'pointer',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  padding: theme.space[2],
+  borderRadius: `${theme.radius.xs}px`,
+
+  boxShadow: isSelected ? '0px 1px 2px rgba(0, 0, 0, 0.15)' : '',
+  backgroundColor: isSelected ? '#E9FFC8' : theme.colors.gray200,
 }))
 
-export const TierItemContainer = styled.div<{ isSelected: boolean }>(
-  ({ theme, isSelected = false }) => ({
-    cursor: 'pointer',
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'space-between',
-    padding: theme.space[2],
-    borderRadius: `${theme.radius.xs}px`,
-
-    boxShadow: isSelected ? '0px 1px 2px rgba(0, 0, 0, 0.15)' : '',
-    backgroundColor: isSelected ? '#E9FFC8' : theme.colors.gray200,
-  }),
-)
-
-export const TitleContainer = styled.div(({ theme }) => ({
+export const TitleContainer = styled.div({
   fontSize: theme.fontSizes[3],
   width: '100%',
   display: 'flex',
   justifyContent: 'space-between',
-}))
+})
 
-export const TitleItem = styled.div(({ theme }) => ({
+export const TitleItem = styled.div({
   paddingBottom: theme.space[1],
-}))
+})
 
-export const SecondaryText = styled.div(({ theme }) => ({
+export const SecondaryText = styled.div({
   color: theme.colors.gray600,
-}))
+})
 
-export const PriceText = styled.div<{ isSelected: boolean }>(({ theme, isSelected }) => ({
+export const PriceText = styled.div<{ isSelected: boolean }>(({ isSelected }) => ({
   color: isSelected ? theme.colors.gray900 : theme.colors.gray600,
 }))

--- a/apps/store/src/components/Timeline/Timeline.tsx
+++ b/apps/store/src/components/Timeline/Timeline.tsx
@@ -1,20 +1,21 @@
 import styled from '@emotion/styled'
+import { theme } from 'ui'
 import { CheckCircleIcon } from './CheckCircleIcon'
 
 const ICON_SIZE = '2.5rem'
 
-export const Root = styled.ul(({ theme }) => ({
+export const Root = styled.ul({
   display: 'flex',
   flexDirection: 'column',
   paddingRight: theme.space[4],
-}))
+})
 
-export const Item = styled.li(({ theme }) => ({
+export const Item = styled.li({
   position: 'relative',
   display: 'flex',
   alignItems: 'center',
   gap: theme.space[2],
-}))
+})
 
 export const Icon = () => {
   return (
@@ -24,10 +25,10 @@ export const Icon = () => {
   )
 }
 
-const IconWrapper = styled.div(({ theme }) => ({
+const IconWrapper = styled.div({
   paddingTop: theme.space[1],
   paddingBottom: theme.space[1],
-}))
+})
 
 export const Separator = styled.div({
   display: 'flex',
@@ -36,15 +37,15 @@ export const Separator = styled.div({
   alignSelf: 'stretch',
 })
 
-export const Connector = styled.div(({ theme }) => ({
+export const Connector = styled.div({
   width: 2,
   backgroundColor: theme.colors.gray900,
   borderRadius: 1,
   flexGrow: 1,
-}))
+})
 
-export const Content = styled.div(({ theme }) => ({
+export const Content = styled.div({
   flex: 1,
   paddingTop: theme.space[3],
   paddingBottom: theme.space[3],
-}))
+})

--- a/apps/store/src/components/TopPickCard/TopPickCard.tsx
+++ b/apps/store/src/components/TopPickCard/TopPickCard.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { default as NextImage } from 'next/image'
-import { Space } from 'ui'
+import { Space, theme } from 'ui'
 
 const PRODUCT_CARD_IMAGE_WIDTH_SMALL = '20.43rem'
 const PRODUCT_CARD_IMAGE_HEIGHT_SMALL = '25rem'
@@ -51,11 +51,11 @@ const Image = styled(NextImage)({
   objectFit: 'cover',
 })
 
-const Title = styled.h1(({ theme }) => ({
+const Title = styled.h1({
   fontSize: theme.fontSizes[2],
-}))
+})
 
-const Subtitle = styled.p(({ theme }) => ({
+const Subtitle = styled.p({
   fontSize: theme.fontSizes[1],
   color: theme.colors.gray600,
-}))
+})

--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -173,7 +173,7 @@ const StyledVideo = styled.video(
   }),
 )
 
-const VideoControls = styled.div(({ theme }) => ({
+const VideoControls = styled.div({
   cursor: 'pointer',
   position: 'absolute',
   inset: 0,
@@ -188,7 +188,7 @@ const VideoControls = styled.div(({ theme }) => ({
     justifyContent: 'flex-end',
     alignItems: 'flex-start',
   },
-}))
+})
 
 const Controls = styled.div({
   opacity: 0,
@@ -199,8 +199,8 @@ const Controls = styled.div({
   },
 })
 
-const PlayPauseButton = styled(Button)(({ theme }) => ({
+const PlayPauseButton = styled(Button)({
   display: 'inline-flex',
   alignItems: 'center',
   gap: theme.space[2],
-}))
+})

--- a/apps/store/src/services/adyen/DropinStyles.tsx
+++ b/apps/store/src/services/adyen/DropinStyles.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
+import { theme } from 'ui'
 
-export const AdyenDropinStyles = styled.div(({ theme }) => ({
+export const AdyenDropinStyles = styled.div({
   '.adyen-checkout__dropin': {
     backgroundColor: theme.colors.white,
     border: `1px solid ${theme.colors.gray500}`,
@@ -35,4 +36,4 @@ export const AdyenDropinStyles = styled.div(({ theme }) => ({
   },
 
   '.adyen-checkout__button__icon': { display: 'none' },
-}))
+})


### PR DESCRIPTION
## Describe your changes

Went from something like this: 
```
const Paragraph = styled.p(({ theme }) => ({
  color: theme.colors.gray700,
}))
```
to something like this: 

```
import {theme} from 'ui'

const Paragraph = styled.p({
  color: theme.colors.gray700,
})
```

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

As a team we talked about moving away from using the function syntax with Emotion and importing our theme directly from our ui package. This PR is a step in that direction.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
