### PR TITLE
Remove Emotion theme provider from store + ui

### DIFF
--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -1,5 +1,5 @@
 import { ApolloProvider } from '@apollo/client'
-import { Global, ThemeProvider } from '@emotion/react'
+import { Global } from '@emotion/react'
 import { Provider as JotaiProvider } from 'jotai'
 import { appWithTranslation } from 'next-i18next'
 import type { AppPropsWithLayout } from 'next/app'
@@ -84,23 +84,21 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
         <Global styles={globalStyles} />
         <GlobalLinkStyles />
         <PageTransitionProgressBar />
-        <ThemeProvider theme={theme}>
-          <JotaiProvider>
-            <ShopSessionProvider shopSessionId={pageProps[SHOP_SESSION_PROP_NAME]}>
-              <TrackingProvider value={tracking}>
-                <BankIdContextProvider>
-                  <BalancerProvider>
-                    <AppErrorProvider>
-                      <AppErrorDialog />
-                      {getLayout(<Component {...pageProps} className={contentFontClassName} />)}
-                    </AppErrorProvider>
-                  </BalancerProvider>
-                  <BankIdDialog />
-                </BankIdContextProvider>
-              </TrackingProvider>
-            </ShopSessionProvider>
-          </JotaiProvider>
-        </ThemeProvider>
+        <JotaiProvider>
+          <ShopSessionProvider shopSessionId={pageProps[SHOP_SESSION_PROP_NAME]}>
+            <TrackingProvider value={tracking}>
+              <BankIdContextProvider>
+                <BalancerProvider>
+                  <AppErrorProvider>
+                    <AppErrorDialog />
+                    {getLayout(<Component {...pageProps} className={contentFontClassName} />)}
+                  </AppErrorProvider>
+                </BalancerProvider>
+                <BankIdDialog />
+              </BankIdContextProvider>
+            </TrackingProvider>
+          </ShopSessionProvider>
+        </JotaiProvider>
       </ApolloProvider>
     </>
   )

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -2,6 +2,7 @@ import isPropValid from '@emotion/is-prop-valid'
 import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { theme } from '../../lib/theme/theme'
 
 type OverlayProps = {
   frosted?: boolean
@@ -33,13 +34,13 @@ const StyledOverlay = styled(DialogPrimitive.Overlay, {
   }),
 }))
 
-export const Window = styled.div(({ theme }) => ({
+export const Window = styled.div({
   backgroundColor: theme.colors.white,
   boxShadow: 'hsl(206 22% 7% / 35%) 0px 10px 38px -10px, hsl(206 22% 7% / 20%) 0px 10px 20px -15px',
   '@media (prefers-reduced-motion: no-preference)': {
     animation: `${contentShow} 150ms cubic-bezier(0.16, 1, 0.3, 1) forwards`,
   },
-}))
+})
 
 type ContentProps = {
   children: React.ReactNode

--- a/packages/ui/src/components/Heading/Heading.tsx
+++ b/packages/ui/src/components/Heading/Heading.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import Balancer from 'react-wrap-balancer'
 import { getMargins, Margins } from '../../lib/margins'
 import { UIColors } from '../../lib/theme/colors/colors'
-import { getColor } from '../../lib/theme/theme'
+import { getColor, theme } from '../../lib/theme/theme'
 import { getHeadingVariantStyles, HeadingVariant } from './Heading.helpers'
 
 export type { PossibleHeadingVariant } from './Heading.helpers'
@@ -29,7 +29,7 @@ type HeadingBaseProps = Pick<HeadingProps, 'color' | 'variant' | 'align'> & Marg
 const HeadingBase = styled(
   'h2',
   elementConfig,
-)<HeadingBaseProps>(({ theme, color, variant, align, ...props }) => {
+)<HeadingBaseProps>(({ color, variant, align, ...props }) => {
   // GOTCHA: We may get empty string from Storyblok, this should be handled safely
   variant = variant || 'standard.32'
   return {

--- a/packages/ui/src/components/HeadingLabel/HeadingLabel.tsx
+++ b/packages/ui/src/components/HeadingLabel/HeadingLabel.tsx
@@ -2,7 +2,7 @@ import isPropValid from '@emotion/is-prop-valid'
 import styled from '@emotion/styled'
 import { getMargins, Margins } from '../../lib/margins'
 import { UIColors } from '../../lib/theme/colors/colors'
-import { getColor } from '../../lib/theme/theme'
+import { getColor, theme } from '../../lib/theme/theme'
 
 type HeadingLabelColors = Pick<UIColors, 'blueFill1' | 'blueFill2'>
 
@@ -21,7 +21,7 @@ type HeadingLabelBaseProps = Pick<HeadingLabelProps, 'color'> & Margins
 export const LabelBase = styled(
   'div',
   elementConfig,
-)<HeadingLabelBaseProps>(({ color, theme, ...props }) => {
+)<HeadingLabelBaseProps>(({ color, ...props }) => {
   color = color || 'blueFill1'
   return {
     display: 'inline-block',

--- a/packages/ui/src/components/InputBase.tsx
+++ b/packages/ui/src/components/InputBase.tsx
@@ -1,38 +1,39 @@
 import styled from '@emotion/styled'
 import { WarningTriangleIcon } from '../icons'
+import { theme } from '../lib/theme/theme'
 import { Space } from './Space'
 
-const Label = styled.label(({ theme }) => ({
+const Label = styled.label({
   fontFamily: theme.fonts.body,
   color: theme.colors.textPrimary,
   fontSize: '0.875rem',
   lineHeight: '1.375rem',
-}))
+})
 
 const MessageWrapper = styled(Space)({
   display: 'flex',
   alignItems: 'center',
 })
 
-const StyledWarningTriangleIcon = styled(WarningTriangleIcon)(({ theme }) => ({
+const StyledWarningTriangleIcon = styled(WarningTriangleIcon)({
   color: theme.colors.red600,
   width: '1rem',
   height: '1rem',
-}))
+})
 
-const ErrorMessage = styled.span(({ theme }) => ({
+const ErrorMessage = styled.span({
   fontFamily: theme.fonts.body,
   color: theme.colors.red600,
   fontSize: '0.75rem',
   lineHeight: '1rem',
-}))
+})
 
-const InfoMessage = styled.span(({ theme }) => ({
+const InfoMessage = styled.span({
   fontFamily: theme.fonts.body,
   color: theme.colors.textSecondary,
   fontSize: '0.75rem',
   lineHeight: '1rem',
-}))
+})
 
 type ChildrenProps = {
   hasError: boolean

--- a/packages/ui/src/components/InputField/InputField.tsx
+++ b/packages/ui/src/components/InputField/InputField.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { theme } from '../../lib/theme/theme'
 import { InputBase, InputBaseProps } from '../InputBase'
 
 type StyleProps = { $error: boolean; $suffix?: string }
@@ -17,7 +18,7 @@ const Wrapper = styled.div(({ $suffix }: StyleProps) => ({
   },
 }))
 
-const StyledInput = styled.input<StyleProps>(({ theme, $error }) => ({
+const StyledInput = styled.input<StyleProps>(({ $error }) => ({
   backgroundColor: theme.colors.white,
   color: theme.colors.textPrimary,
   fontSize: '1.125rem',

--- a/packages/ui/src/icons/Icons.stories.tsx
+++ b/packages/ui/src/icons/Icons.stories.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import { Meta, StoryFn } from '@storybook/react'
 import { Heading } from '../components/Heading/Heading'
 import { Space } from '../components/Space'
+import { theme } from '../lib/theme/theme'
 import * as AllIcons from './index'
 
 type IconProps = {
@@ -43,7 +44,7 @@ const Page = styled.div({
   height: '100vh',
 })
 
-const IconWrapper = styled.div(({ theme }) => ({
+const IconWrapper = styled.div({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -61,7 +62,7 @@ const IconWrapper = styled.div(({ theme }) => ({
   },
   ':active': { backgroundColor: theme.colors.green50 },
   ' svg': { border: 'dotted 1px green' },
-}))
+})
 
 const IconGrid = styled.div({
   display: 'flex',


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Remove the last pieces of emotion runtime theme from store and ui workspaces.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

No need for emotion runtime theme anymore.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
