### PR TITLE
Add inline link styles to RichText

### DIFF
--- a/apps/store/src/blocks/RichTextBlock/RichTextBlock.styles.tsx
+++ b/apps/store/src/blocks/RichTextBlock/RichTextBlock.styles.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react'
 import { getHeadingVariantStyles } from 'ui/src/components/Heading/Heading.helpers'
 import { theme, mq } from 'ui'
 
-export const listStyling = css({
+export const listStyles = css({
   ul: {
     marginLeft: theme.space.xs,
   },
@@ -84,77 +84,100 @@ export const listStyling = css({
   },
 })
 
-export const richTextStyles = css({
-  fontSize: theme.fontSizes.md,
-  '.preamble': {
-    fontSize: theme.fontSizes.xl,
-  },
-
-  p: {
-    marginBlock: theme.space.md,
-    color: theme.colors.textSecondary,
-  },
-
-  'h4 + p': {
-    marginTop: 0,
-  },
-
-  h2: {
-    marginTop: theme.space.xl,
-    ...getHeadingVariantStyles({ _: 'standard.24', md: 'standard.32', xl: 'standard.48' }),
-  },
-
-  h3: {
-    marginTop: theme.space.xl,
-    ...getHeadingVariantStyles({ _: 'standard.18', md: 'standard.24', xl: 'standard.32' }),
-  },
-
-  h4: {
-    marginTop: theme.space.xl,
-    ...getHeadingVariantStyles({ _: 'standard.18', md: 'standard.24', xl: 'standard.32' }),
-  },
-
-  hr: {
-    marginBlock: theme.space.xxxl,
-    height: 1,
-    backgroundColor: theme.colors.borderOpaque,
-  },
-
-  [mq.md]: {
-    fontSize: theme.fontSizes.xl,
-    '.preamble': {
-      fontSize: theme.fontSizes.xxl,
+export const linkStyles = css({
+  a: {
+    position: 'relative',
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      bottom: 1,
+      left: 0,
+      width: '100%',
+      height: 2,
+      backgroundColor: theme.colors.borderOpaque,
     },
 
-    h2: {
-      marginTop: theme.space.xxl,
-    },
-
-    h3: {
-      marginTop: theme.space.xxl,
-    },
-
-    h4: {
-      marginTop: theme.space.xxl,
-    },
-  },
-
-  [mq.xl]: {
-    fontSize: theme.fontSizes.xxl,
-    '.preamble': {
-      fontSize: theme.fontSizes.xxxl,
-    },
-
-    h2: {
-      marginTop: theme.space.xxxl,
-    },
-
-    h3: {
-      marginTop: theme.space.xxxl,
-    },
-
-    h4: {
-      marginTop: theme.space.xxxl,
+    '&:hover::after': {
+      backgroundColor: theme.colors.blue600,
     },
   },
 })
+
+export const richTextStyles = css(
+  {
+    fontSize: theme.fontSizes.md,
+    '.preamble': {
+      fontSize: theme.fontSizes.xl,
+    },
+
+    p: {
+      marginBlock: theme.space.md,
+      color: theme.colors.textSecondary,
+    },
+
+    'h4 + p': {
+      marginTop: 0,
+    },
+
+    h2: {
+      marginTop: theme.space.xl,
+      ...getHeadingVariantStyles({ _: 'standard.24', md: 'standard.32', xl: 'standard.48' }),
+    },
+
+    h3: {
+      marginTop: theme.space.xl,
+      ...getHeadingVariantStyles({ _: 'standard.18', md: 'standard.24', xl: 'standard.32' }),
+    },
+
+    h4: {
+      marginTop: theme.space.xl,
+      ...getHeadingVariantStyles({ _: 'standard.18', md: 'standard.24', xl: 'standard.32' }),
+    },
+
+    hr: {
+      marginBlock: theme.space.xxxl,
+      height: 1,
+      backgroundColor: theme.colors.borderOpaque,
+    },
+
+    [mq.md]: {
+      fontSize: theme.fontSizes.xl,
+      '.preamble': {
+        fontSize: theme.fontSizes.xxl,
+      },
+
+      h2: {
+        marginTop: theme.space.xxl,
+      },
+
+      h3: {
+        marginTop: theme.space.xxl,
+      },
+
+      h4: {
+        marginTop: theme.space.xxl,
+      },
+    },
+
+    [mq.xl]: {
+      fontSize: theme.fontSizes.xxl,
+      '.preamble': {
+        fontSize: theme.fontSizes.xxxl,
+      },
+
+      h2: {
+        marginTop: theme.space.xxxl,
+      },
+
+      h3: {
+        marginTop: theme.space.xxxl,
+      },
+
+      h4: {
+        marginTop: theme.space.xxxl,
+      },
+    },
+  },
+  linkStyles,
+  listStyles,
+)

--- a/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
+++ b/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { Layout } from '../TextContentBlock'
-import { richTextStyles, listStyling } from './RichTextBlock.styles'
+import { richTextStyles } from './RichTextBlock.styles'
 
 export type RichTextBlockProps = SbBaseBlockProps<{
   content: ISbRichtext
@@ -26,4 +26,4 @@ export const RichTextBlock = ({ blok }: RichTextBlockProps) => {
 }
 RichTextBlock.blockName = 'richText'
 
-const Content = styled(GridLayout.Content)(richTextStyles, listStyling)
+const Content = styled(GridLayout.Content)(richTextStyles)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Compose styles a bit cleaner
- Add inline link styling
This styling will be used in more places. So I figure we can import it to whatever blocks/components that need it rather than making it a global style

https://user-images.githubusercontent.com/6661511/225369402-c0ca10bd-f1e9-4319-acf7-5fa1c4f575ae.mov

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Highlight links in text

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
