### PR TITLE
fix(Perils): text overlow on mobile

### DIFF
--- a/apps/store/src/components/Perils/Perils.tsx
+++ b/apps/store/src/components/Perils/Perils.tsx
@@ -25,6 +25,8 @@ export const Perils = ({ items }: Props) => {
 const PerilsAccordionGrid = styled.div(({ fixedCols = false }: { fixedCols?: boolean }) => ({
   display: 'grid',
   gap: theme.space.xxs,
+  // It needs a defined width to trigger ellipses on mobile
+  gridTemplateColumns: '100%',
 
   [mq.md]: {
     gridTemplateColumns: `repeat(auto-fit, ${fixedCols ? '20.75rem' : 'minmax(20.75rem, 1fr)'})`,


### PR DESCRIPTION
## Describe your changes

Perils text overflow on mobile

## Justify why they are needed

**Before**
<img width="396" alt="Screenshot 2023-02-20 at 16 04 01" src="https://user-images.githubusercontent.com/19200662/220141960-31d94d45-0a6e-4faa-ab65-c3d256507cc9.png">

**After**
<img width="404" alt="Screenshot 2023-02-20 at 16 04 20" src="https://user-images.githubusercontent.com/19200662/220141954-bbaff7a4-5517-4c66-8b03-45f6bdf29445.png">

