### PR TITLE
GRW-2191 - fix(ProductPageBlock): display ProductVariantSelector for desktop layout

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -84,8 +84,10 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
               }}
             >
               <TabList>
-                <TabTrigger value="overview">{blok.overviewLabel}</TabTrigger>
-                <TabTrigger value="coverage">{blok.coverageLabel}</TabTrigger>
+                <TablistWrapper>
+                  <TabTrigger value="overview">{blok.overviewLabel}</TabTrigger>
+                  <TabTrigger value="coverage">{blok.coverageLabel}</TabTrigger>
+                </TablistWrapper>
                 {shouldRenderVariantSelector && <StyledProductVariantSelector />}
               </TabList>
 
@@ -131,6 +133,7 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
                       </ContentNavigationTrigger>
                     </li>
                   </ContentNavigationList>
+                  {shouldRenderVariantSelector && <StyledProductVariantSelector />}
                 </ContentNavigation>
                 <OverviewSection id="overview">
                   {blok.overview?.map((nestedBlock) => (
@@ -164,12 +167,12 @@ const sharedListStyles: CSSObject = {
   display: 'flex',
   gap: theme.space.xs,
   height: TABLIST_HEIGHT,
-  paddingInline: theme.space.md,
 }
 
 const sharedStickyStyles: CSSObject = {
   position: 'sticky',
   top: `calc(${theme.space.sm} + ${MENU_BAR_HEIGHT_MOBILE})`,
+  paddingInline: theme.space.md,
   zIndex: zIndexes.tabs,
 
   [mq.md]: {
@@ -259,8 +262,11 @@ const Content = styled.div({
 })
 
 const TabList = styled(RadixTabs.TabsList)({
-  ...sharedListStyles,
   ...sharedStickyStyles,
+})
+
+const TablistWrapper = styled.div({
+  ...sharedListStyles,
 })
 
 const TabTrigger = styled(RadixTabs.Trigger)({
@@ -282,6 +288,7 @@ const ContentNavigationTrigger = styled.a({
 const StyledProductVariantSelector = styled(ProductVariantSelector)({
   minWidth: '12.5rem',
   width: 'fit-content',
+  marginTop: theme.space.xs,
 })
 
 function useActiveSectionChangeListener(


### PR DESCRIPTION
## Describe your changes

* Fix styles for ProductVariantSelector on mobile
* Fix bug where ProductVariantSelector wasn't being displayed on Desktop

**Disclaimer(s)**

* Got feedback from Zak about the size of the `ProductVariantSelector` being not proportional with the other controls. That's going to be part of another [ticket](https://hedvig.atlassian.net/browse/GRW-2194).
* If you decide to test it might happen to you that you can't actually see the `ProductVariantSelector` on Desktop because those controls gets hidden when one reaches _Coverage_ section of the page. There's an open request to make those controls available throughout  bot sections: _Overview_ and _Coverage_ so it's something we'll fixed in the future.
I've "forced" their appearance on desktop just so I could get an screenshot.

## Justify why they are needed

I've introduced that bug while adding some changes to `ProductPageBlock` earlier;

## Jira issue(s): [GRW-2191](https://hedvig.atlassian.net/browse/GRW-2191)

<img width="1198" alt="Screenshot 2023-02-07 at 13 31 31" src="https://user-images.githubusercontent.com/19200662/217245689-771cf507-27c8-45e8-9f25-1ed3af3b507c.png">
<img width="612" alt="Screenshot 2023-02-07 at 13 31 21" src="https://user-images.githubusercontent.com/19200662/217245704-ba69ab90-c39c-4ff6-8547-275b255e9cc8.png">

[GRW-2191]: https://hedvig.atlassian.net/browse/GRW-2191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ