### PR TITLE
Wrap navigation items w/ links

### DIFF
--- a/apps/store/src/blocks/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock.tsx
@@ -70,17 +70,17 @@ export const NestedNavContainerBlock = ({ blok }: NestedNavContainerBlockProps) 
           <NavigationMenuPrimitive.Sub defaultValue={blok.name}>
             <NavigationSecondaryList>
               {filteredNavItems.map((nestedBlock) => (
-                <NavigationMenuSecondaryItem
+                <SecondaryNavigationLink
                   key={nestedBlock._uid}
-                  value={nestedBlock.name}
-                  {...storyblokEditable(nestedBlock)}
+                  href={getLinkFieldURL(nestedBlock.link, nestedBlock.name)}
                 >
-                  <SecondaryNavigationLink
-                    href={getLinkFieldURL(nestedBlock.link, nestedBlock.name)}
+                  <NavigationMenuSecondaryItem
+                    value={nestedBlock.name}
+                    {...storyblokEditable(nestedBlock)}
                   >
                     {nestedBlock.name}
-                  </SecondaryNavigationLink>
-                </NavigationMenuSecondaryItem>
+                  </NavigationMenuSecondaryItem>
+                </SecondaryNavigationLink>
               ))}
             </NavigationSecondaryList>
           </NavigationMenuPrimitive.Sub>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Wrapped the nav items with links to make the whole item clickable. 

![Screenshot 2023-02-14 at 11 28 37](https://user-images.githubusercontent.com/50870173/218710337-47335ab5-96b8-4711-8336-ffa4934a21e3.png)

[Test the issue in the staging env](https://www.store.dev.hedvigit.com/en-se)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Right now the clickable area is only the text. We'd want to give the user more space to click what they want. 

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
