### PR TITLE
Add grid layout to perils block

### DIFF
--- a/apps/store/src/blocks/PerilsBlock.tsx
+++ b/apps/store/src/blocks/PerilsBlock.tsx
@@ -1,7 +1,7 @@
-import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
-import { HeadingLabel, Space, theme, mq } from 'ui'
+import { HeadingLabel, Space } from 'ui'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { Perils } from '@/components/Perils/Perils'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
@@ -27,21 +27,15 @@ export const PerilsBlock = ({ blok }: PerilsBlockProps) => {
   }, [productData, selectedVariant])
 
   return (
-    <Wrapper {...storyblokEditable(blok)}>
-      <Space y={1}>
-        {blok.heading && <HeadingLabel>{blok.heading}</HeadingLabel>}
-        <Perils items={items} />
-      </Space>
-    </Wrapper>
+    <GridLayout.Root {...storyblokEditable(blok)}>
+      <GridLayout.Content width="1">
+        <Space y={1}>
+          {blok.heading && <HeadingLabel>{blok.heading}</HeadingLabel>}
+          <Perils items={items} />
+        </Space>
+      </GridLayout.Content>
+    </GridLayout.Root>
   )
 }
 
 PerilsBlock.blockName = 'perils'
-
-const Wrapper = styled.div({
-  paddingInline: theme.space.md,
-
-  [mq.lg]: {
-    paddingInline: theme.space.lg,
-  },
-})

--- a/apps/store/src/components/Perils/Perils.tsx
+++ b/apps/store/src/components/Perils/Perils.tsx
@@ -50,23 +50,23 @@ export const Perils = ({ items }: Props) => {
   )
 }
 
-const PerilsAccordionGrid = styled.div(() => ({
+const PerilsAccordionGrid = styled.div({
   display: 'grid',
   gap: theme.space.xxs,
   gridTemplateColumns: 'repeat(auto-fit, minmax(20rem, 1fr))',
   [mq.md]: {
     columnGap: theme.space.md,
   },
-}))
+})
 
-const PerilColumnFlex = styled.div(() => ({
+const PerilColumnFlex = styled.div({
   display: 'flex',
   flexDirection: 'column',
   gap: theme.space.xxs,
   [mq.md]: {
     gap: theme.space.xs,
   },
-}))
+})
 
 const PerilsAccordion = ({ peril }: { peril: PerilFragment }) => {
   const { title, description, covered, colorCode } = peril


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Integrate grid layout in perils block.

![Screenshot 2023-03-01 at 16.34.09.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/16d73baf-5bdb-4f1d-9471-132a2f5556a8/Screenshot%202023-03-01%20at%2016.34.09.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Fix an issue where perils block doesn't have the same max width as rest of blocks.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
