### PR TITLE
fix: peril columns bug 🐞

### DIFF
--- a/apps/store/src/components/Perils/Perils.tsx
+++ b/apps/store/src/components/Perils/Perils.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import React, { useState, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { mq, Text, theme, useBreakpoint } from 'ui'
 import * as Accordion from '@/components/Accordion/Accordion'
 import { PerilFragment } from '@/services/apollo/generated'

--- a/apps/store/src/components/Perils/Perils.tsx
+++ b/apps/store/src/components/Perils/Perils.tsx
@@ -5,12 +5,8 @@ import * as Accordion from '@/components/Accordion/Accordion'
 import { PerilFragment } from '@/services/apollo/generated'
 import { CoverageList } from './CoverageList'
 
-type Props = {
-  items: Array<PerilFragment>
-}
-
-const getPerilColumns = (items: PerilFragment[], columns: number) => {
-  const accordions = items.reduce((acc, item, index) => {
+const getPerilColumns = (items: PerilFragment[], columns: number) =>
+  items.reduce((acc, item, index) => {
     const columnIndex = index % columns
     if (!acc[columnIndex]) {
       acc[columnIndex] = []
@@ -19,7 +15,8 @@ const getPerilColumns = (items: PerilFragment[], columns: number) => {
     return acc
   }, [] as Array<Array<PerilFragment>>)
 
-  return accordions
+type Props = {
+  items: Array<PerilFragment>
 }
 
 export const Perils = ({ items }: Props) => {
@@ -53,7 +50,7 @@ export const Perils = ({ items }: Props) => {
 const PerilsAccordionGrid = styled.div({
   display: 'grid',
   gap: theme.space.xxs,
-  gridTemplateColumns: 'repeat(auto-fit, minmax(20rem, 1fr))',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(18rem, 1fr))',
   [mq.md]: {
     columnGap: theme.space.md,
   },


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe the issue

tl;dr: There are about a 100px where the cols were borked!


Between specific breakpoints the perils minWidth was too large for them to break out into their proper columns. 

The changes in this PR are to make their minWidth a bit smaller to fix this.

### before

<img width="1283" alt="Screenshot 2023-03-06 at 09 11 26" src="https://user-images.githubusercontent.com/50870173/223053723-9dcc4972-1c9b-4776-ac71-c17083775630.png">

### after
<img width="1290" alt="Screenshot 2023-03-06 at 09 11 22" src="https://user-images.githubusercontent.com/50870173/223053776-160af5ea-3486-4658-a2e2-20f3b51f46ab.png">


## [test it here](https://hedvig-dot-com-git-fix-breakpoints-bug-hedvig.vercel.app/se/forsakringar/hemforsakring/hyresratt)


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->


<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
