### PR TITLE
Lock scroll position for purchase form

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -4,6 +4,7 @@ import { motion, useScroll } from 'framer-motion'
 import { useState, useEffect, useRef, ReactNode } from 'react'
 import { theme, mq } from 'ui'
 import { GridLayout, MAX_WIDTH } from '@/components/GridLayout/GridLayout'
+import { HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header'
 import { PurchaseForm } from '@/components/ProductPage/PurchaseForm/PurchaseForm'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { zIndexes } from '@/utils/zIndex'
@@ -29,7 +30,7 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
   )
 
   return (
-    <Main {...storyblokEditable(blok)}>
+    <main {...storyblokEditable(blok)}>
       <StickyHeader>
         <nav aria-label="page content">
           <ContentNavigationList>
@@ -82,7 +83,7 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
       {blok.body.map((nestedBlock) => (
         <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
       ))}
-    </Main>
+    </main>
   )
 }
 ProductPageBlock.blockName = 'product'
@@ -174,10 +175,6 @@ const ContentNavigationTrigger = styled.a({
   },
 })
 
-const Main = styled.main({
-  paddingTop: theme.space.sm,
-})
-
 const Grid = styled(GridLayout.Root)({
   // TODO: Ideally padding that are currently spcing content from the edge of the page
   // should be added by the container.
@@ -201,7 +198,7 @@ const PurchaseFormWrapper = styled.div({
 
   [mq.lg]: {
     position: 'sticky',
-    top: 0,
+    top: HEADER_HEIGHT_DESKTOP,
     // Scroll independently if content is too long
     maxHeight: '100vh',
     overflow: 'auto',

--- a/apps/store/src/components/Header/Header.tsx
+++ b/apps/store/src/components/Header/Header.tsx
@@ -9,6 +9,9 @@ import { useScrollState } from '../../utils/useScrollState'
 import { MENU_BAR_HEIGHT_DESKTOP, MENU_BAR_HEIGHT_MOBILE, MENU_BAR_HEIGHT_PX } from './HeaderStyles'
 import { ShoppingCartMenuItem } from './ShoppingCartMenuItem'
 
+const HEADER_HEIGHT_MOBILE = `calc(${MENU_BAR_HEIGHT_MOBILE} + ${theme.space.xs})`
+export const HEADER_HEIGHT_DESKTOP = `calc(${MENU_BAR_HEIGHT_DESKTOP} + ${theme.space.xs})`
+
 // Not possible to animate HSL to "transparent"
 const TRANSPARENT_HSL_COLOR = 'hsla(0, 0%, 98%, 0)'
 
@@ -82,8 +85,8 @@ const GhostWrapper = styled.div({
   right: 0,
   zIndex: zIndexes.header,
 
-  height: `calc(${MENU_BAR_HEIGHT_MOBILE} + ${theme.space.xs})`,
-  [mq.lg]: { height: `calc(${MENU_BAR_HEIGHT_DESKTOP} + ${theme.space.xs})` },
+  height: HEADER_HEIGHT_MOBILE,
+  [mq.lg]: { height: HEADER_HEIGHT_DESKTOP },
 })
 
 export const Wrapper = styled(motion.header)({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Lock the scroll position of purchase form so it never scrolls with the rest of the content.

- Remove the top padding of the PDP video.


![Screenshot 2023-03-21 at 09.14.09.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/0769470c-a300-45b9-8b2c-2c97a24a2aa1/Screenshot%202023-03-21%20at%2009.14.09.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

UI improvements from Wille.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
