### PR TITLE
Add ProductPillow component

### DIFF
--- a/apps/store/src/blocks/ProductPillowsBlock/ProductPillowBlock.tsx
+++ b/apps/store/src/blocks/ProductPillowsBlock/ProductPillowBlock.tsx
@@ -1,0 +1,35 @@
+import { storyblokEditable } from '@storyblok/react'
+import { useProductMetadata } from '@/components/LayoutWithMenu/ProductMetadataContext'
+import { ProductPillow } from '@/components/ProductPillow/ProductPillow'
+import { SbBaseBlockProps, StoryblokAsset, LinkField } from '@/services/storyblok/storyblok'
+import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
+
+export type ProductPillowBlockProps = SbBaseBlockProps<{
+  name: string
+  label?: string
+  image?: StoryblokAsset
+  link: LinkField
+}>
+
+export const ProductPillowBlock = ({ blok }: ProductPillowBlockProps) => {
+  const url = getLinkFieldURL(blok.link, blok.name)
+  const productMetadata = useProductMetadata()
+  const product = productMetadata?.find((product) => isSameLink(url, product.pageLink))
+  const pillowImage = product?.pillowImage.src ?? blok.image?.filename
+  return (
+    <ProductPillow
+      name={blok.name}
+      label={blok.label}
+      image={pillowImage}
+      url={url}
+      {...storyblokEditable(blok)}
+    />
+  )
+}
+ProductPillowBlock.blockName = 'productPillow'
+
+// Make sure /en-se/products/home == en-se/products/home
+const isSameLink = (a: string, b: string) => {
+  const normalize = (url: string) => url.replace(/^\//, '')
+  return normalize(a) === normalize(b)
+}

--- a/apps/store/src/blocks/ProductPillowsBlock/ProductPillowsBlock.tsx
+++ b/apps/store/src/blocks/ProductPillowsBlock/ProductPillowsBlock.tsx
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled'
+import { storyblokEditable } from '@storyblok/react'
+import { useMemo } from 'react'
+import { mq, theme } from 'ui'
+import { SbBaseBlockProps, ExpectedBlockType } from '@/services/storyblok/storyblok'
+import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
+import { isDisabledPetLink } from '@/utils/isDisabledPetLink'
+import { ProductPillowBlock, ProductPillowBlockProps } from './ProductPillowBlock'
+
+export type ProductPillowsBlockProps = SbBaseBlockProps<{
+  items: ExpectedBlockType<ProductPillowBlockProps>
+}>
+
+export const ProductPillowsBlock = ({ blok }: ProductPillowsBlockProps) => {
+  const filteredProductPillowItems = filterByBlockType(blok.items, ProductPillowBlock.blockName)
+  const items = useMemo(
+    () =>
+      filteredProductPillowItems.filter(
+        (item) => !isDisabledPetLink(item.link.story?.full_slug ?? ''),
+      ),
+    [filteredProductPillowItems],
+  )
+  return (
+    <ProductPillowsWrapper {...storyblokEditable(blok)}>
+      {items.map((nestedBlock) => (
+        <ProductPillowBlock key={nestedBlock._uid} blok={nestedBlock} />
+      ))}
+    </ProductPillowsWrapper>
+  )
+}
+ProductPillowsBlock.blockName = 'productPillows'
+
+const ProductPillowsWrapper = styled.nav({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, max-content)',
+  columnGap: theme.space.md,
+  justifyContent: 'center',
+
+  [mq.md]: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    columnGap: 0,
+  },
+})

--- a/apps/store/src/components/ProductPillow/ProductPillow.stories.tsx
+++ b/apps/store/src/components/ProductPillow/ProductPillow.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta, StoryFn } from '@storybook/react'
+import { ProductPillow, ProductPillowProps } from './ProductPillow'
+
+export default {
+  title: 'Product Pillows / Product Pillow',
+  component: ProductPillow,
+  argTypes: {},
+  parameters: {
+    layout: 'centered',
+  },
+} as Meta<typeof ProductPillow>
+
+const Template: StoryFn<ProductPillowProps> = (props) => {
+  return <ProductPillow {...props} />
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  name: 'Olycksfall',
+  image: 'https://a.storyblok.com/f/165473/832x832/fa27811442/hedvig-pillow-home.png',
+  url: '/',
+}

--- a/apps/store/src/components/ProductPillow/ProductPillow.tsx
+++ b/apps/store/src/components/ProductPillow/ProductPillow.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled'
+import Link from 'next/link'
+import React from 'react'
+import { Text, theme } from 'ui'
+import { Pillow } from '@/components/Pillow/Pillow'
+
+export type ProductPillowProps = {
+  name: string
+  label?: string
+  image?: string
+  url: string
+}
+
+export const ProductPillow = ({ name, image, url }: ProductPillowProps) => {
+  return (
+    <PillowLink href={url}>
+      <Pillow src={image} size="xlarge" />
+      <Text as="span" size="md">
+        {name}
+      </Text>
+    </PillowLink>
+  )
+}
+
+const PillowLink = styled(Link)({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: theme.space.sm,
+  padding: `${theme.space.sm} ${theme.space.md}`,
+  borderRadius: theme.radius.sm,
+
+  '@media (hover: hover)': {
+    '&:hover': {
+      backgroundColor: theme.colors.grayTranslucent100,
+    },
+  },
+
+  ':focus': {
+    backgroundColor: theme.colors.grayTranslucent100,
+  },
+})

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -38,6 +38,8 @@ import { ProductCardBlock } from '@/blocks/ProductCardBlock'
 import { ProductDocumentsBlock } from '@/blocks/ProductDocumentsBlock'
 import { ProductGridBlock } from '@/blocks/ProductGridBlock'
 import { ProductPageBlock } from '@/blocks/ProductPageBlock'
+import { ProductPillowBlock } from '@/blocks/ProductPillowsBlock/ProductPillowBlock'
+import { ProductPillowsBlock } from '@/blocks/ProductPillowsBlock/ProductPillowsBlock'
 import { ProductSlideshowBlock } from '@/blocks/ProductSlideshowBlock'
 import { ProductVariantSelectorBlock } from '@/blocks/ProductVariantSelectorBlock'
 import { ReusableBlockReference } from '@/blocks/ReusableBlockReference'
@@ -218,6 +220,8 @@ export const initStoryblok = () => {
     ProductCardBlock,
     ProductDocumentsBlock,
     ProductGridBlock,
+    ProductPillowBlock,
+    ProductPillowsBlock,
     ProductSlideshowBlock,
     ProductVariantSelectorBlock,
     RichTextBlock,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add new block for displaying Pillow navigation

I'm thinking if we should get the product metadata directly from Storyblok so we could statically generate it instead of `useProductMetadata`. I'm thinking if that could get rid of the slower loading for Pillow images when you land on the page 🤔

[Review app](https://hedvig-dot-itnwpfth0-hedvig.vercel.app/api/preview?secret=DWafxGrY6M8&slug=se/forsakringar/&_storyblok=194123251&_storyblok_c=page&_storyblok_version=&_storyblok_lang=default&_storyblok_release=0&_storyblok_rl=1679329399467&_storyblok_tk[space_id]=165473&_storyblok_tk[timestamp]=1679329395&_storyblok_tk[token]=7d76fb44db374ddd26c1d1025a4520f66eef707a)


https://user-images.githubusercontent.com/6661511/226404963-c6394cc9-4122-4f6c-ae98-e448a3473644.mov

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Potentially easier/faster navigation to product pages

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
