### PR TITLE
Hard code slug for confirmation page.

### DIFF
--- a/apps/store/src/pages/confirmation/[shopSessionId].tsx
+++ b/apps/store/src/pages/confirmation/[shopSessionId].tsx
@@ -15,16 +15,16 @@ import { GLOBAL_STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
 import { getMobilePlatform } from '@/utils/getMobilePlatform'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
+const CONFIRMATION_PAGE_SLUG = 'confirmation'
+
 type Params = { shopSessionId: string }
 
 export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Params> = async (
   context,
 ) => {
-  const { req, res, locale, params, resolvedUrl } = context
+  const { req, res, locale, params } = context
 
   if (!isRoutingLocale(locale)) return { notFound: true }
-
-  const slug = getConfirmationPageSlugByUrl(resolvedUrl)
 
   const shopSessionId = params?.shopSessionId
   if (!shopSessionId) return { notFound: true }
@@ -35,7 +35,7 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
     shopSessionService.fetchById(shopSessionId),
     serverSideTranslations(locale),
     getGlobalStory({ locale }),
-    getStoryBySlug(slug, { locale }),
+    getStoryBySlug(CONFIRMATION_PAGE_SLUG, { locale }),
     fetchGlobalProductMetadata({ apolloClient }),
   ])
 
@@ -45,7 +45,7 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
   // }
 
   if (story === undefined) {
-    console.warn(`Page not found: ${slug}, locale: ${locale}`)
+    console.warn(`Page not found: ${CONFIRMATION_PAGE_SLUG}, locale: ${locale}`)
     return { notFound: true }
   }
 
@@ -70,9 +70,3 @@ const CheckoutConfirmationPage: NextPageWithLayout<
 CheckoutConfirmationPage.getLayout = (children) => <LayoutWithMenu>{children}</LayoutWithMenu>
 
 export default CheckoutConfirmationPage
-
-const getConfirmationPageSlugByUrl = (url: string) => {
-  const urlParts = url.split('/')
-  const slug = urlParts[1]
-  return slug
-}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Revert changes from https://github.com/HedvigInsurance/racoon/pull/1561

Keeping the check if the story is undefined. 

Added the `/se` confirmation page by copy/pasta 🍝 the page from `en-se` in storyblok. 

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

After chatting with @robinandeer. I see that we're only not going to be translating slugs for non content pages like the confirmation page. 

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [x] I have performed a self-review of my code
