### PR TITLE
GRW-2346 - feat(Button): support 'open in new window' storyblok feature

### DIFF
--- a/apps/store/src/blocks/ButtonBlock.tsx
+++ b/apps/store/src/blocks/ButtonBlock.tsx
@@ -21,6 +21,7 @@ export const ButtonBlock = ({ blok, nested }: ButtonBlockProps) => {
         href={getLinkFieldURL(blok.link, blok.text)}
         variant={blok.variant ?? 'primary'}
         size={blok.size ?? 'medium'}
+        target={blok.link.target}
       >
         {blok.text}
       </ButtonNextLink>

--- a/apps/store/src/components/ButtonNextLink.tsx
+++ b/apps/store/src/components/ButtonNextLink.tsx
@@ -5,10 +5,11 @@ import { Button } from 'ui'
 type ButtonProps = ComponentProps<typeof Button>
 
 type Props = LinkProps &
+  Partial<Pick<HTMLAnchorElement, 'target'>> &
   Pick<ButtonProps, 'variant' | 'size' | 'loading' | 'onClick' | 'children' | 'className'>
 
 export const ButtonNextLink = (props: Props) => {
-  const { onClick, variant, size, loading, children, className, ...linkProps } = props
+  const { onClick, variant, size, loading, children, className, target, ...linkProps } = props
   return (
     <Link {...linkProps} passHref legacyBehavior>
       <Button
@@ -16,6 +17,7 @@ export const ButtonNextLink = (props: Props) => {
         variant={variant}
         size={size}
         loading={loading}
+        {...(target === '_blank' ? { target: '_blank', rel: 'noreferrer' } : {})}
         className={className}
       >
         {children}

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -98,6 +98,7 @@ export type LinkField = {
   id: string
   url: string
   linktype: 'multilink' | 'story' | 'url'
+  target?: string
   story?: {
     id: number
     uuid: string


### PR DESCRIPTION
## Describe your changes

* Updates `ButtonBlock` so it supports _open in new window_ storyblok feature

<img width="398" alt="Screenshot 2023-03-10 at 12 31 30" src="https://user-images.githubusercontent.com/19200662/224305457-149f8169-7f76-4e20-8455-f07dfe8895c2.png">

## Justify why they are needed

Requested by Peter

## Jira issue(s): [GRW-2346](https://hedvig.atlassian.net/browse/GRW-2346)

[GRW-2346]: https://hedvig.atlassian.net/browse/GRW-2346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ