### PR TITLE
Add fullBleed option to video

### DIFF
--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { mq, theme } from 'ui'
+import { ConditionalWrapper, mq, theme } from 'ui'
 import { Video, VideoProps } from '@/components/Video/Video'
 import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 
@@ -7,6 +7,7 @@ export type VideoBlockProps = SbBaseBlockProps<
   {
     video: StoryblokAsset
     poster?: StoryblokAsset
+    fullBleed?: boolean
   } & Pick<
     VideoProps,
     | 'autoPlay'
@@ -19,7 +20,10 @@ export type VideoBlockProps = SbBaseBlockProps<
 
 export const VideoBlock = ({ className, blok }: VideoBlockProps) => {
   return (
-    <Wrapper className={className}>
+    <ConditionalWrapper
+      condition={!blok.fullBleed}
+      wrapWith={(children) => <Wrapper className={className}>{children}</Wrapper>}
+    >
       <Video
         sources={[{ url: blok.video.filename }]}
         poster={blok.poster?.filename}
@@ -28,8 +32,9 @@ export const VideoBlock = ({ className, blok }: VideoBlockProps) => {
         aspectRatioPortrait={blok.aspectRatioPortrait}
         maxHeightLandscape={blok.maxHeightLandscape}
         maxHeightPortrait={blok.maxHeightPortrait}
+        roundedCorners={!blok.fullBleed}
       />
-    </Wrapper>
+    </ConditionalWrapper>
   )
 }
 VideoBlock.blockName = 'videoBlock'

--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -14,9 +14,10 @@ type VideoSource = {
 
 type VideoSize = {
   aspectRatioLandscape?: '1 / 1' | '16 / 9'
-  aspectRatioPortrait?: '4 / 5' | '4 / 6'
+  aspectRatioPortrait?: '4 / 5' | '4 / 6' | '9 / 16'
   maxHeightLandscape?: number
   maxHeightPortrait?: number
+  roundedCorners?: boolean
 }
 
 export type VideoProps = React.ComponentPropsWithoutRef<'video'> & {
@@ -40,6 +41,7 @@ export const Video = ({
   aspectRatioPortrait,
   maxHeightLandscape,
   maxHeightPortrait,
+  roundedCorners,
   onPlaying,
   onPause,
   ...delegated
@@ -120,6 +122,7 @@ export const Video = ({
         aspectRatioPortrait={aspectRatioPortrait}
         maxHeightLandscape={maxHeightLandscape}
         maxHeightPortrait={maxHeightPortrait}
+        roundedCorners={roundedCorners}
         onPlaying={handlePlaying}
         onPause={handlePause}
         {...autoplayAttributes}
@@ -162,12 +165,12 @@ const StyledVideo = styled.video(
     aspectRatioPortrait,
     maxHeightLandscape,
     maxHeightPortrait,
+    roundedCorners,
   }: Omit<VideoProps, 'sources'>) => ({
     width: '100%',
     background: `url(${poster}) no-repeat`,
     backgroundSize: 'cover',
     objectFit: 'cover',
-    borderRadius: theme.radius.md,
     ['@media (orientation: portrait)']: {
       ...(maxHeightPortrait && { maxHeight: `${maxHeightPortrait}vh` }),
       ...(aspectRatioPortrait && { aspectRatio: aspectRatioPortrait }),
@@ -176,9 +179,13 @@ const StyledVideo = styled.video(
       ...(aspectRatioLandscape && { aspectRatio: aspectRatioLandscape }),
       ...(maxHeightLandscape && { maxHeight: `${maxHeightLandscape}vh` }),
     },
-    [mq.lg]: {
-      borderRadius: theme.radius.xl,
-    },
+
+    ...(roundedCorners && {
+      borderRadius: theme.radius.md,
+      [mq.lg]: {
+        borderRadius: theme.radius.xl,
+      },
+    }),
   }),
 )
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Being able to use the video block full bleed without rounded corners or padding

https://user-images.githubusercontent.com/6661511/217866457-43dc7d7d-c59f-4954-87c9-c690ed0e8f34.mov


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Show videos full screen

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
