### PR TITLE
Fix layout of CMS blocks on confirmation page

### DIFF
--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -75,23 +75,11 @@ export const ConfirmationPage = (props: Props) => {
                   })}
                 </CheckList>
               </Space>
-
-              <Space y={1}>
-                <div>
-                  <Heading as="h2" variant="standard.24">
-                    {story.content.faqTitle}
-                  </Heading>
-                  <Text as="p" color="textSecondary" size="xl">
-                    {story.content.faqSubtitle}
-                  </Text>
-                </div>
-                <BlockLayoutReset>
-                  <ConfirmationPageBlock blok={story.content} />
-                </BlockLayoutReset>
-              </Space>
             </Space>
           </Layout.Content>
         </Layout.Root>
+
+        <ConfirmationPageBlock blok={story.content} />
 
         <FooterSection
           image={{ src: story.content.footerImage.filename, alt: story.content.footerImage.alt }}
@@ -119,8 +107,4 @@ const Wrapper = styled.div({
   [mq.lg]: {
     paddingTop: theme.space.xxxl,
   },
-})
-
-const BlockLayoutReset = styled.div({
-  marginInline: `calc(-1 * ${theme.space.md})`,
 })

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -156,8 +156,6 @@ export type ConfirmationStory = ISbStoryData & {
     checklistTitle: string
     checklistSubtitle: string
     checklist: string
-    faqTitle: string
-    faqSubtitle: string
   }
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Update layout for CMS blocks on the confirmation page.

Expose grid alignment styles and override block styles when rendered on the confirmation page.

Define text + accordion (faq) as CMS blocks.

![Screenshot 2023-02-14 at 16 39 02](https://user-images.githubusercontent.com/1220232/218787133-9c3cff59-caa4-4522-8e39-f2972d236710.png)


## Justify why they are needed

The layout was not correct. The confirmation page has a different layout than the other pages. We should try to harmonize the layout of the pages. I will discuss with design if this is possible.

Otherwise I feel like this is an explicit way of showing that some blocks should render differently on the confirmation page.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
