### PR TITLE
Add support to refresh expired access tokens

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -42,6 +42,7 @@
     "framer-motion": "9.0.4",
     "graphql": "16.6.0",
     "i18next": "22.4.9",
+    "jwt-decode": "3.1.2",
     "next": "13.1.6",
     "next-i18next": "13.1.5",
     "personnummer": "3.1.5",

--- a/apps/store/src/pages/api/campaign/[code].ts
+++ b/apps/store/src/pages/api/campaign/[code].ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { initializeApollo } from '@/services/apollo/client'
+import { initializeApolloServerSide } from '@/services/apollo/client'
 import {
   RedeemCampaignDocument,
   RedeemCampaignMutation,
@@ -43,7 +43,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   const { countryCode } = getCountryByLocale(locale)
 
-  const apolloClient = initializeApollo({ req, res, locale })
+  const apolloClient = await initializeApolloServerSide({ req, res, locale })
   const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
 
   let shopSession: ShopSession

--- a/apps/store/src/pages/api/session/create.ts
+++ b/apps/store/src/pages/api/session/create.ts
@@ -1,6 +1,6 @@
 import { ApolloClient } from '@apollo/client'
 import { NextApiRequest, NextApiResponse } from 'next'
-import { initializeApollo } from '@/services/apollo/client'
+import { initializeApolloServerSide } from '@/services/apollo/client'
 import {
   CartEntryAddDocument,
   CartEntryAddMutation,
@@ -10,6 +10,7 @@ import {
   ShopSessionCustomerUpdateMutationVariables,
 } from '@/services/apollo/generated'
 import { CountryCode } from '@/services/apollo/generated'
+import { resetAuthTokens } from '@/services/authApi/persist'
 import { fetchPriceTemplate } from '@/services/PriceCalculator/PriceCalculator.helpers'
 import {
   PriceIntentService,
@@ -26,7 +27,9 @@ const DEFAULT_COUNTRY_CODE = CountryCode.Se
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const apolloClient = initializeApollo({ req, res, locale: DEFAULT_LOCALE })
+    resetAuthTokens({ req, res })
+
+    const apolloClient = await initializeApolloServerSide({ req, res, locale: DEFAULT_LOCALE })
     const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
 
     const shopSession = await shopSessionService.create({ countryCode: DEFAULT_COUNTRY_CODE })

--- a/apps/store/src/pages/api/session/reset.ts
+++ b/apps/store/src/pages/api/session/reset.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { initializeApollo } from '@/services/apollo/client'
-import { getAuthHeaders, resetAccessToken } from '@/services/authApi/persist'
+import { initializeApolloServerSide } from '@/services/apollo/client'
+import { getAuthHeaders, resetAuthTokens } from '@/services/authApi/persist'
 import { priceIntentServiceInitServerSide } from '@/services/priceIntent/PriceIntentService'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { ORIGIN_URL, PageLink } from '@/utils/PageLink'
@@ -19,14 +19,14 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     nextURL.pathname = nextQueryParam
   }
 
-  const apolloClient = initializeApollo({ req, res })
+  const apolloClient = await initializeApolloServerSide({ req, res })
   const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
   const priceIntentService = priceIntentServiceInitServerSide({ apolloClient, req, res })
   const shopSessionId = shopSessionService.shopSessionId()
 
   if (getAuthHeaders({ req, res })) {
     console.debug('Resetting auth session')
-    resetAccessToken({ req, res })
+    resetAuthTokens({ req, res })
   }
 
   if (shopSessionId) {

--- a/apps/store/src/pages/cart.tsx
+++ b/apps/store/src/pages/cart.tsx
@@ -12,7 +12,7 @@ import {
   GLOBAL_PRODUCT_METADATA_PROP_NAME,
 } from '@/components/LayoutWithMenu/fetchProductMetadata'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
-import { addApolloState, initializeApollo } from '@/services/apollo/client'
+import { addApolloState, initializeApolloServerSide } from '@/services/apollo/client'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
 import { getShopSessionServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
@@ -91,7 +91,7 @@ export const getServerSideProps: GetServerSideProps<
 
   const { countryCode } = getCountryByLocale(locale)
 
-  const apolloClient = initializeApollo({ req, res, locale })
+  const apolloClient = await initializeApolloServerSide({ req, res, locale })
   const [shopSession, translations, globalStory, productMetadata] = await Promise.all([
     getShopSessionServerSide({ apolloClient, countryCode, req, res }),
     serverSideTranslations(locale),

--- a/apps/store/src/pages/checkout/[shopSessionId]/payment/[status].tsx
+++ b/apps/store/src/pages/checkout/[shopSessionId]/payment/[status].tsx
@@ -1,6 +1,6 @@
 import type { GetServerSideProps, NextPage } from 'next'
 import Link from 'next/link'
-import { initializeApollo } from '@/services/apollo/client'
+import { initializeApolloServerSide } from '@/services/apollo/client'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { PageLink } from '@/utils/PageLink'
@@ -26,7 +26,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
   if (!isRoutingLocale(locale)) return { notFound: true }
   if (!shopSessionId) return { notFound: true }
 
-  const apolloClient = initializeApollo({ req, res, locale })
+  const apolloClient = await initializeApolloServerSide({ req, res, locale })
   const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
   const shopSession = await shopSessionService.fetchById(shopSessionId)
 

--- a/apps/store/src/pages/checkout/[shopSessionId]/payment/index.tsx
+++ b/apps/store/src/pages/checkout/[shopSessionId]/payment/index.tsx
@@ -1,5 +1,5 @@
 import type { GetServerSideProps, NextPage } from 'next'
-import { initializeApollo } from '@/services/apollo/client'
+import { initializeApolloServerSide } from '@/services/apollo/client'
 import { createAuthorizationCode } from '@/services/authApi/oauth'
 import { getAuthHeaders } from '@/services/authApi/persist'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
@@ -22,7 +22,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
   if (!shopSessionId) return { notFound: true }
 
   try {
-    const apolloClient = initializeApollo({ req, res, locale })
+    const apolloClient = await initializeApolloServerSide({ req, res, locale })
     await setupShopSessionServiceServerSide({ apolloClient, req, res }).fetchById(shopSessionId)
     // TODO: validate ShopSession
   } catch (error) {

--- a/apps/store/src/pages/checkout/index.tsx
+++ b/apps/store/src/pages/checkout/index.tsx
@@ -11,7 +11,7 @@ import { CheckoutStep } from '@/components/CheckoutHeader/Breadcrumbs'
 import { fetchCheckoutSteps } from '@/components/CheckoutHeader/CheckoutHeader.helpers'
 import CheckoutPage from '@/components/CheckoutPage/CheckoutPage'
 import type { CheckoutPageProps } from '@/components/CheckoutPage/CheckoutPage.types'
-import { addApolloState, initializeApollo } from '@/services/apollo/client'
+import { addApolloState, initializeApolloServerSide } from '@/services/apollo/client'
 import { ShopSessionSigning } from '@/services/apollo/generated'
 import { fetchCurrentShopSessionSigning } from '@/services/Checkout/Checkout.helpers'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
@@ -75,7 +75,7 @@ export const getServerSideProps: GetServerSideProps<NextPageProps> = async (cont
     redirect: { destination: PageLink.home({ locale }), permanent: false },
   } as const
 
-  const apolloClient = initializeApollo({ req, res, locale })
+  const apolloClient = await initializeApolloServerSide({ req, res, locale })
   let shopSession: ShopSession, translations: SSRConfig
   try {
     ;[shopSession, translations] = await Promise.all([

--- a/apps/store/src/pages/checkout/switching-assistant.tsx
+++ b/apps/store/src/pages/checkout/switching-assistant.tsx
@@ -5,7 +5,7 @@ import {
   SwitchingAssistantPage,
   SwitchingAssistantPageProps,
 } from '@/components/SwitchingAssistantPage/SwitchingAssistantPage'
-import { addApolloState, initializeApollo } from '@/services/apollo/client'
+import { addApolloState, initializeApolloServerSide } from '@/services/apollo/client'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
 import { getCurrentShopSessionServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
@@ -23,7 +23,7 @@ export const getServerSideProps: GetServerSideProps<NextPageProps> = async (cont
   const { req, res, locale } = context
   if (!isRoutingLocale(locale)) return { notFound: true }
 
-  const apolloClient = initializeApollo({ req, res, locale })
+  const apolloClient = await initializeApolloServerSide({ req, res, locale })
   const [shopSession, translations] = await Promise.all([
     getCurrentShopSessionServerSide({ apolloClient, req, res }),
     serverSideTranslations(locale),

--- a/apps/store/src/pages/confirmation/[shopSessionId].tsx
+++ b/apps/store/src/pages/confirmation/[shopSessionId].tsx
@@ -8,7 +8,7 @@ import {
   GLOBAL_PRODUCT_METADATA_PROP_NAME,
 } from '@/components/LayoutWithMenu/fetchProductMetadata'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
-import { addApolloState, initializeApollo } from '@/services/apollo/client'
+import { addApolloState, initializeApolloServerSide } from '@/services/apollo/client'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { ConfirmationStory, getGlobalStory, getStoryBySlug } from '@/services/storyblok/storyblok'
@@ -30,7 +30,7 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
   const shopSessionId = params?.shopSessionId
   if (!shopSessionId) return { notFound: true }
 
-  const apolloClient = initializeApollo({ req, res, locale })
+  const apolloClient = await initializeApolloServerSide({ req, res, locale })
   const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
   const [shopSession, translations, globalStory, story, productMetadata] = await Promise.all([
     shopSessionService.fetchById(shopSessionId),

--- a/apps/store/src/pages/session/[shopSessionId].tsx
+++ b/apps/store/src/pages/session/[shopSessionId].tsx
@@ -1,5 +1,5 @@
 import type { GetServerSideProps, NextPage } from 'next'
-import { initializeApollo } from '@/services/apollo/client'
+import { initializeApolloServerSide } from '@/services/apollo/client'
 import {
   RedeemCampaignDocument,
   RedeemCampaignMutation,
@@ -29,7 +29,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
     return fallbackRedirect
   }
 
-  const apolloClient = initializeApollo({ req, res, locale })
+  const apolloClient = await initializeApolloServerSide({ req, res, locale })
   let shopSession: ShopSession
   try {
     const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })

--- a/apps/store/src/services/apollo/apollo.helpers.ts
+++ b/apps/store/src/services/apollo/apollo.helpers.ts
@@ -1,0 +1,34 @@
+import jwtDecode, { JwtPayload } from 'jwt-decode'
+import { refreshAccessToken } from '@/services/authApi/oauth'
+import {
+  CookieParams,
+  getAccessToken,
+  getRefreshToken,
+  resetAuthTokens,
+  saveAuthTokens,
+} from '@/services/authApi/persist'
+
+export const performTokenRefreshIfNeeded = async (cookieParams?: CookieParams) => {
+  const currentAccessToken = getAccessToken(cookieParams)
+
+  if (!currentAccessToken) return
+
+  const { exp: expiryInSeconds } = jwtDecode<JwtPayload>(currentAccessToken)
+  const hasExpired = expiryInSeconds && Date.now() >= expiryInSeconds * 1000
+
+  if (!hasExpired) return { authorization: `Bearer ${currentAccessToken}` }
+
+  const currentRefreshToken = getRefreshToken(cookieParams)
+
+  if (!currentRefreshToken) {
+    console.error('Token refresh: no refresh token found')
+    resetAuthTokens(cookieParams)
+    return
+  }
+
+  const { accessToken, refreshToken } = await refreshAccessToken(currentRefreshToken)
+
+  saveAuthTokens({ accessToken, refreshToken, ...cookieParams })
+
+  return { authorization: `Bearer ${accessToken}` }
+}

--- a/apps/store/src/services/apollo/client.ts
+++ b/apps/store/src/services/apollo/client.ts
@@ -6,11 +6,12 @@ import { GetServerSidePropsContext } from 'next'
 import { i18n } from 'next-i18next'
 import { AppInitialProps } from 'next/app'
 import { useMemo } from 'react'
+import { getAuthHeaders } from '@/services/authApi/persist'
 import { getDeviceIdHeader } from '@/services/LocalContext/LocalContext.helpers'
 import { isBrowser } from '@/utils/env'
 import { getLocaleOrFallback, toIsoLocale } from '@/utils/l10n/localeUtils'
 import { RoutingLocale } from '@/utils/l10n/types'
-import { getAuthHeaders } from '../authApi/persist'
+import { performTokenRefreshIfNeeded } from './apollo.helpers'
 
 const APOLLO_STATE_PROP_NAME = '__APOLLO_STATE__'
 
@@ -40,17 +41,12 @@ const languageLink = setContext((_, { headers = {}, ...context }) => {
 const httpLink = new HttpLink({ uri: process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT })
 
 const createApolloClient = (defaultHeaders?: Record<string, string>) => {
-  const headersLink = setContext((_, prevContext) => {
-    const headers = {
-      ...defaultHeaders,
-    }
+  const headersLink = setContext(async (_, prevContext) => {
+    const headers = { ...defaultHeaders }
     if (isBrowser()) {
-      Object.assign(headers, getAuthHeaders())
+      Object.assign(headers, await performTokenRefreshIfNeeded())
     }
-    return {
-      headers,
-      ...prevContext,
-    }
+    return { headers, ...prevContext }
   })
 
   return new ApolloClient({
@@ -77,13 +73,14 @@ type InitializeApolloParams = {
   req?: GetServerSidePropsContext['req']
   res?: GetServerSidePropsContext['res']
   locale?: RoutingLocale
+  authHeaders?: Record<string, string>
 }
 
 export const initializeApollo = (params: InitializeApolloParams = {}) => {
-  const { initialState = null, req, res, locale } = params
+  const { initialState = null, req, res, locale, authHeaders } = params
   const headers = {
     ...getDeviceIdHeader({ req, res }),
-    ...getAuthHeaders({ req, res }),
+    ...(authHeaders ?? getAuthHeaders({ req, res })),
     ...(locale && getHedvigLanguageHeader(locale)),
   }
 
@@ -96,12 +93,25 @@ export const initializeApollo = (params: InitializeApolloParams = {}) => {
   }
 
   // always create new Apollo Client for SSG/SSR
-  if (typeof window === 'undefined') return _apolloClient
+  if (!isBrowser()) return _apolloClient
 
   // reuse client on the client-side
   if (!apolloClient) apolloClient = _apolloClient
 
   return _apolloClient
+}
+
+type InitializeApolloServerSideParams = InitializeApolloParams & {
+  req: GetServerSidePropsContext['req']
+  res: GetServerSidePropsContext['res']
+}
+
+export const initializeApolloServerSide = async (params: InitializeApolloServerSideParams) => {
+  const { req, res } = params
+  return initializeApollo({
+    ...params,
+    authHeaders: await performTokenRefreshIfNeeded({ req, res }),
+  })
 }
 
 export const useApollo = (pageProps: AppInitialProps['pageProps']) => {

--- a/apps/store/src/services/authApi/persist.ts
+++ b/apps/store/src/services/authApi/persist.ts
@@ -2,6 +2,7 @@ import { getCookie, setCookie, deleteCookie } from 'cookies-next'
 import { OptionsType } from 'cookies-next/lib/types'
 
 const COOKIE_KEY = '_hvsession'
+const REFRESH_TOKEN_COOKIE_KEY = '_hvrefresh'
 const ACCESS_TOKEN_SESSION_FIELD = 'token'
 const MAX_AGE = 60 * 60 * 24 // 24 hours
 
@@ -13,17 +14,30 @@ const OPTIONS: OptionsType = {
   }),
 }
 
-export const saveAccessToken = (accessToken: string, cookieParams: CookieParams = {}) => {
-  setCookie(COOKIE_KEY, serialize(accessToken), { ...cookieParams, ...OPTIONS })
-}
-
 export type CookieParams = Pick<OptionsType, 'req' | 'res'>
 
-export const resetAccessToken = (cookieParams: CookieParams = {}) => {
-  deleteCookie(COOKIE_KEY, { ...cookieParams, ...OPTIONS })
+type SaveAuthTokensParams = CookieParams & {
+  accessToken: string
+  refreshToken: string
 }
 
-const getAccessToken = (cookieParams: CookieParams = {}) => {
+export const saveAuthTokens = (params: SaveAuthTokensParams) => {
+  const { accessToken, refreshToken, ...cookieParams } = params
+  setCookie(COOKIE_KEY, serialize(accessToken), { ...cookieParams, ...OPTIONS })
+  setCookie(REFRESH_TOKEN_COOKIE_KEY, refreshToken, { ...cookieParams, ...OPTIONS })
+}
+
+export const resetAuthTokens = (cookieParams: CookieParams = {}) => {
+  deleteCookie(COOKIE_KEY, { ...cookieParams, ...OPTIONS })
+  deleteCookie(REFRESH_TOKEN_COOKIE_KEY, { ...cookieParams, ...OPTIONS })
+}
+
+export const getRefreshToken = (cookieParams: CookieParams = {}) => {
+  const cookieValue = getCookie(REFRESH_TOKEN_COOKIE_KEY, cookieParams)
+  if (typeof cookieValue === 'string') return cookieValue
+}
+
+export const getAccessToken = (cookieParams: CookieParams = {}) => {
   const cookieValue = getCookie(COOKIE_KEY, cookieParams)
   if (typeof cookieValue !== 'string') return undefined
   return deserialize(cookieValue)

--- a/apps/store/src/services/bankId/useBankIdCheckoutSign.ts
+++ b/apps/store/src/services/bankId/useBankIdCheckoutSign.ts
@@ -6,8 +6,8 @@ import {
   useShopSessionSigningLazyQuery,
   useShopSessionStartSignMutation,
 } from '@/services/apollo/generated'
-import { saveAccessToken } from '@/services/authApi/persist'
-import { exchangeAuthorizationCode } from '../authApi/oauth'
+import { exchangeAuthorizationCode } from '@/services/authApi/oauth'
+import { saveAuthTokens } from '@/services/authApi/persist'
 import { BankIdState, CheckoutSignOptions } from './bankId.types'
 import { apiStatusToBankIdState, bankIdLogger } from './bankId.utils'
 import { BankIdDispatch } from './bankIdReducer'
@@ -93,8 +93,10 @@ export const useBankIdCheckoutSignApi = ({ dispatch }: Options) => {
               if (status === ShopSessionSigningStatus.Signed && completion) {
                 signingResult.stopPolling()
                 bankIdLogger.debug('Signing complete')
-                const accessToken = await exchangeAuthorizationCode(completion.authorizationCode)
-                saveAccessToken(accessToken)
+                const { accessToken, refreshToken } = await exchangeAuthorizationCode(
+                  completion.authorizationCode,
+                )
+                saveAuthTokens({ accessToken, refreshToken })
                 subscriber.complete()
               }
             },

--- a/apps/store/src/services/bankId/useBankIdLogin.ts
+++ b/apps/store/src/services/bankId/useBankIdLogin.ts
@@ -3,7 +3,7 @@ import { Subscription } from 'zen-observable-ts'
 import { useShopSessionAuthenticateMutation } from '@/services/apollo/generated'
 import { loginMemberSeBankId } from '@/services/authApi/login'
 import { exchangeAuthorizationCode } from '@/services/authApi/oauth'
-import { saveAccessToken } from '@/services/authApi/persist'
+import { saveAuthTokens } from '@/services/authApi/persist'
 import { LoginPromptOptions } from './bankId.types'
 import { apiStatusToBankIdState, bankIdLogger } from './bankId.utils'
 import { BankIdDispatch } from './bankIdReducer'
@@ -73,8 +73,10 @@ export const useBankIdLoginApi = ({ dispatch }: HookOptions) => {
             nextOperationState: apiStatusToBankIdState(statusResponse.status),
           })
           if (statusResponse.status === 'COMPLETED') {
-            const accessToken = await exchangeAuthorizationCode(statusResponse.authorizationCode)
-            saveAccessToken(accessToken)
+            const { accessToken, refreshToken } = await exchangeAuthorizationCode(
+              statusResponse.authorizationCode,
+            )
+            saveAuthTokens({ accessToken, refreshToken })
             bankIdLogger.debug('Got access token, authenticating shopSession')
             await authenticateShopSession({ variables: { shopSessionId } })
             bankIdLogger.debug('shopSession authenticated')

--- a/apps/store/src/services/shopSession/ShopSessionContext.tsx
+++ b/apps/store/src/services/shopSession/ShopSessionContext.tsx
@@ -10,7 +10,7 @@ import {
   useState,
 } from 'react'
 import { ShopSessionQueryResult, useShopSessionQuery } from '@/services/apollo/generated'
-import { resetAccessToken } from '@/services/authApi/persist'
+import { resetAuthTokens } from '@/services/authApi/persist'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { isBrowser } from '@/utils/env'
 import { useCurrentCountry } from '@/utils/l10n/useCurrentCountry'
@@ -76,7 +76,7 @@ const useShopSessionContextValue = (initialShopSessionId?: string) => {
 
   queryResult.reset = useCallback(() => {
     shopSessionServiceClientSide.reset()
-    resetAccessToken()
+    resetAuthTokens()
     return shopSessionServiceClientSide.getOrCreate({ countryCode }).then((shopSession) => {
       setShopSessionId(shopSession.id)
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -16264,6 +16264,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jwt-decode@npm:3.1.2":
+  version: 3.1.2
+  resolution: "jwt-decode@npm:3.1.2"
+  checksum: 20a4b072d44ce3479f42d0d2c8d3dabeb353081ba4982e40b83a779f2459a70be26441be6c160bfc8c3c6eadf9f6380a036fbb06ac5406b5674e35d8c4205eeb
+  languageName: node
+  linkType: hard
+
 "kind-of@npm:^3.0.2, kind-of@npm:^3.0.3, kind-of@npm:^3.2.0":
   version: 3.2.2
   resolution: "kind-of@npm:3.2.2"
@@ -21377,6 +21384,7 @@ __metadata:
     i18next-parser: 7.6.0
     jest: 29.4.3
     jest-environment-jsdom: 29.4.3
+    jwt-decode: 3.1.2
     msw: 0.44.2
     next: 13.1.6
     next-i18next: 13.1.5


### PR DESCRIPTION
## Describe your changes

- Save refresh token in cookie
- Add new function `refreshAccessToken` to perform refresh token request
- Add new function `performTokenRefreshIfNeeded` to evaluate if current access token has expired and if so, refresh it.
- Add new function `initializeApolloServerSide` to initialize Apollo server side and perform token refresh if needed.
- Update `headersLink` to perform token refresh if needed (client side).

## Justify why they are needed

The overall goal is to be able to support longer sessions without having to log in again. This is done by saving the refresh token in a cookie and using it to refresh the access token when it expires.

I had to update the apollo initialization a little bit since we need access to cookies to refresh the token and do it async.

Caveat: we only refresh the access token when sending a request. However, if the user is idle for very long, also the refresh token will expire. We should look into putting up a modal saying that your session has expired for example.

## Jira issue(s): [GRW-1830]

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code


[GRW-1830]: https://hedvig.atlassian.net/browse/GRW-1830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ