### PR TITLE
Workaround for openPriceCalculator query param corrupting window.location in production

### DIFF
--- a/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
+++ b/apps/store/src/components/ContactSupport/IntercomChatButton.tsx
@@ -29,7 +29,7 @@ export const IntercomChatButton = ({ children }: Props) => {
   const [isLoaded, setIsLoaded] = useState(false)
 
   useEffect(() => {
-    if (!appId) {
+    if (INTERCOM_ENABLED && !appId) {
       datadogLogs.logger.warn('Expected env variable INTERCOM_APP_ID to be defined')
     }
   }, [appId])

--- a/apps/store/src/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 export const OPEN_PRICE_CALCULATOR_QUERY_PARAM = 'openPriceCalculator'
 
@@ -8,15 +8,15 @@ type Options = {
 }
 export const useOpenPriceCalculatorQueryParam = ({ onQueryParamDetected }: Options) => {
   const router = useRouter()
-  const { [OPEN_PRICE_CALCULATOR_QUERY_PARAM]: openPriceCalculator } = router.query
+  const triggeredRef = useRef(false)
   useEffect(() => {
-    if (router.isReady && openPriceCalculator === '1') {
-      const nextQuery = { ...router.query }
-      delete nextQuery[OPEN_PRICE_CALCULATOR_QUERY_PARAM]
-      router.replace({ pathname: router.pathname, query: nextQuery }, undefined, { shallow: true })
+    const { [OPEN_PRICE_CALCULATOR_QUERY_PARAM]: openPriceCalculator } = router.query
+    if (router.isReady && openPriceCalculator === '1' && !triggeredRef.current) {
+      // Guards against repeated triggers in case any other query param changes
+      // GOTCHA: We've tried removing query param via shallow router.replace, but it triggers some weird
+      // window.location change, and this problem only ever happens in production
+      triggeredRef.current = true
       onQueryParamDetected()
     }
-  }, [onQueryParamDetected, openPriceCalculator, router])
-
-  return openPriceCalculator
+  }, [onQueryParamDetected, router])
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Keep `openPriceCalculator` in URL to avoid issue in production

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
