### PR TITLE
Only resume playing videos after closing modal

### DIFF
--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -86,18 +86,21 @@ export const Video = ({
     [setState, onPause],
   )
 
+  const [wasPlaying, setWasPlaying] = useState(false)
   const handleDialogOpen = useCallback(() => {
     if (state === State.Playing) {
+      setWasPlaying(true)
       pauseVideo()
     }
   }, [state, pauseVideo])
   useDialogEvent('open', handleDialogOpen)
 
   const handleDialogClose = useCallback(() => {
-    if (state === State.Paused) {
+    if (wasPlaying) {
+      setWasPlaying(false)
       playVideo()
     }
-  }, [state, playVideo])
+  }, [wasPlaying, playVideo])
   useDialogEvent('close', handleDialogClose)
 
   return (


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Keep track whether videos were playing when dialog was opened and resume them when dialog is closed.

## Justify why they are needed

Before we resumed videos even if they were not playing when dialog was opened.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
