### PR TITLE
Update to use new cancellation option from API

### DIFF
--- a/apps/store/public/locales/dk/purchase-form.json
+++ b/apps/store/public/locales/dk/purchase-form.json
@@ -1,6 +1,6 @@
 {
   "ADD_TO_CART_BUTTON_LABEL": "Føj til indkøbskurv",
-  "AUTO_SWITCH_INVALID_START_DATE_MESSAGE": "Da din forsikring hos {{company}} snart udløber, skal du selv afmelde den. Bare rolig, vi sender dig en mail med instruktioner.",
+  "AUTO_SWITCH_INVALID_RENEWAL_DATE_MESSAGE": "Da din forsikring hos {{company}} snart udløber, skal du selv afmelde den. Bare rolig, vi sender dig en mail med instruktioner.",
   "AUTO_SWITCH_RENEWAL_DATE_LABEL": "Slutdato {{company}}",
   "CART_TOAST_CART_LINK": "Fortsæt til indkøbskurv",
   "CART_TOAST_HEADING": "Føjet til indkøbskurv",

--- a/apps/store/public/locales/en/purchase-form.json
+++ b/apps/store/public/locales/en/purchase-form.json
@@ -2,7 +2,7 @@
   "ADD_TO_CART_BUTTON_LABEL": "Add to cart",
   "AUTO_SWITCH_FIELD_LABEL": "Switch automatically",
   "AUTO_SWITCH_FIELD_MESSAGE": "We cancel your insurance at {{COMPANY}}. Hedvig is activated when it expires.",
-  "AUTO_SWITCH_INVALID_START_DATE_MESSAGE": "Because your insurance at {{company}} expires soon, you have to manually cancel it. Don't worry, we will email instructions.",
+  "AUTO_SWITCH_INVALID_RENEWAL_DATE_MESSAGE": "Because your insurance at {{company}} expires soon, you have to manually cancel it. Don't worry, we will email instructions.",
   "AUTO_SWITCH_RENEWAL_DATE_LABEL": "End date {{company}}",
   "CART_TOAST_CART_LINK": "Proceed to cart",
   "CART_TOAST_HEADING": "Added to cart",

--- a/apps/store/public/locales/no/purchase-form.json
+++ b/apps/store/public/locales/no/purchase-form.json
@@ -1,6 +1,6 @@
 {
   "AUTO_SWITCH_FIELD_LABEL": "Automatisk bytte",
-  "AUTO_SWITCH_INVALID_START_DATE_MESSAGE": "Din forsikring hos {{company}}har snart forfall. Derfor må du manuelt si den opp. Ta det med ro, vi sender fremgangsmåte til din e-post.",
+  "AUTO_SWITCH_INVALID_RENEWAL_DATE_MESSAGE": "Din forsikring hos {{company}}har snart forfall. Derfor må du manuelt si den opp. Ta det med ro, vi sender fremgangsmåte til din e-post.",
   "AUTO_SWITCH_RENEWAL_DATE_LABEL": "Sluttdato hos {{company}}",
   "CURRENT_INSURANCE_FIELD_PLACEHOLDER": "Velg selskap",
   "FIELD_ANCILLARY_AREA_LABEL": "Sekundærrom",

--- a/apps/store/public/locales/sv-se/purchase-form.json
+++ b/apps/store/public/locales/sv-se/purchase-form.json
@@ -2,7 +2,7 @@
   "ADD_TO_CART_BUTTON_LABEL": "Lägg i varukorgen",
   "AUTO_SWITCH_FIELD_LABEL": "Byt automatiskt",
   "AUTO_SWITCH_FIELD_MESSAGE": "Vi avslutar din försäkring hos {{COMPANY}} åt dig. Hedvig aktiveras när den går ut.",
-  "AUTO_SWITCH_INVALID_START_DATE_MESSAGE": "Eftersom din försäkring hos {{company}} går ut ganska snart behöver du själv säga upp den. Oroa dig inte, vi mejlar instruktioner till dig.",
+  "AUTO_SWITCH_INVALID_RENEWAL_DATE_MESSAGE": "Eftersom din försäkring hos {{company}} går ut ganska snart behöver du själv säga upp den. Oroa dig inte, vi mejlar instruktioner till dig.",
   "AUTO_SWITCH_RENEWAL_DATE_LABEL": "Startdatum {{company}}",
   "CART_TOAST_CART_LINK": "Fortsätt till varukorgen",
   "CART_TOAST_HEADING": "Tillagd i varukorgen",

--- a/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/CancellationForm.stories.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/CancellationForm.stories.tsx
@@ -74,7 +74,7 @@ export const BankSigneringInvalidStartDate: ComponentStoryFn<typeof Cancellation
     <CancellationForm
       {...props}
       option={{
-        type: ExternalInsuranceCancellationOption.BanksigneringInvalidStartDate,
+        type: ExternalInsuranceCancellationOption.BanksigneringInvalidRenewalDate,
         companyName: 'Trygg Hansa',
       }}
     />

--- a/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/CancellationForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/CancellationForm.tsx
@@ -15,7 +15,10 @@ export type CancellationOption =
       companyName: string
       requested: boolean
     }
-  | { type: ExternalInsuranceCancellationOption.BanksigneringInvalidStartDate; companyName: string }
+  | {
+      type: ExternalInsuranceCancellationOption.BanksigneringInvalidRenewalDate
+      companyName: string
+    }
 
 type Props = {
   option: CancellationOption
@@ -42,9 +45,9 @@ export const CancellationForm = ({ option, ...props }: Props) => {
         />
       )
 
-    case ExternalInsuranceCancellationOption.BanksigneringInvalidStartDate:
+    case ExternalInsuranceCancellationOption.BanksigneringInvalidRenewalDate:
       return (
-        <BankSigneringInvalidStartDateCancellation {...props} companyName={option.companyName} />
+        <BankSigneringInvalidRenewalDateCancellation {...props} companyName={option.companyName} />
       )
 
     case ExternalInsuranceCancellationOption.None:
@@ -124,21 +127,21 @@ const BankSigneringCancellation = (props: BankSigneringCancellationProps) => {
   )
 }
 
-type BankSigneringInvalidStartDateProps = Pick<
-  Props,
-  'onStartDateChange' | 'onRenewalDateChange' | 'startDate'
-> & {
+type BankSigneringInvalidRenewalDateProps = Pick<Props, 'onStartDateChange' | 'startDate'> & {
   companyName: string
 }
 
-const BankSigneringInvalidStartDateCancellation = (props: BankSigneringInvalidStartDateProps) => {
-  const { onStartDateChange, onRenewalDateChange, companyName, startDate } = props
+const BankSigneringInvalidRenewalDateCancellation = (
+  props: BankSigneringInvalidRenewalDateProps,
+) => {
+  const { onStartDateChange, companyName, startDate } = props
   const { t } = useTranslation('purchase-form')
-  const message = t('AUTO_SWITCH_INVALID_START_DATE_MESSAGE', { company: companyName })
+  const message = t('AUTO_SWITCH_INVALID_RENEWAL_DATE_MESSAGE', { company: companyName })
 
+  // TODO: figure out how to get back to BANKSIGNERING option
+  // Right now, if the user ends up here, they can't go back to the BANKSIGNERING...
   const handleChange = (date: Date) => {
     onStartDateChange?.(date)
-    onRenewalDateChange?.(date)
   }
 
   return <SmartDateInput {...props} date={startDate} onChange={handleChange} message={message} />

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -319,9 +319,9 @@ const getCancellationOption = (params: GetCancellationOptionParams): Cancellatio
         requested: cancellation.requested,
       }
 
-    case ExternalInsuranceCancellationOption.BanksigneringInvalidStartDate:
+    case ExternalInsuranceCancellationOption.BanksigneringInvalidRenewalDate:
       return {
-        type: ExternalInsuranceCancellationOption.BanksigneringInvalidStartDate,
+        type: ExternalInsuranceCancellationOption.BanksigneringInvalidRenewalDate,
         companyName: externalInsurer?.displayName ?? 'Unknown',
       }
 


### PR DESCRIPTION
## Describe your changes

Update to use the new banksignering invalid renewal date option.

Stop sending both renewal date and start date mutations to the backend.

## Justify why they are needed

The API responds incorrectly when sending both mutations.

We should adresss it some other way in the future.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
