### PR TITLE
Various menu tweaks

### DIFF
--- a/apps/store/src/blocks/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock.tsx
@@ -2,8 +2,9 @@ import styled from '@emotion/styled'
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import { storyblokEditable } from '@storyblok/react'
 import { useTranslation } from 'next-i18next'
+import { useRouter } from 'next/router'
 import { useMemo, useState } from 'react'
-import { Space } from 'ui'
+import { mq, Space, theme, useBreakpoint } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { Header } from '@/components/Header/Header'
 import {
@@ -102,10 +103,12 @@ type ProductNavContainerBlockProps = SbBaseBlockProps<{
 type ProductNavItem = { name: string; url: string; image?: string }
 
 export const ProductNavContainerBlock = ({ blok }: ProductNavContainerBlockProps) => {
+  const router = useRouter()
   const { routingLocale } = useCurrentLocale()
   const { t } = useTranslation()
   const productMetadata = useProductMetadata()
   const filteredNavItems = filterByBlockType(blok.navItems, NavItemBlock.blockName)
+  const isLarge = useBreakpoint('lg')
 
   const productNavItems: Array<ProductNavItem> = []
   filteredNavItems.forEach((item) => {
@@ -125,39 +128,57 @@ export const ProductNavContainerBlock = ({ blok }: ProductNavContainerBlockProps
     }
   })
 
-  return (
-    <NavigationMenuPrimitiveItem value={blok.name} {...storyblokEditable(blok)}>
-      <Space y={{ base: 1.5, lg: 0 }}>
-        <NavigationTrigger>{blok.name}</NavigationTrigger>
-        <NavigationMenuPrimitiveContent>
-          <NavigationMenuListWrapper>
-            <Space y={{ base: 1.5, lg: 1 }}>
-              <NavigationMenuPrimitive.Sub defaultValue={blok.name}>
-                <ProductNavigationList>
-                  {productNavItems.map((item) => (
-                    <NavigationMenuProductItem key={item.name} value={item.name}>
-                      <ProductNavigationLink href={item.url} pillowImageSrc={item.image}>
-                        {item.name}
-                      </ProductNavigationLink>
-                    </NavigationMenuProductItem>
-                  ))}
-                </ProductNavigationList>
-              </NavigationMenuPrimitive.Sub>
-              <ButtonNextLinkFullWidth
-                href={PageLink.store({ locale: routingLocale })}
-                variant="secondary"
-                size="medium"
-              >
-                {t('NAVIGATION_STORE_LINK')}
-              </ButtonNextLinkFullWidth>
-            </Space>
-          </NavigationMenuListWrapper>
-        </NavigationMenuPrimitiveContent>
+  const content = (
+    <NavigationMenuListWrapper>
+      <Space y={{ base: 1.5, lg: 1 }}>
+        <NavigationMenuPrimitive.Sub defaultValue={blok.name}>
+          <ProductNavigationList>
+            {productNavItems.map((item) => (
+              <NavigationMenuProductItem key={item.name} value={item.name}>
+                <ProductNavigationLink href={item.url} pillowImageSrc={item.image}>
+                  {item.name}
+                </ProductNavigationLink>
+              </NavigationMenuProductItem>
+            ))}
+          </ProductNavigationList>
+        </NavigationMenuPrimitive.Sub>
+        <ButtonNextLinkFullWidth
+          href={PageLink.store({ locale: routingLocale })}
+          variant="secondary"
+          size="medium"
+        >
+          {t('NAVIGATION_STORE_LINK')}
+        </ButtonNextLinkFullWidth>
       </Space>
-    </NavigationMenuPrimitiveItem>
+    </NavigationMenuListWrapper>
   )
+
+  if (isLarge) {
+    return (
+      <NavigationMenuPrimitiveItem value={blok.name} {...storyblokEditable(blok)}>
+        <Space y={{ base: 1.5, lg: 0 }}>
+          <DesktopOnly>
+            <NavigationTrigger
+              onClick={() => router.push(PageLink.store({ locale: routingLocale }))}
+            >
+              {blok.name}
+            </NavigationTrigger>
+          </DesktopOnly>
+          <NavigationMenuPrimitiveContent>{content}</NavigationMenuPrimitiveContent>
+        </Space>
+      </NavigationMenuPrimitiveItem>
+    )
+  }
+
+  return <MobileWrapper>{content}</MobileWrapper>
 }
 ProductNavContainerBlock.blockName = 'productNavContainer'
+
+const DesktopOnly = styled.div({ display: 'none', [mq.lg]: { display: 'block' } })
+const MobileWrapper = styled.div({
+  paddingTop: theme.space.lg,
+  borderBottom: `1px solid ${theme.colors.borderOpaque}`,
+})
 
 const ButtonNextLinkFullWidth = styled(ButtonNextLink)({ width: '100%' })
 

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.stories.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.stories.tsx
@@ -91,6 +91,7 @@ export const Default = () => {
           Download the app`,
           faqTitle: 'Frequently asked questions',
           faqSubtitle: 'Here are some answers to the most common questions.',
+          seoTitle: 'Your purchase is complete | Hedvig',
         },
       }}
     />

--- a/apps/store/src/pages/confirmation/[shopSessionId].tsx
+++ b/apps/store/src/pages/confirmation/[shopSessionId].tsx
@@ -1,5 +1,6 @@
 import type { GetServerSideProps, NextPageWithLayout } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import Head from 'next/head'
 import { ConfirmationPage } from '@/components/ConfirmationPage/ConfirmationPage'
 import { ConfirmationPageProps } from '@/components/ConfirmationPage/ConfirmationPage.types'
 import { SuccessAnimation } from '@/components/ConfirmationPage/SuccessAnimation'
@@ -68,9 +69,14 @@ const CheckoutConfirmationPage: NextPageWithLayout<
   ConfirmationPageProps & { story: ConfirmationStory }
 > = (props) => {
   return (
-    <SuccessAnimation>
-      <ConfirmationPage {...props} />
-    </SuccessAnimation>
+    <>
+      <Head>
+        <title>{props.story.content.seoTitle}</title>
+      </Head>
+      <SuccessAnimation>
+        <ConfirmationPage {...props} />
+      </SuccessAnimation>
+    </>
   )
 }
 

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -161,6 +161,7 @@ export type ConfirmationStory = ISbStoryData & {
     checklistTitle: string
     checklistSubtitle: string
     checklist: string
+    seoTitle: string
   }
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Make top menu item clickable (links to store page)
- Remove "försäkringar" heading from product navigation section
- Render product navigation section outside menu item so it never closes



![Screenshot 2023-02-27 at 10.06.38.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/ff0cb0fb-6fa7-4c00-ab72-b9aab01d880f/Screenshot%202023-02-27%20at%2010.06.38.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

I couldn't figure out a way to avoid using "useBreakpoint". The more I work with this component, the more I think we should separate it into two components. One for mobile and one for desktop. It's getting too complicated.

Perhaps we can do that as a mob programming session?

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
