### PR TITLE
Align layout for accordion and document blocks

### DIFF
--- a/apps/store/src/blocks/AccordionBlock.tsx
+++ b/apps/store/src/blocks/AccordionBlock.tsx
@@ -4,11 +4,9 @@ import Head from 'next/head'
 import { Heading, Text, theme, mq } from 'ui'
 import { AccordionItemBlock, AccordionItemBlockProps } from '@/blocks/AccordionItemBlock'
 import * as Accordion from '@/components/Accordion/Accordion'
-import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { GridLayout, TEXT_CONTENT_MAX_WIDTH } from '@/components/GridLayout/GridLayout'
 import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
-
-const TEXTUAL_CONTENT_MAX_WIDTH = '37.5rem'
 
 type Props = SbBaseBlockProps<{
   items: ExpectedBlockType<AccordionItemBlockProps>
@@ -33,24 +31,28 @@ export const AccordionBlock = ({ blok }: Props) => {
       )}
       <Wrapper {...storyblokEditable(blok)}>
         {displayTitleDescriptionSection && (
-          <TitleDescriptionWrapper>
-            {blok.title && (
-              <Heading as="h2" variant={{ _: 'standard.24', md: 'standard.32' }}>
-                {blok.title}
-              </Heading>
-            )}
-            {blok.description && (
-              <Text color="textSecondary" size={{ _: 'xl', md: 'xxl' }}>
-                {blok.description}
-              </Text>
-            )}
-          </TitleDescriptionWrapper>
+          <Column>
+            <TextContent>
+              {blok.title && (
+                <Heading as="h2" variant={{ _: 'standard.24', md: 'standard.32' }}>
+                  {blok.title}
+                </Heading>
+              )}
+              {blok.description && (
+                <Text color="textSecondary" size={{ _: 'xl', md: 'xxl' }}>
+                  {blok.description}
+                </Text>
+              )}
+            </TextContent>
+          </Column>
         )}
-        <StyledAccordion type="multiple">
-          {accordionItems.map((nestedBlock) => (
-            <AccordionItemBlock key={nestedBlock._uid} blok={nestedBlock} />
-          ))}
-        </StyledAccordion>
+        <Column center={!displayTitleDescriptionSection}>
+          <Accordion.Root type="multiple">
+            {accordionItems.map((nestedBlock) => (
+              <AccordionItemBlock key={nestedBlock._uid} blok={nestedBlock} />
+            ))}
+          </Accordion.Root>
+        </Column>
       </Wrapper>
     </>
   )
@@ -58,28 +60,23 @@ export const AccordionBlock = ({ blok }: Props) => {
 AccordionBlock.blockName = 'accordion'
 
 const Wrapper = styled(GridLayout.Root)({
-  paddingInline: theme.space.md,
+  // TODO: harmonize with other grid layouts
+  gap: theme.space.lg,
   [mq.lg]: {
-    paddingInline: theme.space.lg,
+    gap: theme.space.md,
+    paddingInline: theme.space.md,
   },
 })
 
-const TitleDescriptionWrapper = styled.div({
+const Column = styled.div<{ center?: boolean }>(({ center = false }) => ({
   gridColumn: '1 / -1',
   [mq.lg]: {
-    gridColumn: 'span 6',
-    maxWidth: TEXTUAL_CONTENT_MAX_WIDTH,
+    gridColumn: center ? '4 / span 6' : 'span 6',
   },
-})
+}))
 
-const StyledAccordion = styled(Accordion.Root)({
-  gridColumn: '1 / -1',
-  marginTop: theme.space.lg,
-  [mq.lg]: {
-    gridColumn: 'span 6',
-    marginTop: 0,
-    marginLeft: theme.space.xxl,
-  },
+const TextContent = styled.div({
+  maxWidth: TEXT_CONTENT_MAX_WIDTH,
 })
 
 const getFAQStructuredData = (

--- a/apps/store/src/components/Accordion/Accordion.tsx
+++ b/apps/store/src/components/Accordion/Accordion.tsx
@@ -8,6 +8,10 @@ export const Root = styled(AccordionPrimitives.Root)({
   display: 'flex',
   flexDirection: 'column',
   gap: theme.space.xxs,
+
+  [mq.lg]: {
+    gap: theme.space.xs,
+  },
 })
 
 const Trigger = styled(AccordionPrimitives.Trigger)({

--- a/apps/store/src/components/GridLayout/GridLayout.tsx
+++ b/apps/store/src/components/GridLayout/GridLayout.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled'
 import { mq, theme } from 'ui'
 
+export const TEXT_CONTENT_MAX_WIDTH = '37.5rem' // 600px
+
 const Root = styled.div({
   display: 'grid',
   gridTemplateColumns: 'repeat(12, 1fr)',

--- a/apps/store/src/components/ProductPage/ProductDocuments.tsx
+++ b/apps/store/src/components/ProductPage/ProductDocuments.tsx
@@ -13,13 +13,15 @@ export const ProductDocuments = ({ heading, description, docs }: Props) => {
   return (
     <Layout>
       <Column>
-        <Text size={{ _: 'xl', lg: 'xxl' }}>{heading}</Text>
-        <Text size={{ _: 'xl', lg: 'xxl' }} color="textSecondary">
-          {description}
-        </Text>
+        <Content>
+          <Text size={{ _: 'xl', lg: 'xxl' }}>{heading}</Text>
+          <Text size={{ _: 'xl', lg: 'xxl' }} color="textSecondary">
+            {description}
+          </Text>
+        </Content>
       </Column>
       <Column>
-        <Space y={0.5}>
+        <Space y={{ base: 0.25, lg: 0.5 }}>
           {docs.map((doc, index) => (
             <ProductDocument key={index} doc={doc} />
           ))}
@@ -51,9 +53,6 @@ const Layout = styled(GridLayout.Root)({
     gap: theme.space.md,
     paddingInline: theme.space.md,
   },
-
-  maxWidth: '90rem',
-  marginInline: 'auto',
 })
 
 const Column = styled.div({
@@ -62,6 +61,10 @@ const Column = styled.div({
   [mq.lg]: {
     gridColumn: 'span 6',
   },
+})
+
+const Content = styled.div({
+  maxWidth: '37.5rem', // 600px
 })
 
 const DownloadFileLink = styled.a({


### PR DESCRIPTION
## Describe your changes

Unify the layout of accordion and product document blocks.

![Screenshot 2023-02-10 at 13.28.11.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/5582ab30-a3cb-4eb6-8c70-069cac65a7ae/Screenshot%202023-02-10%20at%2013.28.11.png)

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code