### PR TITLE
Fix how to determine checkout steps

### DIFF
--- a/apps/store/src/components/CheckoutHeader/CheckoutHeader.helpers.ts
+++ b/apps/store/src/components/CheckoutHeader/CheckoutHeader.helpers.ts
@@ -4,6 +4,7 @@ import {
   CurrentMemberQuery,
   CurrentMemberQueryVariables,
   ShopSessionAuthenticationStatus,
+  ExternalInsuranceCancellationOption as CancellationOption,
 } from '@/services/apollo/generated'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { PageLink } from '@/utils/PageLink'
@@ -16,7 +17,7 @@ type Params = {
 
 export const fetchCheckoutSteps = async ({ apolloClient, shopSession }: Params) => {
   const switchingEntry = shopSession.cart.entries.find(
-    ({ cancellation: { bankSignering } }) => !!bankSignering,
+    ({ cancellation }) => cancellation.option === CancellationOption.Banksignering,
   )
   const showSwitchingAssistant = !!switchingEntry
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Determine if we should show switching assistant in checkout by looking at cancellation option.

![Screenshot 2023-02-21 at 09.45.44.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/bf40ddec-b207-45f4-8343-e225b1515ffe/Screenshot%202023-02-21%20at%2009.45.44.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

The "banksignering" property isn't filled in until after we sign the shop session so we can't use it to determine if we should show the switching assistant.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
