### PR TITLE
Add gray placeholder while loading images

### DIFF
--- a/apps/store/src/blocks/BannerBlock.tsx
+++ b/apps/store/src/blocks/BannerBlock.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
-import { default as NextImage } from 'next/image'
 import { Heading, Text, mq, theme } from 'ui'
+import { ImageWithPlaceholder } from '@/components/ImageWithPlaceholder/ImageWithPlaceholder'
 import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 
 type ImageSize = {
@@ -65,7 +65,7 @@ const Wrapper = styled('div')<ImageSize>(({ aspectRatioLandscape, aspectRatioPor
   },
 }))
 
-const Image = styled(NextImage)({
+const Image = styled(ImageWithPlaceholder)({
   objectFit: 'cover',
 })
 

--- a/apps/store/src/blocks/HeroBlock.tsx
+++ b/apps/store/src/blocks/HeroBlock.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
-import Image from 'next/image'
 import { theme } from 'ui'
 import { ButtonBlock, ButtonBlockProps } from '@/blocks/ButtonBlock'
 import { HeadingBlock, HeadingBlockProps } from '@/blocks/HeadingBlock'
+import { ImageWithPlaceholder } from '@/components/ImageWithPlaceholder/ImageWithPlaceholder'
 import { ExpectedBlockType, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 
@@ -59,7 +59,7 @@ const HeroImageWrapper = styled.div({
   zIndex: '-1',
 })
 
-const HeroImage = styled(Image)({
+const HeroImage = styled(ImageWithPlaceholder)({
   objectFit: 'cover',
   objectPosition: 'center',
 })

--- a/apps/store/src/blocks/ImageBlock.tsx
+++ b/apps/store/src/blocks/ImageBlock.tsx
@@ -1,9 +1,9 @@
 import isPropValid from '@emotion/is-prop-valid'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
-import NextImage from 'next/image'
 import { ConditionalWrapper, mq, theme } from 'ui'
 import { HeadingBlock, HeadingBlockProps } from '@/blocks/HeadingBlock'
+import { ImageWithPlaceholder } from '@/components/ImageWithPlaceholder/ImageWithPlaceholder'
 import { ExpectedBlockType, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 
@@ -31,7 +31,6 @@ export const ImageBlock = ({ blok, nested }: ImageBlockProps) => {
         aspectRatioPortrait={blok.aspectRatioPortrait}
       >
         <Image
-          style={{ objectFit: 'cover' }}
           src={blok.image.filename}
           roundedCorners={!blok.fullBleed}
           alt={blok.image.alt}
@@ -69,8 +68,9 @@ const ImageWrapper = styled('div', { shouldForwardProp: isPropValid })<WrapperPr
 
 type ImageProps = { roundedCorners: boolean }
 
-const Image = styled(NextImage, { shouldForwardProp: isPropValid })<ImageProps>(
+const Image = styled(ImageWithPlaceholder, { shouldForwardProp: isPropValid })<ImageProps>(
   ({ roundedCorners }) => ({
+    objectFit: 'cover',
     ...(roundedCorners && {
       borderRadius: theme.radius.md,
       [mq.lg]: {

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import Image from 'next/image'
 import Link from 'next/link'
 import { Heading, mq, Space, Text, theme } from 'ui'
 import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
 import { AppStoreBadge } from '@/components/AppStoreBadge/AppStoreBadge'
 import { CartInventory } from '@/components/CartInventory/CartInventory'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { ImageWithPlaceholder } from '@/components/ImageWithPlaceholder/ImageWithPlaceholder'
 import { ConfirmationStory } from '@/services/storyblok/storyblok'
 import { getAppStoreLink } from '@/utils/appStoreLinks'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
@@ -29,7 +29,7 @@ export const ConfirmationPage = (props: Props) => {
       <AppStoreBadge type={platform} locale={locale} />
     </Link>
   ) : (
-    <Image
+    <ImageWithPlaceholder
       src={qrCodeImage}
       alt={t('APP_DOWNLOAD_QRCODE_ALT')}
       width={128}

--- a/apps/store/src/components/ImageWithPlaceholder/ImageWithPlaceholder.tsx
+++ b/apps/store/src/components/ImageWithPlaceholder/ImageWithPlaceholder.tsx
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled'
+import { default as NextImage, ImageProps } from 'next/image'
+import { useState } from 'react'
+import { theme } from 'ui'
+
+export const ImageWithPlaceholder = ({ ...props }: ImageProps) => {
+  const [hasLoaded, setHasLoaded] = useState(false)
+
+  const hasLoadedHandler = () => {
+    setHasLoaded(true)
+  }
+
+  const imageProps = {
+    ...props,
+    ...(hasLoaded && { 'data-loaded': true }),
+  } as const
+
+  return <StyledImage {...imageProps} onLoadingComplete={hasLoadedHandler} />
+}
+
+const StyledImage = styled(NextImage)({
+  backgroundColor: theme.colors.gray100,
+  '&[data-loaded]': { backgroundColor: 'transparent' },
+})

--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -1,11 +1,11 @@
 import { UrlObject } from 'url'
 import styled from '@emotion/styled'
-import { default as NextImage } from 'next/image'
 import Link from 'next/link'
 import { useTranslation } from 'react-i18next'
 import { mq, Space, theme } from 'ui'
 import { ImageSize } from '@/blocks/ProductCardBlock'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
+import { ImageWithPlaceholder } from '@/components/ImageWithPlaceholder/ImageWithPlaceholder'
 import { OPEN_PRICE_CALCULATOR_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam'
 
 type ImageProps = {
@@ -90,7 +90,7 @@ const ImageWrapper = styled.div<ImageSize>(({ aspectRatio }) => ({
   },
 }))
 
-const Image = styled(NextImage)({
+const Image = styled(ImageWithPlaceholder)({
   objectFit: 'cover',
   borderRadius: theme.radius.md,
 

--- a/apps/store/src/components/TopPickCard/TopPickCard.tsx
+++ b/apps/store/src/components/TopPickCard/TopPickCard.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
-import { default as NextImage } from 'next/image'
 import { Space, theme } from 'ui'
+import { ImageWithPlaceholder } from '@/components/ImageWithPlaceholder/ImageWithPlaceholder'
 
 const PRODUCT_CARD_IMAGE_WIDTH_SMALL = '20.43rem'
 const PRODUCT_CARD_IMAGE_HEIGHT_SMALL = '25rem'
@@ -47,7 +47,7 @@ const ImageWrapper = styled.div(() => ({
   width: '100%',
 }))
 
-const Image = styled(NextImage)({
+const Image = styled(ImageWithPlaceholder)({
   objectFit: 'cover',
 })
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Show gray placeholder while loading images.

Tested with adding a blurDataURL with a simple gray image but it automatically adds filter blur which looks weird.
So easier to add a background color, but since images can have alpha layers (opacity) we should remove the background color after the image is loaded.

You can test in [preview app](https://hedvig-dot-8wufb0tih-hedvig.vercel.app/se) by using network throttling 

https://user-images.githubusercontent.com/6661511/222730364-fb4368cf-d439-4ff0-b0c3-db62c6c37cb7.mov

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Should show a placeholder when loading takes a long time. 

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
