### PR TITLE
Video download size optimizations

### DIFF
--- a/apps/store/src/components/HeroVideo/HeroVideo.tsx
+++ b/apps/store/src/components/HeroVideo/HeroVideo.tsx
@@ -38,9 +38,11 @@ const StyledVideo = styled.video(
   ({ poster, height }: Pick<HeroVideoProps, 'poster' | 'height'>) => ({
     width: '100%',
     height: height ?? '80vh',
-    background: `url(${poster}) no-repeat`,
-    backgroundSize: 'cover',
-    objectFit: 'cover',
+    ...(poster && {
+      background: `url(${poster}) no-repeat`,
+      backgroundSize: 'cover',
+      objectFit: 'cover',
+    }),
   }),
 )
 

--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -112,11 +112,13 @@ export const Video = ({
     - Safari on iOS only allows autoplay when the video is `muted`.
     - Safari on iOS will default to autoplay videos in fullscreen unless `playsInline` is added
     Read more: https://webkit.org/blog/6784/new-video-policies-for-ios/
+
+    - We don't want to preload full video.  This is ignored by browsers if autoPlay is set
     */}
       <StyledVideo
         ref={videoRef}
         playsInline
-        preload="auto"
+        preload="metadata"
         poster={poster}
         aspectRatioLandscape={aspectRatioLandscape}
         aspectRatioPortrait={aspectRatioPortrait}

--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -168,9 +168,11 @@ const StyledVideo = styled.video(
     roundedCorners,
   }: Omit<VideoProps, 'sources'>) => ({
     width: '100%',
-    background: `url(${poster}) no-repeat`,
-    backgroundSize: 'cover',
-    objectFit: 'cover',
+    ...(poster && {
+      background: `url(${poster}) no-repeat`,
+      backgroundSize: 'cover',
+      objectFit: 'cover',
+    }),
     ['@media (orientation: portrait)']: {
       ...(maxHeightPortrait && { maxHeight: `${maxHeightPortrait}vh` }),
       ...(aspectRatioPortrait && { aspectRatio: aspectRatioPortrait }),


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Fix invalid style when video poster is missing
- Don't preload full videos by default

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Reduce initial download size of front page

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
