### PR TITLE
GRW-2120 refact(VideoBlock): play one video at a time

### DIFF
--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -1,37 +1,56 @@
 import styled from '@emotion/styled'
+import { forwardRef } from 'react'
 import { mq, theme } from 'ui'
 import { Video, VideoProps } from '@/components/Video/Video'
 import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 
-export type VideoBlockProps = SbBaseBlockProps<
-  {
-    video: StoryblokAsset
-    poster?: StoryblokAsset
-  } & Pick<
+type SbRelatedProps = {
+  video: StoryblokAsset
+  poster?: StoryblokAsset
+} & Pick<
+  VideoProps,
+  | 'autoPlay'
+  | 'aspectRatioLandscape'
+  | 'aspectRatioPortrait'
+  | 'maxHeightLandscape'
+  | 'maxHeightPortrait'
+>
+
+export type VideoBlockProps = SbBaseBlockProps<SbRelatedProps> &
+  // Below are the Video props that will not be controled by the data we get from Storyblok.
+  // We can use them to change some aspects of the Video component that are abstracted from
+  // editors - In other workds, implementation details.
+  Omit<
     VideoProps,
+    | 'sources'
+    | 'poster'
     | 'autoPlay'
     | 'aspectRatioLandscape'
     | 'aspectRatioPortrait'
     | 'maxHeightLandscape'
     | 'maxHeightPortrait'
   >
-> & { className?: string }
 
-export const VideoBlock = ({ className, blok }: VideoBlockProps) => {
-  return (
-    <Wrapper className={className}>
-      <Video
-        sources={[{ url: blok.video.filename }]}
-        poster={blok.poster?.filename}
-        autoPlay={blok.autoPlay}
-        aspectRatioLandscape={blok.aspectRatioLandscape}
-        aspectRatioPortrait={blok.aspectRatioPortrait}
-        maxHeightLandscape={blok.maxHeightLandscape}
-        maxHeightPortrait={blok.maxHeightPortrait}
-      />
-    </Wrapper>
-  )
-}
+export const VideoBlock = forwardRef<HTMLVideoElement, VideoBlockProps>(
+  ({ className, blok, ...delegated }, ref) => {
+    return (
+      <Wrapper className={className}>
+        <Video
+          ref={ref}
+          sources={[{ url: blok.video.filename }]}
+          poster={blok.poster?.filename}
+          autoPlay={blok.autoPlay}
+          aspectRatioLandscape={blok.aspectRatioLandscape}
+          aspectRatioPortrait={blok.aspectRatioPortrait}
+          maxHeightLandscape={blok.maxHeightLandscape}
+          maxHeightPortrait={blok.maxHeightPortrait}
+          {...delegated}
+        />
+      </Wrapper>
+    )
+  },
+)
+VideoBlock.displayName = 'VideoBlock'
 VideoBlock.blockName = 'videoBlock'
 
 const Wrapper = styled.div({

--- a/apps/store/src/components/Slideshow/Slideshow.tsx
+++ b/apps/store/src/components/Slideshow/Slideshow.tsx
@@ -10,21 +10,18 @@ export type SlideshowProps = {
   title?: string
 }
 
-export const Slideshow = React.forwardRef<HTMLDivElement, SlideshowProps>(
-  ({ children, title, alignment = 'left' }, ref) => {
-    return (
-      <Space y={1.5}>
-        {title && <Title>{title}</Title>}
-        <ScollableContainer ref={ref} alignment={alignment}>
-          {React.Children.map(children, (child, index) => (
-            <ScrollableItem key={index}>{child}</ScrollableItem>
-          ))}
-        </ScollableContainer>
-      </Space>
-    )
-  },
-)
-Slideshow.displayName = 'Slideshow'
+export const Slideshow = ({ children, title, alignment = 'left' }: SlideshowProps) => {
+  return (
+    <Space y={1.5}>
+      {title && <Title>{title}</Title>}
+      <ScollableContainer alignment={alignment}>
+        {React.Children.map(children, (child, index) => (
+          <ScrollableItem key={index}>{child}</ScrollableItem>
+        ))}
+      </ScollableContainer>
+    </Space>
+  )
+}
 
 const Title = styled.h2({
   fontSize: theme.fontSizes.sm,


### PR DESCRIPTION
## Describe your changes

This is a working draft for an alternative more _react-y_ version of the _Play one video at a time_ originally implemented [here](https://github.com/HedvigInsurance/racoon/pull/1547).

Basically the idea here was:

* Update `VideoBlock` so it can receive a `ref` that will then be passed to `Video` component. `VideoBlock` would also need to be updated so it can take in more `Video` related props as `onPlay` event handler;
* `Video` component already keeps a `ref` for the `<video>` element so we can control it (play/pause) so we'd need to update `Video` component by getting both `ref`s merged (`ui/merge-refs`);
* Update `VideoListBlock` so we keep a `ref` for each video. Since the number of videos is dynamic I though about storing that list as a ref. Not sure if there's a better way  🤔:

We can use this as an starting point of even discard it and start from scratch. No strings attached.

## Justify why they are needed

It's just some exploration based on some comments I got from the other PR.

## Jira issue(s): [GRW-2120](https://hedvig.atlassian.net/browse/GRW-2120)

[GRW-2120]: https://hedvig.atlassian.net/browse/GRW-2120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

FYI @robinandeer 