### PR TITLE
Prevent purchase form from scrolling too early

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -131,10 +131,11 @@ const Main = styled.main({
 
 const PurchaseFormWrapper = styled.div({
   position: 'sticky',
-  top: 0,
+  top: '9vh',
   // Scroll independently if content is too long
   maxHeight: '100vh',
   overflow: 'auto',
+  paddingBottom: theme.space.xl,
 })
 
 const OverviewSection = styled.div({

--- a/apps/store/src/components/CartInventory/DetailsSheetDialog.tsx
+++ b/apps/store/src/components/CartInventory/DetailsSheetDialog.tsx
@@ -33,7 +33,7 @@ export const DetailsSheetDialog = (props: Props) => {
       >
         <DetailsSheet.Root y={1.5}>
           <DetailsSheet.Header>
-            <Pillow size="large" {...pillow} />
+            <Pillow size="xlarge" {...pillow} />
             <div>
               <Text align="center">{title}</Text>
               <Text color="textSecondary" align="center">

--- a/apps/store/src/components/Pillow/Pillow.tsx
+++ b/apps/store/src/components/Pillow/Pillow.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 const PLACEHOLDER = 'https://a.storyblok.com/f/165473/512x512/7996914970/se-apartment-rental.png'
 
 type PillowProps = {
-  size?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'
+  size?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'
   src?: string
   alt?: string | null
 }
@@ -15,7 +15,7 @@ export const Pillow = ({ alt, src = PLACEHOLDER, ...props }: PillowProps) => (
 
 const StyledImage = styled(Image)<PillowProps>(({ size = 'medium' }) => getSize(size))
 
-const getSize = (size: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge') => {
+const getSize = (size: PillowProps['size']) => {
   switch (size) {
     case 'xsmall':
       return { width: '2.25rem', height: '2.25rem' }
@@ -24,8 +24,10 @@ const getSize = (size: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge') => {
     case 'medium':
       return { width: '3.5rem', height: '3.5rem' }
     case 'large':
-      return { width: '8rem', height: '8rem' }
+      return { width: '5rem', height: '5rem' }
     case 'xlarge':
-      return { width: '13.75rem', height: '13.75rem' }
+      return { width: '6rem', height: '6rem' }
+    case 'xxlarge':
+      return { width: '13rem', height: '13rem' }
   }
 }

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -154,7 +154,7 @@ const Layout = ({ children, pillowSize }: LayoutProps) => {
         <SectionWrapper>
           <SpaceFlex space={1} align="center" direction="vertical">
             <Pillow
-              size={pillowSize === 'large' ? 'xlarge' : 'large'}
+              size={pillowSize === 'large' ? 'xxlarge' : 'large'}
               {...productData.pillowImage}
             />
             <Space y={0.5}>
@@ -398,8 +398,13 @@ const PurchaseFormTop = styled.div({
   flexDirection: 'column',
   justifyContent: 'center',
   gap: '4.5rem',
-  paddingBlock: '9vh',
+  paddingTop: '3vw',
+  paddingBottom: theme.space.xxl,
   paddingInline: theme.space.md,
+
+  [mq.xl]: {
+    paddingTop: '6vw',
+  },
 })
 
 const StickyButtonWrapper = styled.div({


### PR DESCRIPTION
## Describe your changes

Prevent purchase form on desktop to scroll too early.

![Screenshot 2023-02-03 at 09.04.43.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/da905c72-4272-4d01-a9c6-ce5dff91ef24/Screenshot%202023-02-03%20at%2009.04.43.png)

![Screenshot 2023-02-03 at 09.04.18.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/5971a545-0dc7-4375-9e75-a5746a61b286/Screenshot%202023-02-03%20at%2009.04.18.png)

Slightly tweak sizes of the pillow to better match design.

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
