### PR TITLE
`TextField`: allow clicking wrapper to focus input

### DIFF
--- a/apps/store/src/components/TextField/TextField.tsx
+++ b/apps/store/src/components/TextField/TextField.tsx
@@ -1,7 +1,7 @@
 import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import { motion } from 'framer-motion'
-import { ChangeEventHandler, InputHTMLAttributes, MouseEventHandler, useState } from 'react'
+import { ChangeEventHandler, InputHTMLAttributes, MouseEventHandler, useRef, useState } from 'react'
 import { CrossIcon, LockIcon, Space, Text, theme } from 'ui'
 import { useHighlightAnimation } from '@/utils/useHighlightAnimation'
 
@@ -20,6 +20,7 @@ type Props = BaseInputProps & {
 }
 
 export const TextField = (props: Props) => {
+  const inputRef = useRef<HTMLInputElement>(null)
   const { label, variant = 'large', suffix, warning = false, message, ...inputProps } = props
   const [value, setValue] = useState(props.defaultValue || '')
   const { highlight, animationProps } = useHighlightAnimation()
@@ -36,6 +37,10 @@ export const TextField = (props: Props) => {
     inputProps.onValueChange?.(newValue)
   }
 
+  const handleClickWrapper: MouseEventHandler<HTMLDivElement> = () => {
+    inputRef.current?.focus()
+  }
+
   const inputValue = inputProps.value || value
 
   const [Wrapper, InputWrapper, Input] =
@@ -45,12 +50,23 @@ export const TextField = (props: Props) => {
 
   return (
     <Space y={0.25}>
-      <Wrapper {...animationProps} data-active={!!inputValue} data-warning={warning}>
+      <Wrapper
+        {...animationProps}
+        data-active={!!inputValue}
+        data-warning={warning}
+        onClick={handleClickWrapper}
+      >
         <Label htmlFor={inputProps.id} data-disabled={inputProps.disabled} data-variant={variant}>
           {label}
         </Label>
         <InputWrapper>
-          <Input {...inputProps} onKeyDown={highlight} onChange={handleChange} value={inputValue} />
+          <Input
+            {...inputProps}
+            ref={inputRef}
+            onKeyDown={highlight}
+            onChange={handleChange}
+            value={inputValue}
+          />
           {suffix && inputValue && (
             <Text as="span" size={variant === 'large' ? 'xl' : 'lg'} color="textSecondary">
               {suffix}
@@ -100,6 +116,7 @@ const BaseWrapper = styled(motion.div)({
   borderRadius: theme.radius.sm,
   backgroundColor: theme.colors.gray100,
   width: '100%',
+  cursor: 'text',
 
   '&[data-warning=true]': {
     animation: `${warningAnimation} 1.5s cubic-bezier(0.2, -2, 0.8, 2) 2`,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Allow user to click anywhere in the text field wrapper to focus the input field.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

It's generally a bad idea to attach `onClick` to divs but in this case it's just a nice feature for sighted users so we don't need to worry about accessibility I believe.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
