### PR TITLE
SSR: update how to get hedvig-language header

### DIFF
--- a/apps/store/src/pages/404.tsx
+++ b/apps/store/src/pages/404.tsx
@@ -10,17 +10,18 @@ import { initializeApollo } from '@/services/apollo/client'
 import { getGlobalStory } from '@/services/storyblok/storyblok'
 import { GLOBAL_STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+import { RoutingLocale } from '@/utils/l10n/types'
 
 const NextPage: NextPageWithLayout = () => {
   return <FourOhFourPage />
 }
 
 export const getStaticProps: GetStaticProps = async (context) => {
-  let locale = context.locale ?? context.defaultLocale
+  const rawLocale = context.locale ?? context.defaultLocale
   // TODO: Remove this when we have a global 404 page
-  if (!isRoutingLocale(locale)) locale = 'en-se'
+  const locale: RoutingLocale = isRoutingLocale(rawLocale) ? rawLocale : 'en-se'
 
-  const apolloClient = initializeApollo()
+  const apolloClient = initializeApollo({ locale })
   const [globalStory, translations, productMetadata] = await Promise.all([
     getGlobalStory({ locale }),
     serverSideTranslations(locale),

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -74,7 +74,7 @@ export const getStaticProps: GetStaticProps<
 
   const slug = (params?.slug ?? []).join('/')
 
-  const apolloClient = initializeApollo()
+  const apolloClient = initializeApollo({ locale })
   console.time('getStoryblokData')
   const [story, globalStory, translations, productMetadata] = await Promise.all([
     getStoryBySlug(slug, { version, locale }),

--- a/apps/store/src/pages/api/campaign/[code].ts
+++ b/apps/store/src/pages/api/campaign/[code].ts
@@ -43,7 +43,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   const { countryCode } = getCountryByLocale(locale)
 
-  const apolloClient = initializeApollo({ req, res })
+  const apolloClient = initializeApollo({ req, res, locale })
   const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
 
   let shopSession: ShopSession

--- a/apps/store/src/pages/cart.tsx
+++ b/apps/store/src/pages/cart.tsx
@@ -91,7 +91,7 @@ export const getServerSideProps: GetServerSideProps<
 
   const { countryCode } = getCountryByLocale(locale)
 
-  const apolloClient = initializeApollo({ req, res })
+  const apolloClient = initializeApollo({ req, res, locale })
   const [shopSession, translations, globalStory, productMetadata] = await Promise.all([
     getShopSessionServerSide({ apolloClient, countryCode, req, res }),
     serverSideTranslations(locale),

--- a/apps/store/src/pages/checkout/[shopSessionId]/payment/[status].tsx
+++ b/apps/store/src/pages/checkout/[shopSessionId]/payment/[status].tsx
@@ -26,7 +26,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
   if (!isRoutingLocale(locale)) return { notFound: true }
   if (!shopSessionId) return { notFound: true }
 
-  const apolloClient = initializeApollo({ req, res })
+  const apolloClient = initializeApollo({ req, res, locale })
   const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
   const shopSession = await shopSessionService.fetchById(shopSessionId)
 

--- a/apps/store/src/pages/checkout/[shopSessionId]/payment/index.tsx
+++ b/apps/store/src/pages/checkout/[shopSessionId]/payment/index.tsx
@@ -22,7 +22,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
   if (!shopSessionId) return { notFound: true }
 
   try {
-    const apolloClient = initializeApollo({ req, res })
+    const apolloClient = initializeApollo({ req, res, locale })
     await setupShopSessionServiceServerSide({ apolloClient, req, res }).fetchById(shopSessionId)
     // TODO: validate ShopSession
   } catch (error) {

--- a/apps/store/src/pages/checkout/index.tsx
+++ b/apps/store/src/pages/checkout/index.tsx
@@ -75,7 +75,7 @@ export const getServerSideProps: GetServerSideProps<NextPageProps> = async (cont
     redirect: { destination: PageLink.home({ locale }), permanent: false },
   } as const
 
-  const apolloClient = initializeApollo({ req, res })
+  const apolloClient = initializeApollo({ req, res, locale })
   let shopSession: ShopSession, translations: SSRConfig
   try {
     ;[shopSession, translations] = await Promise.all([

--- a/apps/store/src/pages/checkout/switching-assistant.tsx
+++ b/apps/store/src/pages/checkout/switching-assistant.tsx
@@ -23,7 +23,7 @@ export const getServerSideProps: GetServerSideProps<NextPageProps> = async (cont
   const { req, res, locale } = context
   if (!isRoutingLocale(locale)) return { notFound: true }
 
-  const apolloClient = initializeApollo({ req, res })
+  const apolloClient = initializeApollo({ req, res, locale })
   const [shopSession, translations] = await Promise.all([
     getCurrentShopSessionServerSide({ apolloClient, req, res }),
     serverSideTranslations(locale),

--- a/apps/store/src/pages/confirmation/[shopSessionId].tsx
+++ b/apps/store/src/pages/confirmation/[shopSessionId].tsx
@@ -30,7 +30,7 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
   const shopSessionId = params?.shopSessionId
   if (!shopSessionId) return { notFound: true }
 
-  const apolloClient = initializeApollo({ req, res })
+  const apolloClient = initializeApollo({ req, res, locale })
   const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
   const [shopSession, translations, globalStory, story, productMetadata] = await Promise.all([
     shopSessionService.fetchById(shopSessionId),

--- a/apps/store/src/pages/session/[shopSessionId].tsx
+++ b/apps/store/src/pages/session/[shopSessionId].tsx
@@ -29,7 +29,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
     return fallbackRedirect
   }
 
-  const apolloClient = initializeApollo({ req, res })
+  const apolloClient = initializeApollo({ req, res, locale })
   let shopSession: ShopSession
   try {
     const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })


### PR DESCRIPTION
## Describe your changes

Update how to get hedvig-language header on server.

Skip relying on fallback.

## Justify why they are needed

We sometimes fail to determine language on the server. Then we fallback to english (SE) which is not good. Half the UI is in english and half in swedish.

I would like to refactor more and get rid of the fallback but I think this is a good first step.

The language should always be derived from the URL.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
