### PR TITLE
Add React-wrap-balancer to `<Heading />`

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -48,6 +48,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-i18next": "12.1.5",
+    "react-wrap-balancer": "0.4.0",
     "ui": "workspace:",
     "uuid": "9.0.0",
     "zen-observable-ts": "1.2.5"

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -29,6 +29,7 @@ import { useDebugTranslationKeys } from '@/utils/l10n/useDebugTranslationKeys'
 import { useAllowActiveStylesInSafari } from '@/utils/useAllowActiveStylesInSafari'
 import { useReloadOnCountryChange } from '@/utils/useReloadOnCountryChange'
 
+
 // Enable API mocking
 if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
   require('../mocks')

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import { appWithTranslation } from 'next-i18next'
 import type { AppPropsWithLayout } from 'next/app'
 import Head from 'next/head'
 import Router from 'next/router'
+import { Provider as BalancerProvider } from 'react-wrap-balancer'
 import { globalStyles, theme } from 'ui'
 import { BankIdDialog } from '@/components/BankIdDialog'
 import { useApollo } from '@/services/apollo/client'
@@ -80,7 +81,9 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
           <ShopSessionProvider shopSessionId={pageProps[SHOP_SESSION_PROP_NAME]}>
             <TrackingProvider value={tracking}>
               <BankIdContextProvider>
-                {getLayout(<Component {...pageProps} className={contentFontClassName} />)}
+                <BalancerProvider>
+                  {getLayout(<Component {...pageProps} className={contentFontClassName} />)}
+                </BalancerProvider>
                 <BankIdDialog />
               </BankIdContextProvider>
             </TrackingProvider>

--- a/packages/ui/src/components/Heading/Heading.stories.tsx
+++ b/packages/ui/src/components/Heading/Heading.stories.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled'
 import { ComponentMeta, Story } from '@storybook/react'
 import { Heading, HeadingProps } from './Heading'
 
@@ -26,3 +27,11 @@ LightBackground.args = { color: 'textPrimary' }
 export const DarkBackground = Template.bind({})
 DarkBackground.parameters = { backgrounds: { default: 'Dark' } }
 DarkBackground.args = { color: 'textNegative' }
+
+export const WithBoarder: Story<HeadingProps> = ({ children, ...rest }) => (
+  <StyledHeading {...rest}>{children}</StyledHeading>
+)
+
+const StyledHeading = styled(Heading)({
+  border: '2px dotted black',
+})

--- a/packages/ui/src/components/Heading/Heading.tsx
+++ b/packages/ui/src/components/Heading/Heading.tsx
@@ -1,10 +1,12 @@
 import isPropValid from '@emotion/is-prop-valid'
 import styled from '@emotion/styled'
 import React from 'react'
+import Balancer from 'react-wrap-balancer'
 import { getMargins, Margins } from '../../lib/margins'
 import { UIColors } from '../../lib/theme/colors/colors'
 import { getColor } from '../../lib/theme/theme'
 import { getHeadingVariantStyles, HeadingVariant } from './Heading.helpers'
+
 export type { PossibleHeadingVariant } from './Heading.helpers'
 
 type HeadingColors = Pick<UIColors, 'textPrimary' | 'textSecondary' | 'textNegative'>
@@ -43,7 +45,7 @@ const HeadingBase = styled(
 export const Heading = ({ as, color, children, variant, align, ...rest }: HeadingProps) => {
   return (
     <HeadingBase as={as} color={color} variant={variant} align={align} {...rest}>
-      {children}
+      <Balancer>{children}</Balancer>
     </HeadingBase>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19734,6 +19734,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-wrap-balancer@npm:0.4.0":
+  version: 0.4.0
+  resolution: "react-wrap-balancer@npm:0.4.0"
+  peerDependencies:
+    react: ^18.0.0
+  checksum: c43e9ecc5737ecd67a5f38f4ed928a489dd20bf63b24bb31abc94c6e8605e1df7302196b74e5805528c7044864ac7ea1eea64117b74b8a91066f781e3239e9cc
+  languageName: node
+  linkType: hard
+
 "react@npm:18.2.0":
   version: 18.2.0
   resolution: "react@npm:18.2.0"
@@ -21366,6 +21375,7 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-i18next: 12.1.5
+    react-wrap-balancer: 0.4.0
     storybook-addon-next: 1.7.1
     storybook-addon-next-router: 4.0.2
     subscriptions-transport-ws: 0.11.0


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Added react-wrap-balancer
- Updated the heading component to use the balancer
- updated heading story to show better how the balancer works

I see several places where the balancer could be used. It's up to us to decide if/how much we'd like to use it.

### [Balancer Docs](https://react-wrap-balancer.vercel.app/)
### [Balancer Repo](https://github.com/shuding/react-wrap-balancer)

## Heading Example
### Without Balancer

https://user-images.githubusercontent.com/50870173/219662083-c403f6bd-ea5b-411b-ad49-27168108afda.mov

### With Balancer

https://user-images.githubusercontent.com/50870173/219661432-9ed6f1bd-9924-4fd1-abb9-9eb8c263a8e4.mov

### Heading Story

<img width="743" alt="Screenshot 2023-02-17 at 14 21 28" src="https://user-images.githubusercontent.com/50870173/219663980-4e2255a6-3bbc-4d96-996b-7a79963b85cd.png">

## Justify why they are needed

Help make our titles more readable.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
