### PR TITLE
Allow app to recover from network errors while signing

### DIFF
--- a/apps/store/src/services/authApi/fetchJson.ts
+++ b/apps/store/src/services/authApi/fetchJson.ts
@@ -11,7 +11,13 @@ export const fetchJson = async <T extends object>(
   })
   const data = await resp.json()
   if (!resp.ok) {
-    throw new Error(`Error response, status=${resp.status}`, data)
+    throw new ServerError(`Error response, status=${resp.status}`, data)
   }
   return data
+}
+
+export class ServerError extends Error {
+  constructor(message: string, public data: any) {
+    super(message)
+  }
 }

--- a/apps/store/src/services/bankId/useBankIdCheckoutSign.ts
+++ b/apps/store/src/services/bankId/useBankIdCheckoutSign.ts
@@ -101,8 +101,12 @@ export const useBankIdCheckoutSignApi = ({ dispatch }: Options) => {
               }
             },
             onError(error) {
-              bankIdLogger.warn('SigningQuery | Failed to sign', { error })
-              subscriber.error(error)
+              if (error.networkError) {
+                bankIdLogger.warn('SigningQuery | Network error', { error: error.message })
+              } else {
+                bankIdLogger.warn('SigningQuery | Failed to sign', { error: error.message })
+                subscriber.error(error)
+              }
             },
           })
         }


### PR DESCRIPTION
## Describe your changes

Differentiate between API/Server errors and network errors.

Ignore network errors when signing and keep polling for status.

## Justify why they are needed

We failed as soon as we got a network error but we should keep polling for status and only fail if API tells us the request failed.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
