### PR TITLE
GRW-2355 - feat(Combobox): solve some issues and make some improvements

### DIFF
--- a/apps/store/src/components/Combobox/Combobox.stories.tsx
+++ b/apps/store/src/components/Combobox/Combobox.stories.tsx
@@ -26,25 +26,29 @@ const FRUIT = [
 type Fruit = (typeof FRUIT)[number]
 
 export const Default: StoryFn = () => {
-  const [value, setValue] = useState<Fruit | null>(FRUIT[1])
+  const [selectedItem, setSelectedItem] = useState<Fruit | null>(FRUIT[1])
 
   return (
     <Combobox
       placeholder="Search fruit..."
       items={FRUIT}
-      defaultValue={value}
-      onSelect={setValue}
+      selectedItem={selectedItem}
+      onSelectedItemChange={setSelectedItem}
       displayValue={(fruit) => fruit.name}
     />
   )
 }
 
 export const NoOptionFound: StoryFn = () => {
+  const [selectedItem, setSelectedItem] = useState<Fruit | null>({ id: '-1', name: 'no matches' })
+
   return (
     <Combobox
-      items={['Apple', 'Pear', 'Banana']}
+      items={FRUIT}
+      selectedItem={selectedItem}
+      onSelectedItemChange={setSelectedItem}
       placeholder="Search fruit..."
-      defaultValue="Plu"
+      displayValue={(fruit) => fruit.name}
     />
   )
 }

--- a/apps/store/src/components/Combobox/Combobox.stories.tsx
+++ b/apps/store/src/components/Combobox/Combobox.stories.tsx
@@ -40,5 +40,11 @@ export const Default: StoryFn = () => {
 }
 
 export const NoOptionFound: StoryFn = () => {
-  return <Combobox items={['Apple', 'Pear', 'Banana']} defaultValue="Plu" />
+  return (
+    <Combobox
+      items={['Apple', 'Pear', 'Banana']}
+      placeholder="Search fruit..."
+      defaultValue="Plu"
+    />
+  )
 }

--- a/apps/store/src/components/Combobox/Combobox.stories.tsx
+++ b/apps/store/src/components/Combobox/Combobox.stories.tsx
@@ -38,17 +38,3 @@ export const Default: StoryFn = () => {
     />
   )
 }
-
-export const NoOptionFound: StoryFn = () => {
-  const [selectedItem, setSelectedItem] = useState<Fruit | null>({ id: '-1', name: 'no matches' })
-
-  return (
-    <Combobox
-      items={FRUIT}
-      selectedItem={selectedItem}
-      onSelectedItemChange={setSelectedItem}
-      placeholder="Search fruit..."
-      displayValue={(fruit) => fruit.name}
-    />
-  )
-}

--- a/apps/store/src/components/Combobox/Combobox.tsx
+++ b/apps/store/src/components/Combobox/Combobox.tsx
@@ -13,7 +13,6 @@ type Props<Item> = {
   onSelectedItemChange: (item: Item | null) => void
   placeholder?: string
   displayValue?: (item: Item) => string
-  className?: string
   disabled?: boolean
   required?: boolean
 }
@@ -27,7 +26,7 @@ export const Combobox = <Item,>({
   selectedItem,
   onSelectedItemChange,
   displayValue,
-  ...inputProps
+  ...externalInputProps
 }: Props<Item>) => {
   const { highlight, animationProps } = useHighlightAnimation()
 
@@ -93,6 +92,7 @@ export const Combobox = <Item,>({
 
   const handleClickDelete = () => {
     reset()
+    // We need to reset the pieces of state that we control ourselfs
     setInputValue('')
     onSelectedItemChange(null)
     openMenu()
@@ -104,7 +104,7 @@ export const Combobox = <Item,>({
         <Input
           {...getInputProps()}
           {...animationProps}
-          {...inputProps}
+          {...externalInputProps}
           data-expanded={isOpen}
           data-warning={noOptions}
         />
@@ -122,7 +122,7 @@ export const Combobox = <Item,>({
         {isOpen &&
           filteredItems.map((item, index) => (
             <Fragment key={`${item}${index}`}>
-              {index !== 0 && <Separator />}
+              <Separator />
               <ComboboxOption
                 {...getItemProps({ item, index })}
                 data-highlighted={highlightedIndex === index}

--- a/apps/store/src/components/Combobox/Combobox.tsx
+++ b/apps/store/src/components/Combobox/Combobox.tsx
@@ -63,6 +63,31 @@ export const Combobox = <Item,>({
 
       onSelect?.(selectedItem ?? null)
     },
+    stateReducer(state, actionChanges) {
+      const { type, changes } = actionChanges
+
+      switch (type) {
+        case useCombobox.stateChangeTypes.InputKeyDownEnter:
+          if (availableItems.length > 1) {
+            // Keep options when pressing [Enter] and more than one item is available for selection
+            return {
+              ...changes,
+              isOpen: true,
+            }
+          } else if (availableItems.length === 1) {
+            // Select on [Enter] when only one item is available for selection
+            return {
+              ...changes,
+              inputValue: displayValue?.(availableItems[0]) ?? String(availableItems[0]) ?? '',
+              selectedItem: availableItems[0],
+            }
+          }
+
+          return changes
+        default:
+          return changes
+      }
+    },
     itemToString(item) {
       return item ? displayValue?.(item) ?? String(item) : ''
     },

--- a/apps/store/src/components/Combobox/Combobox.tsx
+++ b/apps/store/src/components/Combobox/Combobox.tsx
@@ -13,6 +13,9 @@ type Props<Item> = {
   items: Array<Item>
   onSelect?: (item: Item | null) => void
   displayValue?: (item: Item) => string
+  className?: string
+  disabled?: boolean
+  required?: boolean
 }
 
 /**
@@ -20,7 +23,7 @@ type Props<Item> = {
  * @see https://www.downshift-js.com/use-combobox
  */
 export const Combobox = <Item,>(props: Props<Item>) => {
-  const { placeholder, defaultValue, onSelect, items, displayValue } = props
+  const { defaultValue, onSelect, items, displayValue, ...inputProps } = props
   const { highlight, animationProps } = useHighlightAnimation()
 
   const {
@@ -42,6 +45,9 @@ export const Combobox = <Item,>(props: Props<Item>) => {
       }
 
       onSelect?.(selectedItem ?? null)
+    },
+    itemToString(item) {
+      return item ? displayValue?.(item) ?? String(item) : ''
     },
   })
 
@@ -69,7 +75,7 @@ export const Combobox = <Item,>(props: Props<Item>) => {
         <Input
           {...getInputProps()}
           {...animationProps}
-          placeholder={placeholder}
+          {...inputProps}
           defaultValue={defaultValue}
           data-expanded={isOpen}
           data-warning={noOptions}
@@ -88,7 +94,7 @@ export const Combobox = <Item,>(props: Props<Item>) => {
         {isOpen &&
           filteredItems.map((item, index) => (
             <Fragment key={`${item}${index}`}>
-              <Separator />
+              {index !== 0 && <Separator />}
               <ComboboxOption
                 {...getItemProps({ item, index })}
                 data-highlighted={highlightedIndex === index}


### PR DESCRIPTION
## Describe your changes

* Solve an issue where wrong item gets selected with keyboard navigation. Check the video below:

https://user-images.githubusercontent.com/19200662/225616676-b099f9f8-a1d5-45ad-b782-9e9f22c579e1.mov

Basically what is happening is, if we don't update the list of items provided to `useCombobox` with a filtered list based on `inputValue` it will be possible to "navigate" through the whole list with keyboard even though we can't see it. In the video the list is filtered to an single item but I've hit ArrowDow 3 times and then [Enter] which allowed me to select the third item of the list: _Banana_.
* Add a custom behaviour where an item gets selected with [Enter] when there's only one available for selection
* Set `selecteddItem` as `null` when clearing the input - backspace or _clear input_ button

## Justify why they are needed

To better support Breed selector field
