### PR TITLE
Make balancing the header optional

### DIFF
--- a/apps/store/src/blocks/HeadingBlock.tsx
+++ b/apps/store/src/blocks/HeadingBlock.tsx
@@ -21,6 +21,7 @@ export type HeadingBlockProps = SbBaseBlockProps<{
   variantDesktop?: PossibleHeadingVariant
   textAlignment?: HeadingProps['align']
   nested?: boolean
+  balance?: boolean
 }>
 
 export const HeadingBlock = ({ blok }: HeadingBlockProps) => {
@@ -34,6 +35,7 @@ export const HeadingBlock = ({ blok }: HeadingBlockProps) => {
         variant={{ _: blok.variant ?? 'standard.32', md: blok.variantDesktop ?? 'standard.40' }}
         color={blok.color}
         align={blok.textAlignment}
+        balance={blok.balance}
         {...storyblokEditable(blok)}
       >
         {blok.text}

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -4,7 +4,6 @@ import { appWithTranslation } from 'next-i18next'
 import type { AppPropsWithLayout } from 'next/app'
 import Head from 'next/head'
 import Router from 'next/router'
-import { Provider as BalancerProvider } from 'react-wrap-balancer'
 import { globalStyles, theme } from 'ui'
 import { BankIdDialog } from '@/components/BankIdDialog'
 import { useApollo } from '@/services/apollo/client'
@@ -28,7 +27,6 @@ import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
 import { useDebugTranslationKeys } from '@/utils/l10n/useDebugTranslationKeys'
 import { useAllowActiveStylesInSafari } from '@/utils/useAllowActiveStylesInSafari'
 import { useReloadOnCountryChange } from '@/utils/useReloadOnCountryChange'
-
 
 // Enable API mocking
 if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
@@ -82,9 +80,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
           <ShopSessionProvider shopSessionId={pageProps[SHOP_SESSION_PROP_NAME]}>
             <TrackingProvider value={tracking}>
               <BankIdContextProvider>
-                <BalancerProvider>
-                  {getLayout(<Component {...pageProps} className={contentFontClassName} />)}
-                </BalancerProvider>
+                {getLayout(<Component {...pageProps} className={contentFontClassName} />)}
                 <BankIdDialog />
               </BankIdContextProvider>
             </TrackingProvider>

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import { appWithTranslation } from 'next-i18next'
 import type { AppPropsWithLayout } from 'next/app'
 import Head from 'next/head'
 import Router from 'next/router'
+import { Provider as BalancerProvider } from 'react-wrap-balancer'
 import { globalStyles, theme } from 'ui'
 import { BankIdDialog } from '@/components/BankIdDialog'
 import { useApollo } from '@/services/apollo/client'
@@ -80,7 +81,9 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
           <ShopSessionProvider shopSessionId={pageProps[SHOP_SESSION_PROP_NAME]}>
             <TrackingProvider value={tracking}>
               <BankIdContextProvider>
-                {getLayout(<Component {...pageProps} className={contentFontClassName} />)}
+                <BalancerProvider>
+                  {getLayout(<Component {...pageProps} className={contentFontClassName} />)}
+                </BalancerProvider>
                 <BankIdDialog />
               </BankIdContextProvider>
             </TrackingProvider>

--- a/packages/ui/src/components/Heading/Heading.tsx
+++ b/packages/ui/src/components/Heading/Heading.tsx
@@ -17,6 +17,7 @@ export type HeadingProps = Margins & {
   children: React.ReactNode
   variant?: HeadingVariant
   align?: 'center' | 'left' | 'right'
+  balance?: boolean
 }
 
 const elementConfig = {
@@ -42,10 +43,16 @@ const HeadingBase = styled(
   }
 })
 
-export const Heading = ({ as, color, children, variant, align, ...rest }: HeadingProps) => {
-  return (
-    <HeadingBase as={as} color={color} variant={variant} align={align} {...rest}>
-      <Balancer>{children}</Balancer>
-    </HeadingBase>
-  )
-}
+export const Heading = ({
+  as,
+  color,
+  children,
+  variant,
+  align,
+  balance,
+  ...rest
+}: HeadingProps) => (
+  <HeadingBase as={as} color={color} variant={variant} align={align} {...rest}>
+    {!balance ? children : <Balancer>{children}</Balancer>}
+  </HeadingBase>
+)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Added a `balance` prop to the `<Heading /> ` component to allow for the balancer to be adopted in a case by case basis.
- removed the balancer provider from the `_app` dir
- Updated the Heading block in Storyblok to allow the balancer to be toggled. 


## notes
- If we decide to use react-wrap-balancer more around the app we'd probably want to use a provider to share the balancing script with all the components. 
- If we start using server components there are some optimisations available as well.

**(Note the 'balance' option in the bottom right of the screenshots)**
<img width="736" alt="Screenshot 2023-02-21 at 10 24 51" src="https://user-images.githubusercontent.com/50870173/220305094-dc2655c0-86a8-4cb1-9217-09cdd815da51.png">

<img width="727" alt="Screenshot 2023-02-21 at 10 24 58" src="https://user-images.githubusercontent.com/50870173/220305149-252a4fdc-cf3f-4d07-8c27-9889c1598160.png">

## Justify why they are needed

Adding the balancer to every heading component caused issues with some of the headings around the app. [Check out this thread from slack](https://hedviginsurance.slack.com/archives/G01MARCFUUW/p1676966424962669)

(screenshot of the issue)
![image](https://user-images.githubusercontent.com/50870173/220305895-298c6f8c-84aa-4581-8a3e-4c6f23cc9208.png)


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
