### PR TITLE
Optimize useBreakpoint to only rerender when size crosses the threshold

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -175,6 +175,17 @@ const sharedTriggerStyles = css({
     backgroundColor: theme.colors.grayTranslucent400,
   },
 
+  '@media (hover: hover)': {
+    ':hover': {
+      backgroundColor: theme.colors.gray200,
+      transition: `background-color ${theme.transitions.hover}`,
+
+      '&[data-state=active]': {
+        backgroundColor: theme.colors.grayTranslucent500,
+      },
+    },
+  },
+
   '&:focus-visible': {
     boxShadow: `0 0 0 2px ${theme.colors.purple500}`,
   },

--- a/apps/store/src/components/Accordion/Accordion.tsx
+++ b/apps/store/src/components/Accordion/Accordion.tsx
@@ -48,6 +48,7 @@ export const Item = styled(AccordionPrimitives.Item)({
   '@media (hover: hover)': {
     [`:has(${Trigger}:hover)`]: {
       backgroundColor: theme.colors.gray200,
+      transition: `background ${theme.transitions.hover}`,
     },
   },
 })

--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -86,7 +86,7 @@ const ImageWrapper = styled.div<ImageSize>(({ aspectRatio }) => ({
 
   ':hover, :active': {
     opacity: 0.95,
-    transition: 'opacity 0.1s ease-out',
+    transition: `opacity ${theme.transitions.hover}`,
   },
 }))
 

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -64,8 +64,7 @@ const StyledButton = styled.button<CustomButtonProps>(
 
     whiteSpace: 'nowrap',
     lineHeight: 1,
-    transition:
-      'background-color 0.1s ease-out 0s, box-shadow 0.15s cubic-bezier(0.47, 0.03, 0.49, 1.38) 0s',
+    transition: `background-color ${theme.transitions.hover}, box-shadow 0.15s cubic-bezier(0.47, 0.03, 0.49, 1.38) 0s`,
 
     display: 'inline-flex',
     alignItems: 'center',

--- a/packages/ui/src/lib/media-query.ts
+++ b/packages/ui/src/lib/media-query.ts
@@ -31,11 +31,13 @@ function getWindowDimensions() {
  */
 export const useBreakpoint = (level: Level) => {
   // Initial value must be the same on SSR and CSR to prevent hydration errors
-  const [windowDimensions, setWindowDimensions] = useState({ width: 0, height: 0 })
+  const [isLarger, setIsLarger] = useState(false)
 
   useIsomorphicLayoutEffect(() => {
     const handleResize = () => {
-      setWindowDimensions(getWindowDimensions())
+      const breakpointWidth = breakpoints[level]
+      if (!breakpointWidth) throw new Error(`Unknown breakpoint ${level}`)
+      setIsLarger(getWindowDimensions().width >= breakpointWidth)
     }
 
     handleResize()
@@ -44,10 +46,7 @@ export const useBreakpoint = (level: Level) => {
     return () => window.removeEventListener('resize', handleResize)
   }, [])
 
-  const breakpointWidth = breakpoints[level]
-  if (!breakpointWidth) throw new Error(`Unknown breakpoint ${level}`)
-
-  return windowDimensions.width >= breakpointWidth
+  return isLarger
 }
 
 const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect

--- a/packages/ui/src/lib/theme/theme.ts
+++ b/packages/ui/src/lib/theme/theme.ts
@@ -1,6 +1,7 @@
 import { colors, UIColorKeys } from './colors/colors'
 import { radius } from './radius'
 import { space } from './space'
+import { transitions } from './transitions'
 import { fonts, fontSizes } from './typography'
 
 export const theme = {
@@ -9,6 +10,7 @@ export const theme = {
   fontSizes,
   radius,
   space,
+  transitions,
 } as const
 
 export const getColor = (color: UIColorKeys) => {

--- a/packages/ui/src/lib/theme/transitions.ts
+++ b/packages/ui/src/lib/theme/transitions.ts
@@ -1,0 +1,3 @@
+export const transitions = {
+  hover: '0.1s ease-out 0s',
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Prevent rerenders from useBreakpoint on every resize - we only care about hook result

Decided not to use external library for now to keep it small

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
