### PR TITLE
Integrate deductibles from API

### DIFF
--- a/apps/store/src/graphql/ProductOfferFragment.graphql
+++ b/apps/store/src/graphql/ProductOfferFragment.graphql
@@ -50,4 +50,8 @@ fragment ProductOffer on ProductOffer {
     }
   }
   priceIntentData
+  deductible {
+    displayName
+    tagline
+  }
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add deductible selector to the offer presenter.


![Screenshot 2023-03-17 at 11.19.52.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/7a7b0044-7a61-4c4d-9309-f66af93326f0/Screenshot%202023-03-17%20at%2011.19.52.png)

Refactor offer presenter to keep track of selected offer rather than selected type of contract.

Infer tiers and deductibles from the API.

Update deductible selector and log if we get unexpected data from API.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Support for pet insurance.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
