### PR TITLE
Pause/resume videos when FullscreenDialog opens or closes

### DIFF
--- a/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
+++ b/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
@@ -1,5 +1,8 @@
 import styled from '@emotion/styled'
+import { DialogProps } from '@radix-ui/react-dialog'
+import { useEffect, useRef } from 'react'
 import { CrossIcon, Dialog, mq, theme } from 'ui'
+import { sendDialogEvent } from '@/utils/dialogEvent'
 
 type Props = {
   children: React.ReactNode
@@ -96,5 +99,26 @@ const FooterWrapper = styled.footer({
   },
 })
 
-export const Root = Dialog.Root
+export const Root = (props: DialogProps) => {
+  useSendDialogEvents(!!(props.open || props.defaultOpen))
+  return <Dialog.Root {...props} />
+}
 export const Close = Dialog.Close
+
+// Reliably trigger open | close events for mount, unmount and prop change
+// Too bad onOpenChange only notifies about prop change
+const useSendDialogEvents = (open: boolean) => {
+  const openRef = useRef<boolean | null>(null)
+  useEffect(() => {
+    if (open && openRef.current === null) {
+      sendDialogEvent('open')
+    }
+    if (!open && openRef.current) {
+      sendDialogEvent('close')
+    }
+    openRef.current = open
+    return () => {
+      openRef.current && sendDialogEvent('close')
+    }
+  }, [open])
+}

--- a/apps/store/src/components/PriceCalculator/SsnSeSection.tsx
+++ b/apps/store/src/components/PriceCalculator/SsnSeSection.tsx
@@ -90,7 +90,7 @@ SsnSeSection.sectionId = 'ssn-se'
 const ChangeSsnWarning = ({ onCompleted }: Props) => {
   const { t } = useTranslation('purchase-form')
   return (
-    <FullscreenDialog.Root open={true} onOpenChange={onCompleted}>
+    <FullscreenDialog.Root defaultOpen={true} onOpenChange={onCompleted}>
       <FullscreenDialog.Modal
         center
         Footer={

--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -107,7 +107,10 @@ export const Video = ({
   useDialogEvent('open', handleDialogOpen)
 
   const handleDialogClose = useCallback(() => {
-    if (wasPlaying) {
+    // We may have dialogs on top of dialogs.  Need to check that all are closed to resume video
+    // Since we don't have anything stable like data attribute for it, let's check styles
+    const hasOpenDialog = window.getComputedStyle(document.body).pointerEvents === 'none'
+    if (wasPlaying && !hasOpenDialog) {
       setWasPlaying(false)
       playVideo()
     }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Send open/close events from FullscreenDialog to pause/resume videos in background

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We use FullscreenDialog in Change SSN warning.  Tried to make this solution generic so that it works for BankId dialog,  potential error alerts, etc

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
