### PR TITLE
Fix various text field bugs

### DIFF
--- a/apps/store/src/components/CartInventory/CampaignsSection.tsx
+++ b/apps/store/src/components/CartInventory/CampaignsSection.tsx
@@ -46,6 +46,7 @@ export const CampaignsSection = ({ cartId, campaigns }: Props) => {
             variant="small"
             warning={!!errorMessage}
             message={errorMessage}
+            required={true}
           />
           <Button variant="primary-alt" loading={loadingRedeem}>
             {t('CHECKOUT_ADD_DISCOUNT_BUTTON')}

--- a/apps/store/src/components/TextField/TextField.tsx
+++ b/apps/store/src/components/TextField/TextField.tsx
@@ -77,7 +77,7 @@ export const TextField = (props: Props) => {
             (inputProps.disabled ? (
               <LockIcon size="1rem" color={theme.colors.textSecondary} />
             ) : (
-              <DeleteButton type="button" onClick={handleClickDelete}>
+              <DeleteButton type="button" onClick={handleClickDelete} aria-hidden={true}>
                 <CrossIcon size="1rem" />
               </DeleteButton>
             ))}
@@ -104,7 +104,7 @@ const warningColorAnimation = keyframes({
     color: theme.colors.amberText,
   },
   '100%': {
-    color: theme.colors.textPrimary,
+    color: theme.colors.textSecondary,
   },
 })
 
@@ -119,7 +119,7 @@ const BaseWrapper = styled(motion.div)({
   cursor: 'text',
 
   '&[data-warning=true]': {
-    animation: `${warningAnimation} 1.5s cubic-bezier(0.2, -2, 0.8, 2) 2`,
+    animation: `${warningAnimation} 1.5s cubic-bezier(0.2, -2, 0.8, 2) 1`,
   },
 })
 
@@ -158,7 +158,7 @@ const Label = styled.label({
   },
 
   [`${LargeWrapper}[data-warning=true] > &, ${SmallWrapper}[data-warning=true] > &`]: {
-    animation: `${warningColorAnimation} 1.5s cubic-bezier(0.2, -2, 0.8, 2) 2`,
+    animation: `${warningColorAnimation} 1.5s cubic-bezier(0.2, -2, 0.8, 2) 1`,
   },
 
   '&&[data-disabled=true]': {
@@ -199,10 +199,10 @@ const SmallInput = styled(LargeInput)({ fontSize: theme.fontSizes.lg })
 const MessageText = styled(Text)({ paddingLeft: theme.space.md })
 
 const DeleteButton = styled.button({
-  display: 'none',
   cursor: 'pointer',
+  opacity: 0,
 
   [`${LargeWrapper}:focus-within &, ${SmallWrapper}:focus-within &`]: {
-    display: 'block',
+    opacity: 1,
   },
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Fix delete button on Safari by not using `display: none`
- Only run warning animation 1 time (instead of 2)
- Fix label color warning animation
- Make campaign code input required

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Safari doesn't like setting display to none on a button. It seems like it just doesn't register the event handlers. Instead I just show/hide the button with opacity which I think works fine. Let me know if you think there are some accessibility issues with this.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
