### PR TITLE
Put nested prop outside of Storyblok data

### DIFF
--- a/apps/store/src/blocks/HeadingBlock.tsx
+++ b/apps/store/src/blocks/HeadingBlock.tsx
@@ -20,16 +20,12 @@ export type HeadingBlockProps = SbBaseBlockProps<{
   variant?: PossibleHeadingVariant
   variantDesktop?: PossibleHeadingVariant
   textAlignment?: HeadingProps['align']
-  nested?: boolean
   balance?: boolean
 }>
 
-export const HeadingBlock = ({ blok }: HeadingBlockProps) => {
+export const HeadingBlock = ({ blok, nested }: HeadingBlockProps) => {
   return (
-    <ConditionalWrapper
-      condition={!blok.nested}
-      wrapWith={(children) => <Wrapper>{children}</Wrapper>}
-    >
+    <ConditionalWrapper condition={!nested} wrapWith={(children) => <Wrapper>{children}</Wrapper>}>
       <Heading
         as={blok.as}
         variant={{ _: blok.variant ?? 'standard.32', md: blok.variantDesktop ?? 'standard.40' }}

--- a/apps/store/src/blocks/TextContentBlock.tsx
+++ b/apps/store/src/blocks/TextContentBlock.tsx
@@ -25,10 +25,7 @@ export const TextContentBlock = ({ blok }: Props) => {
       >
         <Space y={1}>
           {blok.body?.map((nestedBlock) => (
-            <StoryblokComponent
-              key={nestedBlock._uid}
-              blok={{ ...nestedBlock, ...{ nested: true } }}
-            />
+            <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} nested={true} />
           ))}
         </Space>
       </GridLayout.Content>

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -57,6 +57,7 @@ import { GLOBAL_STORY_PROP_NAME, STORY_PROP_NAME } from './Storyblok.constant'
 
 export type SbBaseBlockProps<T> = {
   blok: SbBlokData & T
+  nested?: boolean
 }
 
 export type ExpectedBlockType<T> = [T] extends [{ blok: SbBlokData }]


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Put `nested` prop outside Storyblok data
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
When using blocks inside other blocks, we don't want to render any padding (meaning no need for a `Wrapper`). So instead of overriding with nested CSS, exporting Wrapper from every component, I'm leaning towards the `ConditionalWrapper` pattern that we can reuse across blocks. 

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
