### PR TITLE
GRW-2257 - feat(ProductPage): support default product variant definition from Storyblok

### DIFF
--- a/apps/store/src/components/ProductPage/ProductPage.types.ts
+++ b/apps/store/src/components/ProductPage/ProductPage.types.ts
@@ -4,8 +4,13 @@ import { ProductStory, StoryblokPageProps } from '@/services/storyblok/storyblok
 
 export type ProductData = Exclude<ProductDataQuery['product'], null | undefined>
 
+export type ProductDataVariant =
+  | Exclude<ProductDataQuery['product'], undefined | null>['variants'][number]
+  | null
+
 export type ProductPageProps = StoryblokPageProps & {
   story: ProductStory
   priceTemplate: Template
   productData: ProductData
+  initialSelectedVariant?: ProductDataVariant
 }

--- a/apps/store/src/components/ProductPage/ProductPageContext.tsx
+++ b/apps/store/src/components/ProductPage/ProductPageContext.tsx
@@ -1,10 +1,5 @@
 import { createContext, PropsWithChildren, useContext, useMemo, useState } from 'react'
-import { ProductDataQuery } from '@/services/apollo/generated'
-import { ProductPageProps } from './ProductPage.types'
-
-type ProductDataVariant =
-  | Exclude<ProductDataQuery['product'], undefined | null>['variants'][number]
-  | null
+import { ProductPageProps, ProductDataVariant } from './ProductPage.types'
 
 type ProductPageContextData = ProductPageProps & {
   selectedVariant: ProductDataVariant

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -103,6 +103,11 @@ export const getStaticProps: GetStaticProps<
       productName: story.content.productId,
     })
 
+    const initialSelectedVariant =
+      productData.variants.find(
+        (variant) => variant.typeOfContract === story.content.defaultProductVariant,
+      ) ?? null
+
     return {
       props: {
         type: 'product',
@@ -110,6 +115,7 @@ export const getStaticProps: GetStaticProps<
         [STORY_PROP_NAME]: story,
         productData,
         priceTemplate,
+        initialSelectedVariant,
       },
       revalidate,
     }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -125,6 +125,7 @@ export type ProductStory = ISbStoryData<
     name?: string
     description?: string
     tagline?: string
+    defaultProductVariant?: string
     productId: string
     priceFormTemplateId: string
     body: Array<SbBlokData>


### PR DESCRIPTION
## Describe your changes

* Move 'ProductDataVariant' type definition into ProductPage.types
* Get default product variant from storyblok

## Justify why they are needed

Requested by Peter

## Jira issue(s): [GRW-2257](https://hedvig.atlassian.net/browse/GRW-2257)


[GRW-2257]: https://hedvig.atlassian.net/browse/GRW-2257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ