### PR TITLE
GRW-2240 - fix(ProductPage): full width coverage section

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -120,48 +120,48 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
         </MobileLayout>
 
         <DesktopLayout>
+          <AnimatedHeader>
+            <nav aria-label="page content">
+              <ContentNavigationList>
+                <li>
+                  <ContentNavigationTrigger
+                    href="#overview"
+                    data-state={activeSection === 'overview' ? 'active' : 'inactive'}
+                    aria-current={activeSection === 'overview' ? 'true' : undefined}
+                  >
+                    {blok.overviewLabel}
+                  </ContentNavigationTrigger>
+                </li>
+                <li>
+                  <ContentNavigationTrigger
+                    href="#coverage"
+                    data-state={activeSection === 'coverage' ? 'active' : 'inactive'}
+                    aria-current={activeSection === 'coverage' ? 'true' : undefined}
+                  >
+                    {blok.coverageLabel}
+                  </ContentNavigationTrigger>
+                </li>
+              </ContentNavigationList>
+              {shouldRenderVariantSelector && <StyledProductVariantSelector />}
+            </nav>
+          </AnimatedHeader>
           <Grid>
             <Content>
-              <AnimatedHeader>
-                <nav aria-label="page content">
-                  <ContentNavigationList>
-                    <li>
-                      <ContentNavigationTrigger
-                        href="#overview"
-                        data-state={activeSection === 'overview' ? 'active' : 'inactive'}
-                        aria-current={activeSection === 'overview' ? 'true' : undefined}
-                      >
-                        {blok.overviewLabel}
-                      </ContentNavigationTrigger>
-                    </li>
-                    <li>
-                      <ContentNavigationTrigger
-                        href="#coverage"
-                        data-state={activeSection === 'coverage' ? 'active' : 'inactive'}
-                        aria-current={activeSection === 'coverage' ? 'true' : undefined}
-                      >
-                        {blok.coverageLabel}
-                      </ContentNavigationTrigger>
-                    </li>
-                  </ContentNavigationList>
-                  {shouldRenderVariantSelector && <StyledProductVariantSelector />}
-                </nav>
-              </AnimatedHeader>
               <OverviewSection id="overview">
                 {blok.overview?.map((nestedBlock) => (
                   <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
                 ))}
               </OverviewSection>
-              <section id="coverage">
-                {blok.coverage?.map((nestedBlock) => (
-                  <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
-                ))}
-              </section>
             </Content>
             <PurchaseFormWrapper>
               <PurchaseForm />
             </PurchaseFormWrapper>
           </Grid>
+          <section id="coverage">
+            {blok.coverage?.map((nestedBlock) => (
+              <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+            ))}
+          </section>
         </DesktopLayout>
 
         {blok.body.map((nestedBlock) => (
@@ -223,7 +223,7 @@ const OverviewSection = styled.section({
     marginTop: `calc(-${TABLIST_HEIGHT} - ${theme.space.md})`,
   },
   [mq.lg]: {
-    marginTop: `-${TABLIST_HEIGHT}`,
+    marginTop: 0,
   },
 })
 
@@ -279,6 +279,7 @@ const StickyHeader = styled(motion.div)({
     paddingInline: theme.space.lg,
   },
   [mq.lg]: {
+    position: 'fixed',
     top: `calc(${theme.space.md} + ${MENU_BAR_HEIGHT_DESKTOP})`,
     paddingInline: theme.space.xl,
   },


### PR DESCRIPTION
## Describe your changes

* Fix a bug introduced while making the tab navigation available through the whole page on desktop layout, where coverage section only occupies half of the screen.
* Makes Overview/Coverage tab visible throughout the whole page on desktop

## Jira issue(s): [GRW-2240](https://hedvig.atlassian.net/browse/GRW-2240)

https://user-images.githubusercontent.com/19200662/218691774-73207557-f9c8-46b8-8829-67c520fffe49.mov


[GRW-2240]: https://hedvig.atlassian.net/browse/GRW-2240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ