### PR TITLE
Use Storyblok CDN for non-draft stories with cache version taken from Vercel config

### DIFF
--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import React, { useCallback, useId, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { mq, theme, PlayIcon, PauseIcon, Button } from 'ui'
 import { useDialogEvent } from '@/utils/dialogEvent'
 
@@ -34,6 +34,7 @@ const autoplaySettings = {
   loop: true,
 }
 
+const missingPosters = new Set()
 export const Video = ({
   sources,
   poster,
@@ -51,6 +52,14 @@ export const Video = ({
   const playPauseButtonRef = useRef<HTMLButtonElement | null>(null)
 
   const [state, setState] = useState<State>(State.Paused)
+
+  const videoUrl = sources[0].url
+  useEffect(() => {
+    if (!poster && !missingPosters.has(videoUrl)) {
+      console.log('Video block has no poster', videoUrl)
+      missingPosters.add(videoUrl)
+    }
+  }, [poster, videoUrl])
 
   const autoplayAttributes = delegated.autoPlay ? autoplaySettings : {}
 

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -1,5 +1,6 @@
 import { StoryblokClient } from '@storyblok/js'
 import { SbBlokData, ISbStoryData } from '@storyblok/react'
+import { get as getFromConfig } from '@vercel/edge-config'
 import { Language } from '@/utils/l10n/types'
 import { LinkField, ProductStory, StoryblokVersion } from './storyblok'
 
@@ -40,8 +41,13 @@ export const fetchStory = async <StoryData extends ISbStoryData | undefined>(
   slug: string,
   params: StoryblokFetchParams,
 ): Promise<StoryData> => {
+  let cv: number | undefined
+  if (params.version === 'published') {
+    cv = await getFromConfig('storyblokCacheVersion')
+  }
   const response = await storyblokClient.get(`cdn/stories/${slug}`, {
     ...params,
+    cv,
     resolve_links: 'url',
   })
 

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -235,7 +235,9 @@ export const initStoryblok = () => {
   storyblokInit({
     accessToken: process.env.NEXT_PUBLIC_STORYBLOK_ACCESS_TOKEN,
     apiOptions: {
-      // ~290ms -> ~15ms for subsequent page renders
+      // ~290ms -> ~15ms for subsequent page renders locally
+      // Does not work on Vercel due to never sharing memory between requests.  We're using cv there
+      //
       cache: {
         type: 'memory',
         clear: 'auto',


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Use storyblok CDN by applying cv (cacheVersion) value to non-draft pages

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

First step towards faster Storyblok access on Vercel where in-memory cache is useless

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
