### PR TITLE
Redirect to cart page after removing last entry

### DIFF
--- a/apps/store/src/components/CartInventory/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem.tsx
@@ -3,15 +3,20 @@ import { useTranslation } from 'next-i18next'
 import { Button, CrossIconSmall, Dialog, Space, Text, theme } from 'ui'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
+import { CartFragmentFragment } from '@/services/apollo/generated'
 import { useFormatter } from '@/utils/useFormatter'
 import { CartEntry } from './CartInventory.types'
 import { DetailsSheetDialog } from './DetailsSheetDialog'
 import { RemoveEntryDialog } from './RemoveEntryDialog'
 
-type Props = CartEntry & { cartId: string; readOnly?: boolean }
+type Props = CartEntry & {
+  cartId: string
+  readOnly?: boolean
+  onRemove?: (cart: CartFragmentFragment) => void
+}
 
 export const CartEntryItem = (props: Props) => {
-  const { cartId, readOnly, ...cartEntry } = props
+  const { cartId, readOnly, onRemove, ...cartEntry } = props
   const { title: titleLabel, startDate, cost, pillow } = cartEntry
   const { t } = useTranslation('cart')
   const formatter = useFormatter()
@@ -34,7 +39,7 @@ export const CartEntryItem = (props: Props) => {
       <Layout.Close>
         {!readOnly && (
           <SpaceFlex align="end" direction="vertical">
-            <RemoveEntryDialog cartId={cartId} {...cartEntry}>
+            <RemoveEntryDialog cartId={cartId} onCompleted={onRemove} {...cartEntry}>
               <Dialog.Trigger asChild>
                 <InvisibleButton aria-label="delete button">
                   <CrossIconSmall />

--- a/apps/store/src/components/CartInventory/RemoveEntryDialog.tsx
+++ b/apps/store/src/components/CartInventory/RemoveEntryDialog.tsx
@@ -2,16 +2,21 @@ import { useTranslation } from 'next-i18next'
 import { FormEventHandler, ReactNode, useId } from 'react'
 import { Button, Text } from 'ui'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
+import { CartFragmentFragment } from '@/services/apollo/generated'
 import { CartEntry } from './CartInventory.types'
 import { useRemoveCartEntry } from './useRemoveCartEntry'
 
-type Props = CartEntry & { cartId: string; children: ReactNode }
+type Props = CartEntry & {
+  cartId: string
+  children: ReactNode
+  onCompleted?: (cart: CartFragmentFragment) => void
+}
 
-export const RemoveEntryDialog = ({ children, cartId, offerId, title }: Props) => {
+export const RemoveEntryDialog = ({ children, title, ...mutationParams }: Props) => {
   const { t } = useTranslation('cart')
   const formId = useId()
 
-  const [removeCartEntry, { loading }] = useRemoveCartEntry({ cartId, offerId })
+  const [removeCartEntry, { loading }] = useRemoveCartEntry(mutationParams)
 
   const handleSubmit: FormEventHandler = (event) => {
     event.preventDefault()

--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -20,6 +20,7 @@ import { useProductRecommendations } from '@/components/ProductRecommendationLis
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { TextField } from '@/components/TextField/TextField'
 import {
+  CartFragmentFragment,
   CurrentMemberDocument,
   CurrentMemberQuery,
   CurrentMemberQueryVariables,
@@ -79,6 +80,12 @@ const CheckoutPage = (props: CheckoutPageProps) => {
     },
   })
 
+  const handleRemoveCartEntry = (cart: CartFragmentFragment) => {
+    if (cart.entries.length === 0) {
+      router.push(PageLink.cart())
+    }
+  }
+
   const { productRecommendationOffers } = useProductRecommendations()
 
   const userErrorMessage = userError?.message
@@ -104,7 +111,12 @@ const CheckoutPage = (props: CheckoutPageProps) => {
                 <CartCollapsibleInner y={{ base: 1, lg: 1.5 }}>
                   <CartEntryList>
                     {cart.entries.map((item) => (
-                      <CartEntryItem key={item.offerId} cartId={cart.id} {...item} />
+                      <CartEntryItem
+                        key={item.offerId}
+                        cartId={cart.id}
+                        onRemove={handleRemoveCartEntry}
+                        {...item}
+                      />
                     ))}
                   </CartEntryList>
                   <HorizontalLine />


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Redirect the user to the cart page if they remove the last item in the cart on the Checkout page.

## Justify why they are needed

This is a bug fix.

It would be nice to avoid prop-drilling. I was considering some Jotai solution but not sure how it would work. I was also considering sending some event you can subscribe to but maybe this is still the easiest.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
