### PR TITLE
GRW-2284 - add ProductVariantSelectorBlock

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -4,13 +4,11 @@ import { motion, useScroll } from 'framer-motion'
 import { useState, useEffect, useRef, ReactNode } from 'react'
 import { theme, mq } from 'ui'
 import { GridLayout, MAX_WIDTH } from '@/components/GridLayout/GridLayout'
-import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { PurchaseForm } from '@/components/ProductPage/PurchaseForm/PurchaseForm'
-import { ProductVariantSelector } from '@/components/ProductVariantSelector/ProductVariantSelector'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { zIndexes } from '@/utils/zIndex'
 
-const TABLIST_HEIGHT = '2.5rem'
+const NAVIGATION_LIST_HEIGHT = '2.5rem'
 const SCROLL_PERCENTAGE_THRESHOLD = 10 // 10%
 
 export type PageSection = 'overview' | 'coverage'
@@ -24,44 +22,37 @@ export type ProductPageBlockProps = SbBaseBlockProps<{
 }>
 
 export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
-  const { productData } = useProductPageContext()
   const [activeSection, setActiveSection] = useState<PageSection>('overview')
 
   useActiveSectionChangeListener(['overview', 'coverage'], (sectionId) =>
     setActiveSection(sectionId as PageSection),
   )
 
-  const shouldRenderVariantSelector =
-    activeSection === 'coverage' && productData.variants.length > 1
-
   return (
     <Main {...storyblokEditable(blok)}>
       <StickyHeader>
-        <>
-          <nav aria-label="page content">
-            <ContentNavigationList>
-              <li>
-                <ContentNavigationTrigger
-                  href="#overview"
-                  data-state={activeSection === 'overview' ? 'active' : 'inactive'}
-                  aria-current={activeSection === 'overview' ? 'true' : undefined}
-                >
-                  {blok.overviewLabel}
-                </ContentNavigationTrigger>
-              </li>
-              <li>
-                <ContentNavigationTrigger
-                  href="#coverage"
-                  data-state={activeSection === 'coverage' ? 'active' : 'inactive'}
-                  aria-current={activeSection === 'coverage' ? 'true' : undefined}
-                >
-                  {blok.coverageLabel}
-                </ContentNavigationTrigger>
-              </li>
-            </ContentNavigationList>
-          </nav>
-          {shouldRenderVariantSelector && <VariantSelector />}
-        </>
+        <nav aria-label="page content">
+          <ContentNavigationList>
+            <li>
+              <ContentNavigationTrigger
+                href="#overview"
+                data-state={activeSection === 'overview' ? 'active' : 'inactive'}
+                aria-current={activeSection === 'overview' ? 'true' : undefined}
+              >
+                {blok.overviewLabel}
+              </ContentNavigationTrigger>
+            </li>
+            <li>
+              <ContentNavigationTrigger
+                href="#coverage"
+                data-state={activeSection === 'coverage' ? 'active' : 'inactive'}
+                aria-current={activeSection === 'coverage' ? 'true' : undefined}
+              >
+                {blok.coverageLabel}
+              </ContentNavigationTrigger>
+            </li>
+          </ContentNavigationList>
+        </nav>
       </StickyHeader>
 
       <Grid>
@@ -95,14 +86,6 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
   )
 }
 ProductPageBlock.blockName = 'product'
-
-const VariantSelector = () => {
-  return (
-    <VariantSelectorWrapper>
-      <StyledProductVariantSelector />
-    </VariantSelectorWrapper>
-  )
-}
 
 const StickyHeader = ({ children }: { children: ReactNode }) => {
   const { scrollY } = useScroll()
@@ -144,14 +127,13 @@ const StyledStickyHeader = styled(motion.header)({
   },
   [mq.lg]: {
     top: theme.space.md,
-    paddingInline: theme.space.xl,
   },
 })
 
 const ContentNavigationList = styled.ol({
   display: 'flex',
   gap: theme.space.xs,
-  height: TABLIST_HEIGHT,
+  height: NAVIGATION_LIST_HEIGHT,
 })
 
 const ContentNavigationTrigger = styled.a({
@@ -189,21 +171,6 @@ const ContentNavigationTrigger = styled.a({
 
   '&:focus-visible': {
     boxShadow: `0 0 0 2px ${theme.colors.purple500}`,
-  },
-})
-
-const VariantSelectorWrapper = styled.div({
-  width: 'fit-content',
-  minWidth: '12.5rem',
-  marginTop: theme.space.xs,
-})
-
-const StyledProductVariantSelector = styled(ProductVariantSelector)({
-  backgroundColor: theme.colors.greenFill1,
-  boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.15)',
-
-  ':hover, :focus-within': {
-    backgroundColor: theme.colors.greenFill3,
   },
 })
 

--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -8,7 +8,7 @@ import { PurchaseForm } from '@/components/ProductPage/PurchaseForm/PurchaseForm
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { zIndexes } from '@/utils/zIndex'
 
-const NAVIGATION_LIST_HEIGHT = '2.5rem'
+export const NAVIGATION_LIST_HEIGHT = '2.5rem'
 const SCROLL_PERCENTAGE_THRESHOLD = 10 // 10%
 
 export type PageSection = 'overview' | 'coverage'

--- a/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
+++ b/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
@@ -1,70 +1,36 @@
 import styled from '@emotion/styled'
-import { useScroll } from 'framer-motion'
-import { useState, useEffect, useRef } from 'react'
-import { ConditionalWrapper, Space, Text, theme } from 'ui'
-import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { ConditionalWrapper, theme, mq } from 'ui'
 import { ProductVariantSelector } from '@/components/ProductVariantSelector/ProductVariantSelector'
-import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { zIndexes } from '@/utils/zIndex'
+import { NAVIGATION_LIST_HEIGHT } from './ProductPageBlock'
 
-type ProductVariantSelectorBlockProps = SbBaseBlockProps<{
-  content?: string
-}>
+type ProductVariantSelectorBlockProps = {
+  nested?: boolean
+}
 
-export const ProductVariantSelectorBlock = ({ blok, nested }: ProductVariantSelectorBlockProps) => {
+export const ProductVariantSelectorBlock = ({ nested }: ProductVariantSelectorBlockProps) => {
   return (
     <ConditionalWrapper
       condition={!nested}
-      wrapWith={(children) => (
-        <GridLayout.Root>
-          <GridLayout.Content width="1/2" align="left">
-            {children}
-          </GridLayout.Content>
-        </GridLayout.Root>
-      )}
+      wrapWith={(children) => <VariantSelectorWrapper>{children}</VariantSelectorWrapper>}
     >
-      <Space y={1}>
-        <VariantSelector />
-        {blok.content && <StyledText size={{ _: 'xl', lg: 'xxl' }}>{blok.content}</StyledText>}
-      </Space>
+      <StyledProductVariantSelector />
     </ConditionalWrapper>
   )
 }
 
-const VariantSelector = () => {
-  const ref = useRef<HTMLDivElement | null>(null)
-  const { scrollY } = useScroll()
-
-  const [reachedTopScreen, setReachedTopScreen] = useState(false)
-  useEffect(() => {
-    if (!ref.current) return
-
-    const initialElementOffsetTop = ref.current.offsetTop
-    // TODO: derivate this from ProductPageBlock's navigation links height
-    const offset = 64
-
-    scrollY.on('change', (currentScrollY) => {
-      if (ref.current) {
-        setReachedTopScreen(currentScrollY >= initialElementOffsetTop - offset)
-      }
-    })
-  }, [scrollY])
-
-  return (
-    <VariantSelectorWrapper ref={ref} data-fixed={reachedTopScreen ? 'true' : 'false'}>
-      <StyledProductVariantSelector />
-    </VariantSelectorWrapper>
-  )
-}
+const OFFSET = '1.5rem'
 
 const VariantSelectorWrapper = styled.div({
+  position: 'sticky',
+  top: `calc(${NAVIGATION_LIST_HEIGHT} + ${OFFSET})`,
   width: 'fit-content',
   minWidth: '12.5rem',
+  paddingInline: theme.space.md,
+  zIndex: zIndexes.tabs,
 
-  ['&[data-fixed=true]']: {
-    position: 'fixed',
-    top: 64,
-    zIndex: zIndexes.tabs,
+  [mq.lg]: {
+    paddingInline: theme.space.lg,
   },
 })
 
@@ -75,10 +41,6 @@ const StyledProductVariantSelector = styled(ProductVariantSelector)({
   ':hover, :focus-within': {
     backgroundColor: theme.colors.greenFill3,
   },
-})
-
-const StyledText = styled(Text)({
-  maxWidth: '37.5rem', // 600px
 })
 
 ProductVariantSelectorBlock.blockName = 'productVariantSelector'

--- a/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
+++ b/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import { ConditionalWrapper, theme, mq } from 'ui'
+import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { ProductVariantSelector } from '@/components/ProductVariantSelector/ProductVariantSelector'
 import { zIndexes } from '@/utils/zIndex'
 import { NAVIGATION_LIST_HEIGHT } from './ProductPageBlock'
@@ -9,6 +10,10 @@ type ProductVariantSelectorBlockProps = {
 }
 
 export const ProductVariantSelectorBlock = ({ nested }: ProductVariantSelectorBlockProps) => {
+  const { productData } = useProductPageContext()
+
+  if (productData.variants.length < 2) return null
+
   return (
     <ConditionalWrapper
       condition={!nested}

--- a/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
+++ b/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled'
+import { ConditionalWrapper, Space, Text, theme } from 'ui'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { ProductVariantSelector } from '@/components/ProductVariantSelector/ProductVariantSelector'
+import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+
+type ProductVariantSelectorBlockProps = SbBaseBlockProps<{
+  content?: string
+}>
+
+export const ProductVariantSelectorBlock = ({ blok, nested }: ProductVariantSelectorBlockProps) => {
+  return (
+    <ConditionalWrapper
+      condition={!nested}
+      wrapWith={(children) => (
+        <GridLayout.Root>
+          <GridLayout.Content width="1/2" align="left">
+            {children}
+          </GridLayout.Content>
+        </GridLayout.Root>
+      )}
+    >
+      <Space y={1}>
+        <VariantSelectorWrapper>
+          <StyledProductVariantSelector />
+        </VariantSelectorWrapper>
+        {blok.content && <StyledText size={{ _: 'xl', lg: 'xxl' }}>{blok.content}</StyledText>}
+      </Space>
+    </ConditionalWrapper>
+  )
+}
+
+const VariantSelectorWrapper = styled.div({
+  width: 'fit-content',
+  minWidth: '12.5rem',
+})
+
+const StyledProductVariantSelector = styled(ProductVariantSelector)({
+  backgroundColor: theme.colors.greenFill1,
+  boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.15)',
+
+  ':hover, :focus-within': {
+    backgroundColor: theme.colors.greenFill3,
+  },
+})
+
+const StyledText = styled(Text)({
+  maxWidth: '37.5rem', // 600px
+})
+
+ProductVariantSelectorBlock.blockName = 'productVariantSelector'

--- a/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
+++ b/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
@@ -24,17 +24,16 @@ export const ProductVariantSelectorBlock = ({ nested }: ProductVariantSelectorBl
   )
 }
 
-const OFFSET = '1.5rem'
-
 const VariantSelectorWrapper = styled.div({
   position: 'sticky',
-  top: `calc(${NAVIGATION_LIST_HEIGHT} + ${OFFSET})`,
+  top: `calc(${NAVIGATION_LIST_HEIGHT} + 1.2rem)`,
   width: 'fit-content',
   minWidth: '12.5rem',
   paddingInline: theme.space.md,
   zIndex: zIndexes.tabs,
 
   [mq.md]: {
+    top: `calc(${NAVIGATION_LIST_HEIGHT} + 1.5rem)`,
     paddingInline: theme.space.lg,
   },
 })

--- a/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
+++ b/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
@@ -34,7 +34,7 @@ const VariantSelectorWrapper = styled.div({
   paddingInline: theme.space.md,
   zIndex: zIndexes.tabs,
 
-  [mq.lg]: {
+  [mq.md]: {
     paddingInline: theme.space.lg,
   },
 })

--- a/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
+++ b/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
@@ -1,8 +1,11 @@
 import styled from '@emotion/styled'
+import { useScroll } from 'framer-motion'
+import { useState, useEffect, useRef } from 'react'
 import { ConditionalWrapper, Space, Text, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { ProductVariantSelector } from '@/components/ProductVariantSelector/ProductVariantSelector'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { zIndexes } from '@/utils/zIndex'
 
 type ProductVariantSelectorBlockProps = SbBaseBlockProps<{
   content?: string
@@ -21,18 +24,48 @@ export const ProductVariantSelectorBlock = ({ blok, nested }: ProductVariantSele
       )}
     >
       <Space y={1}>
-        <VariantSelectorWrapper>
-          <StyledProductVariantSelector />
-        </VariantSelectorWrapper>
+        <VariantSelector />
         {blok.content && <StyledText size={{ _: 'xl', lg: 'xxl' }}>{blok.content}</StyledText>}
       </Space>
     </ConditionalWrapper>
   )
 }
 
+const VariantSelector = () => {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const { scrollY } = useScroll()
+
+  const [reachedTopScreen, setReachedTopScreen] = useState(false)
+  useEffect(() => {
+    if (!ref.current) return
+
+    const initialElementOffsetTop = ref.current.offsetTop
+    // TODO: derivate this from ProductPageBlock's navigation links height
+    const offset = 64
+
+    scrollY.on('change', (currentScrollY) => {
+      if (ref.current) {
+        setReachedTopScreen(currentScrollY >= initialElementOffsetTop - offset)
+      }
+    })
+  }, [scrollY])
+
+  return (
+    <VariantSelectorWrapper ref={ref} data-fixed={reachedTopScreen ? 'true' : 'false'}>
+      <StyledProductVariantSelector />
+    </VariantSelectorWrapper>
+  )
+}
+
 const VariantSelectorWrapper = styled.div({
   width: 'fit-content',
   minWidth: '12.5rem',
+
+  ['&[data-fixed=true]']: {
+    position: 'fixed',
+    top: 64,
+    zIndex: zIndexes.tabs,
+  },
 })
 
 const StyledProductVariantSelector = styled(ProductVariantSelector)({

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -38,6 +38,7 @@ import { ProductDocumentsBlock } from '@/blocks/ProductDocumentsBlock'
 import { ProductGridBlock } from '@/blocks/ProductGridBlock'
 import { ProductPageBlock } from '@/blocks/ProductPageBlock'
 import { ProductSlideshowBlock } from '@/blocks/ProductSlideshowBlock'
+import { ProductVariantSelectorBlock } from '@/blocks/ProductVariantSelectorBlock'
 import { ReusableBlockReference } from '@/blocks/ReusableBlockReference'
 import { SpacerBlock } from '@/blocks/SpacerBlock'
 import { TabsBlock } from '@/blocks/TabsBlock'
@@ -214,6 +215,7 @@ export const initStoryblok = () => {
     ProductDocumentsBlock,
     ProductGridBlock,
     ProductSlideshowBlock,
+    ProductVariantSelectorBlock,
     SpacerBlock,
     TabsBlock,
     TimelineBlock,


### PR DESCRIPTION
## Describe your changes

* Promote `ProductVariantSelect` as its own block

**Disclaimer**: **This PR should not be merged while we don't get all PDP pages updated**.

## Justify why they are needed

To support the implementation of new design for _variant selector_ section.
By having only the input select as a block we can use it to compound the the attached design while making it easy to implement _sticky variant selector_ feature.

Can be tested [here](https://hedvig-dot-com-git-grw-2284-refactproduct-variant-7bd542-hedvig.vercel.app/se/forsakringar/bilforsakring/bill-sandbox)

https://user-images.githubusercontent.com/19200662/223766061-512221d9-b470-4a63-a82a-c9bf2bb98269.mov

![image](https://user-images.githubusercontent.com/19200662/223764690-f2f3b6c4-79eb-4b72-b9fd-8652087e7f30.png)

## Jira issue(s): [GRW-2284](https://hedvig.atlassian.net/browse/GRW-2284)

[GRW-2284]: https://hedvig.atlassian.net/browse/GRW-2284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ