### PR TITLE
GRW-2237 - styles(ProductDocuments): style updates

### DIFF
--- a/apps/store/src/blocks/AccordionBlock.tsx
+++ b/apps/store/src/blocks/AccordionBlock.tsx
@@ -64,11 +64,17 @@ const Wrapper = styled(GridLayout.Root)({
   gap: theme.space.lg,
   [mq.lg]: {
     gap: theme.space.md,
-    paddingInline: theme.space.md,
+    paddingInline: theme.space.lg,
   },
 })
 
-const TextContent = styled.div({ maxWidth: TEXT_CONTENT_MAX_WIDTH })
+const TextContent = styled.div({
+  maxWidth: TEXT_CONTENT_MAX_WIDTH,
+
+  [mq.lg]: {
+    paddingRight: theme.space.xl,
+  },
+})
 
 const getFAQStructuredData = (
   accordions: ReadonlyArray<Pick<AccordionItemBlockProps['blok'], 'title' | 'body'>>,

--- a/apps/store/src/components/ProductPage/ProductDocuments.tsx
+++ b/apps/store/src/components/ProductPage/ProductDocuments.tsx
@@ -47,15 +47,20 @@ const ProductDocument = ({ doc }: { doc: InsuranceDocument }) => {
 
 const Layout = styled(GridLayout.Root)({
   // TODO: harmonize with other grid layouts
-
   gap: theme.space.lg,
   [mq.lg]: {
     gap: theme.space.md,
-    paddingInline: theme.space.md,
+    paddingInline: theme.space.lg,
   },
 })
 
-const Content = styled.div({ maxWidth: TEXT_CONTENT_MAX_WIDTH })
+const Content = styled.div({
+  maxWidth: TEXT_CONTENT_MAX_WIDTH,
+
+  [mq.lg]: {
+    paddingRight: theme.space.xl,
+  },
+})
 
 const DownloadFileLink = styled.a({
   display: 'flex',


### PR DESCRIPTION
**Disclaimer**: We're not aiming for a _pixel perfect_ implementation on this one for the first lunch. At the end, it was decided to not include the short description and, as a compromise on the document names, the _country based prefix_ will be removed: ~_SE Hyresrätt Villkor_~ --> _Hyresrätt Villkor_. However, nothing will need to be have done on our end in order to get this in place. So as part of this PR I've just updated some spacing styles.

## Describe your changes

Update spacing as requested by design. The idea was to change _ProductDocuments_ only but I've noticed the same spacing was missing for _Accordion_ as well.

<img width="1112" alt="Screenshot 2023-02-20 at 09 12 14" src="https://user-images.githubusercontent.com/19200662/220049253-8fb08ff3-4ec7-4e08-9387-236cd5f465b5.png">
<img width="1116" alt="Screenshot 2023-02-20 at 09 11 54" src="https://user-images.githubusercontent.com/19200662/220049260-db611241-269b-46eb-b056-9e70fb6f0146.png">

## Jira issue(s): [GRW-2237](https://hedvig.atlassian.net/browse/GRW-2237)

[GRW-2237]: https://hedvig.atlassian.net/browse/GRW-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ