### PR TITLE
Remove gray border on lazy loading images

### DIFF
--- a/packages/ui/src/lib/globalStyles.ts
+++ b/packages/ui/src/lib/globalStyles.ts
@@ -46,6 +46,13 @@ export const globalStyles = css`
     height: auto;
   }
 
+  /* Remove gray border from loading images https://nextjs.org/docs/api-reference/next/image#known-browser-bugs */
+  @supports (font: -apple-system-body) and (-webkit-appearance: none) {
+    img[loading='lazy'] {
+      clip-path: inset(0.6px);
+    }
+  }
+
   /* Sane display value for media elements */
   img,
   iframe,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
When lazy loading images, safari displays a gray border. Known bug referenced in Next.js doc:
https://nextjs.org/docs/api-reference/next/image#known-browser-bugs

### Before:
<img width="970" alt="Screenshot 2023-03-01 at 15 18 42" src="https://user-images.githubusercontent.com/6661511/222171359-043f36ba-7ec7-46a4-8c26-d516a3f12242.png">

### After:
<img width="969" alt="Screenshot 2023-03-01 at 15 19 03" src="https://user-images.githubusercontent.com/6661511/222171396-ef9e67db-ce9e-4a3a-8d98-f4487b265337.png">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
