### PR TITLE
Update text contnent block

### DIFF
--- a/apps/store/src/blocks/HeadingBlock.tsx
+++ b/apps/store/src/blocks/HeadingBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
-import { Heading, HeadingProps, PossibleHeadingVariant, theme } from 'ui'
+import { ConditionalWrapper, Heading, HeadingProps, PossibleHeadingVariant, theme } from 'ui'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
 export const Wrapper = styled.div({
@@ -15,11 +15,15 @@ export type HeadingBlockProps = SbBaseBlockProps<{
   variant?: PossibleHeadingVariant
   variantDesktop?: PossibleHeadingVariant
   textAlignment?: HeadingProps['align']
+  nested?: boolean
 }>
 
 export const HeadingBlock = ({ blok }: HeadingBlockProps) => {
   return (
-    <Wrapper>
+    <ConditionalWrapper
+      condition={!blok.nested}
+      wrapWith={(children) => <Wrapper>{children}</Wrapper>}
+    >
       <Heading
         as={blok.as}
         variant={{ _: blok.variant ?? 'standard.32', md: blok.variantDesktop ?? 'standard.40' }}
@@ -29,7 +33,7 @@ export const HeadingBlock = ({ blok }: HeadingBlockProps) => {
       >
         {blok.text}
       </Heading>
-    </Wrapper>
+    </ConditionalWrapper>
   )
 }
 HeadingBlock.blockName = 'heading'

--- a/apps/store/src/blocks/HeadingLabelBlock.tsx
+++ b/apps/store/src/blocks/HeadingLabelBlock.tsx
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled'
+import { storyblokEditable } from '@storyblok/react'
+import { HeadingLabelProps } from 'ui/src/components/HeadingLabel/HeadingLabel'
+import { ConditionalWrapper, HeadingLabel, theme } from 'ui'
+import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+
+export const Wrapper = styled.div({
+  paddingLeft: theme.space.md,
+  paddingRight: theme.space.md,
+})
+
+export type HeadingLabelBlockProps = SbBaseBlockProps<{
+  text: string
+  as: HeadingLabelProps['as']
+  nested?: boolean
+}>
+
+export const HeadingLabelBlock = ({ blok }: HeadingLabelBlockProps) => {
+  return (
+    <ConditionalWrapper
+      condition={!blok.nested}
+      wrapWith={(children) => <Wrapper>{children}</Wrapper>}
+    >
+      <HeadingLabel as={blok.as} {...storyblokEditable(blok)}>
+        {blok.text}
+      </HeadingLabel>
+    </ConditionalWrapper>
+  )
+}
+HeadingLabelBlock.blockName = 'headingLabel'

--- a/apps/store/src/blocks/TextContentBlock.tsx
+++ b/apps/store/src/blocks/TextContentBlock.tsx
@@ -1,0 +1,50 @@
+import styled from '@emotion/styled'
+import { StoryblokComponent, storyblokEditable } from '@storyblok/react'
+import { mq, Space, theme } from 'ui'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { HeadingBlockProps } from './HeadingBlock'
+import { HeadingLabelBlockProps } from './HeadingLabelBlock'
+import { TextBlockProps } from './TextBlock'
+
+type Alignment = 'left' | 'center' | 'right' | 'justify'
+
+export type Props = SbBaseBlockProps<{
+  heading?: ExpectedBlockType<HeadingBlockProps | HeadingLabelBlockProps>
+  body: ExpectedBlockType<TextBlockProps>
+  alignment?: Alignment
+}>
+
+export const TextContentBlock = ({ blok }: Props) => {
+  return (
+    <Wrapper {...storyblokEditable(blok)}>
+      <TextWrapper y={1} alignment={blok.alignment ?? 'left'}>
+        {blok.body?.map((nestedBlock) => (
+          <StoryblokComponent
+            key={nestedBlock._uid}
+            blok={{ ...nestedBlock, ...{ nested: true } }}
+          />
+        ))}
+      </TextWrapper>
+    </Wrapper>
+  )
+}
+TextContentBlock.blockName = 'textContent'
+
+const Wrapper = styled(GridLayout.Root)({
+  paddingLeft: theme.space.md,
+  paddingRight: theme.space.md,
+})
+
+const TextWrapper = styled(Space)<{ alignment: Alignment }>(({ alignment }) => ({
+  gridColumn: '1 / span 12',
+  textAlign: alignment,
+
+  [mq.md]: {
+    gridColumn: '2 / span 10',
+  },
+
+  [mq.lg]: {
+    gridColumn: '3 / span 8',
+  },
+}))

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -22,6 +22,7 @@ import {
   ProductNavContainerBlock,
 } from '@/blocks/HeaderBlock'
 import { HeadingBlock } from '@/blocks/HeadingBlock'
+import { HeadingLabelBlock } from '@/blocks/HeadingLabelBlock'
 import { HeroBlock } from '@/blocks/HeroBlock'
 import { HeroVideoBlock } from '@/blocks/HeroVideoBlock'
 import { HeroVideoVimeoBlock } from '@/blocks/HeroVideoVimeoBlock'
@@ -39,6 +40,7 @@ import { ReusableBlockReference } from '@/blocks/ReusableBlockReference'
 import { SpacerBlock } from '@/blocks/SpacerBlock'
 import { TabsBlock } from '@/blocks/TabsBlock'
 import { TextBlock } from '@/blocks/TextBlock'
+import { TextContentBlock } from '@/blocks/TextContentBlock'
 import { TimelineBlock } from '@/blocks/TimelineBlock'
 import { TimelineItemBlock } from '@/blocks/TimelineItemBlock'
 import { TopPickCardBlock } from '@/blocks/TopPickCardBlock'
@@ -183,6 +185,7 @@ export const initStoryblok = () => {
     // TODO: Header vs Heading is easy to confuse.  Discuss with team if we should rename one of these
     HeaderBlock,
     HeadingBlock,
+    HeadingLabelBlock,
     HeroBlock,
     HeroVideoBlock,
     HeroVideoVimeoBlock,
@@ -203,6 +206,7 @@ export const initStoryblok = () => {
     TimelineBlock,
     TimelineItemBlock,
     TextBlock,
+    TextContentBlock,
     TopPickCardBlock,
     VideoBlock,
     VideoListBlock,

--- a/packages/ui/src/components/HeadingLabel/HeadingLabel.tsx
+++ b/packages/ui/src/components/HeadingLabel/HeadingLabel.tsx
@@ -1,7 +1,7 @@
 import isPropValid from '@emotion/is-prop-valid'
 import styled from '@emotion/styled'
 
-export type LabelProps = {
+export type HeadingLabelProps = {
   as?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
   color?: string
   children: React.ReactNode
@@ -14,7 +14,7 @@ const elementConfig = {
 export const LabelBase = styled(
   'div',
   elementConfig,
-)<Pick<LabelProps, 'color'>>(({ color, theme }) => ({
+)<Pick<HeadingLabelProps, 'color'>>(({ color, theme }) => ({
   display: 'inline-block',
   padding: `${theme.space[2]} ${theme.space[3]}`,
   fontSize: theme.fontSizes[1],
@@ -24,7 +24,7 @@ export const LabelBase = styled(
   borderRadius: theme.radius.xs,
 }))
 
-export const HeadingLabel = ({ as, children, color }: LabelProps) => (
+export const HeadingLabel = ({ as, children, color }: HeadingLabelProps) => (
   <LabelBase as={as} color={color}>
     {children}
   </LabelBase>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -13,6 +13,7 @@ export type { HeadingProps, PossibleHeadingVariant } from './components/Heading/
 export { Text } from './components/Text/Text'
 export * as Dialog from './components/Dialog/Dialog'
 export { HeadingLabel } from './components/HeadingLabel/HeadingLabel'
+export { ConditionalWrapper } from './components/ConditionalWrapper'
 
 export type { Level } from './lib/media-query'
 export { mq, useBreakpoint } from './lib/media-query'


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
New block that we will use for text content
The block can render `Heading`, `HeadingLabel` and `Text`.

`Content` block is still left but this will replace that block once migrated


https://user-images.githubusercontent.com/6661511/217306036-b6fcd659-84cc-48ea-b8ca-87a6f526ed33.mov


Next steps: Add settings for controlling column layout/width and spacing between text.
The plan is to align the content to the 12 column grid.
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
To work with text heavy pages we need more options to render text
## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
