### PR TITLE
GRW-2255 - refact(HeadSeoInfo): replace seoMetaTitle --> seoTitle

### DIFF
--- a/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
+++ b/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
@@ -6,7 +6,7 @@ import { ORIGIN_URL } from '@/utils/PageLink'
 
 export const HeadSeoInfo = ({ story }: { story: ISbStoryData<SEOData> }) => {
   // AB testing
-  const { canonicalUrl, robots, seoMetaTitle, seoMetaDescription, seoMetaOgImage } = story.content
+  const { canonicalUrl, robots, seoTitle, seoMetaDescription, seoMetaOgImage } = story.content
   // Translations and other alternates
   const { alternates } = story
 
@@ -15,12 +15,6 @@ export const HeadSeoInfo = ({ story }: { story: ISbStoryData<SEOData> }) => {
       <Head>
         {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
         <meta name="robots" content={robots} />
-        {seoMetaTitle && (
-          <>
-            <meta name="title" content={seoMetaTitle} />
-            <meta property="og:title" content={seoMetaTitle} />
-          </>
-        )}
         {seoMetaDescription && (
           <>
             <meta name="description" content={seoMetaDescription} />
@@ -28,6 +22,12 @@ export const HeadSeoInfo = ({ story }: { story: ISbStoryData<SEOData> }) => {
           </>
         )}
         {seoMetaOgImage?.filename && <meta property="og:image" content={seoMetaOgImage.filename} />}
+        {seoTitle && (
+          <>
+            <meta property="og:title" content={seoTitle} />
+            <title>{seoTitle}</title>
+          </>
+        )}
       </Head>
       {/* Must include link to self along with other variants */}
 

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -1,7 +1,6 @@
 import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
 import type { GetStaticPaths, GetStaticProps, NextPageWithLayout } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import Head from 'next/head'
 import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
 import {
   fetchGlobalProductMetadata,
@@ -42,9 +41,6 @@ const NextStoryblokPage = ({ story: initialStory }: StoryblokPageProps) => {
 
   return (
     <>
-      <Head>
-        <title>{story.name}</title>
-      </Head>
       <HeadSeoInfo story={story} />
       <StoryblokComponent blok={story.content} />
     </>
@@ -57,9 +53,6 @@ const NextProductPage = (props: ProductPageProps) => {
 
   return (
     <>
-      <Head>
-        <title>{story.name}</title>
-      </Head>
       <HeadSeoInfo story={story} />
       <ProductPage {...pageProps} story={story} />
     </>

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -106,7 +106,7 @@ export type LinkField = {
 
 export type SEOData = {
   robots: 'index' | 'noindex'
-  seoMetaTitle?: string
+  seoTitle?: string
   seoMetaDescription?: string
   seoMetaOgImage?: StoryblokAsset
   canonicalUrl?: string


### PR DESCRIPTION
## Describe your changes

* Rename ~seoMetaTtile~ --> seoTitle field for _Product_ and _Page_ Storyblok page types;
* Move `<title>` insertion into `HeadSeoInfo` component

## Justify why they are needed

There’s no reason to <title> and <meta name=”title”> tags since in that case only <title> will be considered. With that said, we need to update SEO tab for Product and Page strobyblok page types by renaming seoMetaTitle field to seoTitle and use its value only for setting a <title> tag for the page.

## Jira issue(s): [GRW-2255](https://hedvig.atlassian.net/browse/GRW-2255)

[GRW-2255]: https://hedvig.atlassian.net/browse/GRW-2255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>


> 
> #### What changed
> - Changed property name from `seoMetaTitle` to `seoTitle`
> - Added `<title>` tag with `seoTitle`
> - Removed `<meta name="title" content={seoMetaTitle} />` and `<meta property="og:title" content={seoMetaTitle} />`
> 
> #### Impact
> The diff changes the title of the page and the `<title>` tag.
> 
> #### Testing
> This diff can be tested by verifying that the page title and `<title>` tag are updated appropriately.
</details>