### PR TITLE
GRW-2217 - Add Accordion hover styles

### DIFF
--- a/apps/store/src/blocks/AccordionItemBlock.tsx
+++ b/apps/store/src/blocks/AccordionItemBlock.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { storyblokEditable, renderRichText, ISbRichtext } from '@storyblok/react'
 import { useId } from 'react'
-import { Text } from 'ui'
+import { Text, mq, theme } from 'ui'
 import * as Accordion from '@/components/Accordion/Accordion'
 import { RichTextContent } from '@/components/RichTextContent/RichTextContent'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
@@ -19,14 +19,21 @@ export const AccordionItemBlock = ({ blok }: AccordionItemBlockProps) => {
       <Accordion.HeaderWithTrigger>
         <Text size={{ _: 'md', md: 'lg' }}>{blok.title}</Text>
       </Accordion.HeaderWithTrigger>
-      <Content asChild>
-        <RichTextContent dangerouslySetInnerHTML={{ __html: contentHtml }} />
-      </Content>
+      <Accordion.Content>
+        <ContentWrapper>
+          <RichTextContent dangerouslySetInnerHTML={{ __html: contentHtml }} />
+        </ContentWrapper>
+      </Accordion.Content>
     </Accordion.Item>
   )
 }
 AccordionItemBlock.blockName = 'accordionItem'
 
-const Content = styled(Accordion.Content)({
-  paddingTop: 0,
+const ContentWrapper = styled.div({
+  paddingTop: theme.space.md,
+  paddingBottom: theme.space.xxs,
+
+  [mq.lg]: {
+    paddingBottom: theme.space.xs,
+  },
 })

--- a/apps/store/src/components/Accordion/Accordion.tsx
+++ b/apps/store/src/components/Accordion/Accordion.tsx
@@ -10,20 +10,6 @@ export const Root = styled(AccordionPrimitives.Root)({
   gap: theme.space.xxs,
 })
 
-export const Item = styled(AccordionPrimitives.Item)({
-  backgroundColor: theme.colors.opaque1,
-  borderRadius: theme.radius.sm,
-  paddingInline: theme.space.md,
-  paddingBlock: theme.space.sm,
-
-  [mq.lg]: {
-    paddingInline: theme.space.lg,
-    paddingBlock: theme.space.md,
-  },
-})
-
-const Header = AccordionPrimitives.Header
-
 const Trigger = styled(AccordionPrimitives.Trigger)({
   width: '100%',
   cursor: 'pointer',
@@ -36,6 +22,31 @@ const Trigger = styled(AccordionPrimitives.Trigger)({
   [mq.lg]: {
     fontSize: theme.fontSizes.lg,
   },
+
+  '@media (hover: hover)': {
+    ':hover': {
+      cursor: 'pointer',
+      backgroundColor: theme.colors.gray200,
+    },
+  },
+})
+
+export const Item = styled(AccordionPrimitives.Item)({
+  backgroundColor: theme.colors.opaque1,
+  borderRadius: theme.radius.sm,
+  paddingInline: theme.space.md,
+  paddingBlock: theme.space.sm,
+
+  [mq.lg]: {
+    paddingInline: theme.space.lg,
+    paddingBlock: theme.space.md,
+  },
+
+  '@media (hover: hover)': {
+    [`:has(${Trigger}:hover)`]: {
+      backgroundColor: theme.colors.gray200,
+    },
+  },
 })
 
 type HeaderWithTriggerProps = PropsWithChildren<unknown> & {
@@ -44,14 +55,14 @@ type HeaderWithTriggerProps = PropsWithChildren<unknown> & {
 
 export const HeaderWithTrigger = ({ children }: HeaderWithTriggerProps) => {
   return (
-    <Header>
+    <AccordionPrimitives.Header>
       <Trigger>
         {children}
 
         <OpenIcon size="1rem" />
         <CloseIcon size="1rem" />
       </Trigger>
-    </Header>
+    </AccordionPrimitives.Header>
   )
 }
 
@@ -92,7 +103,6 @@ export const Content = styled(AccordionPrimitives.Content)({
   '[data-state=open] &': {
     animation: `${slideDown} 400ms cubic-bezier(0.65,0.05,0.36,1)`,
   },
-
   '[data-state=closed] &': {
     animation: `${slideUp} 400ms cubic-bezier(0.65,0.05,0.36,1)`,
   },

--- a/apps/store/src/components/RichTextContent/RichTextContent.tsx
+++ b/apps/store/src/components/RichTextContent/RichTextContent.tsx
@@ -2,8 +2,8 @@ import styled from '@emotion/styled'
 import { theme } from 'ui'
 
 export const RichTextContent = styled.div({
-  '& > p': {
-    marginBlock: theme.space.md,
+  '& > p:not(:last-of-type)': {
+    marginBottom: theme.space.md,
   },
   '& b': {
     fontWeight: 'bold',


### PR DESCRIPTION
## Describe your changes

* Apply hover styles to `AccordionBlock` by changing `Accordion` component

Can be tested by interacting with _Frequent asked questions section_ on this [page](https://hedvig-dot-com-git-grw-2217-refactperils-hedvig.vercel.app/se/forsakringar/hemforsakring/hyresratt)

## Jira issue(s): [GRW-2217](https://hedvig.atlassian.net/browse/GRW-2217)


[GRW-2217]: https://hedvig.atlassian.net/browse/GRW-2217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ