### PR TITLE
Expand content on confirmation page

### DIFF
--- a/apps/store/src/blocks/AccordionItemBlock.tsx
+++ b/apps/store/src/blocks/AccordionItemBlock.tsx
@@ -17,7 +17,7 @@ export const AccordionItemBlock = ({ blok }: AccordionItemBlockProps) => {
   return (
     <Accordion.Item value={blok._uid || defaultId} {...storyblokEditable(blok)}>
       <Accordion.HeaderWithTrigger>
-        <Text size={{ _: 'md', md: 'xl' }}>{blok.title}</Text>
+        <Text size={{ _: 'md', md: 'lg' }}>{blok.title}</Text>
       </Accordion.HeaderWithTrigger>
       <Content asChild>
         <RichTextContent dangerouslySetInnerHTML={{ __html: contentHtml }} />

--- a/apps/store/src/components/Accordion/Accordion.tsx
+++ b/apps/store/src/components/Accordion/Accordion.tsx
@@ -29,6 +29,7 @@ const Trigger = styled(AccordionPrimitives.Trigger)({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
+  gap: theme.space.xs,
   fontSize: theme.fontSizes.md,
 
   [mq.lg]: {

--- a/apps/store/src/components/CartInventory/DetailsSheetDialog.tsx
+++ b/apps/store/src/components/CartInventory/DetailsSheetDialog.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import type { TFunction } from 'i18next'
 import { useTranslation } from 'next-i18next'
 import { Button, Text } from 'ui'
@@ -61,11 +60,9 @@ export const DetailsSheetDialog = (props: Props) => {
               <DetailsSheet.Row>
                 <Text color="textSecondary">{t('DATA_TABLE_START_DATE_LABEL')}</Text>
                 <Text>
-                  {startDate ? (
-                    <Capitalize>{formatter.fromNow(startDate)}</Capitalize>
-                  ) : (
-                    t('DATA_TABLE_START_DATE_AUTO_SWITCH')
-                  )}
+                  {startDate
+                    ? formatter.fromNow(startDate)
+                    : t('DATA_TABLE_START_DATE_AUTO_SWITCH')}
                 </Text>
               </DetailsSheet.Row>
               {dataTableRows?.map((item) => (
@@ -83,8 +80,6 @@ export const DetailsSheetDialog = (props: Props) => {
     </FullscreenDialog.Root>
   )
 }
-
-const Capitalize = styled.span({ textTransform: 'capitalize' })
 
 const useGetDataTableValue = () => {
   const { t } = useTranslation('cart')

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link'
 import { Heading, mq, Space, Text, theme } from 'ui'
 import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
 import { CartInventory } from '@/components/CartInventory/CartInventory'
-import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { ConfirmationStory } from '@/services/storyblok/storyblok'
 import { appStoreLinks } from '@/utils/appStoreLinks'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
@@ -15,6 +14,7 @@ import { ConfirmationPageProps } from './ConfirmationPage.types'
 // TODO: update to point to production deployment
 import qrCodeImage from './download-app-qrcode.png'
 import { FooterSection } from './FooterSection'
+import { Layout } from './Layout'
 
 type Props = ConfirmationPageProps & {
   story: ConfirmationStory
@@ -38,8 +38,8 @@ export const ConfirmationPage = (props: Props) => {
   return (
     <Wrapper>
       <Space y={4}>
-        <GridLayout.Root>
-          <GridLayout.Content>
+        <Layout.Root>
+          <Layout.Content>
             <Space y={4}>
               <Space y={{ base: 1.5, lg: 3 }}>
                 <div>
@@ -90,8 +90,8 @@ export const ConfirmationPage = (props: Props) => {
                 </BlockLayoutReset>
               </Space>
             </Space>
-          </GridLayout.Content>
-        </GridLayout.Root>
+          </Layout.Content>
+        </Layout.Root>
 
         <FooterSection
           image={{ src: story.content.footerImage.filename, alt: story.content.footerImage.alt }}

--- a/apps/store/src/components/ConfirmationPage/FooterSection.tsx
+++ b/apps/store/src/components/ConfirmationPage/FooterSection.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import Image from 'next/image'
 import type { ReactNode } from 'react'
 import { mq } from 'ui'
-import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { Layout } from './Layout'
 
 type Props = {
   image: { src: string; alt: string }
@@ -13,9 +13,9 @@ export const FooterSection = ({ image, children }: Props) => {
   return (
     <Wrapper>
       <FooterImage {...image} fill />
-      <GridLayout.Root>
-        <GridLayout.Content>{children}</GridLayout.Content>
-      </GridLayout.Root>
+      <Layout.Root>
+        <Layout.Content>{children}</Layout.Content>
+      </Layout.Root>
     </Wrapper>
   )
 }
@@ -38,7 +38,7 @@ const FooterImage = styled(Image)({
   objectFit: 'contain',
   objectPosition: 'right bottom',
 
-  maxWidth: '1920px',
+  maxWidth: '120rem',
   marginInline: 'auto',
 
   [mq.lg]: {

--- a/apps/store/src/components/ConfirmationPage/Layout.tsx
+++ b/apps/store/src/components/ConfirmationPage/Layout.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled'
+import { mq } from 'ui'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+
+const Content = styled(GridLayout.Content)({
+  [mq.xl]: {
+    gridColumn: '4 / span 6',
+  },
+
+  [mq.xxl]: {
+    gridColumn: '5 / span 4',
+  },
+})
+
+export const Layout = {
+  Root: GridLayout.Root,
+  Content,
+}

--- a/apps/store/src/components/ProductPage/ProductDocuments.tsx
+++ b/apps/store/src/components/ProductPage/ProductDocuments.tsx
@@ -49,13 +49,16 @@ const ProductDocument = ({ doc }: { doc: InsuranceDocument }) => {
 }
 
 const Layout = styled(GridLayout.Root)({
+  // TODO: harmonize with other grid layouts
+
   gap: theme.space.lg,
   [mq.lg]: {
     gap: theme.space.md,
-
-    // TODO: harmonize with other grid layouts
     paddingInline: theme.space.md,
   },
+
+  maxWidth: '90rem',
+  marginInline: 'auto',
 })
 
 const Column = styled.div({
@@ -73,7 +76,11 @@ const DownloadFileButton = styled(Button)({
   // Counter the padding from the "DocumentType"
   paddingTop: theme.space.xs,
   height: 'auto',
-  fontSize: theme.fontSizes.xl,
+  fontSize: theme.fontSizes.md,
+
+  [mq.lg]: {
+    fontSize: theme.fontSizes.lg,
+  },
 })
 
 const Ellipsis = styled.span({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Expand content on confirmation page. Keep 6 column layout for xl media query.

Create override layout componentn for confirmation page.

![Screenshot 2023-02-09 at 11.59.01.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/a2ce6806-7d5d-406b-be61-058bd49f4f61/Screenshot%202023-02-09%20at%2011.59.01.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Let's see if we really need a special layout for this page in the future.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
