### PR TITLE
Fix issue when creating new price intent (post add to cart)

### DIFF
--- a/apps/store/src/components/PriceCalculator/useHandleSubmitPriceCalculator.ts
+++ b/apps/store/src/components/PriceCalculator/useHandleSubmitPriceCalculator.ts
@@ -15,7 +15,7 @@ type Params = {
 
 export const useHandleSubmitPriceCalculator = ({ onSuccess }: Params) => {
   const { shopSession } = useShopSession()
-  const [{ priceIntent }] = usePriceIntent()
+  const [priceIntent] = usePriceIntent()
   const [updateData, { loading: loadingData }] = usePriceIntentDataUpdateMutation({
     onCompleted: (data) => {
       const { priceIntent } = data.priceIntentDataUpdate

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -1,4 +1,3 @@
-import { useApolloClient } from '@apollo/client'
 import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
 import { motion, Variants } from 'framer-motion'
@@ -16,7 +15,6 @@ import { useOpenPriceCalculatorQueryParam } from '@/components/ProductPage/Purch
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { ProductOfferFragment, usePriceIntentConfirmMutation } from '@/services/apollo/generated'
 import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
-import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntentService'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { TrackingContextKey } from '@/services/Tracking/Tracking'
@@ -36,9 +34,8 @@ export const PurchaseForm = () => {
   const [formState, setFormState] = useState<FormState>('IDLE')
   const { priceTemplate, productData } = useProductPageContext()
   const { shopSession } = useShopSession()
-  const apolloClient = useApolloClient()
   const formatter = useFormatter()
-  const [{ priceIntent }, setupPriceIntent] = usePriceIntent()
+  const [priceIntent, , createNewPriceIntent] = usePriceIntent()
   const tracking = useTracking()
   const isLarge = useBreakpoint('lg')
 
@@ -117,10 +114,8 @@ export const PurchaseForm = () => {
                   }),
             })
 
-            const service = priceIntentServiceInitClientSide(apolloClient)
-            service.clear(priceTemplate.name, shopSession.id)
             try {
-              await setupPriceIntent(shopSession)
+              await createNewPriceIntent(shopSession)
             } catch (error) {
               datadogLogs.logger.error('Failed to create new price intent', {
                 error,


### PR DESCRIPTION
## Describe your changes

Refactor `PriceIntentContext` to use active instead of lazy query.

Separate functions:

- Use `useEffect` to setup initial price intent on page load
- Add new function to create new price intent (post add to cart). This just resets cookie and refreshes the page.

## Justify why they are needed

We have a bug where we keep the existing price intent after adding to cart.

This has to do with not resetting the cookie because we don't refresh the page after calling "clear" on the price intent service.

I think this setup is slightly more standard and easier to understand.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
