### PR TITLE
Fix padding in non-full-bleed image block

### DIFF
--- a/apps/store/src/blocks/ImageBlock.tsx
+++ b/apps/store/src/blocks/ImageBlock.tsx
@@ -1,7 +1,7 @@
 import isPropValid from '@emotion/is-prop-valid'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
-import { default as NextImage } from 'next/image'
+import NextImage from 'next/image'
 import { mq, theme } from 'ui'
 import { HeadingBlock, HeadingBlockProps } from '@/blocks/HeadingBlock'
 import { ExpectedBlockType, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
@@ -20,12 +20,11 @@ type ImageBlockProps = SbBaseBlockProps<{
 export const ImageBlock = ({ blok }: ImageBlockProps) => {
   const headingBlocks = filterByBlockType(blok.body, HeadingBlock.blockName)
 
-  return (
+  const content = (
     <Wrapper
       {...storyblokEditable(blok)}
       aspectRatioLandscape={blok.aspectRatioLandscape}
       aspectRatioPortrait={blok.aspectRatioPortrait}
-      includePadding={!blok.fullBleed}
     >
       <Image
         style={{ objectFit: 'cover' }}
@@ -41,20 +40,23 @@ export const ImageBlock = ({ blok }: ImageBlockProps) => {
       </BodyWrapper>
     </Wrapper>
   )
+
+  if (blok.fullBleed) return content
+
+  return <Layout>{content}</Layout>
 }
 ImageBlock.blockName = 'image'
 
+const Layout = styled.div({ paddingInline: theme.space.md })
+
 type WrapperProps = {
-  includePadding: boolean
   aspectRatioLandscape?: ImageAspectRatio
   aspectRatioPortrait?: ImageAspectRatio
 }
 
 const Wrapper = styled('div', { shouldForwardProp: isPropValid })<WrapperProps>(
-  ({ includePadding, aspectRatioLandscape = '3 / 2', aspectRatioPortrait = '3 / 2' }) => ({
+  ({ aspectRatioLandscape = '3 / 2', aspectRatioPortrait = '3 / 2' }) => ({
     position: 'relative',
-    paddingLeft: includePadding ? theme.space.md : 0,
-    paddingRight: includePadding ? theme.space.md : 0,
     ['@media (orientation: landscape)']: {
       aspectRatio: aspectRatioLandscape,
     },


### PR DESCRIPTION
## Describe your changes

Add wrapper layout div with padding to image block that isn't fullbleed.

![Screenshot 2023-02-09 at 08.55.03.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/015a75a2-4da2-49a3-b42e-599a221ab721/Screenshot%202023-02-09%20at%2008.55.03.png)

![Screenshot 2023-02-09 at 08.54.38.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/eb8cceed-80d9-4fd1-b1e1-9229cbbf13db/Screenshot%202023-02-09%20at%2008.54.38.png)

## Justify why they are needed

When we added padding to the same div as the relative wrapper, it caused the image to ignore the padding. This fixes that.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
