### PR TITLE
GRW-2289 - refact(ImageTextBlock): updated image field

### DIFF
--- a/apps/store/src/blocks/ImageTextBlock.tsx
+++ b/apps/store/src/blocks/ImageTextBlock.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import { SbBlokData, StoryblokComponent } from '@storyblok/react'
 import { mq, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
-import { SbBaseBlockProps, StoryblokAsset, ExpectedBlockType } from '@/services/storyblok/storyblok'
+import { SbBaseBlockProps, ExpectedBlockType } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 import { ImageBlock, ImageBlockProps } from './ImageBlock'
 
@@ -15,8 +15,7 @@ const DEFAULT_TEXT_ALIGNMENT: TextAlignment = 'top'
 const DEFAULT_IMAGE_PLACEMENT: ImagePlacement = 'right'
 
 type ImageTextBlockProps = SbBaseBlockProps<{
-  image: StoryblokAsset
-  imageBlock: ExpectedBlockType<ImageBlockProps>
+  image: ExpectedBlockType<ImageBlockProps>
   body?: SbBlokData[]
   orientation?: Orientation
   textAlignment?: TextAlignment
@@ -25,8 +24,8 @@ type ImageTextBlockProps = SbBaseBlockProps<{
 
 export const ImageTextBlock = ({ blok }: ImageTextBlockProps) => {
   const { orientation = DEFAULT_ORIENTATION } = blok
-  // We only expect only one image from Storyblok
-  const imageBlock = filterByBlockType(blok.imageBlock, ImageBlock.blockName)[0]
+  // We expect only one image from Storyblok
+  const imageBlock = filterByBlockType(blok.image, ImageBlock.blockName)[0]
 
   switch (orientation) {
     case 'fluid':


### PR DESCRIPTION
## Describe your changes

* Updated `ImageTextBlock`'s `image` field so instead of taking in a _Image Asset_ it takes in an `Image` block

## Justify why they are needed

This is part of enabling image format configuration for `ImageTextBlock` - like aspect ratio - as we have for `ImageBlock`

**Before**

<img width="391" alt="image" src="https://user-images.githubusercontent.com/19200662/221514430-8e829f07-f78c-42a6-8bc9-1746f513e84b.png">

**After**

<img width="391" alt="image" src="https://user-images.githubusercontent.com/19200662/221514525-820b9436-4695-4670-a174-03d26d9ccc10.png">

## Jira issue(s): [GRW-2289](https://hedvig.atlassian.net/browse/GRW-2289)

## Relates with

https://github.com/HedvigInsurance/racoon/pull/1754

[GRW-2289]: https://hedvig.atlassian.net/browse/GRW-2289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ