### PR TITLE
GRW-2289 - refact(ImageTextBlock): leverage ImageBlock for image rendering

### DIFF
--- a/apps/store/src/blocks/ButtonBlock.tsx
+++ b/apps/store/src/blocks/ButtonBlock.tsx
@@ -1,11 +1,10 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { ComponentProps } from 'react'
-import { Button, theme } from 'ui'
+import { Button, ConditionalWrapper, theme } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
-import { VerticalBodyWrapper, FluidBodyWrapper } from './ImageTextBlock'
 
 export type ButtonBlockProps = SbBaseBlockProps<{
   text: string
@@ -14,17 +13,18 @@ export type ButtonBlockProps = SbBaseBlockProps<{
   size: ComponentProps<typeof Button>['size']
 }>
 
-export const ButtonBlock = ({ blok }: ButtonBlockProps) => {
+export const ButtonBlock = ({ blok, nested }: ButtonBlockProps) => {
   return (
-    <Wrapper {...storyblokEditable(blok)}>
+    <ConditionalWrapper condition={!nested} wrapWith={(children) => <Wrapper>{children}</Wrapper>}>
       <ButtonNextLink
+        {...storyblokEditable(blok)}
         href={getLinkFieldURL(blok.link, blok.text)}
         variant={blok.variant ?? 'primary'}
         size={blok.size ?? 'medium'}
       >
         {blok.text}
       </ButtonNextLink>
-    </Wrapper>
+    </ConditionalWrapper>
   )
 }
 ButtonBlock.blockName = 'button'
@@ -34,13 +34,4 @@ const Wrapper = styled.div({
   justifyContent: 'center',
   paddingLeft: theme.space.md,
   paddingRight: theme.space.md,
-
-  [`${VerticalBodyWrapper} &, ${FluidBodyWrapper} &`]: {
-    display: 'inline-block',
-    padding: 0,
-    '&:not(:last-of-type)': {
-      marginBottom: theme.space.xs,
-      marginRight: theme.space.xs,
-    },
-  },
 })

--- a/apps/store/src/blocks/HeadingBlock.tsx
+++ b/apps/store/src/blocks/HeadingBlock.tsx
@@ -2,15 +2,10 @@ import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { ConditionalWrapper, Heading, HeadingProps, PossibleHeadingVariant, theme } from 'ui'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
-import { VerticalBodyWrapper, FluidBodyWrapper } from './ImageTextBlock'
 
 const Wrapper = styled.div({
   paddingLeft: theme.space.md,
   paddingRight: theme.space.md,
-
-  [`${VerticalBodyWrapper} &, ${FluidBodyWrapper} &`]: {
-    padding: 0,
-  },
 })
 
 export type HeadingBlockProps = SbBaseBlockProps<{

--- a/apps/store/src/blocks/ImageBlock.tsx
+++ b/apps/store/src/blocks/ImageBlock.tsx
@@ -2,14 +2,14 @@ import isPropValid from '@emotion/is-prop-valid'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import NextImage from 'next/image'
-import { mq, theme } from 'ui'
+import { ConditionalWrapper, mq, theme } from 'ui'
 import { HeadingBlock, HeadingBlockProps } from '@/blocks/HeadingBlock'
 import { ExpectedBlockType, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 
 export type ImageAspectRatio = '1 / 1' | '2 / 1' | '3 / 2' | '4 / 3' | '5 / 4' | '16 / 9'
 
-type ImageBlockProps = SbBaseBlockProps<{
+export type ImageBlockProps = SbBaseBlockProps<{
   image: StoryblokAsset
   aspectRatioLandscape?: ImageAspectRatio
   aspectRatioPortrait?: ImageAspectRatio
@@ -17,33 +17,34 @@ type ImageBlockProps = SbBaseBlockProps<{
   body?: ExpectedBlockType<HeadingBlockProps>
 }>
 
-export const ImageBlock = ({ blok }: ImageBlockProps) => {
+export const ImageBlock = ({ blok, nested }: ImageBlockProps) => {
   const headingBlocks = filterByBlockType(blok.body, HeadingBlock.blockName)
 
-  const content = (
-    <Wrapper
-      {...storyblokEditable(blok)}
-      aspectRatioLandscape={blok.aspectRatioLandscape}
-      aspectRatioPortrait={blok.aspectRatioPortrait}
+  return (
+    <ConditionalWrapper
+      condition={!blok.fullBleed && !nested}
+      wrapWith={(children) => <Layout>{children}</Layout>}
     >
-      <Image
-        style={{ objectFit: 'cover' }}
-        src={blok.image.filename}
-        roundedCorners={!blok.fullBleed}
-        alt={blok.image.alt}
-        fill
-      />
-      <BodyWrapper>
-        {headingBlocks.map((nestedBlock) => (
-          <HeadingBlock key={nestedBlock._uid} blok={nestedBlock} />
-        ))}
-      </BodyWrapper>
-    </Wrapper>
+      <ImageWrapper
+        {...storyblokEditable(blok)}
+        aspectRatioLandscape={blok.aspectRatioLandscape}
+        aspectRatioPortrait={blok.aspectRatioPortrait}
+      >
+        <Image
+          style={{ objectFit: 'cover' }}
+          src={blok.image.filename}
+          roundedCorners={!blok.fullBleed}
+          alt={blok.image.alt}
+          fill
+        />
+        <BodyWrapper>
+          {headingBlocks.map((nestedBlock) => (
+            <HeadingBlock key={nestedBlock._uid} blok={nestedBlock} />
+          ))}
+        </BodyWrapper>
+      </ImageWrapper>
+    </ConditionalWrapper>
   )
-
-  if (blok.fullBleed) return content
-
-  return <Layout>{content}</Layout>
 }
 ImageBlock.blockName = 'image'
 
@@ -54,7 +55,7 @@ type WrapperProps = {
   aspectRatioPortrait?: ImageAspectRatio
 }
 
-const Wrapper = styled('div', { shouldForwardProp: isPropValid })<WrapperProps>(
+const ImageWrapper = styled('div', { shouldForwardProp: isPropValid })<WrapperProps>(
   ({ aspectRatioLandscape = '3 / 2', aspectRatioPortrait = '3 / 2' }) => ({
     position: 'relative',
     ['@media (orientation: landscape)']: {


### PR DESCRIPTION
## Describe your changes

* Update `ImageTextBlock` so it leverages an `ImageBlock` to get an image rendered;
* General updates: Export _wrapper_ components defined inside `ButtonBlock`, `HeadingBlock` and `ImageBlock` components so I can use then to override spacing related styles (E.g: padding) while rendering those blocks inside an `ImageTextBlock`. Due to cycle dependencies, I couldn't achieve the same by doing the inverse as we've done in some places in the codebase; That would mean, import parent container inside children and use it to get children's styles overridden.

## Justify why they are needed

What _design team_ requested was a way for editors to configure `ImageTextBlock`'s image aspect ratios based on screen orientation - something that's already supported by `ImageBlock`. So instead of updating `ImageTextBlock` to receive the same controls `ImageBlock` does to achieve that goal, I'm composing both blocks.

## Next steps

As one can see, I've added a new field for `ImageTextBlock` - `imageBlock`. My idea is to get this reviewed and merged first. Then I'm going to remove old `image` field and rename ~`imageBlock`~ --> `image`.

<img width="399" alt="image" src="https://user-images.githubusercontent.com/19200662/220856807-f725ac79-32cf-4341-a916-7b39e54ce574.png">


## Jira issue(s): [GRW-2289](https://hedvig.atlassian.net/browse/GRW-2289)

[GRW-2289]: https://hedvig.atlassian.net/browse/GRW-2289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ