### PR TITLE
Make top menu static on PDP

### DIFF
--- a/apps/store/src/blocks/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock.tsx
@@ -184,9 +184,10 @@ export type HeaderBlockProps = SbBaseBlockProps<{
   >
 }> & {
   overlay?: boolean
+  static?: boolean
 }
 
-export const HeaderBlock = ({ blok, overlay }: HeaderBlockProps) => {
+export const HeaderBlock = ({ blok, ...headerProps }: HeaderBlockProps) => {
   const [isOpen, setIsOpen] = useState(false)
 
   const productNavItem = useMemo(
@@ -201,7 +202,7 @@ export const HeaderBlock = ({ blok, overlay }: HeaderBlockProps) => {
   )
 
   return (
-    <Header {...storyblokEditable(blok)} opaque={isOpen} overlay={overlay}>
+    <Header {...storyblokEditable(blok)} opaque={isOpen} {...headerProps}>
       <TopMenuDesktop>{blok.navMenuContainer.map(NestedNavigationBlock)}</TopMenuDesktop>
       <TopMenuMobile isOpen={isOpen} setIsOpen={setIsOpen} defaultValue={productNavItem}>
         {blok.navMenuContainer.map(NestedNavigationBlock)}

--- a/apps/store/src/blocks/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import { storyblokEditable } from '@storyblok/react'
 import { useTranslation } from 'next-i18next'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Space } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { Header } from '@/components/Header/Header'
@@ -189,10 +189,21 @@ export type HeaderBlockProps = SbBaseBlockProps<{
 export const HeaderBlock = ({ blok, overlay }: HeaderBlockProps) => {
   const [isOpen, setIsOpen] = useState(false)
 
+  const productNavItem = useMemo(
+    () =>
+      blok.navMenuContainer.find((item) =>
+        checkBlockType<ProductNavContainerBlockProps['blok']>(
+          item,
+          ProductNavContainerBlock.blockName,
+        ),
+      )?.name,
+    [blok.navMenuContainer],
+  )
+
   return (
     <Header {...storyblokEditable(blok)} opaque={isOpen} overlay={overlay}>
       <TopMenuDesktop>{blok.navMenuContainer.map(NestedNavigationBlock)}</TopMenuDesktop>
-      <TopMenuMobile isOpen={isOpen} setIsOpen={setIsOpen}>
+      <TopMenuMobile isOpen={isOpen} setIsOpen={setIsOpen} defaultValue={productNavItem}>
         {blok.navMenuContainer.map(NestedNavigationBlock)}
       </TopMenuMobile>
     </Header>

--- a/apps/store/src/blocks/ProductPageBlock/DesktopLayout.tsx
+++ b/apps/store/src/blocks/ProductPageBlock/DesktopLayout.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled'
 import { StoryblokComponent } from '@storyblok/react'
 import { useRef, useEffect, useState } from 'react'
-import { theme } from 'ui'
+import { mq, theme } from 'ui'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { PurchaseForm } from '@/components/ProductPage/PurchaseForm/PurchaseForm'
 import { ProductPageBlockProps } from './ProductPageBlock'
 import { PageSection } from './ProductPageBlock.types'
 import {
-  AnimatedHeader,
+  StickyHeader,
   Content,
   OverviewSection,
   StyledProductVariantSelector,
@@ -27,8 +27,8 @@ export const DesktopLayout = ({ blok }: ProductPageBlockProps) => {
     activeSection === 'coverage' && productData.variants.length > 1
 
   return (
-    <>
-      <AnimatedHeader>
+    <Wrapper>
+      <StickyHeader>
         <nav aria-label="page content">
           <ContentNavigationList>
             <li>
@@ -52,7 +52,7 @@ export const DesktopLayout = ({ blok }: ProductPageBlockProps) => {
           </ContentNavigationList>
           {shouldRenderVariantSelector && <StyledProductVariantSelector />}
         </nav>
-      </AnimatedHeader>
+      </StickyHeader>
       <Grid>
         <Content>
           <OverviewSection id="overview">
@@ -70,9 +70,11 @@ export const DesktopLayout = ({ blok }: ProductPageBlockProps) => {
           <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
         ))}
       </section>
-    </>
+    </Wrapper>
   )
 }
+
+const Wrapper = styled.div({ [mq.lg]: { paddingTop: theme.space.sm } })
 
 const Grid = styled.div({
   display: 'grid',
@@ -86,11 +88,14 @@ const ContentNavigationTrigger = styled.a(triggerStyles)
 
 const PurchaseFormWrapper = styled.div({
   position: 'sticky',
-  top: '9vh',
+  top: 0,
   // Scroll independently if content is too long
   maxHeight: '100vh',
   overflow: 'auto',
-  paddingBottom: theme.space.xl,
+  paddingBlock: theme.space.xl,
+
+  paddingTop: '3vw',
+  [mq.lg]: { paddingTop: '6vw' },
 })
 
 const useActiveSectionChangeListener = (

--- a/apps/store/src/blocks/ProductPageBlock/MobileLayout.tsx
+++ b/apps/store/src/blocks/ProductPageBlock/MobileLayout.tsx
@@ -8,7 +8,7 @@ import * as Tabs from '@/components/ProductPage/Tabs'
 import { ProductPageBlockProps } from './ProductPageBlock'
 import { PageSection } from './ProductPageBlock.types'
 import {
-  AnimatedHeader,
+  StickyHeader,
   Content,
   OverviewSection,
   StyledProductVariantSelector,
@@ -33,7 +33,7 @@ export const MobileLayout = ({ blok }: ProductPageBlockProps) => {
       <PurchaseForm />
       <Content>
         <RadixTabs.Tabs value={activeSection} onValueChange={handleTabClick}>
-          <AnimatedHeader>
+          <StickyHeader>
             <RadixTabs.TabsList>
               <TablistWrapper>
                 <TabTrigger value="overview">{blok.overviewLabel}</TabTrigger>
@@ -41,7 +41,7 @@ export const MobileLayout = ({ blok }: ProductPageBlockProps) => {
               </TablistWrapper>
               {shouldRenderVariantSelector && <StyledProductVariantSelector />}
             </RadixTabs.TabsList>
-          </AnimatedHeader>
+          </StickyHeader>
 
           <OverviewSection>
             <Tabs.TabsContent value="overview">

--- a/apps/store/src/blocks/ProductPageBlock/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock/ProductPageBlock.tsx
@@ -1,8 +1,6 @@
-import { Global } from '@emotion/react'
 import styled from '@emotion/styled'
 import { storyblokEditable, StoryblokComponent, SbBlokData } from '@storyblok/react'
-import { mq, useBreakpoint } from 'ui'
-import { MENU_BAR_HEIGHT_DESKTOP } from '@/components/Header/HeaderStyles'
+import { useBreakpoint } from 'ui'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { DesktopLayout } from './DesktopLayout'
 import { MobileLayout } from './MobileLayout'
@@ -19,24 +17,13 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
   const isLarge = useBreakpoint('lg')
 
   return (
-    <>
-      <Global
-        styles={{
-          html: {
-            [mq.md]: {
-              scrollPaddingTop: MENU_BAR_HEIGHT_DESKTOP,
-            },
-          },
-        }}
-      />
-      <Main {...storyblokEditable(blok)}>
-        {isLarge && <DesktopLayout blok={blok} />}
-        {!isLarge && <MobileLayout blok={blok} />}
-        {blok.body.map((nestedBlock) => (
-          <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
-        ))}
-      </Main>
-    </>
+    <Main {...storyblokEditable(blok)}>
+      {isLarge && <DesktopLayout blok={blok} />}
+      {!isLarge && <MobileLayout blok={blok} />}
+      {blok.body.map((nestedBlock) => (
+        <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+      ))}
+    </Main>
   )
 }
 ProductPageBlock.blockName = 'product'

--- a/apps/store/src/blocks/ProductPageBlock/ProductPageBlockBase.tsx
+++ b/apps/store/src/blocks/ProductPageBlock/ProductPageBlockBase.tsx
@@ -1,14 +1,7 @@
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
-import { motion } from 'framer-motion'
 import { theme, mq } from 'ui'
-import {
-  MENU_BAR_HEIGHT_MOBILE,
-  MENU_BAR_HEIGHT_DESKTOP,
-  MENU_BAR_HEIGHT_PX,
-} from '@/components/Header/HeaderStyles'
 import { ProductVariantSelector } from '@/components/ProductVariantSelector/ProductVariantSelector'
-import { useScrollState } from '@/utils/useScrollState'
 import { zIndexes } from '@/utils/zIndex'
 
 const TABLIST_HEIGHT = '2.5rem'
@@ -22,44 +15,23 @@ export const Content = styled.div({
 
 export const OverviewSection = styled.section({
   marginTop: `calc(-${TABLIST_HEIGHT} - ${theme.space.xs})`,
-  [mq.md]: {
-    marginTop: `calc(-${TABLIST_HEIGHT} - ${theme.space.md})`,
-  },
-  [mq.lg]: {
-    marginTop: 0,
-  },
+  [mq.md]: { marginTop: `calc(-${TABLIST_HEIGHT} - ${theme.space.md})` },
 })
 
-const StickyHeader = styled(motion.div)({
+export const StickyHeader = styled.div({
   position: 'sticky',
-  top: `calc(${theme.space.sm} + ${MENU_BAR_HEIGHT_MOBILE})`,
+  top: theme.space.sm,
   zIndex: zIndexes.tabs,
   paddingInline: theme.space.md,
 
   [mq.md]: {
-    top: `calc(${theme.space.sm} + ${MENU_BAR_HEIGHT_DESKTOP})`,
     paddingInline: theme.space.lg,
   },
   [mq.lg]: {
-    position: 'fixed',
-    top: `calc(${theme.space.md} + ${MENU_BAR_HEIGHT_DESKTOP})`,
+    top: theme.space.md,
     paddingInline: theme.space.xl,
   },
 })
-
-export const AnimatedHeader = ({ children }: { children: React.ReactNode }) => {
-  const state = useScrollState({ threshold: MENU_BAR_HEIGHT_PX })
-  const scrollUp = state === 'SCROLL_DOWN' || state === 'BELOW'
-
-  return (
-    <StickyHeader
-      animate={{ top: scrollUp ? theme.space.md : undefined }}
-      transition={theme.transitions.framer.easeInOutCubic}
-    >
-      {children}
-    </StickyHeader>
-  )
-}
 
 export const StyledProductVariantSelector = styled(ProductVariantSelector)({
   minWidth: '12.5rem',

--- a/apps/store/src/components/Header/Header.tsx
+++ b/apps/store/src/components/Header/Header.tsx
@@ -37,9 +37,11 @@ type HeaderProps = {
   children: React.ReactNode
   opaque?: boolean
   overlay?: boolean
+  static?: boolean
 }
 
-export const Header = ({ children, opaque = false, overlay = false }: HeaderProps) => {
+export const Header = (props: HeaderProps) => {
+  const { children, opaque = false, overlay = false, static: staticPosition = false } = props
   const scrollState = useScrollState({ threshold: MENU_BAR_HEIGHT_PX * 2 })
 
   const defaultPosition = overlay ? 'absolute' : 'relative'
@@ -50,6 +52,7 @@ export const Header = ({ children, opaque = false, overlay = false }: HeaderProp
   let animate: AnimationVariant = scrollState === 'SCROLL_UP' ? 'SLIDE_IN' : undefined
   animate = scrollState === 'BELOW' ? 'HIDE' : animate
   animate = scrollState === 'SCROLL_DOWN' ? 'SLIDE_OUT' : animate
+  animate = staticPosition ? undefined : animate
 
   return (
     <GhostWrapper style={{ position: defaultPosition, backgroundColor }}>
@@ -77,8 +80,8 @@ const GhostWrapper = styled.div({
   right: 0,
   zIndex: zIndexes.header,
 
-  height: MENU_BAR_HEIGHT_MOBILE,
-  [mq.lg]: { height: MENU_BAR_HEIGHT_DESKTOP },
+  height: `calc(${MENU_BAR_HEIGHT_MOBILE} + ${theme.space.xs})`,
+  [mq.lg]: { height: `calc(${MENU_BAR_HEIGHT_DESKTOP} + ${theme.space.xs})` },
 })
 
 export const Wrapper = styled(motion.header)({

--- a/apps/store/src/components/Header/HeaderStyles.tsx
+++ b/apps/store/src/components/Header/HeaderStyles.tsx
@@ -100,6 +100,7 @@ export const NavigationPrimaryList = styled(NavigationMenuPrimitive.List)({
   display: 'flex',
   flexDirection: 'column',
   padding: `0 ${theme.space.md} `,
+  overflowY: 'auto',
 
   [mq.lg]: {
     position: 'static',

--- a/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
+++ b/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
@@ -51,10 +51,12 @@ const StyledAndroidIcon = styled(AndroidIcon)({
 export type TopMenuMobileProps = {
   isOpen: boolean
   setIsOpen: (isOpen: boolean) => void
+  defaultValue?: string
   children: React.ReactNode
 }
 
-export const TopMenuMobile = ({ children, isOpen, setIsOpen }: TopMenuMobileProps) => {
+export const TopMenuMobile = (props: TopMenuMobileProps) => {
+  const { children, isOpen, setIsOpen, defaultValue } = props
   const router = useRouter()
   const { t } = useTranslation('common')
 
@@ -73,7 +75,7 @@ export const TopMenuMobile = ({ children, isOpen, setIsOpen }: TopMenuMobileProp
           <DialogTrigger>{t('NAV_MENU_DIALOG_OPEN')}</DialogTrigger>
         )}
         <DialogContent>
-          <Navigation>
+          <Navigation defaultValue={defaultValue}>
             <NavigationPrimaryList>
               <div>{children}</div>
               <ButtonWrapper x={0.25}>

--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -3,7 +3,7 @@ import { ReactElement } from 'react'
 import { FooterBlock } from '@/blocks/FooterBlock'
 import { HeaderBlock } from '@/blocks/HeaderBlock'
 import { StoryblokPageProps } from '@/services/storyblok/storyblok'
-import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
+import { filterByBlockType, isProductStory } from '@/services/storyblok/Storyblok.helpers'
 import { useChangeLocale } from '@/utils/l10n/useChangeLocale'
 import { GlobalProductMetadata, GLOBAL_PRODUCT_METADATA_PROP_NAME } from './fetchProductMetadata'
 import { ProductMetadataProvider } from './ProductMetadataContext'
@@ -44,6 +44,7 @@ export const LayoutWithMenu = ({ children, overlayMenu = false }: LayoutWithMenu
               key={nestedBlock._uid}
               blok={nestedBlock}
               overlay={story?.content.overlayMenu ?? overlayMenu}
+              static={story && isProductStory(story)}
             />
           ))}
         {children}

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -403,13 +403,11 @@ const PurchaseFormTop = styled.div({
   flexDirection: 'column',
   justifyContent: 'center',
   gap: '4.5rem',
-  paddingTop: '3vw',
-  paddingBottom: theme.space.xxl,
+  minHeight: '80vh',
   paddingInline: theme.space.md,
+  paddingBottom: theme.space.xl,
 
-  [mq.xl]: {
-    paddingTop: '6vw',
-  },
+  [mq.lg]: { minHeight: 'revert' },
 })
 
 const StickyButtonWrapper = styled.div({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Make top menu static on PDP pages
- Remove header animation on PDP pages
- Tweak tabs and top content on PDP pages

![Screenshot 2023-02-21 at 16.23.55.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/0aa69a75-822c-4339-b0de-6cf5c8aab586/Screenshot%202023-02-21%20at%2016.23.55.png)

> :warning: easiest to try out in the preview deployment

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Requested from design -- menu takes up too much vertical space on PDP pages.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
