### PR TITLE
GRW-2271 - refact(TabsBlock): updated to match latest designs

### DIFF
--- a/apps/store/src/blocks/AccordionBlock.tsx
+++ b/apps/store/src/blocks/AccordionBlock.tsx
@@ -3,6 +3,7 @@ import { storyblokEditable, renderRichText } from '@storyblok/react'
 import Head from 'next/head'
 import { Heading, Text, theme, mq } from 'ui'
 import { AccordionItemBlock, AccordionItemBlockProps } from '@/blocks/AccordionItemBlock'
+import { Wrapper as TabsBlockWrapper } from '@/blocks/TabsBlock'
 import * as Accordion from '@/components/Accordion/Accordion'
 import { GridLayout, TEXT_CONTENT_MAX_WIDTH } from '@/components/GridLayout/GridLayout'
 import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
@@ -65,6 +66,10 @@ const Wrapper = styled(GridLayout.Root)({
   [mq.lg]: {
     gap: theme.space.md,
     paddingInline: theme.space.lg,
+  },
+
+  [`${TabsBlockWrapper} &`]: {
+    all: 'unset',
   },
 })
 

--- a/apps/store/src/blocks/ProductPageBlock/MobileLayout.tsx
+++ b/apps/store/src/blocks/ProductPageBlock/MobileLayout.tsx
@@ -4,7 +4,6 @@ import { StoryblokComponent } from '@storyblok/react'
 import { useState, useCallback, useRef } from 'react'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { PurchaseForm } from '@/components/ProductPage/PurchaseForm/PurchaseForm'
-import * as Tabs from '@/components/ProductPage/Tabs'
 import { ProductPageBlockProps } from './ProductPageBlock'
 import { PageSection } from './ProductPageBlock.types'
 import {
@@ -45,18 +44,18 @@ export const MobileLayout = ({ blok }: ProductPageBlockProps) => {
           </StickyHeader>
 
           <OverviewSection>
-            <Tabs.TabsContent value="overview">
+            <RadixTabs.TabsContent value="overview">
               {blok.overview?.map((nestedBlock) => (
                 <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
               ))}
-            </Tabs.TabsContent>
+            </RadixTabs.TabsContent>
           </OverviewSection>
 
-          <Tabs.TabsContent value="coverage">
+          <RadixTabs.TabsContent value="coverage">
             {blok.coverage?.map((nestedBlock) => (
               <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
             ))}
-          </Tabs.TabsContent>
+          </RadixTabs.TabsContent>
         </RadixTabs.Tabs>
       </Content>
     </>

--- a/apps/store/src/blocks/TabsBlock.tsx
+++ b/apps/store/src/blocks/TabsBlock.tsx
@@ -1,56 +1,119 @@
+import styled from '@emotion/styled'
+import * as RadixTabs from '@radix-ui/react-tabs'
 import { SbBlokData, StoryblokComponent, storyblokEditable } from '@storyblok/react'
-import { useMemo } from 'react'
-import * as Tabs from '@/components/ProductPage/Tabs'
-import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
-
-type TabsBlockProps = SbBaseBlockProps<{
-  items: Array<SbBlokData>
-}>
+import { mq, theme } from 'ui'
+import { Heading } from 'ui'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { SbBaseBlockProps, ExpectedBlockType } from '@/services/storyblok/storyblok'
+import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 
 type TabBlockFields = {
   title: string
   body: Array<SbBlokData>
 }
 
-type TabBlockData = SbBlokData & TabBlockFields
-
 type TabBlockProps = SbBaseBlockProps<TabBlockFields>
 
+type TabsBlockProps = SbBaseBlockProps<{
+  items: ExpectedBlockType<TabBlockProps>
+  heading?: string
+}>
+
 export const TabsBlock = ({ blok }: TabsBlockProps) => {
-  // TODO: Use storyblok-level filter to ensure all items are tabs instead of filtering here
-  const tabBlocks = useMemo(() => blok.items.filter(isTabBlock), [blok.items])
-  const firstTabValue = blok.items[0]?._uid
+  const tabBlocks = filterByBlockType(blok.items, TabBlock.blockName)
+  const firstTabValue = tabBlocks[0]?._uid
 
   return (
-    <Tabs.Tabs defaultValue={firstTabValue} {...storyblokEditable(blok)}>
-      <Tabs.TabsList>
-        {tabBlocks.map((tabBlock) => {
-          const tabId = tabBlock._uid || tabBlock.title
-          return (
-            <Tabs.TabsTrigger key={tabId} value={tabId}>
-              {tabBlock.title}
-            </Tabs.TabsTrigger>
-          )
-        })}
-      </Tabs.TabsList>
-      {tabBlocks.map((tabBlock) => (
-        <TabBlock key={tabBlock._uid || tabBlock.title} blok={tabBlock} />
-      ))}
-    </Tabs.Tabs>
+    <Wrapper {...storyblokEditable(blok)}>
+      {blok.heading && (
+        <Title as="h2" variant={{ _: 'standard.24', lg: 'standard.32' }} align="center">
+          {blok.heading}
+        </Title>
+      )}
+      <RadixTabs.Tabs defaultValue={firstTabValue}>
+        <GridLayout.Root>
+          <GridLayout.Content width="1/2" align="center">
+            <TabList>
+              {tabBlocks.map((tabBlock) => {
+                const tabId = tabBlock._uid || tabBlock.title
+                return (
+                  <TabTrigger key={tabId} value={tabId}>
+                    {tabBlock.title}
+                  </TabTrigger>
+                )
+              })}
+            </TabList>
+            {tabBlocks.map((tabBlock) => (
+              <TabBlock key={tabBlock._uid || tabBlock.title} blok={tabBlock} />
+            ))}
+          </GridLayout.Content>
+        </GridLayout.Root>
+      </RadixTabs.Tabs>
+    </Wrapper>
   )
 }
 TabsBlock.blockName = 'tabs'
 
 const TabBlock = ({ blok }: TabBlockProps) => {
   return (
-    <Tabs.TabsContent value={blok._uid || blok.title}>
+    <RadixTabs.TabsContent value={blok._uid || blok.title}>
       {blok.body.map((nestedBlock) => (
         <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} />
       ))}
-    </Tabs.TabsContent>
+    </RadixTabs.TabsContent>
   )
 }
+TabBlock.blockName = 'tab'
 
-const isTabBlock = (blok: SbBlokData): blok is TabBlockData => {
-  return blok.component === 'tab'
-}
+// We use this for applying some contextual styles
+export const Wrapper = styled.div({})
+
+const Title = styled(Heading)({
+  marginBottom: theme.space.lg,
+  paddingInline: theme.space.md,
+
+  [mq.lg]: {
+    marginBottom: theme.space.xl,
+  },
+})
+
+const TabTrigger = styled(RadixTabs.Trigger)({
+  cursor: 'pointer',
+  fontSize: theme.fontSizes.xs,
+  borderRadius: theme.radius.sm,
+  border: '2px solid transparent',
+  padding: ` ${theme.space.xs} ${theme.space.sm}`,
+  // So we can center a scrollable flex container.
+  // Justify content won't work. https://rb.gy/uii7pl
+  ':first-of-type': { marginLeft: 'auto' },
+  ':last-of-type': { marginRight: 'auto' },
+  '&[data-state="active"] ': {
+    backgroundColor: theme.colors.translucent1,
+  },
+  ':focus-visible': {
+    backgroundColor: theme.colors.translucent1,
+    borderColor: theme.colors.purple500,
+  },
+
+  [mq.md]: {
+    fontSize: theme.fontSizes.md,
+  },
+
+  '@media (hover: hover)': {
+    ':hover': {
+      backgroundColor: theme.colors.translucent1,
+    },
+  },
+})
+
+const TabList = styled(RadixTabs.TabsList)({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.space.xs,
+  paddingBottom: theme.space.lg,
+  overflowX: 'auto',
+
+  [mq.lg]: {
+    paddingBottom: theme.space.xl,
+  },
+})

--- a/apps/store/src/components/GridLayout/GridLayout.tsx
+++ b/apps/store/src/components/GridLayout/GridLayout.tsx
@@ -48,7 +48,7 @@ const twoThirdsCenterStyles: CSSObject = {
 }
 
 const halfCenterStyles: CSSObject = {
-  [mq.md]: { gridColumn: '2 / span 8' },
+  [mq.md]: { gridColumn: '2 / span 10' },
   [mq.lg]: { gridColumn: '4 / span 6' },
 }
 


### PR DESCRIPTION
## Describe your changes

* Update TabsBlock to match latest designs and support [Support page implementation](https://www.figma.com/file/qUhLjrKl98PAzHov9ilaDH/*NEW*-.com-UI-Kit?node-id=1565%3A7541&t=NWIjsInKHcoEsoQf-4)

**Disclaimer**: Only the vertical Layout was implemented for now. We can iterate over it later

## Justify why they are needed

<img width="972" alt="image" src="https://user-images.githubusercontent.com/19200662/220562205-bb0c43d2-de83-4b48-bee8-bf9528acc3ad.png">

Can be tested [here](https://hedvig-dot-com-git-grw-2271-refacttabs-block-hedvig.vercel.app/se/hjalp/support-link-card)

## Jira issue(s): [GRW-2271](https://hedvig.atlassian.net/browse/GRW-2271)

[GRW-2271]: https://hedvig.atlassian.net/browse/GRW-2271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ