### PR TITLE
PerilGrid refactor

### DIFF
--- a/apps/store/src/components/Perils/Perils.stories.tsx
+++ b/apps/store/src/components/Perils/Perils.stories.tsx
@@ -77,7 +77,7 @@ const PageWrapper = styled.div({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'space-between',
-  height: '95vh',
+  height: '95dvh',
 })
 
 const PerilsWrapper = styled.div({

--- a/apps/store/src/components/Perils/Perils.stories.tsx
+++ b/apps/store/src/components/Perils/Perils.stories.tsx
@@ -77,7 +77,7 @@ const PageWrapper = styled.div({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'space-between',
-  height: '95dvh',
+  height: ['95dvh', '95vh'],
 })
 
 const PerilsWrapper = styled.div({

--- a/apps/store/src/components/Perils/Perils.tsx
+++ b/apps/store/src/components/Perils/Perils.tsx
@@ -24,10 +24,10 @@ const getPerilColumns = (items: PerilFragment[], columns: number) => {
 
 export const Perils = ({ items }: Props) => {
   const BREAKPOINTS = {
-    sm: useBreakpoint('sm'),
-    md: useBreakpoint('md'),
-    lg: useBreakpoint('lg'),
     xl: useBreakpoint('xl'),
+    lg: useBreakpoint('lg'),
+    md: useBreakpoint('md'),
+    sm: useBreakpoint('sm'),
   } as const
 
   const getColumnCountByBreakpoint = (breakpoints: typeof BREAKPOINTS) => {

--- a/apps/store/src/components/Perils/Perils.tsx
+++ b/apps/store/src/components/Perils/Perils.tsx
@@ -71,7 +71,7 @@ const PerilsAccordion = ({ peril }: { peril: PerilFragment }) => {
   }, [])
 
   return (
-    <Accordion.Root type="single" value={openedItems} onValueChange={handleValueChange}>
+    <Accordion.Root type="multiple" value={openedItems} onValueChange={handleValueChange}>
       <Accordion.Item key={title} value={title}>
         <Accordion.HeaderWithTrigger>
           <HeaderWrapper>

--- a/apps/store/src/components/Perils/Perils.tsx
+++ b/apps/store/src/components/Perils/Perils.tsx
@@ -40,11 +40,11 @@ export const Perils = ({ items }: Props) => {
   return (
     <PerilsAccordionGrid>
       {getPerilColumns(items, getColumnCountByBreakpoint(BREAKPOINTS)).map((perils, index) => (
-        <div key={index}>
+        <PerilColumnFlex key={index}>
           {perils.map((peril) => (
             <PerilsAccordion key={index} peril={peril} />
           ))}
-        </div>
+        </PerilColumnFlex>
       ))}
     </PerilsAccordionGrid>
   )
@@ -53,10 +53,13 @@ export const Perils = ({ items }: Props) => {
 const PerilsAccordionGrid = styled.div(() => ({
   display: 'grid',
   gap: theme.space.xxs,
-  // It needs a defined width to trigger ellipses on mobile
-  // gridTemplateColumns: '100%',
-
   gridTemplateColumns: 'repeat(auto-fit, minmax(17rem, 1fr))',
+}))
+
+const PerilColumnFlex = styled.div(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.space.xxs,
 }))
 
 const PerilsAccordion = ({ peril }: { peril: PerilFragment }) => {
@@ -68,7 +71,7 @@ const PerilsAccordion = ({ peril }: { peril: PerilFragment }) => {
   }, [])
 
   return (
-    <Accordion.Root type="multiple" value={openedItems} onValueChange={handleValueChange}>
+    <Accordion.Root type="single" value={openedItems} onValueChange={handleValueChange}>
       <Accordion.Item key={title} value={title}>
         <Accordion.HeaderWithTrigger>
           <HeaderWrapper>

--- a/apps/store/src/components/Perils/Perils.tsx
+++ b/apps/store/src/components/Perils/Perils.tsx
@@ -9,7 +9,7 @@ type Props = {
   items: Array<PerilFragment>
 }
 
-const createPerilColumns = (items: PerilFragment[], columns: number) => {
+const getPerilColumns = (items: PerilFragment[], columns: number) => {
   const accordions = items.reduce((acc, item, index) => {
     const columnIndex = index % columns
     if (!acc[columnIndex]) {
@@ -23,34 +23,23 @@ const createPerilColumns = (items: PerilFragment[], columns: number) => {
 }
 
 export const Perils = ({ items }: Props) => {
-  const twoCols = createPerilColumns(items, 2)
-  const threeCols = createPerilColumns(items, 3)
-  const fourCols = createPerilColumns(items, 4)
-
-  const breakpoints = {
+  const BREAKPOINTS = {
     sm: useBreakpoint('sm'),
     md: useBreakpoint('md'),
     lg: useBreakpoint('lg'),
     xl: useBreakpoint('xl'),
-  }
+  } as const
 
-  const columnCount = () => {
-    if (breakpoints.xl) {
-      return 4
-    }
-    if (breakpoints.lg) {
-      return 4
-    }
-    if (breakpoints.md) {
-      return 3
-    }
+  const getColumnCountByBreakpoint = (breakpoints: typeof BREAKPOINTS) => {
+    if (breakpoints.xl) return 4
+    if (breakpoints.lg) return 3
+    if (breakpoints.md) return 2
     return 1
   }
 
-  console.log(columnCount())
   return (
     <PerilsAccordionGrid>
-      {createPerilColumns(items, columnCount()).map((perils, index) => (
+      {getPerilColumns(items, getColumnCountByBreakpoint(BREAKPOINTS)).map((perils, index) => (
         <div key={index}>
           {perils.map((peril) => (
             <PerilsAccordion key={index} peril={peril} />
@@ -65,14 +54,9 @@ const PerilsAccordionGrid = styled.div(() => ({
   display: 'grid',
   gap: theme.space.xxs,
   // It needs a defined width to trigger ellipses on mobile
-  gridTemplateColumns: '100%',
+  // gridTemplateColumns: '100%',
 
-  [mq.md]: {
-    gridTemplateColumns: 'repeat(auto-fit, minmax(20rem, 1fr))',
-  },
-  [mq.lg]: {
-    // gridTemplateColumns: 'repeat(auto-fit, minmax(20rem, 1fr))',
-  },
+  gridTemplateColumns: 'repeat(auto-fit, minmax(17rem, 1fr))',
 }))
 
 const PerilsAccordion = ({ peril }: { peril: PerilFragment }) => {

--- a/apps/store/src/components/Perils/Perils.tsx
+++ b/apps/store/src/components/Perils/Perils.tsx
@@ -53,13 +53,19 @@ export const Perils = ({ items }: Props) => {
 const PerilsAccordionGrid = styled.div(() => ({
   display: 'grid',
   gap: theme.space.xxs,
-  gridTemplateColumns: 'repeat(auto-fit, minmax(17rem, 1fr))',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(20rem, 1fr))',
+  [mq.md]: {
+    columnGap: theme.space.md,
+  },
 }))
 
 const PerilColumnFlex = styled.div(() => ({
   display: 'flex',
   flexDirection: 'column',
   gap: theme.space.xxs,
+  [mq.md]: {
+    gap: theme.space.xs,
+  },
 }))
 
 const PerilsAccordion = ({ peril }: { peril: PerilFragment }) => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

**The issue**
The Perils grid would push other perils down when expanded because the grid was creating additional rows that would get pushed down.

**My solution**
Decided to create arrays of perils. Each representing a column in the grid. This way each column can expand down without pushing others down. 

**Tradeoffs**

one thing we lose here is when there are 2 or 3 perils they fill the width of the container rather than taking of 1/4th of the container each. Looking around the app it seems like we don't really have any situations where we only show < 4 perils so perhaps not an issue. 

## Before

https://user-images.githubusercontent.com/50870173/221164612-08609e32-f38f-4759-bca6-47a32f17fc72.mov

## After 

https://user-images.githubusercontent.com/50870173/221165526-fbe890ad-f221-43b2-9196-e10f1c0556d9.mov

## Storybook Playground

https://user-images.githubusercontent.com/50870173/221167450-3dbe5bc2-37ee-434f-952a-3eddb075b9a1.mov


## Justify why they are needed

Improved UX

## Jira issue(s): [https://hedvig.atlassian.net/browse/GRW-2263]


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
