### PR TITLE
Make sure root layout doesn't collpase

### DIFF
--- a/apps/store/src/components/GridLayout/GridLayout.tsx
+++ b/apps/store/src/components/GridLayout/GridLayout.tsx
@@ -12,6 +12,7 @@ const Root = styled.div({
   columnGap: theme.space.md,
   paddingInline: theme.space.md,
 
+  width: '100%',
   maxWidth: MAX_WIDTH,
   marginInline: 'auto',
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Make grid layout take up full width of container.


![Screenshot 2023-03-22 at 13.48.40.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/27b62194-315f-492f-b976-f5aa0253cf66/Screenshot%202023-03-22%20at%2013.48.40.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We have a bug since the layout collapses with `margin-inline: auto` unless we set a 100% width.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
