### PR TITLE
Enforce timeout on Apollo requests with ApolloLinkTimeout

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -38,6 +38,7 @@
     "@types/uuid": "9.0.0",
     "@vercel/edge-config": "0.1.1",
     "ajv": "8.12.0",
+    "apollo-link-timeout": "1.3.1",
     "cookies-next": "2.1.1",
     "framer-motion": "9.0.7",
     "graphql": "16.6.0",

--- a/apps/store/src/services/apollo/client.ts
+++ b/apps/store/src/services/apollo/client.ts
@@ -2,14 +2,15 @@ import {
   ApolloClient,
   ApolloError,
   ApolloLink,
+  createHttpLink,
   from,
-  HttpLink,
   InMemoryCache,
   NormalizedCacheObject,
 } from '@apollo/client'
 import { setContext } from '@apollo/client/link/context'
 import { ErrorResponse, onError } from '@apollo/client/link/error'
 import { mergeDeep } from '@apollo/client/utilities'
+import ApolloLinkTimeout from 'apollo-link-timeout'
 import { GetServerSidePropsContext } from 'next'
 import { i18n } from 'next-i18next'
 import { AppInitialProps } from 'next/app'
@@ -59,7 +60,10 @@ const languageLink = setContext((_, { headers = {}, ...context }) => {
   }
 })
 
-const httpLink = new HttpLink({ uri: process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT })
+const httpLink = createHttpLink({ uri: process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT })
+
+const DEFAULT_TIMEOUT = 50 * 1000
+const timeoutLink = new ApolloLinkTimeout(DEFAULT_TIMEOUT) as unknown as ApolloLink
 
 const createApolloClient = (defaultHeaders?: Record<string, string>) => {
   const headersLink = setContext(async (_, prevContext) => {
@@ -83,6 +87,7 @@ const createApolloClient = (defaultHeaders?: Record<string, string>) => {
       errorLink,
       headersLink,
       languageLink,
+      timeoutLink,
       httpLink,
     ]),
     cache: new InMemoryCache({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7544,6 +7544,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wry/equality@npm:^0.1.2":
+  version: 0.1.11
+  resolution: "@wry/equality@npm:0.1.11"
+  dependencies:
+    tslib: ^1.9.3
+  checksum: 1a26a0fd11e3e3a6a197d9a54a5bec523caf693daa24ad2709f496e43dd3cd12290a0d17df81f8a783437795f6c64a1ca2717cdac6e79022bde4450c11e705c9
+  languageName: node
+  linkType: hard
+
 "@wry/equality@npm:^0.5.0":
   version: 0.5.2
   resolution: "@wry/equality@npm:0.5.2"
@@ -7983,6 +7992,43 @@ __metadata:
     normalize-path: ^3.0.0
     picomatch: ^2.0.4
   checksum: 985163db2292fac9e5a1e072bf99f1b5baccf196e4de25a0b0b81865ebddeb3b3eb4480734ef0a2ac8c002845396b91aa89121f5b84f93981a4658164a9ec6e9
+  languageName: node
+  linkType: hard
+
+"apollo-link-timeout@npm:1.3.1":
+  version: 1.3.1
+  resolution: "apollo-link-timeout@npm:1.3.1"
+  dependencies:
+    apollo-link: ^1.2.2
+  checksum: 5f62ad8ae8c9be2c014c1f7cb805762e82a4edc8937c985fc6fecb54af75ce4226ce0b636fd12e3aa56b566f0f1e08f31fc71f7f737fb9de1ae223cee79b37fe
+  languageName: node
+  linkType: hard
+
+"apollo-link@npm:^1.2.2":
+  version: 1.2.14
+  resolution: "apollo-link@npm:1.2.14"
+  dependencies:
+    apollo-utilities: ^1.3.0
+    ts-invariant: ^0.4.0
+    tslib: ^1.9.3
+    zen-observable-ts: ^0.8.21
+  peerDependencies:
+    graphql: ^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0
+  checksum: ad8d051ffceb270cdbbcc71d499bce2fda437a65fac6edc859a9e2dc0dbcb10b6a3f4da41789e786270aa358719c8b71315f383a698a74957df0d7aeea042918
+  languageName: node
+  linkType: hard
+
+"apollo-utilities@npm:^1.3.0":
+  version: 1.3.4
+  resolution: "apollo-utilities@npm:1.3.4"
+  dependencies:
+    "@wry/equality": ^0.1.2
+    fast-json-stable-stringify: ^2.0.0
+    ts-invariant: ^0.4.0
+    tslib: ^1.10.0
+  peerDependencies:
+    graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+  checksum: 6e0192a3420782909c930f5230808d7fbbdbcdfccddd960120e19bab251b77a16e590b05dbb4a7da2c27c59077fbfd53e56819a9fae694debe7f898e8b0ec1e9
   languageName: node
   linkType: hard
 
@@ -21398,6 +21444,7 @@ __metadata:
     "@types/uuid": 9.0.0
     "@vercel/edge-config": 0.1.1
     ajv: 8.12.0
+    apollo-link-timeout: 1.3.1
     babel-loader: 9.1.2
     cookies-next: 2.1.1
     eslint-config-custom: "workspace:"
@@ -22369,6 +22416,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-invariant@npm:^0.4.0":
+  version: 0.4.4
+  resolution: "ts-invariant@npm:0.4.4"
+  dependencies:
+    tslib: ^1.9.3
+  checksum: 58b32fb6b7c479e602e55b9eb63bb99a203c5db09367d3aa7c3cbe000ba62f919eea7f031f55172df9b6d362a6f1a87e906df84b04b8c74c88e507ac58f7a554
+  languageName: node
+  linkType: hard
+
 "ts-jest@npm:29.0.5":
   version: 29.0.5
   resolution: "ts-jest@npm:29.0.5"
@@ -22504,7 +22560,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.0.0, tslib@npm:^1.8.1":
+"tslib@npm:^1.0.0, tslib@npm:^1.10.0, tslib@npm:^1.8.1, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -24364,7 +24420,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zen-observable@npm:0.8.15":
+"zen-observable-ts@npm:^0.8.21":
+  version: 0.8.21
+  resolution: "zen-observable-ts@npm:0.8.21"
+  dependencies:
+    tslib: ^1.9.3
+    zen-observable: ^0.8.0
+  checksum: 2931628598937effcc77acf88ac8d3468c0584bbc4488726ae2c94f6a02615ff80e9d6dc0943b71bc874466ab371837737ce8245eed3bfea38daa466a2fdc6ce
+  languageName: node
+  linkType: hard
+
+"zen-observable@npm:0.8.15, zen-observable@npm:^0.8.0":
   version: 0.8.15
   resolution: "zen-observable@npm:0.8.15"
   checksum: b7289084bc1fc74a559b7259faa23d3214b14b538a8843d2b001a35e27147833f4107590b1b44bf5bc7f6dfe6f488660d3a3725f268e09b3925b3476153b7821


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add 50s timeout to ApolloClient requesta

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We want to crash with useful stacktrace if some request takes too long.  Hitting 60s will lead to Vercel function timeout without any debugging info

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
