### PR TITLE
Set Pillow image size to largest possible size to avoid blurry image

### DIFF
--- a/apps/store/src/components/Pillow/Pillow.tsx
+++ b/apps/store/src/components/Pillow/Pillow.tsx
@@ -9,7 +9,7 @@ type PillowProps = {
 
 export const Pillow = ({ alt, src, ...props }: PillowProps) => {
   if (!src) return <FallbackPillow size={props.size} />
-  return <StyledImage {...props} src={src} alt={alt ?? ''} width={80} height={80} />
+  return <StyledImage {...props} src={src} alt={alt ?? ''} width={208} height={208} />
 }
 
 const StyledImage = styled(Image)<PillowProps>(({ size = 'medium' }) => getSize(size))


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Set Pillow image size to largest possible size to avoid blurry image. FIle sizes is still very small

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Size was set to 80x80, but largest size option is 208x208 so it sometimes rendered a blurry Pillow image
## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
