### PR TITLE
Add header for shop session id to apollo client

### DIFF
--- a/apps/store/README.md
+++ b/apps/store/README.md
@@ -85,3 +85,15 @@ To analyze bundle size run the following command and this will open a report in 
 ```bash
 yarn workspace store analyze-bundle
 ```
+
+## HTTP Headers
+
+We use a few custom headers when communicating with the API. These are:
+
+- `Hedvig-ShopSessionID`: The ID of the current shop session, used for debugging purposes.
+- `Hedvig-Language`: Java Locale code (e.g. `ca-ES`), used for API localisation including error messages.
+- `Hedvig-Device-ID`: A unique ID for the current device.
+
+  > :warning: What are we using this for? 🤔
+
+- `Authorization`: Bearer token for the currently authenticated user.

--- a/apps/store/src/services/apollo/apollo.helpers.ts
+++ b/apps/store/src/services/apollo/apollo.helpers.ts
@@ -1,12 +1,13 @@
 import jwtDecode, { JwtPayload } from 'jwt-decode'
 import { refreshAccessToken } from '@/services/authApi/oauth'
 import {
-  CookieParams,
   getAccessToken,
   getRefreshToken,
   resetAuthTokens,
   saveAuthTokens,
 } from '@/services/authApi/persist'
+import { getShopSessionId } from '@/services/shopSession/ShopSession.helpers'
+import { CookieParams } from '@/utils/types'
 
 export const performTokenRefreshIfNeeded = async (cookieParams?: CookieParams) => {
   const currentAccessToken = getAccessToken(cookieParams)
@@ -31,4 +32,10 @@ export const performTokenRefreshIfNeeded = async (cookieParams?: CookieParams) =
   saveAuthTokens({ accessToken, refreshToken, ...cookieParams })
 
   return { authorization: `Bearer ${accessToken}` }
+}
+
+export const getShopSessionHeader = (cookieParams?: CookieParams) => {
+  const shopSessionId = getShopSessionId(cookieParams)
+  if (shopSessionId) return { 'Hedvig-ShopSessionID': shopSessionId }
+  return undefined
 }

--- a/apps/store/src/services/apollo/client.ts
+++ b/apps/store/src/services/apollo/client.ts
@@ -11,7 +11,7 @@ import { getDeviceIdHeader } from '@/services/LocalContext/LocalContext.helpers'
 import { isBrowser } from '@/utils/env'
 import { getLocaleOrFallback, toIsoLocale } from '@/utils/l10n/localeUtils'
 import { RoutingLocale } from '@/utils/l10n/types'
-import { performTokenRefreshIfNeeded } from './apollo.helpers'
+import { getShopSessionHeader, performTokenRefreshIfNeeded } from './apollo.helpers'
 
 const APOLLO_STATE_PROP_NAME = '__APOLLO_STATE__'
 
@@ -44,7 +44,10 @@ const createApolloClient = (defaultHeaders?: Record<string, string>) => {
   const headersLink = setContext(async (_, prevContext) => {
     const headers = { ...defaultHeaders }
     if (isBrowser()) {
-      Object.assign(headers, await performTokenRefreshIfNeeded())
+      Object.assign(headers, {
+        ...(await performTokenRefreshIfNeeded()),
+        ...getShopSessionHeader(),
+      })
     }
     return { headers, ...prevContext }
   })
@@ -82,6 +85,7 @@ export const initializeApollo = (params: InitializeApolloParams = {}) => {
     ...getDeviceIdHeader({ req, res }),
     ...(authHeaders ?? getAuthHeaders({ req, res })),
     ...(locale && getHedvigLanguageHeader(locale)),
+    ...getShopSessionHeader({ req, res }),
   }
 
   const _apolloClient = apolloClient ?? createApolloClient(headers)

--- a/apps/store/src/services/authApi/persist.ts
+++ b/apps/store/src/services/authApi/persist.ts
@@ -1,5 +1,6 @@
 import { getCookie, setCookie, deleteCookie } from 'cookies-next'
 import { OptionsType } from 'cookies-next/lib/types'
+import { CookieParams } from '@/utils/types'
 
 const COOKIE_KEY = '_hvsession'
 const REFRESH_TOKEN_COOKIE_KEY = '_hvrefresh'
@@ -13,8 +14,6 @@ const OPTIONS: OptionsType = {
     secure: true,
   }),
 }
-
-export type CookieParams = Pick<OptionsType, 'req' | 'res'>
 
 type SaveAuthTokensParams = CookieParams & {
   accessToken: string

--- a/apps/store/src/services/persister/ServerCookiePersister.ts
+++ b/apps/store/src/services/persister/ServerCookiePersister.ts
@@ -1,13 +1,13 @@
 import { deleteCookie, getCookie, getCookies, setCookie } from 'cookies-next'
 import { OptionsType } from 'cookies-next/lib/types'
-import { GetServerSidePropsContext } from 'next'
+import { CookieParams } from '@/utils/types'
 import { SimplePersister } from './Persister.types'
 
 export class ServerCookiePersister implements SimplePersister {
   constructor(
     private readonly cookieKey: string,
-    private readonly request: GetServerSidePropsContext['req'],
-    private readonly response: GetServerSidePropsContext['res'],
+    private readonly request: CookieParams['req'],
+    private readonly response: CookieParams['res'],
   ) {}
 
   public save(value: string, cookieKey = this.cookieKey, options?: OptionsType) {

--- a/apps/store/src/services/shopSession/ShopSession.helpers.ts
+++ b/apps/store/src/services/shopSession/ShopSession.helpers.ts
@@ -1,15 +1,13 @@
 import { ApolloClient } from '@apollo/client'
-import type { GetServerSidePropsContext } from 'next'
 import type { CountryCode } from '@/services/apollo/generated'
 import { CookiePersister } from '@/services/persister/CookiePersister'
 import { ServerCookiePersister } from '@/services/persister/ServerCookiePersister'
+import { CookieParams } from '@/utils/types'
 import { COOKIE_KEY_SHOP_SESSION } from './ShopSession.constants'
 import { ShopSessionService } from './ShopSessionService'
 
-type Params = {
+type Params = CookieParams & {
   apolloClient: ApolloClient<unknown>
-  req: GetServerSidePropsContext['req']
-  res: GetServerSidePropsContext['res']
 }
 
 export const getCurrentShopSessionServerSide = async (params: Params) => {
@@ -39,4 +37,9 @@ export const setupShopSessionServiceServerSide = (params: Omit<Params, 'locale'>
     new ServerCookiePersister(COOKIE_KEY_SHOP_SESSION, req, res),
     apolloClient,
   )
+}
+
+export const getShopSessionId = ({ req, res }: CookieParams = {}) => {
+  if (req && res) return new ServerCookiePersister(COOKIE_KEY_SHOP_SESSION, req, res).fetch()
+  return new CookiePersister(COOKIE_KEY_SHOP_SESSION).fetch()
 }

--- a/apps/store/src/utils/types.ts
+++ b/apps/store/src/utils/types.ts
@@ -1,0 +1,3 @@
+import { OptionsType } from 'cookies-next/lib/types'
+
+export type CookieParams = Pick<OptionsType, 'req' | 'res'>


### PR DESCRIPTION
## Describe your changes

- Add header to all apollo client requests with shop session ID
- Update README with information about HTTP headers
- Make `CookieParams` a global app type

## Justify why they are needed

We want this to make it simpler to debug things in the backend/API.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
