### PR TITLE
Disable tap highlight for webkit browsers

### DIFF
--- a/apps/store/src/components/Accordion/Accordion.tsx
+++ b/apps/store/src/components/Accordion/Accordion.tsx
@@ -30,7 +30,6 @@ const Trigger = styled(AccordionPrimitives.Trigger)({
   alignItems: 'center',
   justifyContent: 'space-between',
   fontSize: theme.fontSizes.md,
-  WebkitTapHighlightColor: 'transparent',
 
   [mq.lg]: {
     fontSize: theme.fontSizes.lg,

--- a/apps/store/src/components/Header/Header.tsx
+++ b/apps/store/src/components/Header/Header.tsx
@@ -100,7 +100,6 @@ export const Wrapper = styled(motion.header)({
 
 const LogoWrapper = styled(Link)({
   flex: 1,
-  WebkitTapHighlightColor: 'transparent',
   ':active': { opacity: 0.75 },
 })
 

--- a/apps/store/src/components/Header/HeaderStyles.tsx
+++ b/apps/store/src/components/Header/HeaderStyles.tsx
@@ -7,7 +7,6 @@ export const MENU_BAR_HEIGHT_DESKTOP = '4rem'
 
 export const focusableStyles = {
   cursor: 'pointer',
-  WebkitTapHighlightColor: 'transparent',
   '&:focus-visible': {
     outline: `2px solid ${theme.colors.gray900}`,
   },

--- a/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
+++ b/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
@@ -16,6 +16,11 @@ const triggerStyles = {
   ...focusableStyles,
   fontSize: theme.fontSizes.md,
   marginRight: theme.space.md,
+
+  ':active': {
+    color: theme.colors.textSecondary,
+  },
+
   [mq.lg]: {
     display: 'none',
   },

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -25,6 +25,7 @@ import { contentFontClassName } from '@/utils/fonts'
 import { getCountryByLocale } from '@/utils/l10n/countryUtils'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
 import { useDebugTranslationKeys } from '@/utils/l10n/useDebugTranslationKeys'
+import { useAllowActiveStylesInSafari } from '@/utils/useAllowActiveStylesInSafari'
 import { useReloadOnCountryChange } from '@/utils/useReloadOnCountryChange'
 
 // Enable API mocking
@@ -60,6 +61,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
   useRemoveExperimentQueryParam()
   useDebugTranslationKeys()
   useReloadOnCountryChange()
+  useAllowActiveStylesInSafari()
 
   const apolloClient = useApollo(pageProps)
   const getLayout = Component.getLayout || ((page) => page)

--- a/apps/store/src/utils/useAllowActiveStylesInSafari.ts
+++ b/apps/store/src/utils/useAllowActiveStylesInSafari.ts
@@ -1,0 +1,10 @@
+import { useEffect } from 'react'
+
+// Source: https://css-tricks.com/snippets/css/remove-gray-highlight-when-tapping-links-in-mobile-safari/
+export const useAllowActiveStylesInSafari = () => {
+  useEffect(() => {
+    const handler = () => {}
+    document.addEventListener('touchstart', handler, true)
+    return () => document.removeEventListener('touchstart', handler, true)
+  }, [])
+}

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -112,9 +112,12 @@ const PrimaryButton = styled(StyledButton)({
 
   '@media (hover: hover)': {
     ':hover': {
-      // TODO: update to use translucent gray900
-      backgroundColor: theme.colors.gray900,
+      backgroundColor: theme.colors.grayTranslucent900,
     },
+  },
+
+  ':active': {
+    backgroundColor: theme.colors.grayTranslucent900,
   },
 
   '&:not([data-loading])': {
@@ -145,6 +148,10 @@ const PrimaryAltButton = styled(StyledButton)(
       },
     },
 
+    ':active': {
+      backgroundColor: theme.colors.green100,
+    },
+
     '&:not([data-loading])': {
       '&:disabled': {
         backgroundColor: theme.colors.gray200,
@@ -168,6 +175,10 @@ const SecondaryButton = styled(StyledButton)(
       },
     },
 
+    ':active': {
+      backgroundColor: theme.colors.translucent2,
+    },
+
     '&:not([data-loading])': {
       '&:disabled': {
         backgroundColor: theme.colors.gray200,
@@ -189,6 +200,10 @@ const GhostButton = styled(StyledButton)({
       // TODO: update to use translucent gray100
       backgroundColor: theme.colors.gray100,
     },
+  },
+
+  '&:active': {
+    backgroundColor: theme.colors.gray100,
   },
 
   '&:not([data-loading])': {

--- a/packages/ui/src/lib/globalStyles.ts
+++ b/packages/ui/src/lib/globalStyles.ts
@@ -24,6 +24,7 @@ export const globalStyles = css`
 
   html {
     scroll-behavior: smooth;
+    -webkit-tap-highlight-color: transparent;
   }
   @media screen and (prefers-reduced-motion: reduce) {
     html {


### PR DESCRIPTION
## Describe your changes

Remove tap highlight globally from the app for webkit browsers.

Add custom hook to make sure active styles work on mobile devices.

Add active styles to at least the buttons.

## Justify why they are needed

Annoying tap highlight.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
