### PR TITLE
Dynamically import Lottie animations

### DIFF
--- a/apps/store/src/components/Animations/Message/Message.tsx
+++ b/apps/store/src/components/Animations/Message/Message.tsx
@@ -1,5 +1,7 @@
-import { LottieAnimation } from '../Root'
+import dynamic from 'next/dynamic'
 import animationData from './message.json'
+
+const LottieAnimation = dynamic(() => import('../Root').then((mod) => mod.LottieAnimation))
 
 export const Message = () => {
   return <LottieAnimation autoplay loop src={animationData} />

--- a/apps/store/src/components/Animations/NumberPad/NumberPad.tsx
+++ b/apps/store/src/components/Animations/NumberPad/NumberPad.tsx
@@ -1,5 +1,7 @@
-import { LottieAnimation } from '../Root'
+import dynamic from 'next/dynamic'
 import animationData from './numberPad.json'
+
+const LottieAnimation = dynamic(() => import('../Root').then((mod) => mod.LottieAnimation))
 
 export const NumberPad = () => {
   return <LottieAnimation autoplay loop src={animationData} />


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Using next dynamic import to lazy load Lottie animation. https://nextjs.org/docs/advanced-features/dynamic-import
Was unsure what's the best place to do it however. Would it be better to do it in `ContactSupportBlock` 🤔
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Decrease initial load time
## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
