### PR TITLE
Site menu: animate in/out as you scroll

### DIFF
--- a/apps/store/src/blocks/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import { storyblokEditable } from '@storyblok/react'
 import { useTranslation } from 'next-i18next'
+import { useState } from 'react'
 import { Space } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { Header } from '@/components/Header/Header'
@@ -181,13 +182,19 @@ export type HeaderBlockProps = SbBaseBlockProps<{
   navMenuContainer: ExpectedBlockType<
     NestedNavContainerBlockProps | NavItemBlockProps | ProductNavContainerBlockProps
   >
-}>
+}> & {
+  overlay?: boolean
+}
 
-export const HeaderBlock = ({ blok }: HeaderBlockProps) => {
+export const HeaderBlock = ({ blok, overlay }: HeaderBlockProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+
   return (
-    <Header {...storyblokEditable(blok)}>
+    <Header {...storyblokEditable(blok)} opaque={isOpen} overlay={overlay}>
       <TopMenuDesktop>{blok.navMenuContainer.map(NestedNavigationBlock)}</TopMenuDesktop>
-      <TopMenuMobile>{blok.navMenuContainer.map(NestedNavigationBlock)} </TopMenuMobile>
+      <TopMenuMobile isOpen={isOpen} setIsOpen={setIsOpen}>
+        {blok.navMenuContainer.map(NestedNavigationBlock)}
+      </TopMenuMobile>
     </Header>
   )
 }

--- a/apps/store/src/components/Header/Header.stories.tsx
+++ b/apps/store/src/components/Header/Header.stories.tsx
@@ -81,7 +81,7 @@ const MockedNavItems = () => {
 }
 
 export type TopMenuProps = {
-  isOpen?: boolean
+  isOpen: boolean
   currentActiveItem?: string
   count?: number
 }
@@ -89,12 +89,12 @@ export type TopMenuProps = {
 const Template: Story<TopMenuProps> = (props) => {
   return (
     <>
-      <MockedHeaderWrapper>
+      <MockedHeaderWrapper opaque={false}>
         <TopMenuDesktop>
           <MockedNavItems />
         </TopMenuDesktop>
 
-        <TopMenuMobile>
+        <TopMenuMobile isOpen={props.isOpen} setIsOpen={() => {}}>
           <MockedNavItems />
         </TopMenuMobile>
 

--- a/apps/store/src/components/Header/Header.tsx
+++ b/apps/store/src/components/Header/Header.tsx
@@ -1,22 +1,64 @@
+import { css } from '@emotion/react'
 import styled from '@emotion/styled'
+import { AnimatePresence, motion } from 'framer-motion'
 import Link from 'next/link'
 import { HedvigLogo, mq, theme } from 'ui'
 import { PageLink } from '@/utils/PageLink'
 import { zIndexes } from '@/utils/zIndex'
 import { MENU_BAR_HEIGHT_DESKTOP, MENU_BAR_HEIGHT_MOBILE } from './HeaderStyles'
 import { ShoppingCartMenuItem } from './ShoppingCartMenuItem'
+import { useScrollDirection } from './useScrollDirection'
 
-export const Wrapper = styled.header({
+type HeaderProps = {
+  children: React.ReactNode
+  opaque?: boolean
+  overlay?: boolean
+}
+
+export const Header = ({ children, opaque = false, overlay = false }: HeaderProps) => {
+  const scrollDirection = useScrollDirection({ threshold: 128 })
+
+  const headerContent = (
+    <>
+      <LogoWrapper href={PageLink.home()}>
+        <HedvigLogo />
+      </LogoWrapper>
+      <ContentWrapper>
+        {children}
+        <ShoppingCartMenuItem />
+      </ContentWrapper>
+    </>
+  )
+
+  return (
+    <>
+      <Wrapper opaque={opaque} overlay={overlay}>
+        {headerContent}
+      </Wrapper>
+
+      <AnimatePresence>
+        {scrollDirection === 'up' && (
+          <FloatingWrapper
+            initial={{ y: '-150%' }}
+            animate={{ y: 0 }}
+            exit={{ opacity: 0, transition: { duration: 0.15 } }}
+            transition={{ type: 'just' }}
+          >
+            {headerContent}
+          </FloatingWrapper>
+        )}
+      </AnimatePresence>
+    </>
+  )
+}
+
+const wrapperStyles = css({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
   width: '100%',
   height: MENU_BAR_HEIGHT_MOBILE,
-  padding: ` 0 ${theme.space.md}`,
-  position: 'sticky',
-  zIndex: zIndexes.header,
-  top: 0,
-  backgroundColor: theme.colors.light,
+  paddingInline: theme.space.md,
 
   [mq.lg]: {
     flexDirection: 'row',
@@ -25,8 +67,30 @@ export const Wrapper = styled.header({
   },
 })
 
+type WrapperProps = Pick<HeaderProps, 'opaque' | 'overlay'>
+
+export const Wrapper = styled.header<WrapperProps>(wrapperStyles, ({ opaque, overlay }) => ({
+  backgroundColor: opaque ? theme.colors.backgroundStandard : 'transparent',
+
+  ...(overlay && {
+    position: 'absolute',
+    top: 0,
+    zIndex: zIndexes.header,
+  }),
+}))
+
+const FloatingWrapper = styled(motion.header)(wrapperStyles, {
+  position: 'fixed',
+  top: 0,
+  zIndex: zIndexes.header,
+  backgroundColor: theme.colors.backgroundStandard,
+  boxShadow: 'rgba(0, 0, 0, 0.06) 0px 2px 12px',
+})
+
 const LogoWrapper = styled(Link)({
   flex: 1,
+  WebkitTapHighlightColor: 'transparent',
+  ':active': { opacity: 0.75 },
 })
 
 const ContentWrapper = styled.div({
@@ -35,24 +99,8 @@ const ContentWrapper = styled.div({
   justifyContent: 'flex-end',
   alignItems: 'center',
   flex: 1,
+
   [mq.lg]: {
     justifyContent: 'space-between',
   },
 })
-
-type HeaderProps = {
-  children: React.ReactNode
-}
-export const Header = ({ children }: HeaderProps) => {
-  return (
-    <Wrapper>
-      <LogoWrapper href={PageLink.home()}>
-        <HedvigLogo />
-      </LogoWrapper>
-      <ContentWrapper>
-        {children}
-        <ShoppingCartMenuItem />
-      </ContentWrapper>
-    </Wrapper>
-  )
-}

--- a/apps/store/src/components/Header/HeaderStyles.tsx
+++ b/apps/store/src/components/Header/HeaderStyles.tsx
@@ -7,13 +7,13 @@ export const MENU_BAR_HEIGHT_DESKTOP = '4rem'
 
 export const focusableStyles = {
   cursor: 'pointer',
+  WebkitTapHighlightColor: 'transparent',
   '&:focus-visible': {
     outline: `2px solid ${theme.colors.gray900}`,
   },
 }
 
 export const Navigation = styled(NavigationMenuPrimitive.Root)({
-  backgroundColor: theme.colors.light,
   fontSize: theme.fontSizes.xl,
 
   [mq.lg]: {
@@ -100,7 +100,6 @@ export const NavigationPrimaryList = styled(NavigationMenuPrimitive.List)({
   display: 'flex',
   flexDirection: 'column',
   padding: `0 ${theme.space.md} `,
-  backgroundColor: theme.colors.light,
 
   [mq.lg]: {
     position: 'static',

--- a/apps/store/src/components/Header/TopMenuDesktop/TopMenuDesktop.tsx
+++ b/apps/store/src/components/Header/TopMenuDesktop/TopMenuDesktop.tsx
@@ -8,13 +8,6 @@ export type TopMenuDesktopProps = {
   children: React.ReactNode
 }
 
-const Wrapper = styled.div({
-  display: 'none',
-  [mq.lg]: {
-    display: 'block',
-  },
-})
-
 export const TopMenuDesktop = ({ children }: TopMenuDesktopProps) => {
   return (
     <Wrapper>
@@ -24,3 +17,11 @@ export const TopMenuDesktop = ({ children }: TopMenuDesktopProps) => {
     </Wrapper>
   )
 }
+
+const Wrapper = styled.div({
+  display: 'none',
+
+  [mq.lg]: {
+    display: 'block',
+  },
+})

--- a/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
+++ b/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
@@ -2,10 +2,15 @@ import styled from '@emotion/styled'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { AndroidIcon, AppleIcon, Button, mq, Space, theme } from 'ui'
 import { appStoreLinks } from '@/utils/appStoreLinks'
-import { focusableStyles, Navigation, NavigationPrimaryList } from '../HeaderStyles'
+import {
+  focusableStyles,
+  MENU_BAR_HEIGHT_MOBILE,
+  Navigation,
+  NavigationPrimaryList,
+} from '../HeaderStyles'
 
 const triggerStyles = {
   ...focusableStyles,
@@ -39,25 +44,25 @@ const StyledAndroidIcon = styled(AndroidIcon)({
 })
 
 export type TopMenuMobileProps = {
-  isOpen?: boolean
+  isOpen: boolean
+  setIsOpen: (isOpen: boolean) => void
   children: React.ReactNode
 }
 
-export const TopMenuMobile = ({ children }: TopMenuMobileProps) => {
-  const [open, setOpen] = useState(false)
+export const TopMenuMobile = ({ children, isOpen, setIsOpen }: TopMenuMobileProps) => {
   const router = useRouter()
   const { t } = useTranslation('common')
 
   useEffect(() => {
-    const closeDialog = () => setOpen(false)
-    router.events.on('routeChangeComplete', closeDialog)
-    return () => router.events.off('routeChangeComplete', closeDialog)
-  }, [router.events])
+    const closeDialog = () => setIsOpen(false)
+    router.events.on('routeChangeStart', closeDialog)
+    return () => router.events.off('routeChangeStart', closeDialog)
+  }, [router.events, setIsOpen])
 
   return (
     <>
-      <DialogPrimitive.Root open={open} onOpenChange={() => setOpen((prevOpen) => !prevOpen)}>
-        {open ? (
+      <DialogPrimitive.Root open={isOpen} onOpenChange={setIsOpen}>
+        {isOpen ? (
           <DialogClose>{t('NAV_MENU_DIALOG_CLOSE')}</DialogClose>
         ) : (
           <DialogTrigger>{t('NAV_MENU_DIALOG_OPEN')}</DialogTrigger>
@@ -96,11 +101,6 @@ export const TopMenuMobile = ({ children }: TopMenuMobileProps) => {
   )
 }
 
-export const StyledDialogOverlay = styled(DialogPrimitive.Overlay)({
-  position: 'fixed',
-  inset: 0,
-})
-
 export const DialogContent = (props: DialogPrimitive.DialogContentProps) => {
   return (
     <DialogPrimitive.Portal>
@@ -109,3 +109,10 @@ export const DialogContent = (props: DialogPrimitive.DialogContentProps) => {
     </DialogPrimitive.Portal>
   )
 }
+
+const StyledDialogOverlay = styled(DialogPrimitive.Overlay)({
+  position: 'fixed',
+  inset: 0,
+  top: MENU_BAR_HEIGHT_MOBILE,
+  backgroundColor: theme.colors.light,
+})

--- a/apps/store/src/components/Header/useScrollDirection.ts
+++ b/apps/store/src/components/Header/useScrollDirection.ts
@@ -1,0 +1,20 @@
+import { useScroll } from 'framer-motion'
+import { useEffect, useState } from 'react'
+
+type Params = { threshold?: number }
+
+export const useScrollDirection = ({ threshold = 0 }: Params) => {
+  const [scrollDirection, setScrollDirection] = useState<'up' | 'down' | null>(null)
+  const { scrollY } = useScroll()
+
+  useEffect(() => {
+    return scrollY.on('change', (latest) => {
+      if (latest < threshold) return setScrollDirection(null)
+
+      const isScrollingDown = scrollY.getPrevious() - latest < 0
+      setScrollDirection(isScrollingDown ? 'down' : 'up')
+    })
+  }, [scrollY, threshold])
+
+  return scrollDirection
+}

--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -37,12 +37,16 @@ export const LayoutWithMenu = ({ children }: LayoutWithMenuProps) => {
   return (
     <ProductMetadataProvider value={globalProductMetadata}>
       <Wrapper className={className}>
-        {(!story || !story.content.hideMenu) &&
+        {!(story && story.content.hideMenu) &&
           headerBlock?.map((nestedBlock) => (
-            <HeaderBlock key={nestedBlock._uid} blok={nestedBlock} />
+            <HeaderBlock
+              key={nestedBlock._uid}
+              blok={nestedBlock}
+              overlay={story?.content.overlayMenu}
+            />
           ))}
         {children}
-        {(!story || !story.content.hideMenu) &&
+        {!(story && story.content.hideFooter) &&
           footerBlock?.map((nestedBlock) => (
             <FooterBlock
               key={nestedBlock._uid}

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -64,7 +64,7 @@ export type StoryblokQueryParams = {
 }
 
 export type StoryblokPageProps = {
-  [STORY_PROP_NAME]: ISbStoryData
+  [STORY_PROP_NAME]: PageStory
   [GLOBAL_STORY_PROP_NAME]: GlobalStory
 }
 
@@ -99,6 +99,14 @@ export type LinkField = {
     // Can be overridden in Storyblok editor: "Entry configuration" > "Real path".
     url: string
     full_slug: string
+  }
+}
+
+export type PageStory = ISbStoryData & {
+  content: ISbStoryData['content'] & {
+    hideMenu?: boolean
+    overlayMenu?: boolean
+    hideFooter?: boolean
   }
 }
 


### PR DESCRIPTION
## Describe your changes

[Screen Recording 2023-02-07 at 09.36.24.mov](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/ce6fbf9f-e8d5-4e03-8a8c-2fcdbc353e18/Screen%20Recording%202023-02-07%20at%2009.36.24.mov)

1. Show menu on-top of content

    - Remove background color from menu, apply background only when mobile menu is open

1. Scroll menu with content
1. When user scrolls up, show menu with animation

    - Implement custom hook to determine scroll direction

1. When user scrolls down, hide menu with animation
1. When user scrolls to top, hide overlayed menu to show the static menu

Also remove some webkit tab highlight styles :P

## Justify why they are needed

Implemented it according to menu found on [https://www.mindbloom.com/](https://www.mindbloom.com/).

I had to duplicate the menu content and render it twice. Otherwise, we would have to transition between 3 states which leads to inconsistent behavior. Instead I just show/hide the overlay menu using `AnimatePresence`.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
