### PR TITLE
Fix IconRoot passing invalid size values to svg element

### DIFF
--- a/packages/ui/src/icons/Root.tsx
+++ b/packages/ui/src/icons/Root.tsx
@@ -1,3 +1,4 @@
+import isPropValid from '@emotion/is-prop-valid'
 import styled from '@emotion/styled'
 
 export type IconRootProps = {
@@ -7,7 +8,13 @@ export type IconRootProps = {
   transform?: string
 }
 
-export const IconRoot = styled.svg<IconRootProps>(({ size, color, transform }) => ({
+const elementConfig = {
+  shouldForwardProp: (prop: string) => isPropValid(prop) && prop !== 'width' && prop !== 'height',
+}
+export const IconRoot = styled(
+  'svg',
+  elementConfig,
+)<IconRootProps>(({ size, color, transform }) => ({
   width: size ? size : '1rem',
   height: size ? size : '1rem',
   fill: color ? color : 'currentColor',


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Don't pass down size="1rem" to svg DOM nodes via IconRoot

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Fixes noisy console errors in Safari

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
