### PR TITLE
GRW-2236 - fix(InputSelect icon): ignore click events

### DIFF
--- a/apps/store/src/components/InputSelect/InputSelect.tsx
+++ b/apps/store/src/components/InputSelect/InputSelect.tsx
@@ -15,6 +15,7 @@ const StyledChevronIcon = styled(ChevronIcon)(() => ({
   top: '50%',
   right: '1.125rem',
   transform: 'translateY(-50%)',
+  pointerEvents: 'none',
 }))
 
 const StyledSelect = styled.select({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

* Make icon ignores pointer events
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

So the whole select input gets clickable

## Jira issue(s): [GRW-2236](https://hedvig.atlassian.net/browse/GRW-2236)

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-2236]: https://hedvig.atlassian.net/browse/GRW-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ