### PR TITLE
GRW-2275 / Lazy load autoplaying videos

### DIFF
--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -154,15 +154,17 @@ export const Video = ({
         {...autoplayAttributes}
         {...delegated}
       >
-        {sources.map((source) => (
-          // TODO: its adviced to provide the media format type ('type' attribute)
-          // More info http://bitly.ws/y4Jf
-          <source
-            key={source.url}
-            src={delegated.autoPlay ? '' : source.url}
-            data-src={source.url}
-          />
-        ))}
+        {sources.map((source) => {
+          const sourceProps = {
+            src: delegated.autoPlay ? '' : source.url,
+            ...(delegated.autoPlay && { 'data-src': source.url }),
+          }
+          return (
+            // TODO: its adviced to provide the media format type ('type' attribute)
+            // More info http://bitly.ws/y4Jf
+            <source key={source.url} {...sourceProps} />
+          )
+        })}
       </StyledVideo>
       <VideoControls data-state={state} onClick={() => playPauseButtonRef.current?.click()}>
         <Controls>

--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { useInView } from 'framer-motion'
 import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { mq, theme, PlayIcon, PauseIcon, Button } from 'ui'
 import { useDialogEvent } from '@/utils/dialogEvent'
@@ -48,10 +49,24 @@ export const Video = ({
   ...delegated
 }: VideoProps) => {
   const videoRef = useRef<HTMLVideoElement | null>(null)
+  const isInView = useInView(videoRef)
   const playButtonId = useId()
   const playPauseButtonRef = useRef<HTMLButtonElement | null>(null)
 
   const [state, setState] = useState<State>(State.Paused)
+
+  useEffect(() => {
+    // Lazy load videos that are autoplaying
+    if (isInView && videoRef.current) {
+      Array.from(videoRef.current.children).map((videoSource) => {
+        if (videoSource instanceof HTMLSourceElement && videoSource.dataset.src) {
+          videoSource.src = videoSource.dataset.src
+        }
+      })
+
+      videoRef.current.load()
+    }
+  }, [isInView])
 
   const videoUrl = sources[0].url
   useEffect(() => {
@@ -142,7 +157,11 @@ export const Video = ({
         {sources.map((source) => (
           // TODO: its adviced to provide the media format type ('type' attribute)
           // More info http://bitly.ws/y4Jf
-          <source key={source.url} src={source.url} />
+          <source
+            key={source.url}
+            src={delegated.autoPlay ? '' : source.url}
+            data-src={source.url}
+          />
         ))}
       </StyledVideo>
       <VideoControls data-state={state} onClick={() => playPauseButtonRef.current?.click()}>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Lazy load autoplaying videos

To do this we add the video src to a  `data-src` attribute, observe when it enters the viewport and then load the video.

Review app: https://hedvig-dot-gb1pjdijv-hedvig.vercel.app/se
### Before
**16.9 MB transferred** 🐌

<img width="1792" alt="Screenshot 2023-03-08 at 11 10 31 (2)" src="https://user-images.githubusercontent.com/6661511/223685236-4ea65012-327d-458e-86db-37ee7423d127.png">

### After
**66 kB transferred** 🚀

<img width="1792" alt="Screenshot 2023-03-08 at 11 10 58 (2)" src="https://user-images.githubusercontent.com/6661511/223685110-134b0fd5-cb93-441d-94c5-d56ce71e4e22.png">
 

Possible improvement:
We treat autoplaying videos above fold the same (like the product pages). It loads slightly slower but barely noticeable. Let's see if we want to add similar functionality as images for above the fold media to preload the video instead.
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Since the `autoplay` attribute on videos override the `preload` attribute, we fetch all autoplaying videos on page load. 
## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
