### PR TITLE
Intercom - lazy loading 🐡

### DIFF
--- a/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
+++ b/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
@@ -37,7 +37,7 @@ export const IntercomChatButton = ({ children }: Props) => {
     }
   }, [appId])
 
-  // if (!appId || !INTERCOM_ENABLED) return <>{children}</>
+  if (!appId || !INTERCOM_ENABLED) return <>{children}</>
 
   if (!isLoaded)
     return <IntercomButton onClick={() => setIsLoaded(true)}>{children}</IntercomButton>

--- a/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
+++ b/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
@@ -1,17 +1,15 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
 import dynamic from 'next/dynamic'
-import { Fragment, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useIntercom } from 'react-use-intercom'
-// import { Flags } from '@/services/Flags/Flags'
+import { Flags } from '@/services/Flags/Flags'
 
 const IntercomProvider = dynamic(() =>
   import('react-use-intercom').then((mod) => mod.IntercomProvider),
 )
 
-// const ONE_SECOND = 2000
-
-// const INTERCOM_ENABLED = Flags.getFeature('INTERCOM')
+const INTERCOM_ENABLED = Flags.getFeature('INTERCOM')
 
 type Props = {
   children: React.ReactNode
@@ -25,14 +23,14 @@ const WithIntercom = ({ children }: Props) => {
     return () => {
       hide()
     }
-  }, [show])
+  }, [])
 
   return <div onClick={isOpen ? hide : show}>{children}</div>
 }
 
 export const IntercomChatButton = ({ children }: Props) => {
   const appId = process.env.NEXT_PUBLIC_INTERCOM_APP_ID
-  const [isLoaded, setIsloaded] = useState(false)
+  const [isLoaded, setIsLoaded] = useState(false)
 
   useEffect(() => {
     if (!appId) {
@@ -44,10 +42,10 @@ export const IntercomChatButton = ({ children }: Props) => {
 
   if (!appId) return withoutIntercom
 
-  // if (!INTERCOM_ENABLED) return withoutIntercom
+  if (!INTERCOM_ENABLED) return withoutIntercom
 
   return (
-    <IntercomButton onClick={() => setIsloaded(true)}>
+    <IntercomButton onClick={() => setIsLoaded(true)}>
       {isLoaded ? (
         <IntercomProvider appId={appId} autoBoot autoBootProps={{ hideDefaultLauncher: true }}>
           <WithIntercom>{children}</WithIntercom>
@@ -58,8 +56,6 @@ export const IntercomChatButton = ({ children }: Props) => {
     </IntercomButton>
   )
 }
-
-// styles
 
 const IntercomButton = styled.button({
   cursor: 'pointer',

--- a/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
+++ b/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
@@ -23,7 +23,7 @@ const WithIntercom = ({ children }: Props) => {
     return () => {
       hide()
     }
-  }, [])
+  }, [hide, show])
 
   return <div onClick={isOpen ? hide : show}>{children}</div>
 }
@@ -38,21 +38,16 @@ export const IntercomChatButton = ({ children }: Props) => {
     }
   }, [appId])
 
-  const withoutIntercom = <>{children}</>
+  if (!appId || !INTERCOM_ENABLED) return children
 
-  if (!appId) return withoutIntercom
-
-  if (!INTERCOM_ENABLED) return withoutIntercom
+  if (!isLoaded)
+    return <IntercomButton onClick={() => setIsLoaded(true)}>{children}</IntercomButton>
 
   return (
-    <IntercomButton onClick={() => setIsLoaded(true)}>
-      {isLoaded ? (
-        <IntercomProvider appId={appId} autoBoot autoBootProps={{ hideDefaultLauncher: true }}>
-          <WithIntercom>{children}</WithIntercom>
-        </IntercomProvider>
-      ) : (
-        children
-      )}
+    <IntercomButton>
+      <IntercomProvider appId={appId} autoBoot autoBootProps={{ hideDefaultLauncher: true }}>
+        <WithIntercom>{children}</WithIntercom>
+      </IntercomProvider>
     </IntercomButton>
   )
 }

--- a/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
+++ b/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
@@ -38,7 +38,7 @@ export const IntercomChatButton = ({ children }: Props) => {
     }
   }, [appId])
 
-  if (!appId || !INTERCOM_ENABLED) return children
+  if (!appId || !INTERCOM_ENABLED) return <>{children}</>
 
   if (!isLoaded)
     return <IntercomButton onClick={() => setIsLoaded(true)}>{children}</IntercomButton>

--- a/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
+++ b/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 import dynamic from 'next/dynamic'
 import { Fragment, useEffect, useState } from 'react'
 import { useIntercom } from 'react-use-intercom'
-import { Flags } from '@/services/Flags/Flags'
+// import { Flags } from '@/services/Flags/Flags'
 
 const IntercomProvider = dynamic(() =>
   import('react-use-intercom').then((mod) => mod.IntercomProvider),
@@ -11,7 +11,7 @@ const IntercomProvider = dynamic(() =>
 
 // const ONE_SECOND = 2000
 
-const INTERCOM_ENABLED = Flags.getFeature('INTERCOM')
+// const INTERCOM_ENABLED = Flags.getFeature('INTERCOM')
 
 type Props = {
   children: React.ReactNode

--- a/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
+++ b/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
@@ -4,7 +4,6 @@ import dynamic from 'next/dynamic'
 import { useEffect, useState } from 'react'
 import { useIntercom } from 'react-use-intercom'
 import { Flags } from '@/services/Flags/Flags'
-
 const IntercomProvider = dynamic(() =>
   import('react-use-intercom').then((mod) => mod.IntercomProvider),
 )
@@ -25,7 +24,7 @@ const WithIntercom = ({ children }: Props) => {
     }
   }, [hide, show])
 
-  return <div onClick={isOpen ? hide : show}>{children}</div>
+  return <IntercomButton onClick={isOpen ? hide : show}>{children}</IntercomButton>
 }
 
 export const IntercomChatButton = ({ children }: Props) => {
@@ -38,17 +37,15 @@ export const IntercomChatButton = ({ children }: Props) => {
     }
   }, [appId])
 
-  if (!appId || !INTERCOM_ENABLED) return <>{children}</>
+  // if (!appId || !INTERCOM_ENABLED) return <>{children}</>
 
   if (!isLoaded)
     return <IntercomButton onClick={() => setIsLoaded(true)}>{children}</IntercomButton>
 
   return (
-    <IntercomButton>
-      <IntercomProvider appId={appId} autoBoot autoBootProps={{ hideDefaultLauncher: true }}>
-        <WithIntercom>{children}</WithIntercom>
-      </IntercomProvider>
-    </IntercomButton>
+    <IntercomProvider appId={appId} autoBoot autoBootProps={{ hideDefaultLauncher: true }}>
+      <WithIntercom>{children}</WithIntercom>
+    </IntercomProvider>
   )
 }
 

--- a/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
+++ b/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
@@ -15,16 +15,13 @@ type Props = {
 }
 
 const WithIntercom = ({ children }: Props) => {
-  const { show, hide, isOpen } = useIntercom()
+  const { show } = useIntercom()
 
   useEffect(() => {
     show()
-    return () => {
-      hide()
-    }
-  }, [hide, show])
+  }, [show])
 
-  return <IntercomButton onClick={isOpen ? hide : show}>{children}</IntercomButton>
+  return <IntercomButton onClick={show}>{children}</IntercomButton>
 }
 
 export const IntercomChatButton = ({ children }: Props) => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Refactored the intercom button to allow it to be lazy loaded. 

Intercom is now loaded after the user clicks on the support button.

Allow the user to click the button to open and close the intercom window.

### note
since we're loading the scrips onclick we may want to have a loading state for this component

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Intercom is hurting our page performance and should only be loaded when the user needs it.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code

### could use a hand 

When testing this component (sometimes) there is now a while flash the first time the user clicks on the button to open intercom. I tried several ways to fix this but could not get it sorted.