### PR TITLE
Fix - discount cross out display amount

### DIFF
--- a/apps/store/src/components/CartInventory/CartInventory.helpers.tsx
+++ b/apps/store/src/components/CartInventory/CartInventory.helpers.tsx
@@ -69,12 +69,5 @@ export const getCrossOut = (shopSession: ShopSession) => {
   const hasDiscount = shopSession.cart.redeemedCampaigns.length !== 0
 
   if (!hasDiscount) return undefined
-  switch (shopSession.cart.redeemedCampaigns[0].discount.type) {
-    case CampaignDiscountType.FreeMonths:
-    case CampaignDiscountType.MonthlyPercentage:
-      return shopSession.cart.cost.gross
-    case CampaignDiscountType.IndefinitePercentage:
-    case CampaignDiscountType.MonthlyCost:
-      return shopSession.cart.cost.discount
-  }
+  return shopSession.cart.cost.gross
 }


### PR DESCRIPTION
## Describe your changes

Fixed the getCrossOut function logic for displaying the crossed out discount information.

![Screenshot 2023-02-20 at 13 34 42](https://user-images.githubusercontent.com/50870173/220109471-498403aa-2eec-4b26-8381-cac8004c8558.png)


## Justify why they are needed

Previously not working as intended.

## [Design prio List](https://www.notion.so/hedviginsurance/Design-Prio-List-16fa7df5968e43058e675c28d80c450a?pvs=4)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
