### PR TITLE
Add hover state to edit price calculator

### DIFF
--- a/apps/store/src/components/Accordion/Accordion.tsx
+++ b/apps/store/src/components/Accordion/Accordion.tsx
@@ -30,7 +30,6 @@ const Trigger = styled(AccordionPrimitives.Trigger)({
   '@media (hover: hover)': {
     ':hover': {
       cursor: 'pointer',
-      backgroundColor: theme.colors.gray200,
     },
   },
 })

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -159,7 +159,7 @@ export const OfferPresenter = (props: Props) => {
               </Text>
               <Centered>
                 <TextButton onClick={onClickEdit}>
-                  <Text align="center" size="xs" color="textSecondary">
+                  <Text align="center" size="xs" color="textSecondary" as="span">
                     {t('PRESENT_OFFER_EDIT_BUTTON')}
                   </Text>
                 </TextButton>
@@ -262,11 +262,18 @@ const Centered = styled.div({
 
 const TextButton = styled.button({
   cursor: 'pointer',
+  lineHeight: 1,
 
   backgroundColor: theme.colors.light,
   ':focus-visible': {
     borderRadius: theme.radius.xs,
     boxShadow: `${theme.colors.light} 0 0 0 3px, ${theme.colors.textPrimary} 0 0 0 4px`,
+  },
+
+  '@media (hover: hover)': {
+    ':hover > span': {
+      color: theme.colors.textPrimary,
+    },
   },
 })
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add hover state to edit button in price calculator.

![Screenshot 2023-02-14 at 15.41.29.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/ec6e8915-ffb5-40be-ba48-e0a4c7b116c7/Screenshot%202023-02-14%20at%2015.41.29.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
