### PR TITLE
Safari: fix product grid layout

### DIFF
--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -29,7 +29,7 @@ export const ProductCard = ({
 }: ProductCardProps) => {
   const { t } = useTranslation('common')
   return (
-    <Wrapper y={0.25}>
+    <Space y={0.25}>
       <Link href={link} legacyBehavior passHref>
         <ImageWrapper aspectRatio={aspectRatio} tabIndex={-1} aria-hidden={true}>
           <Image {...imageProps} alt={alt} fill sizes="100vw" />
@@ -44,13 +44,9 @@ export const ProductCard = ({
           </ButtonNextLink>
         </CallToAction>
       </ContentWrapper>
-    </Wrapper>
+    </Space>
   )
 }
-
-const Wrapper = styled(Space)({
-  height: '100%',
-})
 
 const ImageWrapper = styled.a<ImageSize>(({ aspectRatio }) => ({
   display: 'block',

--- a/apps/store/src/components/ProductGrid/ProductGrid.tsx
+++ b/apps/store/src/components/ProductGrid/ProductGrid.tsx
@@ -39,7 +39,7 @@ const Title = styled.p({
 const Grid = styled.div({
   display: 'grid',
   gap: `${theme.space.xxxl} ${theme.space.xs}`,
-  alignItems: 'baseline',
+  alignItems: 'end',
   gridTemplateColumns: `repeat(auto-fit, minmax(20rem, 1fr))`,
 
   [mq.md]: {

--- a/apps/store/src/components/ProductRecommendationList/ProductRecommendationList.tsx
+++ b/apps/store/src/components/ProductRecommendationList/ProductRecommendationList.tsx
@@ -2,9 +2,9 @@ import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { Heading, mq, Space, theme } from 'ui'
 import { ImageSize } from '@/blocks/ProductCardBlock'
+import { ProductCard } from '@/components/ProductCard/ProductCard'
 import { ProductRecommendationFragment } from '@/services/apollo/generated'
 import { getStoryblokImageSize } from '@/services/storyblok/Storyblok.helpers'
-import { ProductCard } from '../ProductCard/ProductCard'
 
 type Props = {
   recommendations: Array<ProductRecommendationFragment>
@@ -14,7 +14,7 @@ export const ProductRecommendationList = ({ recommendations }: Props) => {
   const { t } = useTranslation('cart')
 
   return (
-    <Wrapper y={1.5}>
+    <Wrapper y={{ base: 1.5, md: 3 }}>
       <MobileHeader>
         <Heading as="h2" variant="standard.24">
           {t('RECOMMENDATIONS_HEADING')}
@@ -72,29 +72,20 @@ const calculateAspectRatio = ({
 }
 
 const Wrapper = styled(Space)({
-  paddingInline: theme.space.md,
-
-  [mq.sm]: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(28rem, 33%)',
-    justifyContent: 'center',
-  },
-
-  [mq.lg]: { display: 'block' },
+  paddingInline: theme.space.xs,
+  [mq.lg]: { paddingInline: theme.space.lg },
 })
 
 const MobileHeader = styled.div({
   paddingInline: theme.space.xs,
 
-  [mq.lg]: {
-    display: 'none',
-  },
+  [mq.md]: { display: 'none' },
 })
 
 const DesktopHeader = styled.div({
   display: 'none',
 
-  [mq.lg]: {
+  [mq.md]: {
     display: 'flex',
     justifyContent: 'center',
   },
@@ -103,11 +94,13 @@ const DesktopHeader = styled.div({
 // TODO: reuse styles as product grid
 const List = styled.div({
   display: 'grid',
-  gap: `${theme.space.xxxl} ${theme.space.xs}`,
-  alignItems: 'baseline',
+  rowGap: theme.space.xxxl,
+  columnGap: theme.space.xs,
+  alignItems: 'end',
   gridTemplateColumns: `repeat(auto-fit, minmax(20rem, 1fr))`,
 
   [mq.md]: {
-    gap: '2rem 1rem',
+    rowGap: theme.space.xl,
+    columnGap: theme.space.md,
   },
 })


### PR DESCRIPTION
## Describe your changes

Fix Safari CSS grid bug in product grid.

![Screenshot 2023-02-13 at 18.18.04.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/fc0ff227-9fb7-4ee0-8cea-87397205ddb4/Screenshot%202023-02-13%20at%2018.18.04.png)

## Justify why they are needed

CSS grid with `align-items: baseline` isn't working in Safari. This is a known bug: https://stackoverflow.com/questions/52502989/css-grid-align-items-baseline-not-working-in-safari.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
