### PR TITLE
GRW-2120 - feat(VideoListBlock): play only one video at a time

### DIFF
--- a/apps/store/src/blocks/VideoListBlock.tsx
+++ b/apps/store/src/blocks/VideoListBlock.tsx
@@ -5,13 +5,35 @@ import { Slideshow } from '@/components/Slideshow/Slideshow'
 import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { VideoBlock, VideoBlockProps } from './VideoBlock'
 
+const playVideoExclusively = (
+  videoList: Array<HTMLVideoElement>,
+  videoToBePlayed: HTMLVideoElement,
+) => {
+  videoList.forEach((videoNode) => {
+    if (videoNode === videoToBePlayed) return
+    if (videoNode.played.length > 0 && !videoNode.paused) {
+      videoNode.pause()
+    }
+  })
+}
+
 type VideoListBlockProps = SbBaseBlockProps<{
   videos: ExpectedBlockType<VideoBlockProps>
 }>
 
 export const VideoListBlock = ({ blok }: VideoListBlockProps) => {
   return (
-    <Slideshow alignment="center" {...storyblokEditable(blok)}>
+    <Slideshow
+      ref={(node) => {
+        const videos = Array.from(node?.querySelectorAll('video') ?? [])
+
+        videos.forEach((video) => {
+          video.addEventListener('play', () => playVideoExclusively(videos, video))
+        })
+      }}
+      alignment="center"
+      {...storyblokEditable(blok)}
+    >
       {blok.videos.map((nestedVideoBlock) => (
         <StyledVideoBlock key={nestedVideoBlock._uid} blok={nestedVideoBlock} />
       ))}

--- a/apps/store/src/components/Slideshow/Slideshow.tsx
+++ b/apps/store/src/components/Slideshow/Slideshow.tsx
@@ -10,18 +10,21 @@ export type SlideshowProps = {
   title?: string
 }
 
-export const Slideshow = ({ children, title, alignment = 'left' }: SlideshowProps) => {
-  return (
-    <Space y={1.5}>
-      {title && <Title>{title}</Title>}
-      <ScollableContainer alignment={alignment}>
-        {React.Children.map(children, (child, index) => (
-          <ScrollableItem key={index}>{child}</ScrollableItem>
-        ))}
-      </ScollableContainer>
-    </Space>
-  )
-}
+export const Slideshow = React.forwardRef<HTMLDivElement, SlideshowProps>(
+  ({ children, title, alignment = 'left' }, ref) => {
+    return (
+      <Space y={1.5}>
+        {title && <Title>{title}</Title>}
+        <ScollableContainer ref={ref} alignment={alignment}>
+          {React.Children.map(children, (child, index) => (
+            <ScrollableItem key={index}>{child}</ScrollableItem>
+          ))}
+        </ScollableContainer>
+      </Space>
+    )
+  },
+)
+Slideshow.displayName = 'Slideshow'
 
 const Title = styled.h2({
   fontSize: theme.fontSizes.sm,


### PR DESCRIPTION
## Describe your changes

* Update `Slideshow` so it can get a ref;
* Add an event handler for `play` event to each video of `VideoListBlock` that make sure only one video gets played at a time.

## Justify why they are needed

Requested by design.

## Jira issue(s): [GRW-2120](https://hedvig.atlassian.net/browse/GRW-2120)

https://user-images.githubusercontent.com/19200662/216939688-cc8f2800-2bd4-4c3d-8783-a97cce962385.mov



[GRW-2120]: https://hedvig.atlassian.net/browse/GRW-2120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ