### PR TITLE
Fix disabled state for text field

### DIFF
--- a/apps/store/src/components/TextField/TextField.tsx
+++ b/apps/store/src/components/TextField/TextField.tsx
@@ -75,19 +75,13 @@ const LargeWrapper = styled(motion.div)({
   height: '4rem',
   width: '100%',
 
-  ':focus-within, &[data-active=true]': {
-    '> label': {
-      transform: `translate(calc(${theme.space.md} * 0.4), -0.5rem) scale(0.6)`,
-      overflow: 'visible',
-      color: theme.colors.textPrimary,
-    },
-  },
-
   border: '1px solid transparent',
   '&[data-warning=true]': {
     animation: `${warningAnimation} 1.5s cubic-bezier(0.2, -2, 0.8, 2) 2`,
   },
 })
+
+const SmallWrapper = styled(LargeWrapper)({ height: '3.25rem' })
 
 const Label = styled.label({
   position: 'absolute',
@@ -109,8 +103,18 @@ const Label = styled.label({
     fontSize: theme.fontSizes.lg,
   },
 
-  '&[data-disabled=true]': {
-    color: theme.colors.textDisabled,
+  [`${LargeWrapper}:focus-within > &, ${LargeWrapper}[data-active=true] > &`]: {
+    overflow: 'visible',
+    color: theme.colors.textPrimary,
+    transform: `translate(calc(${theme.space.md} * 0.4), -0.5rem) scale(0.6)`,
+  },
+
+  [`${SmallWrapper}:focus-within > &, ${SmallWrapper}[data-active=true] > &`]: {
+    transform: `translate(calc(${theme.space.md} * 0.2), -0.6rem) scale(0.8)`,
+  },
+
+  '&&[data-disabled=true]': {
+    color: theme.colors.textSecondary,
   },
 })
 
@@ -121,11 +125,11 @@ const LargeInput = styled.input({
   paddingTop: theme.space.md,
 
   ':disabled': {
-    color: theme.colors.textDisabled,
+    color: theme.colors.textSecondary,
     cursor: 'not-allowed',
 
     // Webkit overrides
-    WebkitTextFillColor: theme.colors.textDisabled,
+    WebkitTextFillColor: theme.colors.textSecondary,
     opacity: 1,
   },
 })
@@ -137,16 +141,6 @@ const StyledLargeSuffix = styled(Text)({ paddingRight: theme.space.md })
 const LargeSuffix = (props: BaseProps) => (
   <StyledLargeSuffix as="span" size="xl" color="textSecondary" {...props} />
 )
-
-const SmallWrapper = styled(LargeWrapper)({
-  height: '3.25rem',
-
-  ':focus-within, &[data-active=true]': {
-    '> label': {
-      transform: `translate(calc(${theme.space.md} * 0.2), -0.6rem) scale(0.8)`,
-    },
-  },
-})
 
 const SmallInput = styled(LargeInput)({ fontSize: theme.fontSizes.lg })
 


### PR DESCRIPTION
## Describe your changes

Fix text field disabled state to show label with same color as input.

Refactor text field to use component selectors.

![Screenshot 2023-02-09 at 10.17.14.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/4b0bb86c-a5e0-43e1-9a7c-b7ca4bbb90de/Screenshot%202023-02-09%20at%2010.17.14.png)

## Justify why they are needed

I think it's always nice to make styled components self-contained rather than being referenced from other places. Deletability!

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
