### PR TITLE
Add horizontal stacking option to radio input

### DIFF
--- a/apps/store/src/components/PriceCalculator/AutomaticField.tsx
+++ b/apps/store/src/components/PriceCalculator/AutomaticField.tsx
@@ -73,7 +73,23 @@ export const AutomaticField = ({ field, priceIntent, onSubmit, loading, autoFocu
       )
 
     case 'radio':
-      return (
+      return field.stacking === 'horizontal' ? (
+        <InputRadio.HorizontalRoot
+          name={field.name}
+          label={translateLabel(field.label)}
+          required={field.required}
+          defaultValue={field.value ?? field.defaultValue}
+        >
+          {field.options.map((option, index) => (
+            <InputRadio.HorizontalItem
+              key={option.value}
+              label={translateLabel(option.label)}
+              value={option.value}
+              autoFocus={autoFocus && index === 0}
+            />
+          ))}
+        </InputRadio.HorizontalRoot>
+      ) : (
         <InputRadio.Root
           name={field.name}
           label={translateLabel(field.label)}

--- a/apps/store/src/components/PriceCalculator/InputRadio.tsx
+++ b/apps/store/src/components/PriceCalculator/InputRadio.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import * as RadioGroup from '@radix-ui/react-radio-group'
 import { motion } from 'framer-motion'
+import { FormEventHandler } from 'react'
 import { Space, Text, theme } from 'ui'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { useHighlightAnimation } from '@/utils/useHighlightAnimation'
@@ -28,7 +29,7 @@ export const Root = ({ children, label, onValueChange, ...props }: RootProps) =>
       <Text size="xs" color="textSecondary">
         {label}
       </Text>
-      <RadioGroup.Root onValueChange={handleValueChange} {...props}>
+      <RadioGroup.Root onValueChange={handleValueChange} aria-label={label} {...props}>
         <SpaceFlex space={1} align="center">
           {children}
         </SpaceFlex>
@@ -48,14 +49,15 @@ type ItemProps = {
   value: string
   id?: string
   autoFocus?: boolean
+  onChange?: FormEventHandler<HTMLButtonElement>
 }
 
-export const Item = ({ value, label, id, autoFocus }: ItemProps) => {
+export const Item = ({ value, label, id, ...itemProps }: ItemProps) => {
   const identifier = id ?? `radio-${value}`
 
   return (
     <SpaceFlex space={0.5} align="center">
-      <StyledItem id={identifier} value={value} autoFocus={autoFocus}>
+      <StyledItem id={identifier} value={value} {...itemProps}>
         <StyledIndicator />
       </StyledItem>
       <label htmlFor={identifier}>
@@ -91,3 +93,32 @@ const StyledIndicator = styled(RadioGroup.Indicator)({
   width: '100%',
   height: '100%',
 })
+
+export const HorizontalRoot = ({ label, children, ...rootProps }: RootProps) => {
+  return (
+    <StyledHorizontalRoot aria-label={label} {...rootProps}>
+      {children}
+    </StyledHorizontalRoot>
+  )
+}
+
+const StyledHorizontalRoot = styled(RadioGroup.Root)({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: theme.space.xxs,
+})
+
+export const HorizontalItem = ({ onChange, ...props }: ItemProps) => {
+  const { highlight, animationProps } = useHighlightAnimation()
+
+  const handleChange: FormEventHandler<HTMLButtonElement> = (event) => {
+    highlight()
+    onChange?.(event)
+  }
+
+  return (
+    <Card {...animationProps}>
+      <Item {...props} onChange={handleChange} />
+    </Card>
+  )
+}

--- a/apps/store/src/services/PriceCalculator/Field.types.ts
+++ b/apps/store/src/services/PriceCalculator/Field.types.ts
@@ -33,6 +33,7 @@ export type DateField = BaseField<string> & {
 type RadioField = BaseField<string> & {
   type: 'radio'
   options: Array<FieldOption>
+  stacking?: 'horizontal'
 }
 
 export type FieldOption = {

--- a/apps/store/src/services/PriceCalculator/data/SE_PET_CAT.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_PET_CAT.ts
@@ -36,6 +36,7 @@ export const SE_PET_CAT: Template = {
         {
           field: {
             type: 'radio',
+            stacking: 'horizontal',
             name: 'gender',
             label: { key: tKey('FIELD_GENDER_LABEL') },
             required: true,

--- a/apps/store/src/services/PriceCalculator/data/SE_PET_DOG.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_PET_DOG.ts
@@ -39,6 +39,7 @@ export const SE_PET_DOG: Template = {
         {
           field: {
             type: 'radio',
+            stacking: 'horizontal',
             name: 'gender',
             label: { key: tKey('FIELD_GENDER_LABEL') },
             options: [


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add option to stack radio group input horizontally (without showing the label).


![Screenshot 2023-03-16 at 17.55.20.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/a5aa4878-087c-4e27-b827-1ddfcbaa1880/Screenshot%202023-03-16%20at%2017.55.20.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Needed for pet gender field.

Only supports two options (design).

Only supports horizontal option - let's add vertical stacking when we need it.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
