### PR TITLE
Only show Get a Price button for leaf product pages

### DIFF
--- a/apps/store/src/blocks/ProductCardBlock.tsx
+++ b/apps/store/src/blocks/ProductCardBlock.tsx
@@ -1,4 +1,5 @@
 import { storyblokEditable } from '@storyblok/react'
+import { useProductMetadata } from '@/components/LayoutWithMenu/ProductMetadataContext'
 import { ProductCard } from '@/components/ProductCard/ProductCard'
 import { SbBaseBlockProps, LinkField, StoryblokAsset } from '@/services/storyblok/storyblok'
 import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
@@ -18,6 +19,10 @@ export type ProductCardBlockProps = SbBaseBlockProps<
 
 export const ProductCardBlock = ({ blok }: ProductCardBlockProps) => {
   const link = getLinkFieldURL(blok.link, blok.title)
+  const productMetadata = useProductMetadata()
+  const linkType = productMetadata?.some((product) => isSameLink(link, product.pageLink))
+    ? 'product'
+    : 'content'
 
   return (
     <ProductCard
@@ -25,10 +30,15 @@ export const ProductCardBlock = ({ blok }: ProductCardBlockProps) => {
       subtitle={blok.subtitle}
       image={{ src: blok.image.filename, alt: blok.image.alt }}
       aspectRatio={blok.aspectRatio ?? '5 / 4'}
-      // TODO: determine if link is to a product or content page
-      link={{ url: link, type: 'product' }}
+      link={{ url: link, type: linkType }}
       {...storyblokEditable(blok)}
     />
   )
 }
 ProductCardBlock.blockName = 'productCard'
+
+// Make sure /en-se/products/home == en-se/products/home
+const isSameLink = (a: string, b: string) => {
+  const normalize = (url: string) => url.replace(/^\//, '')
+  return normalize(a) === normalize(b)
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Hide Get a Price button for product cards leading to CMS pages like "Home"

![Screenshot 2023-02-24 at 10.57.53.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/12331a93-62f1-4746-983d-833ac8cdf28b/Screenshot%202023-02-24%20at%2010.57.53.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We cannot get a price unless target page is "real" product page, not a CMS page for some product group

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
