### PR TITLE
chore: replace :first-child --> :first-of-type

### DIFF
--- a/apps/store/src/blocks/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock.tsx
@@ -153,7 +153,7 @@ const Column = styled.div({
   [mq.md]: { gridColumn: 'span 3' },
   [mq.xxl]: {
     gridColumn: 'auto / span 2',
-    ':first-child': { gridColumnStart: 3 },
+    ':first-of-type': { gridColumnStart: 3 },
   },
 })
 


### PR DESCRIPTION
## Describe your changes

Handles a warning that advises use :first-of-type instead of :first-child 

## Justify why they are needed

It seems the order `<style>` tags gets added in the document can affect `:first-child` selectors. That's why `:first-of-type` is referred as a better replacement.
