### PR TITLE
Add global product metadata to layout header

### DIFF
--- a/apps/store/src/components/Header/NavigationLink.tsx
+++ b/apps/store/src/components/Header/NavigationLink.tsx
@@ -40,7 +40,9 @@ const StyledPillow = styled(Pillow)({
 })
 
 type NavigationLinkProps = Pick<LinkProps, 'href'> &
-  Omit<NavigationMenuPrimitive.NavigationMenuLinkProps, 'href'>
+  Omit<NavigationMenuPrimitive.NavigationMenuLinkProps, 'href'> & {
+    pillowImageSrc?: string
+  }
 
 export const NavigationLink = ({ href, children, ...rest }: NavigationLinkProps) => {
   return (
@@ -68,11 +70,11 @@ const StyledNavigationLink = styled(NavigationMenuPrimitive.Link)({
   },
 })
 
-export const ProductNavigationLink = ({ href, children }: NavigationLinkProps) => {
+export const ProductNavigationLink = ({ href, children, pillowImageSrc }: NavigationLinkProps) => {
   return (
     <Link href={href}>
       <ProductNavigationLinkCard y={0.75}>
-        <StyledPillow size="large" />
+        <StyledPillow size="large" src={pillowImageSrc} />
         <Text>{children}</Text>
       </ProductNavigationLinkCard>
     </Link>

--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -5,6 +5,8 @@ import { HeaderBlock } from '@/blocks/HeaderBlock'
 import { StoryblokPageProps } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 import { useChangeLocale } from '@/utils/l10n/useChangeLocale'
+import { GlobalProductMetadata, GLOBAL_PRODUCT_METADATA_PROP_NAME } from './fetchProductMetadata'
+import { ProductMetadataProvider } from './ProductMetadataContext'
 
 const Wrapper = styled.div({
   minHeight: '100vh',
@@ -12,31 +14,43 @@ const Wrapper = styled.div({
 })
 
 type LayoutWithMenuProps = {
-  children: ReactElement<StoryblokPageProps & { className: string }>
+  children: ReactElement<
+    StoryblokPageProps & {
+      className: string
+      [GLOBAL_PRODUCT_METADATA_PROP_NAME]: GlobalProductMetadata
+    }
+  >
 }
 
 export const LayoutWithMenu = ({ children }: LayoutWithMenuProps) => {
-  const { story, globalStory, className } = children.props
+  const {
+    story,
+    globalStory,
+    [GLOBAL_PRODUCT_METADATA_PROP_NAME]: globalProductMetadata,
+    className,
+  } = children.props
   const headerBlock = filterByBlockType(globalStory?.content.header, HeaderBlock.blockName)
   const footerBlock = filterByBlockType(globalStory?.content.footer, FooterBlock.blockName)
 
   const handleLocaleChange = useChangeLocale(story)
 
   return (
-    <Wrapper className={className}>
-      {(!story || !story.content.hideMenu) &&
-        headerBlock?.map((nestedBlock) => (
-          <HeaderBlock key={nestedBlock._uid} blok={nestedBlock} />
-        ))}
-      {children}
-      {(!story || !story.content.hideMenu) &&
-        footerBlock?.map((nestedBlock) => (
-          <FooterBlock
-            key={nestedBlock._uid}
-            blok={nestedBlock}
-            onLocaleChange={handleLocaleChange}
-          />
-        ))}
-    </Wrapper>
+    <ProductMetadataProvider value={globalProductMetadata}>
+      <Wrapper className={className}>
+        {(!story || !story.content.hideMenu) &&
+          headerBlock?.map((nestedBlock) => (
+            <HeaderBlock key={nestedBlock._uid} blok={nestedBlock} />
+          ))}
+        {children}
+        {(!story || !story.content.hideMenu) &&
+          footerBlock?.map((nestedBlock) => (
+            <FooterBlock
+              key={nestedBlock._uid}
+              blok={nestedBlock}
+              onLocaleChange={handleLocaleChange}
+            />
+          ))}
+      </Wrapper>
+    </ProductMetadataProvider>
   )
 }

--- a/apps/store/src/components/LayoutWithMenu/ProductMetadataContext.tsx
+++ b/apps/store/src/components/LayoutWithMenu/ProductMetadataContext.tsx
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react'
+import { GlobalProductMetadata } from './fetchProductMetadata'
+
+const ProductMetadataContext = createContext<GlobalProductMetadata | null>(null)
+
+export const useProductMetadata = () => {
+  const context = useContext(ProductMetadataContext)
+  if (context === undefined) {
+    throw new Error('useGlobalProductMetadata must be used within a GlobalProductMetadataProvider')
+  }
+  return context
+}
+
+export const ProductMetadataProvider = ProductMetadataContext.Provider

--- a/apps/store/src/components/LayoutWithMenu/fetchProductMetadata.ts
+++ b/apps/store/src/components/LayoutWithMenu/fetchProductMetadata.ts
@@ -1,0 +1,17 @@
+import { ApolloClient } from '@apollo/client'
+import { ProductMetadataDocument, ProductMetadataQuery } from '@/services/apollo/generated'
+
+export const GLOBAL_PRODUCT_METADATA_PROP_NAME = 'globalProductMetadata'
+
+type Params = {
+  apolloClient: ApolloClient<unknown>
+}
+
+export const fetchGlobalProductMetadata = async ({ apolloClient }: Params) => {
+  const { data } = await apolloClient.query<ProductMetadataQuery>({
+    query: ProductMetadataDocument,
+  })
+  return data.availableProducts
+}
+
+export type GlobalProductMetadata = Awaited<ReturnType<typeof fetchGlobalProductMetadata>>

--- a/apps/store/src/graphql/ProductMetadata.graphql
+++ b/apps/store/src/graphql/ProductMetadata.graphql
@@ -1,0 +1,13 @@
+query ProductMetadata {
+  availableProducts {
+    id
+    name
+    displayNameShort
+    pageLink
+    pillowImage {
+      id
+      alt
+      src
+    }
+  }
+}

--- a/apps/store/src/pages/cart.tsx
+++ b/apps/store/src/pages/cart.tsx
@@ -7,6 +7,10 @@ import {
   getTotal,
 } from '@/components/CartInventory/CartInventory.helpers'
 import { CartPage } from '@/components/CartPage/CartPage'
+import {
+  fetchGlobalProductMetadata,
+  GLOBAL_PRODUCT_METADATA_PROP_NAME,
+} from '@/components/LayoutWithMenu/fetchProductMetadata'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
 import { addApolloState, initializeApollo } from '@/services/apollo/client'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
@@ -87,10 +91,11 @@ export const getServerSideProps: GetServerSideProps<
   const { countryCode } = getCountryByLocale(locale)
 
   const apolloClient = initializeApollo({ req, res })
-  const [shopSession, translations, globalStory] = await Promise.all([
+  const [shopSession, translations, globalStory, productMetadata] = await Promise.all([
     getShopSessionServerSide({ apolloClient, countryCode, req, res }),
     serverSideTranslations(locale),
     getGlobalStory({ version, locale }),
+    fetchGlobalProductMetadata({ apolloClient }),
   ])
 
   return addApolloState(apolloClient, {
@@ -98,6 +103,7 @@ export const getServerSideProps: GetServerSideProps<
       ...translations,
       [SHOP_SESSION_PROP_NAME]: shopSession.id,
       [GLOBAL_STORY_PROP_NAME]: globalStory,
+      [GLOBAL_PRODUCT_METADATA_PROP_NAME]: productMetadata,
     },
   })
 }

--- a/apps/store/src/pages/confirmation/[shopSessionId].tsx
+++ b/apps/store/src/pages/confirmation/[shopSessionId].tsx
@@ -2,6 +2,10 @@ import type { GetServerSideProps, NextPageWithLayout } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { ConfirmationPage } from '@/components/ConfirmationPage/ConfirmationPage'
 import { ConfirmationPageProps } from '@/components/ConfirmationPage/ConfirmationPage.types'
+import {
+  fetchGlobalProductMetadata,
+  GLOBAL_PRODUCT_METADATA_PROP_NAME,
+} from '@/components/LayoutWithMenu/fetchProductMetadata'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
 import { addApolloState, initializeApollo } from '@/services/apollo/client'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
@@ -27,11 +31,12 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
 
   const apolloClient = initializeApollo({ req, res })
   const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
-  const [shopSession, translations, globalStory, story] = await Promise.all([
+  const [shopSession, translations, globalStory, story, productMetadata] = await Promise.all([
     shopSessionService.fetchById(shopSessionId),
     serverSideTranslations(locale),
     getGlobalStory({ locale }),
     getStoryBySlug(CONFIRMATION_PAGE_SLUG, { locale }),
+    fetchGlobalProductMetadata({ apolloClient }),
   ])
 
   // @TODO: uncomment after implementing signing
@@ -44,6 +49,7 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
       ...translations,
       [SHOP_SESSION_PROP_NAME]: shopSession.id,
       [GLOBAL_STORY_PROP_NAME]: globalStory,
+      [GLOBAL_PRODUCT_METADATA_PROP_NAME]: productMetadata,
       cart: shopSession.cart,
       currency: shopSession.currencyCode,
       platform: getMobilePlatform(req.headers['user-agent'] ?? ''),


### PR DESCRIPTION
## Describe your changes

Introduce the concept of global product metadata that can be used in places like the layout header/navigation.

Currently implemented as React context around the layout component.

Add pillow image option to nav item in Storyblok to be able to override the default image.

![Screenshot 2023-02-01 at 13.48.19.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/0e2e21aa-a32b-4c61-843d-9be92eba962d/Screenshot%202023-02-01%20at%2013.48.19.png)

## Justify why they are needed

To be able to render product info in global places like the layout header.

I don't want to fetch this on every render but rather fetch onces during build and just pass it down to the layout component like other static CMS-driven data.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
