### PR TITLE
Add priority loading option to Imageblock

### DIFF
--- a/apps/store/src/blocks/ImageBlock.tsx
+++ b/apps/store/src/blocks/ImageBlock.tsx
@@ -15,6 +15,7 @@ export type ImageBlockProps = SbBaseBlockProps<{
   aspectRatioPortrait?: ImageAspectRatio
   fullBleed?: boolean
   body?: ExpectedBlockType<HeadingBlockProps>
+  priority?: boolean
 }>
 
 export const ImageBlock = ({ blok, nested }: ImageBlockProps) => {
@@ -35,6 +36,7 @@ export const ImageBlock = ({ blok, nested }: ImageBlockProps) => {
           roundedCorners={!blok.fullBleed}
           alt={blok.image.alt}
           fill
+          priority={blok.priority}
         />
         <BodyWrapper>
           {headingBlocks.map((nestedBlock) => (
@@ -68,17 +70,17 @@ const ImageWrapper = styled('div', { shouldForwardProp: isPropValid })<WrapperPr
 
 type ImageProps = { roundedCorners: boolean }
 
-const Image = styled(ImageWithPlaceholder, { shouldForwardProp: isPropValid })<ImageProps>(
-  ({ roundedCorners }) => ({
-    objectFit: 'cover',
-    ...(roundedCorners && {
-      borderRadius: theme.radius.md,
-      [mq.lg]: {
-        borderRadius: theme.radius.xl,
-      },
-    }),
+const Image = styled(ImageWithPlaceholder, {
+  shouldForwardProp: (prop) => (prop === 'priority' ? true : isPropValid(prop)),
+})<ImageProps>(({ roundedCorners }) => ({
+  objectFit: 'cover',
+  ...(roundedCorners && {
+    borderRadius: theme.radius.md,
+    [mq.lg]: {
+      borderRadius: theme.radius.xl,
+    },
   }),
-)
+}))
 
 const BodyWrapper = styled.div({
   position: 'absolute',


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add option to set loading priority to Storyblok

<img width="399" alt="Screenshot 2023-03-07 at 10 55 30" src="https://user-images.githubusercontent.com/6661511/223392194-3bb31fbf-a99a-4988-95ac-5bd08b2e6588.png">


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Fix LCP warning from Lighthouse. Images rendered above the fold should be loaded with priority.
## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
