### PR TITLE
GRW-2241 - feat(StoryblokPage): added SEO info

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled'
 import * as RadixTabs from '@radix-ui/react-tabs'
 import { storyblokEditable, StoryblokComponent, SbBlokData } from '@storyblok/react'
 import { motion, Transition } from 'framer-motion'
-import Head from 'next/head'
 import { useRef, useState, useEffect } from 'react'
 import { mq, theme } from 'ui'
 import {
@@ -15,7 +14,7 @@ import { useProductPageContext } from '@/components/ProductPage/ProductPageConte
 import { PurchaseForm } from '@/components/ProductPage/PurchaseForm/PurchaseForm'
 import * as Tabs from '@/components/ProductPage/Tabs'
 import { ProductVariantSelector } from '@/components/ProductVariantSelector/ProductVariantSelector'
-import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
+import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { useScrollState } from '@/utils/useScrollState'
 import { zIndexes } from '@/utils/zIndex'
 
@@ -26,22 +25,13 @@ const TRANSITION: Transition = { ease: [0.65, 0.05, 0.36, 1] }
 
 type PageSection = 'overview' | 'coverage'
 
-type SEOData = {
-  robots: 'index' | 'noindex'
-  seoMetaTitle?: string
-  seoMetaDescription?: string
-  seoMetaOgImage?: StoryblokAsset
-}
-
-type ProductPageBlockProps = SbBaseBlockProps<
-  {
-    overviewLabel: string
-    coverageLabel: string
-    overview: SbBlokData[]
-    coverage: SbBlokData[]
-    body: SbBlokData[]
-  } & SEOData
->
+type ProductPageBlockProps = SbBaseBlockProps<{
+  overviewLabel: string
+  coverageLabel: string
+  overview: SbBlokData[]
+  coverage: SbBlokData[]
+  body: SbBlokData[]
+}>
 
 export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
   const { productData } = useProductPageContext()
@@ -56,22 +46,6 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
 
   return (
     <>
-      <Head>
-        <meta name="robots" content={blok.robots} />
-        {blok.seoMetaTitle && (
-          <>
-            <meta name="title" content={blok.seoMetaTitle} />
-            <meta property="og:title" content={blok.seoMetaTitle} />
-          </>
-        )}
-        {blok.seoMetaDescription && (
-          <>
-            <meta name="description" content={blok.seoMetaDescription} />
-            <meta property="og:description" content={blok.seoMetaDescription} />
-          </>
-        )}
-        {blok.seoMetaOgImage && <meta property="og:image" content={blok.seoMetaOgImage.filename} />}
-      </Head>
       <Global
         styles={{
           html: {

--- a/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
+++ b/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
@@ -1,17 +1,34 @@
 import { ISbStoryData } from '@storyblok/react'
 import Head from 'next/head'
+import { SEOData } from '@/services/storyblok/storyblok'
 import { isRoutingLocale, toIsoLocale } from '@/utils/l10n/localeUtils'
 import { ORIGIN_URL } from '@/utils/PageLink'
 
-export const HeadSeoInfo = ({ story }: { story: ISbStoryData }) => {
+export const HeadSeoInfo = ({ story }: { story: ISbStoryData<SEOData> }) => {
   // AB testing
-  const { canonicalUrl } = story.content
+  const { canonicalUrl, robots, seoMetaTitle, seoMetaDescription, seoMetaOgImage } = story.content
   // Translations and other alternates
   const { alternates } = story
 
   return (
     <>
-      <Head>{canonicalUrl && <link rel="canonical" href={canonicalUrl} />}</Head>
+      <Head>
+        {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+        <meta name="robots" content={robots} />
+        {seoMetaTitle && (
+          <>
+            <meta name="title" content={seoMetaTitle} />
+            <meta property="og:title" content={seoMetaTitle} />
+          </>
+        )}
+        {seoMetaDescription && (
+          <>
+            <meta name="description" content={seoMetaDescription} />
+            <meta property="og:description" content={seoMetaDescription} />
+          </>
+        )}
+        {seoMetaOgImage?.filename && <meta property="og:image" content={seoMetaOgImage.filename} />}
+      </Head>
       {/* Must include link to self along with other variants */}
 
       <AlternateLink fullSlug={story.full_slug} />

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -20,6 +20,8 @@ import {
   StoryblokQueryParams,
   getFilteredPageLinks,
   StoryblokPreviewData,
+  PageStory,
+  ProductStory,
 } from '@/services/storyblok/storyblok'
 import { GLOBAL_STORY_PROP_NAME, STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
 import { isProductStory } from '@/services/storyblok/Storyblok.helpers'
@@ -77,7 +79,7 @@ export const getStaticProps: GetStaticProps<
   const apolloClient = initializeApollo({ locale })
   console.time('getStoryblokData')
   const [story, globalStory, translations, productMetadata] = await Promise.all([
-    getStoryBySlug(slug, { version, locale }),
+    getStoryBySlug<PageStory | ProductStory>(slug, { version, locale }),
     getGlobalStory({ version, locale }),
     serverSideTranslations(locale),
     fetchGlobalProductMetadata({ apolloClient }),

--- a/apps/store/src/pages/_document.tsx
+++ b/apps/store/src/pages/_document.tsx
@@ -14,7 +14,6 @@ export default class MyDocument extends Document {
       <Html lang={this.lang()} dir="ltr">
         <Head>
           {/*TODO: Allow indexing right before going live*/}
-          <meta name="robots" content="none" />
           <meta name="twitter:site" content="@hedvigapp" />
           <meta name="twitter:card" content="summary_large_image" />
           <meta name="theme-color" content={theme.colors.light} />

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -35,11 +35,11 @@ export type StoryblokFetchParams = {
   resolve_relations?: string
 }
 
-export const fetchStory = async (
+export const fetchStory = async <StoryData extends ISbStoryData | undefined>(
   storyblokClient: StoryblokClient,
   slug: string,
   params: StoryblokFetchParams,
-): Promise<ISbStoryData | undefined> => {
+): Promise<StoryData> => {
   const response = await storyblokClient.get(`cdn/stories/${slug}`, {
     ...params,
     resolve_links: 'url',

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -104,16 +104,24 @@ export type LinkField = {
   }
 }
 
-export type PageStory = ISbStoryData & {
-  content: ISbStoryData['content'] & {
+export type SEOData = {
+  robots: 'index' | 'noindex'
+  seoMetaTitle?: string
+  seoMetaDescription?: string
+  seoMetaOgImage?: StoryblokAsset
+  canonicalUrl?: string
+}
+
+export type PageStory = ISbStoryData<
+  {
     hideMenu?: boolean
     overlayMenu?: boolean
     hideFooter?: boolean
-  }
-}
+  } & SEOData
+>
 
-export type ProductStory = ISbStoryData & {
-  content: ISbStoryData['content'] & {
+export type ProductStory = ISbStoryData<
+  {
     name?: string
     description?: string
     tagline?: string
@@ -121,8 +129,8 @@ export type ProductStory = ISbStoryData & {
     priceFormTemplateId: string
     body: Array<SbBlokData>
     global: Array<SbBlokData>
-  }
-}
+  } & SEOData
+>
 
 export type GlobalStory = ISbStoryData & {
   content: ISbStoryData['content'] & {
@@ -245,12 +253,15 @@ type StoryOptions = {
   version?: StoryblokVersion
 }
 
-export const getStoryBySlug = async (slug: string, { version, locale }: StoryOptions) => {
+export const getStoryBySlug = async <StoryData extends ISbStoryData | undefined>(
+  slug: string,
+  { version, locale }: StoryOptions,
+) => {
   const params: StoryblokFetchParams = {
     version: version ?? 'published',
     resolve_relations: 'reusableBlockReference.reference',
   }
-  return await fetchStory(getStoryblokApi(), `${locale}/${slug}`, params)
+  return await fetchStory<StoryData>(getStoryblokApi(), `${locale}/${slug}`, params)
 }
 
 export const getPageLinks = async (): Promise<PageLink[]> => {


### PR DESCRIPTION
## Describe your changes

* Updates `HeadSeoInfo` so it handles more SEO related tags
* Refactor `ProductPageBlock` by leveraging `HeadSeoInfo` in order to add seo related tags into documents `<head>`

![image](https://user-images.githubusercontent.com/19200662/218744313-960d69e5-2103-4a96-803c-e905bda2127c.png)

## Justify why they are needed

Requested by Peter.

## Jira issue(s): [GRW-2241](https://hedvig.atlassian.net/browse/GRW-2241)




[GRW-2241]: https://hedvig.atlassian.net/browse/GRW-2241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ