### PR TITLE
Optimize video posters through Storyblok optimization server

### DIFF
--- a/apps/store/src/blocks/HeroVideoBlock.tsx
+++ b/apps/store/src/blocks/HeroVideoBlock.tsx
@@ -1,3 +1,4 @@
+import { breakpoints } from 'ui/src/lib/media-query'
 import { HeroVideo } from '@/components/HeroVideo/HeroVideo'
 import { ExpectedBlockType, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 import { filterByBlockType, getOptimizedImageUrl } from '@/services/storyblok/Storyblok.helpers'
@@ -15,7 +16,10 @@ type HeroVideoBlockProps = SbBaseBlockProps<{
 export const HeroVideoBlock = ({ blok }: HeroVideoBlockProps) => {
   const headingBlocks = filterByBlockType(blok.headings, HeadingBlock.blockName)
   const posterUrl = blok.poster?.filename
-    ? getOptimizedImageUrl(blok.poster.filename, { maxWidth: 1536 })
+    ? getOptimizedImageUrl(blok.poster.filename, {
+        maxWidth: breakpoints.xxl,
+        maxHeight: blok.height,
+      })
     : undefined
 
   return (

--- a/apps/store/src/blocks/HeroVideoBlock.tsx
+++ b/apps/store/src/blocks/HeroVideoBlock.tsx
@@ -1,6 +1,6 @@
 import { HeroVideo } from '@/components/HeroVideo/HeroVideo'
 import { ExpectedBlockType, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
-import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
+import { filterByBlockType, getOptimizedImageUrl } from '@/services/storyblok/Storyblok.helpers'
 import { HeadingBlockProps, HeadingBlock } from './HeadingBlock'
 
 type HeroVideoBlockProps = SbBaseBlockProps<{
@@ -14,12 +14,15 @@ type HeroVideoBlockProps = SbBaseBlockProps<{
 
 export const HeroVideoBlock = ({ blok }: HeroVideoBlockProps) => {
   const headingBlocks = filterByBlockType(blok.headings, HeadingBlock.blockName)
+  const posterUrl = blok.poster?.filename
+    ? getOptimizedImageUrl(blok.poster.filename, { maxWidth: 1536 })
+    : undefined
 
   return (
     <HeroVideo
       sources={[{ url: blok.video.filename, format: blok.format }]}
       height={blok.height}
-      poster={blok.poster?.filename}
+      poster={posterUrl}
       childrenPadding={blok.headingsPadding}
     >
       {headingBlocks.map((nestedBlock) => (

--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { breakpoints } from 'ui/src/lib/media-query'
 import { ConditionalWrapper, mq, theme } from 'ui'
 import { Video, VideoProps } from '@/components/Video/Video'
 import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
@@ -23,7 +24,7 @@ export const VideoBlock = ({ className, blok }: VideoBlockProps) => {
   const posterUrl = blok.poster?.filename
     ? getOptimizedImageUrl(blok.poster.filename, {
         maxHeight: Math.max(blok.maxHeightLandscape ?? 0, blok.maxHeightPortrait ?? 0),
-        maxWidth: 1024,
+        maxWidth: breakpoints.lg,
       })
     : undefined
   return (

--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import { ConditionalWrapper, mq, theme } from 'ui'
 import { Video, VideoProps } from '@/components/Video/Video'
 import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
+import { getOptimizedImageUrl } from '@/services/storyblok/Storyblok.helpers'
 
 export type VideoBlockProps = SbBaseBlockProps<
   {
@@ -19,6 +20,12 @@ export type VideoBlockProps = SbBaseBlockProps<
 > & { className?: string }
 
 export const VideoBlock = ({ className, blok }: VideoBlockProps) => {
+  const posterUrl = blok.poster?.filename
+    ? getOptimizedImageUrl(blok.poster.filename, {
+        maxHeight: Math.max(blok.maxHeightLandscape ?? 0, blok.maxHeightPortrait ?? 0),
+        maxWidth: 1024,
+      })
+    : undefined
   return (
     <ConditionalWrapper
       condition={!blok.fullBleed}
@@ -26,7 +33,7 @@ export const VideoBlock = ({ className, blok }: VideoBlockProps) => {
     >
       <Video
         sources={[{ url: blok.video.filename }]}
-        poster={blok.poster?.filename}
+        poster={posterUrl}
         autoPlay={blok.autoPlay}
         aspectRatioLandscape={blok.aspectRatioLandscape}
         aspectRatioPortrait={blok.aspectRatioPortrait}

--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -68,7 +68,7 @@ const getPriceLink = (productLink: string): LinkHref | undefined => {
   }
   return {
     pathname: productLink,
-    query: { [OPEN_PRICE_CALCULATOR_QUERY_PARAM]: true },
+    query: { [OPEN_PRICE_CALCULATOR_QUERY_PARAM]: 1 },
   } as const
 }
 

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -83,3 +83,18 @@ export const getStoryblokImageSize = (filename: string) => {
 
   return { width: Number(width), height: Number(height) }
 }
+
+type ImageOptimizationOptions = {
+  maxHeight?: number
+  maxWidth?: number
+}
+export const getOptimizedImageUrl = (
+  originalUrl: string,
+  options: ImageOptimizationOptions = {},
+) => {
+  let optimizationRules = ''
+  if (options.maxHeight || options.maxWidth) {
+    optimizationRules = `fit-in/${options.maxWidth ?? 0}x${options.maxHeight ?? 0}`
+  }
+  return `${originalUrl}/m/${optimizationRules}`
+}

--- a/packages/ui/src/lib/media-query.ts
+++ b/packages/ui/src/lib/media-query.ts
@@ -2,20 +2,20 @@ import { useState, useLayoutEffect, useEffect } from 'react'
 
 export type Level = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl'
 
-const breakpoints: Array<[Level, number]> = [
-  ['xs', 480],
-  ['sm', 640],
-  ['md', 768],
-  ['lg', 1024],
-  ['xl', 1280],
-  ['xxl', 1536],
-]
-// FIXME: export enum with values
+export const breakpoints: Record<Level, number> = {
+  xs: 480,
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  xxl: 1536,
+}
 
-export const mq = breakpoints.reduce((mediaQueries, [name, value]) => {
-  mediaQueries[name] = `@media (min-width: ${value}px)`
-  return mediaQueries
-}, {} as Record<Level, string>)
+export const mq = Object.fromEntries(
+  Object.entries(breakpoints).map(([name, width]) => {
+    return [name, `@media (min-width: ${width}px)`]
+  }),
+)
 
 function getWindowDimensions() {
   const { innerWidth: width, innerHeight: height } = window
@@ -44,11 +44,8 @@ export const useBreakpoint = (level: Level) => {
     return () => window.removeEventListener('resize', handleResize)
   }, [])
 
-  const breakpoint = breakpoints.find(([breakpointName]) => breakpointName === level)
-
-  if (!breakpoint) throw new Error(`Unknown breakpoint ${level}`)
-
-  const [, breakpointWidth] = breakpoint
+  const breakpointWidth = breakpoints[level]
+  if (!breakpointWidth) throw new Error(`Unknown breakpoint ${level}`)
 
   return windowDimensions.width >= breakpointWidth
 }

--- a/packages/ui/src/lib/media-query.ts
+++ b/packages/ui/src/lib/media-query.ts
@@ -10,6 +10,7 @@ const breakpoints: Array<[Level, number]> = [
   ['xl', 1280],
   ['xxl', 1536],
 ]
+// FIXME: export enum with values
 
 export const mq = breakpoints.reduce((mediaQueries, [name, value]) => {
   mediaQueries[name] = `@media (min-width: ${value}px)`


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Use Storyblok image optimization for video posters

This reduces resources dramatically, ~15MB total savings on /se, for example.  I'd love to use Vercel for this optimization, but they don't have a documented API outside of Image component

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
