### PR TITLE
Add combobox component based on downshift

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -39,6 +39,7 @@
     "ajv": "8.12.0",
     "apollo-link-timeout": "4.0.0",
     "cookies-next": "2.1.1",
+    "downshift": "7.3.2",
     "framer-motion": "10.1.0",
     "graphql": "16.6.0",
     "i18next": "22.4.11",

--- a/apps/store/src/components/Combobox/Combobox.stories.tsx
+++ b/apps/store/src/components/Combobox/Combobox.stories.tsx
@@ -1,0 +1,44 @@
+import { ComponentMeta, StoryFn } from '@storybook/react'
+import { useState } from 'react'
+import { Combobox } from './Combobox'
+
+export default {
+  title: 'Combobox',
+  component: Combobox,
+  argTypes: {},
+} as ComponentMeta<typeof Combobox>
+
+const FRUIT = [
+  {
+    id: '1',
+    name: 'Apple',
+  },
+  {
+    id: '2',
+    name: 'Pear',
+  },
+  {
+    id: '3',
+    name: 'Banana',
+  },
+]
+
+type Fruit = (typeof FRUIT)[number]
+
+export const Default: StoryFn = () => {
+  const [value, setValue] = useState<Fruit | null>(FRUIT[1])
+
+  return (
+    <Combobox
+      placeholder="Search fruit..."
+      items={FRUIT}
+      defaultValue={value}
+      onSelect={setValue}
+      displayValue={(fruit) => fruit.name}
+    />
+  )
+}
+
+export const NoOptionFound: StoryFn = () => {
+  return <Combobox items={['Apple', 'Pear', 'Banana']} defaultValue="Plu" />
+}

--- a/apps/store/src/components/Combobox/Combobox.tsx
+++ b/apps/store/src/components/Combobox/Combobox.tsx
@@ -1,0 +1,219 @@
+import styled from '@emotion/styled'
+import { useCombobox } from 'downshift'
+import { motion } from 'framer-motion'
+import { Fragment, useDeferredValue, useMemo } from 'react'
+import { ChevronIcon, CrossIconSmall, Text, theme, WarningTriangleIcon } from 'ui'
+import { useHighlightAnimation } from '@/utils/useHighlightAnimation'
+
+const ITEMS_TO_SHOW = 5
+
+type Props<Item> = {
+  placeholder?: string
+  defaultValue?: Item | null
+  items: Array<Item>
+  onSelect?: (item: Item | null) => void
+  displayValue?: (item: Item) => string
+}
+
+/**
+ * Combobox component
+ * @see https://www.downshift-js.com/use-combobox
+ */
+export const Combobox = <Item,>(props: Props<Item>) => {
+  const { placeholder, defaultValue, onSelect, items, displayValue } = props
+  const { highlight, animationProps } = useHighlightAnimation()
+
+  const {
+    isOpen,
+    inputValue,
+    highlightedIndex,
+    getInputProps,
+    getMenuProps,
+    getItemProps,
+    getToggleButtonProps,
+    reset,
+    openMenu,
+  } = useCombobox({
+    items,
+    initialSelectedItem: defaultValue,
+    onSelectedItemChange({ selectedItem }) {
+      if (selectedItem) {
+        highlight()
+      }
+
+      onSelect?.(selectedItem ?? null)
+    },
+  })
+
+  const deferredInputValue = useDeferredValue(inputValue)
+  const filteredItems = useMemo(() => {
+    const lowerCaseInputValue = deferredInputValue.toLowerCase() ?? ''
+    return items
+      .filter((item) => {
+        const stringValue = displayValue?.(item) ?? String(item)
+        return stringValue.toLowerCase().includes(lowerCaseInputValue)
+      })
+      .slice(0, ITEMS_TO_SHOW)
+  }, [deferredInputValue, items, displayValue])
+
+  const noOptions = filteredItems.length === 0
+
+  const handleClickDelete = () => {
+    reset()
+    openMenu()
+  }
+
+  return (
+    <Wrapper data-expanded={isOpen}>
+      <InputWrapper>
+        <Input
+          {...getInputProps()}
+          {...animationProps}
+          placeholder={placeholder}
+          defaultValue={defaultValue}
+          data-expanded={isOpen}
+          data-warning={noOptions}
+        />
+        <Actions>
+          <DeleteButton onClick={handleClickDelete} hidden={inputValue.length === 0}>
+            <CrossIconSmall />
+          </DeleteButton>
+          <ToggleButton {...getToggleButtonProps()} data-warning={noOptions}>
+            <ChevronIcon size="1rem" />
+          </ToggleButton>
+        </Actions>
+      </InputWrapper>
+
+      <List {...getMenuProps()}>
+        {isOpen &&
+          filteredItems.map((item, index) => (
+            <Fragment key={`${item}${index}`}>
+              <Separator />
+              <ComboboxOption
+                {...getItemProps({ item, index })}
+                data-highlighted={highlightedIndex === index}
+              >
+                {displayValue?.(item) ?? String(item)}
+              </ComboboxOption>
+            </Fragment>
+          ))}
+      </List>
+      {noOptions && (
+        <WarningBox>
+          <WarningTriangleIcon color={theme.colors.amberElement} size={theme.fontSizes.xs} />
+          <SingleLineText as="p" size="xs">
+            Vi kan inte hitta den här rasen, försök igen
+          </SingleLineText>
+        </WarningBox>
+      )}
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div({
+  position: 'relative',
+  isolation: 'isolate',
+})
+
+const InputWrapper = styled.div({
+  position: 'relative',
+})
+
+const Input = styled(motion.input)({
+  color: theme.colors.textPrimary,
+  borderRadius: theme.radius.sm,
+  width: '100%',
+  height: '3rem',
+  paddingLeft: theme.space.md,
+  paddingRight: theme.space.xxl,
+  backgroundColor: theme.colors.opaque1,
+  fontSize: theme.fontSizes.md,
+
+  '&[data-expanded=true]': {
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
+  },
+
+  '&[data-warning=true]': {
+    borderBottomLeftRadius: theme.radius.sm,
+    borderBottomRightRadius: theme.radius.sm,
+  },
+})
+
+const Actions = styled.div({
+  position: 'absolute',
+  top: '50%',
+  right: '1.125rem',
+  transform: 'translateY(-50%)',
+  display: 'flex',
+  gap: theme.space.xs,
+  alignItems: 'center',
+})
+
+const ToggleButton = styled.button({
+  cursor: 'pointer',
+
+  transition: 'transform 200ms cubic-bezier(0.77,0,0.18,1)',
+
+  ['&[aria-expanded=true]']: {
+    transform: 'rotate(180deg)',
+  },
+
+  ['&[data-warning=true]']: {
+    transform: 'rotate(0)',
+  },
+})
+
+const DeleteButton = styled.button({
+  cursor: 'pointer',
+})
+
+const Separator = styled.hr({
+  height: 1,
+  backgroundColor: theme.colors.opaque2,
+  marginInline: theme.space.md,
+})
+
+const List = styled.ul({
+  backgroundColor: theme.colors.opaque1,
+  borderBottomLeftRadius: theme.radius.sm,
+  borderBottomRightRadius: theme.radius.sm,
+
+  position: 'absolute',
+  width: '100%',
+})
+
+export const ComboboxOption = styled.li({
+  height: '3rem',
+  fontSize: theme.fontSizes.md,
+  display: 'flex',
+  alignItems: 'center',
+  paddingInline: theme.space.md,
+
+  '&[data-highlighted=true]': {
+    backgroundColor: theme.colors.gray200,
+  },
+
+  '&:hover': {
+    backgroundColor: theme.colors.gray300,
+  },
+
+  '&:last-of-type': {
+    borderBottomLeftRadius: theme.radius.sm,
+    borderBottomRightRadius: theme.radius.sm,
+  },
+})
+
+const WarningBox = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  paddingTop: theme.space.xxs,
+  paddingInline: theme.space.xs,
+  gap: theme.space.xxs,
+})
+
+const SingleLineText = styled(Text)({
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1794,6 +1794,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.14.8":
+  version: 7.21.0
+  resolution: "@babel/runtime@npm:7.21.0"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: 7b33e25bfa9e0e1b9e8828bb61b2d32bdd46b41b07ba7cb43319ad08efc6fda8eb89445193e67d6541814627df0ca59122c0ea795e412b99c5183a0540d338ab
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.20.13":
   version: 7.20.13
   resolution: "@babel/runtime@npm:7.20.13"
@@ -9915,6 +9924,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"compute-scroll-into-view@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "compute-scroll-into-view@npm:2.0.4"
+  checksum: f3d1db9276c16af42155b572750514939cd0ab0a0f46498906f6811c5b654c5ff2b3f9bfd65958e57439e000a5e1ae092eb96b9e153d194a73e52ffd2380550c
+  languageName: node
+  linkType: hard
+
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -11013,6 +11029,21 @@ __metadata:
   version: 8.6.0
   resolution: "dotenv@npm:8.6.0"
   checksum: 38e902c80b0666ab59e9310a3d24ed237029a7ce34d976796349765ac96b8d769f6df19090f1f471b77a25ca391971efde8a1ea63bb83111bd8bec8e5cc9b2cd
+  languageName: node
+  linkType: hard
+
+"downshift@npm:7.3.2":
+  version: 7.3.2
+  resolution: "downshift@npm:7.3.2"
+  dependencies:
+    "@babel/runtime": ^7.14.8
+    compute-scroll-into-view: ^2.0.4
+    prop-types: ^15.7.2
+    react-is: ^17.0.2
+    tslib: ^2.3.0
+  peerDependencies:
+    react: ">=16.12.0"
+  checksum: 4ed19fbf5a8d2afe35d2c55d35bd6de1e992d3553540ef0a4371ecdc4fc9e9643f999dcbc6fabb87dc6ab046dbff402231adaeb2ed47e66a70d10d59dd1552d8
   languageName: node
   linkType: hard
 
@@ -19479,7 +19510,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:17.0.2, react-is@npm:^17.0.1":
+"react-is@npm:17.0.2, react-is@npm:^17.0.1, react-is@npm:^17.0.2":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
@@ -21187,6 +21218,7 @@ __metadata:
     apollo-link-timeout: 4.0.0
     babel-loader: 9.1.2
     cookies-next: 2.1.1
+    downshift: 7.3.2
     eslint-config-custom: "workspace:"
     framer-motion: 10.1.0
     graphql: 16.6.0


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add combobox component (autocomplete).


![Screenshot 2023-03-09 at 09.02.41.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/5680dfc7-1ea4-4f72-bc78-6beaa35505da/Screenshot%202023-03-09%20at%2009.02.41.png)

## Justify why they are needed

This will be needed for breed selector to launch PET.

Based on downshift lib. We don't want to implement all the accessibility stuff ourselves.

I investigated Radix but they don't offer a combobox so we would have to do a lot of wiring ourselves. I also tried out Reach UI but it wasn't working 100% they way we wanted. It has has also not been updated in 6 months which is a red flag.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
