### PR TITLE
styles(ProductDetailsPage): remove double scroll

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock/DesktopLayout.tsx
+++ b/apps/store/src/blocks/ProductPageBlock/DesktopLayout.tsx
@@ -89,9 +89,6 @@ const ContentNavigationTrigger = styled.a(triggerStyles)
 const PurchaseFormWrapper = styled.div({
   position: 'sticky',
   top: 0,
-  // Scroll independently if content is too long
-  maxHeight: '100vh',
-  overflow: 'auto',
   paddingBlock: theme.space.xl,
 
   paddingTop: '3vw',


### PR DESCRIPTION
## Describe your changes

See title ☝🏻 

## Justify why they are needed

It was added [here](https://github.com/HedvigInsurance/racoon/pull/1230/files). Not sure the problem it was trying to fix when it got added. Maybe @robinandeer remembers it?!
Let me know if I'm missing something.

**Before**

<img width="1297" alt="Screenshot 2023-03-07 at 11 06 43" src="https://user-images.githubusercontent.com/19200662/223391893-67644d78-6bcb-495d-8f23-1006b50f3679.png">

**After**
<img width="1282" alt="Screenshot 2023-03-07 at 11 10 47" src="https://user-images.githubusercontent.com/19200662/223391867-27ba23a0-5c71-48eb-b3d6-f3c744ebab1f.png">


