### PR TITLE
Refresh price calculator when switching PDP

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -289,6 +289,7 @@ const EditingState = (props: EditingStateProps) => {
   ) : (
     <PriceCalculatorWrapper>
       <PriceCalculator
+        key={priceIntent.id}
         priceIntent={priceIntent}
         shopSession={shopSession}
         onConfirm={handleConfirm}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Remount `PriceCalculator` when switching between PDPs.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We need to clear state when switching between PDPs.

We have a bug when you switch between PDP and the price calculator is stuck on a step that doesn't exist for the new PDP.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
