### PR TITLE
Quick add to cart: scroll to top of page

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -7,7 +7,7 @@ import { Button, PlusIcon, Space, Text, theme } from 'ui'
 import { useUpdateCancellation } from '@/components/ProductPage/PurchaseForm/useUpdateCancellation'
 import { useUpdateStartDate } from '@/components/ProductPage/PurchaseForm/useUpdateStartDate'
 import { ScrollPast } from '@/components/ProductPage/ScrollPast/ScrollPast'
-import { ScrollToButton } from '@/components/ProductPage/ScrollToButton/ScrollToButton'
+import { ScrollToTopButton } from '@/components/ProductPage/ScrollToButton/ScrollToButton'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { TierSelector } from '@/components/TierSelector/TierSelector'
 import {
@@ -188,13 +188,13 @@ export const OfferPresenter = (props: Props) => {
         )}
       </Space>
       <ScrollPast targetRef={scrollPastRef}>
-        <ScrollToButton targetRef={scrollPastRef} type="button">
+        <ScrollToTopButton type="button">
           <ScrollPastButtonContent>
             <span>{displayPrice}</span>
             <Separator />
             <span>{t('ADD_TO_CART_BUTTON_LABEL')}</span>
           </ScrollPastButtonContent>
-        </ScrollToButton>
+        </ScrollToTopButton>
       </ScrollPast>
     </>
   )

--- a/apps/store/src/components/ProductPage/ScrollToButton/ScrollToButton.stories.tsx
+++ b/apps/store/src/components/ProductPage/ScrollToButton/ScrollToButton.stories.tsx
@@ -1,14 +1,14 @@
-import { ComponentMeta, Story } from '@storybook/react'
-import { ScrollToButton, ScrollToButtonProps } from './ScrollToButton'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { ScrollToTopButton } from './ScrollToButton'
 
 export default {
-  title: 'Product Page / Scroll To Button',
-  component: ScrollToButton,
+  title: 'Product Page / Scroll To Top Button',
+  component: ScrollToTopButton,
   argTypes: {},
-} as ComponentMeta<typeof ScrollToButton>
+} as ComponentMeta<typeof ScrollToTopButton>
 
-const Template: Story<ScrollToButtonProps> = (props) => {
-  return <ScrollToButton {...props} />
+const Template: ComponentStory<typeof ScrollToTopButton> = (props) => {
+  return <ScrollToTopButton {...props} />
 }
 
 export const Default = Template.bind({})

--- a/apps/store/src/components/ProductPage/ScrollToButton/ScrollToButton.tsx
+++ b/apps/store/src/components/ProductPage/ScrollToButton/ScrollToButton.tsx
@@ -1,15 +1,14 @@
 import styled from '@emotion/styled'
-import { ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { Button, mq, theme } from 'ui'
 
-export type ScrollToButtonProps = {
+type ScrollToTopButtonProps = {
   type: 'button' | 'submit'
-  targetRef: React.RefObject<HTMLElement>
   children: ReactNode
 }
 
-export const ScrollToButton = ({ children, type, targetRef }: ScrollToButtonProps) => {
-  const handleClick = () => targetRef.current?.scrollIntoView({ behavior: 'smooth' })
+export const ScrollToTopButton = ({ children, type }: ScrollToTopButtonProps) => {
+  const handleClick = () => window.scrollTo({ top: 0 })
 
   return (
     <Wrapper>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Update quick "add to cart" button on the footer of PDP page (mobile only)

Scroll all the way to the top of the page when clicking on the "add to cart" button

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Before it just scrolled to the main "add to cart" button, which looks a bit weird.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
