### PR TITLE
Create Storyblok plugin for column settings

### DIFF
--- a/apps/store/src/blocks/TextContentBlock.tsx
+++ b/apps/store/src/blocks/TextContentBlock.tsx
@@ -2,26 +2,29 @@ import styled from '@emotion/styled'
 import { StoryblokComponent, storyblokEditable } from '@storyblok/react'
 import { Space, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { ContentAlignment, ContentWidth } from '@/components/GridLayout/GridLayout.helper'
 import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { HeadingBlockProps } from './HeadingBlock'
 import { HeadingLabelBlockProps } from './HeadingLabelBlock'
 import { TextBlockProps } from './TextBlock'
 
-type Alignment = 'left' | 'center' | 'right' | 'justify'
+export type Layout = {
+  widths: ContentWidth
+  alignment: ContentAlignment
+}
 
 export type Props = SbBaseBlockProps<{
   heading?: ExpectedBlockType<HeadingBlockProps | HeadingLabelBlockProps>
   body: ExpectedBlockType<TextBlockProps>
-  alignment?: Alignment
+  layout?: Layout
 }>
 
 export const TextContentBlock = ({ blok }: Props) => {
   return (
     <Wrapper {...storyblokEditable(blok)}>
       <GridLayout.Content
-        width="2/3"
-        align="center"
-        style={{ textAlign: blok.alignment ?? 'left' }}
+        width={blok.layout?.widths ?? '2/3'}
+        align={blok.layout?.alignment ?? 'center'}
       >
         <Space y={1}>
           {blok.body?.map((nestedBlock) => (

--- a/apps/store/src/components/GridLayout/GridLayout.helper.tsx
+++ b/apps/store/src/components/GridLayout/GridLayout.helper.tsx
@@ -1,0 +1,107 @@
+import { CSSObject } from '@emotion/react'
+import { mq, Level } from 'ui'
+
+type PartialRecord<K extends keyof any, T> = Partial<Record<K, T>>
+
+export type ColumnWidth = '1' | '2/3' | '1/2' | '1/3'
+export type ContentAlignment = 'left' | 'center' | 'right'
+export type ContentWidth = ColumnWidth | PartialRecord<Level | 'base', ColumnWidth>
+
+const breakpointsOrder = ['base', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl'] as const
+
+export const getGridLayout = (width: ContentWidth, align: ContentAlignment): CSSObject => {
+  if (typeof width !== 'object') {
+    return STYLES[width][align ?? 'left']
+  }
+
+  let styles: CSSObject = {}
+
+  const breakpoints = Object.keys(width) as Array<keyof typeof width>
+  // Media queries need to be sorted
+  breakpoints.sort(function (a, b) {
+    return breakpointsOrder.indexOf(a) - breakpointsOrder.indexOf(b)
+  })
+  breakpoints.forEach((breakpoint) => {
+    const sizeAtBreakpoint = width[breakpoint]
+    if (!sizeAtBreakpoint) {
+      return
+    }
+    if (breakpoint === 'base') {
+      // Default
+      const baseStyles = RESPONSIVE_STYLES[sizeAtBreakpoint][align ?? 'left']
+      styles = { ...baseStyles, ...styles }
+    } else {
+      styles[mq[breakpoint as Level]] = {
+        ...RESPONSIVE_STYLES[sizeAtBreakpoint][align ?? 'left'],
+      }
+    }
+  })
+  return styles
+}
+
+const RESPONSIVE_STYLES: Record<ColumnWidth, Record<ContentAlignment, CSSObject>> = {
+  '1': { left: {}, center: {}, right: {} },
+  '2/3': {
+    left: { gridColumn: 'auto / span 8' },
+    center: { gridColumn: '3 / span 8' },
+    right: { gridColumn: '5 / span 8' },
+  },
+  '1/2': {
+    left: { gridColumn: 'auto / span 6' },
+    center: { gridColumn: '4 / span 6' },
+    right: { gridColumn: '7 / span 6' },
+  },
+  '1/3': {
+    left: { gridColumn: 'auto / span 4' },
+    center: { gridColumn: '5 / span 4' },
+    right: { gridColumn: '9 / span 4' },
+  },
+}
+
+const twoThirdsCenterStyles: CSSObject = {
+  [mq.lg]: { gridColumn: '4 / span 6' },
+}
+
+const halfCenterStyles: CSSObject = {
+  [mq.md]: { gridColumn: '2 / span 10' },
+  [mq.lg]: { gridColumn: '4 / span 6' },
+}
+
+const halfLeftStyles: CSSObject = {
+  [mq.lg]: { gridColumn: 'span 6' },
+}
+
+const halfRightStyles: CSSObject = {
+  [mq.lg]: { gridColumn: '7 / span 6' },
+}
+
+const thirdCenterStyles: CSSObject = {
+  [mq.md]: { gridColumn: '3 / span 8' },
+  [mq.lg]: { gridColumn: '4 / span 6' },
+  [mq.xl]: { gridColumn: '5 / span 4' },
+}
+
+const thirdLeftStyles: CSSObject = {
+  [mq.md]: { gridColumn: 'auto / span 8' },
+  [mq.lg]: { gridColumn: 'auto / span 6' },
+  [mq.xl]: { gridColumn: 'auto / span 4' },
+}
+
+const STYLES: Record<ColumnWidth, Record<ContentAlignment, CSSObject>> = {
+  '1': { left: {}, center: {}, right: {} },
+  '2/3': {
+    left: {},
+    center: twoThirdsCenterStyles,
+    right: {},
+  },
+  '1/2': {
+    left: halfLeftStyles,
+    center: halfCenterStyles,
+    right: halfRightStyles,
+  },
+  '1/3': {
+    left: thirdLeftStyles,
+    center: thirdCenterStyles,
+    right: {},
+  },
+}

--- a/apps/store/src/components/GridLayout/GridLayout.tsx
+++ b/apps/store/src/components/GridLayout/GridLayout.tsx
@@ -1,6 +1,7 @@
 import isPropValid from '@emotion/is-prop-valid'
-import styled, { CSSObject } from '@emotion/styled'
+import styled from '@emotion/styled'
 import { mq, theme } from 'ui'
+import { ContentAlignment, getGridLayout, ContentWidth } from './GridLayout.helper'
 
 export const TEXT_CONTENT_MAX_WIDTH = '37.5rem' // 600px
 
@@ -18,9 +19,6 @@ const Root = styled.div({
   },
 })
 
-type ContentWidth = '1' | '2/3' | '1/2' | '1/3'
-type ContentAlignment = 'left' | 'center' | 'right'
-
 type ContentProps = {
   width: ContentWidth
   align?: ContentAlignment
@@ -35,58 +33,10 @@ const Content = styled(
   elementConfig,
 )<ContentProps>(({ width, align }) => ({
   gridColumn: '1 / span 12',
-  ...STYLES[width][align ?? 'left'],
+  ...getGridLayout(width, align ?? 'left'),
 }))
 
 export const GridLayout = {
   Root,
   Content,
-}
-
-const twoThirdsCenterStyles: CSSObject = {
-  [mq.lg]: { gridColumn: '4 / span 6' },
-}
-
-const halfCenterStyles: CSSObject = {
-  [mq.md]: { gridColumn: '2 / span 10' },
-  [mq.lg]: { gridColumn: '4 / span 6' },
-}
-
-const halfLeftStyles: CSSObject = {
-  [mq.lg]: { gridColumn: 'span 6' },
-}
-
-const halfRightStyles: CSSObject = {
-  [mq.lg]: { gridColumn: '7 / span 6' },
-}
-
-const thirdCenterStyles: CSSObject = {
-  [mq.md]: { gridColumn: '3 / span 8' },
-  [mq.lg]: { gridColumn: '4 / span 6' },
-  [mq.xl]: { gridColumn: '5 / span 4' },
-}
-
-const thirdLeftStyles: CSSObject = {
-  [mq.md]: { gridColumn: 'auto / span 8' },
-  [mq.lg]: { gridColumn: 'auto / span 6' },
-  [mq.xl]: { gridColumn: 'auto / span 4' },
-}
-
-const STYLES: Record<ContentWidth, Record<ContentAlignment, CSSObject>> = {
-  '1': { left: {}, center: {}, right: {} },
-  '2/3': {
-    left: {},
-    center: twoThirdsCenterStyles,
-    right: {},
-  },
-  '1/2': {
-    left: halfLeftStyles,
-    center: halfCenterStyles,
-    right: halfRightStyles,
-  },
-  '1/3': {
-    left: thirdLeftStyles,
-    center: thirdCenterStyles,
-    right: {},
-  },
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add a plugin that sets how many columns a block should span at different breakpoints and how it should align
- Extend GridLayout to take an array of widths 
- Add Layout options to TextBlock 

https://user-images.githubusercontent.com/6661511/221601809-556b30d0-8712-43ef-8281-ffbcd343d538.mov

<img width="1792" alt="Screenshot 2023-02-27 at 16 11 37" src="https://user-images.githubusercontent.com/6661511/221601842-460ff510-2ee1-422e-a239-6e7769ec1782.png">

Next step:
- Refactor usage of GridLayout so we can get rid of `STYLES` object
- Move plugin code inside repository (post launch)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
We want the flexibility to set content widths from Storyblok. We will start with TextContent block and then see what more blocks that we will add it to.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
