### PR TITLE
Group together purchase form content in page context

### DIFF
--- a/apps/store/src/components/ProductPage/ProductPageContext.tsx
+++ b/apps/store/src/components/ProductPage/ProductPageContext.tsx
@@ -9,6 +9,13 @@ type ProductDataVariant =
 type ProductPageContextData = ProductPageProps & {
   selectedVariant: ProductDataVariant
   selectedVariantUpdate: (variant: ProductDataVariant) => void
+  content: {
+    product: {
+      name: string
+      description: string
+      tagline?: string
+    }
+  }
 }
 
 const ProductPageContext = createContext<ProductPageContextData | null>(null)
@@ -22,7 +29,6 @@ type Props = PropsWithChildren<
 export const ProductPageContextProvider = ({
   children,
   initialSelectedVariant = null,
-  productData,
   ...rest
 }: Props) => {
   const [selectedVariant, setSelectVariant] = useState(initialSelectedVariant)
@@ -32,13 +38,15 @@ export const ProductPageContextProvider = ({
       ...rest,
       selectedVariant,
       selectedVariantUpdate: setSelectVariant,
-      productData: {
-        ...productData,
-        displayNameShort: rest.story.content.name || productData.displayNameShort,
-        displayNameFull: rest.story.content.description || productData.displayNameFull,
+      content: {
+        product: {
+          name: rest.story.content.name || rest.productData.displayNameShort,
+          description: rest.story.content.description || rest.productData.displayNameFull,
+          tagline: rest.story.content.tagline,
+        },
       },
     }),
-    [rest, productData, selectedVariant],
+    [rest, selectedVariant],
   )
 
   return <ProductPageContext.Provider value={contextValue}>{children}</ProductPageContext.Provider>

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -142,7 +142,7 @@ type LayoutProps = {
 
 const Layout = ({ children, pillowSize }: LayoutProps) => {
   const toastRef = useRef<CartToastAttributes | null>(null)
-  const { productData } = useProductPageContext()
+  const { productData, content } = useProductPageContext()
 
   const notifyProductAdded = (item: ProductItemProps) => {
     toastRef.current?.publish(item)
@@ -159,11 +159,11 @@ const Layout = ({ children, pillowSize }: LayoutProps) => {
             />
             <Space y={0.5}>
               <Heading as="h1" variant="standard.24" align="center">
-                {productData.displayNameShort}
+                {content.product.name}
                 <CircledHSuperscript />
               </Heading>
               <Text size="xs" color="textSecondary" align="center">
-                {productData.displayNameFull}
+                {content.product.description}
               </Text>
             </Space>
           </SpaceFlex>
@@ -177,22 +177,16 @@ const Layout = ({ children, pillowSize }: LayoutProps) => {
 }
 
 const Tagline = () => {
-  const { story } = useProductPageContext()
+  const { content } = useProductPageContext()
+
+  if (!content.product.tagline) return null
+
   return (
-    <TaglineWrapper>
-      <Text color="textSecondary" size="xs">
-        {story.content.tagline}
-      </Text>
-    </TaglineWrapper>
+    <Text color="textSecondary" size="xs" align="center">
+      {content.product.tagline}
+    </Text>
   )
 }
-
-const TaglineWrapper = styled.div({
-  display: 'flex',
-  width: '100%',
-  justifyContent: 'center',
-  alignItems: 'center',
-})
 
 const PendingState = () => {
   const { t } = useTranslation('purchase-form')


### PR DESCRIPTION
## Describe your changes

![Screenshot 2023-02-09 at 08.43.34.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/88ac5751-d8b6-47e2-8cbc-8e19deb042e8/Screenshot%202023-02-09%20at%2008.43.34.png)

1. Group together content for the purchase form inside page context
1. Hide tagline above "calculate price" button if empty
1. Always use display name from product data for purchase notification

## Justify why they are needed

We were mixing up when to use which display name for the purchase notification. This PR makes sure we always use the display name from the product data.

Also wanted to avoid overriding content in the page context, so I grouped the content together.

## Jira issue(s): [GRW-2211]

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-2211]: https://hedvig.atlassian.net/browse/GRW-2211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ