### PR TITLE
Make sure image field of object type doesn't break the page

### DIFF
--- a/apps/store/src/blocks/ImageTextBlock.tsx
+++ b/apps/store/src/blocks/ImageTextBlock.tsx
@@ -25,7 +25,9 @@ type ImageTextBlockProps = SbBaseBlockProps<{
 export const ImageTextBlock = ({ blok }: ImageTextBlockProps) => {
   const { orientation = DEFAULT_ORIENTATION } = blok
   // We expect only one image from Storyblok
-  const imageBlock = filterByBlockType(blok.image, ImageBlock.blockName)[0]
+  const imageBlock = Array.isArray(blok.image)
+    ? filterByBlockType(blok.image, ImageBlock.blockName)[0]
+    : undefined
 
   switch (orientation) {
     case 'fluid':


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Make sure image field of object type doesn't break the page
Issue in datadog: https://app.datadoghq.eu/rum/error-tracking/issue/406e6a8c-b6b9-11ed-bd7e-da7ad0900005?query=%40application.id%3Ad86e86d8-8d9a-4b00-a2cb-10b8d7671fa2&from_ts=1677487249796&start=1677488486454&end=1677574885540&to_ts=1677573649517&live=true&paused=false
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
While working on the cache issue this could mitigate the error on the page hopefully


## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
