### PR TITLE
Bug: keep track of latest selected offer on PDP

### DIFF
--- a/apps/store/src/components/ProductPage/PriceIntentContext.tsx
+++ b/apps/store/src/components/ProductPage/PriceIntentContext.tsx
@@ -17,6 +17,7 @@ import {
 import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntentService'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useSelectedOffer } from './PurchaseForm/useSelectedOffer'
 
 type SetupPriceIntent = (shopSession: ShopSession) => Promise<void>
 type ContextValue =
@@ -37,10 +38,19 @@ const usePriceIntentContextValue = () => {
   const apolloClient = useApolloClient()
   const { onReady } = useShopSession()
 
+  const [, setSelectedOffer] = useSelectedOffer()
   const [priceIntentId, setPriceIntentId] = useState<string | null>(null)
   const result = usePriceIntentQuery({
     skip: !priceIntentId,
     variables: priceIntentId ? { priceIntentId } : undefined,
+    onCompleted(data) {
+      setSelectedOffer(
+        (prev) =>
+          data.priceIntent.offers.find(
+            (item) => item.variant.typeOfContract === prev?.variant.typeOfContract,
+          ) ?? data.priceIntent.offers[0],
+      )
+    },
   })
 
   const router = useRouter()

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -2,7 +2,7 @@ import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
 import { useInView } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
-import { RefObject, useEffect, useMemo, useRef, useState } from 'react'
+import { RefObject, useEffect, useMemo, useRef } from 'react'
 import { Button, Space, Text, theme } from 'ui'
 import { useUpdateCancellation } from '@/components/ProductPage/PurchaseForm/useUpdateCancellation'
 import { useUpdateStartDate } from '@/components/ProductPage/PurchaseForm/useUpdateStartDate'
@@ -25,10 +25,12 @@ import { PriceMatchBubble } from './PriceMatchBubble/PriceMatchBubble'
 import { ProductTierSelector } from './ProductTierSelector'
 import { FormElement } from './PurchaseForm.constants'
 import { useHandleSubmitAddToCart } from './useHandleSubmitAddToCart'
+import { useSelectedOffer } from './useSelectedOffer'
 
 type Props = {
   priceIntent: PriceIntent
   shopSession: ShopSession
+  selectedOffer: ProductOfferFragment
   scrollPastRef: RefObject<HTMLElement>
   // TODO: Use better type
   onAddedToCart: (productOffer: ProductOfferFragment) => void
@@ -37,9 +39,10 @@ type Props = {
 
 export const OfferPresenter = (props: Props) => {
   const { priceIntent, shopSession, scrollPastRef, onAddedToCart, onClickEdit } = props
+  const { selectedOffer } = props
+  const [, setSelectedOffer] = useSelectedOffer()
   const { t } = useTranslation('purchase-form')
   const formatter = useFormatter()
-  const [selectedOffer, setSelectedOffer] = useState(priceIntent.offers[0])
 
   const handleOfferChange = (offerId: string) => {
     const offer = priceIntent.offers.find((offer) => offer.id === offerId)

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -29,6 +29,7 @@ import { ScrollPast } from '../ScrollPast/ScrollPast'
 import { OfferPresenter } from './OfferPresenter'
 import { PriceCalculatorDialog } from './PriceCalculatorDialog'
 import { PURCHASE_FORM_MAX_WIDTH } from './PurchaseForm.constants'
+import { useSelectedOffer } from './useSelectedOffer'
 
 type FormState = 'IDLE' | 'EDIT' | 'ERROR'
 
@@ -39,6 +40,7 @@ export const PurchaseForm = () => {
   const { shopSession } = useShopSession()
   const formatter = useFormatter()
   const [priceIntent, , createNewPriceIntent] = usePriceIntent()
+  const [selectedOffer] = useSelectedOffer()
   const tracking = useTracking()
   const isLarge = useBreakpoint('lg')
 
@@ -110,7 +112,7 @@ export const PurchaseForm = () => {
           )
         }
 
-        if (priceIntent.offers.length > 0) {
+        if (selectedOffer) {
           const handleAddedToCart = async (item: ProductOfferFragment) => {
             notifyProductAdded({
               name: productData.displayNameFull,
@@ -143,6 +145,7 @@ export const PurchaseForm = () => {
               priceIntent={priceIntent}
               onAddedToCart={handleAddedToCart}
               onClickEdit={editForm}
+              selectedOffer={selectedOffer}
             />
           )
         }
@@ -384,10 +387,11 @@ type ShowOfferStateProps = {
   shopSession: ShopSession
   onAddedToCart: (item: ProductOfferFragment) => void
   onClickEdit: () => void
+  selectedOffer: ProductOfferFragment
 }
 
 const ShowOfferState = (props: ShowOfferStateProps) => {
-  const { shopSession, priceIntent, onAddedToCart, onClickEdit } = props
+  const { shopSession, priceIntent, selectedOffer, onAddedToCart, onClickEdit } = props
   const scrollPastRef = useRef<HTMLDivElement | null>(null)
 
   return (
@@ -398,6 +402,7 @@ const ShowOfferState = (props: ShowOfferStateProps) => {
         scrollPastRef={scrollPastRef}
         onAddedToCart={onAddedToCart}
         onClickEdit={onClickEdit}
+        selectedOffer={selectedOffer}
       />
     </SectionWrapper>
   )

--- a/apps/store/src/components/ProductPage/PurchaseForm/useSelectedOffer.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/useSelectedOffer.ts
@@ -1,0 +1,8 @@
+import { atom, useAtom } from 'jotai'
+import { ProductOfferFragment } from '@/services/apollo/generated'
+
+const selectedOfferAtom = atom<ProductOfferFragment | null>(null)
+
+export const useSelectedOffer = () => {
+  return useAtom(selectedOfferAtom)
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Refresh selected offer after editing price intent/offer (start date or re-confirm).

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We have a bug now where you don't see the updated start date after you edit. This is because we store the selected offer in local state and don't update it after editing. This PR fixes that.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
