### PR TITLE
GRW-2385 - fix: Submit Pet[Cat|Dog]BreedFields info only when confirming the whole section they are in

### DIFF
--- a/apps/store/src/components/Combobox/Combobox.tsx
+++ b/apps/store/src/components/Combobox/Combobox.tsx
@@ -12,12 +12,14 @@ type Props<Item> = {
   selectedItem?: Item | null
   onSelectedItemChange?: (item: Item | null) => void
   defaultSelectedItem?: Item | null
-  placeholder?: string
   displayValue?: (item: Item) => string
+  getFormValue?: (item: Item) => string | undefined
+  noMatchesMessage?: string
+  placeholder?: string
+  name?: string
   disabled?: boolean
   required?: boolean
   mutliSelect?: boolean
-  noMatchesMessage?: string
 }
 
 /**
@@ -30,8 +32,10 @@ export const Combobox = <Item,>({
   onSelectedItemChange,
   defaultSelectedItem,
   displayValue = (item) => String(item),
+  getFormValue = (item) => String(item) ?? undefined,
   mutliSelect = false,
   noMatchesMessage = 'No matches found',
+  name,
   ...externalInputProps
 }: Props<Item>) => {
   const { highlight, animationProps } = useHighlightAnimation()
@@ -59,6 +63,8 @@ export const Combobox = <Item,>({
     getToggleButtonProps,
     reset,
     openMenu,
+    selectItem,
+    selectedItem: internalSelectedItem,
   } = useCombobox({
     items: filteredItems,
     selectedItem,
@@ -77,7 +83,7 @@ export const Combobox = <Item,>({
       // Set selectedItem to 'null' when clearing the input with delete/backspace
       // shorturl.at/f0158
       if (internalInputValue === '' && selectedItem) {
-        onSelectedItemChange?.(null)
+        selectItem(null)
       }
     },
     stateReducer(state, actionChanges) {
@@ -118,7 +124,7 @@ export const Combobox = <Item,>({
     reset()
     // We need to reset the pieces of state that we control ourselfs
     setInputValue('')
-    onSelectedItemChange?.(null)
+    selectItem(null)
     openMenu()
   }
 
@@ -132,6 +138,9 @@ export const Combobox = <Item,>({
           data-expanded={isOpen}
           data-warning={noOptions}
         />
+        {internalSelectedItem && (
+          <input type="hidden" name={name} value={getFormValue(internalSelectedItem)} />
+        )}
         <Actions>
           <DeleteButton type="button" onClick={handleClickDelete} hidden={inputValue.length === 0}>
             <CrossIconSmall />

--- a/apps/store/src/components/PriceCalculator/AutomaticField.tsx
+++ b/apps/store/src/components/PriceCalculator/AutomaticField.tsx
@@ -173,7 +173,7 @@ export const AutomaticField = ({ field, priceIntent, onSubmit, loading, autoFocu
       return <PetCatBreedsField field={field} loading={loading} />
 
     case 'pet-dog-breeds':
-      return <PetDogBreedsField field={field} onSubmit={onSubmit} loading={loading} />
+      return <PetDogBreedsField field={field} loading={loading} />
 
     default: {
       const badField: never = field

--- a/apps/store/src/components/PriceCalculator/AutomaticField.tsx
+++ b/apps/store/src/components/PriceCalculator/AutomaticField.tsx
@@ -170,7 +170,7 @@ export const AutomaticField = ({ field, priceIntent, onSubmit, loading, autoFocu
       )
 
     case 'pet-cat-breeds':
-      return <PetCatBreedsField field={field} onSubmit={onSubmit} loading={loading} />
+      return <PetCatBreedsField field={field} loading={loading} />
 
     case 'pet-dog-breeds':
       return <PetDogBreedsField field={field} onSubmit={onSubmit} loading={loading} />

--- a/apps/store/src/components/PriceCalculator/MixedBreedPicker/MixedBreedPicker.stories.tsx
+++ b/apps/store/src/components/PriceCalculator/MixedBreedPicker/MixedBreedPicker.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentMeta, StoryFn } from '@storybook/react'
-import { useState } from 'react'
 import { Breed } from '@/services/PriceCalculator/Field.types'
 import { MixedBreedPicker } from './MixedBreedPicker'
 
@@ -32,17 +31,5 @@ const BREEDS: Array<Breed> = [
 ]
 
 export const Default: StoryFn<typeof MixedBreedPicker> = () => {
-  const [selectedBreeds, setSelectedBreeds] = useState<Array<Breed>>([])
-
-  const handleBreedsChange = (breeds: Array<Breed>) => {
-    setSelectedBreeds(breeds)
-  }
-
-  return (
-    <MixedBreedPicker
-      breeds={BREEDS}
-      selectedBreeds={selectedBreeds}
-      onBreedsChange={handleBreedsChange}
-    />
-  )
+  return <MixedBreedPicker breeds={BREEDS} />
 }

--- a/apps/store/src/components/PriceCalculator/MixedBreedPicker/MixedBreedPicker.tsx
+++ b/apps/store/src/components/PriceCalculator/MixedBreedPicker/MixedBreedPicker.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Space, Text, CrossIconSmall, InfoIcon, theme } from 'ui'
 import { Combobox } from '@/components/Combobox/Combobox'
@@ -8,29 +8,34 @@ import { Breed } from '@/services/PriceCalculator/Field.types'
 
 type Props = {
   breeds: Array<Breed>
-  selectedBreeds: Array<Breed>
+  defaultSelectedBreeds?: Array<Breed>
   onBreedsChange?: (selectedBreeds: Array<Breed>) => void
   loading?: boolean
   required?: boolean
+  name?: string
 }
 
 export const MixedBreedPicker = ({
   breeds,
-  selectedBreeds,
+  defaultSelectedBreeds,
   onBreedsChange,
   loading,
+  name,
   required,
 }: Props) => {
+  const [selectedBreeds, setSelectedBreeds] = useState<Array<Breed>>(defaultSelectedBreeds ?? [])
   const { t } = useTranslation('purchase-form')
 
   const handleDelete = (id: Breed['id']) => () => {
     const newSelectedBreeds = selectedBreeds.filter((breed) => breed.id !== id)
+    setSelectedBreeds(newSelectedBreeds)
     onBreedsChange?.(newSelectedBreeds)
   }
 
   const handleAdd = (breed: Breed | null) => {
     if (breed) {
       const newSelectedBreeds = [...selectedBreeds, breed]
+      setSelectedBreeds(newSelectedBreeds)
       onBreedsChange?.(newSelectedBreeds)
     }
   }
@@ -47,16 +52,21 @@ export const MixedBreedPicker = ({
         </Text>
 
         {selectedBreeds.length > 0 && (
-          <List>
+          <>
+            <List>
+              {selectedBreeds.map((breed) => (
+                <ListItem key={breed.id}>
+                  <Text size="xl">{breed.displayName}</Text>
+                  <DeleteButton type="button" onClick={handleDelete(breed.id)} disabled={loading}>
+                    <CrossIconSmall />
+                  </DeleteButton>
+                </ListItem>
+              ))}
+            </List>
             {selectedBreeds.map((breed) => (
-              <ListItem key={breed.id}>
-                <Text size="xl">{breed.displayName}</Text>
-                <DeleteButton type="button" onClick={handleDelete(breed.id)} disabled={loading}>
-                  <CrossIconSmall />
-                </DeleteButton>
-              </ListItem>
+              <input key={breed.id} type="hidden" name={name} value={breed.id} />
             ))}
-          </List>
+          </>
         )}
 
         <StyledCombobox
@@ -68,7 +78,7 @@ export const MixedBreedPicker = ({
           noMatchesMessage={t('FIELD_BREEDS_NO_OPTIONS')}
           mutliSelect={true}
           disabled={loading}
-          required={required}
+          required={required && selectedBreeds.length === 0}
         />
       </Space>
     </Wrapper>

--- a/apps/store/src/components/PriceCalculator/PetCatBreedsField.tsx
+++ b/apps/store/src/components/PriceCalculator/PetCatBreedsField.tsx
@@ -23,14 +23,12 @@ export const PetCatBreedsField = ({ field, loading }: Props) => {
     defaultSelectedBreed = breeds.find((breed) => breed.id === field.value?.[0]) ?? null
   }
 
-  // Used to re-mount Combobox when 'breeds' becomes available,
-  // otherwise it might happen the case where 'defaultSelectedItem'
-  // doesn't get taken into account due the absence of 'breeds'
-  const key = useMemo(() => JSON.stringify(breeds), [breeds])
-
   return (
     <Combobox
-      key={key}
+      // Re-mount Combobox when 'breeds' becomes available,
+      // otherwise it might happen the case where 'defaultSelectedItem'
+      // doesn't get taken into account due the absence of 'breeds'
+      key={breeds.length}
       items={breeds}
       defaultSelectedItem={defaultSelectedBreed}
       placeholder={translateLabel(field.label)}

--- a/apps/store/src/components/PriceCalculator/PetDogBreedsField.tsx
+++ b/apps/store/src/components/PriceCalculator/PetDogBreedsField.tsx
@@ -27,15 +27,14 @@ export const PetDogBreedsField = ({ field, loading }: Props) => {
     setShowMixedPicker(breed?.id === MIXED_BREED_OPTION_ID)
   }
 
-  // Used to re-mount Combobox when 'breeds' becomes available,
-  // otherwise it might happen the case where 'defaultSelectedItem'
-  // doesn't get taken into account due the absence of 'breeds'
-  const key = useMemo(() => JSON.stringify(breeds), [breeds])
-
   return (
     <Space y={0.25}>
       <Combobox
-        key={key}
+        // Re-mount Combobox when 'breeds' becomes available,
+        // otherwise it might happen the case where 'defaultSelectedItem'
+        // doesn't get taken into account due the absence of 'breeds'
+        // const key = useMemo(() => JSON.stringify(breeds), [breeds])
+        key={breeds.length}
         items={comboboxAvailableBreeds}
         defaultSelectedItem={comboboxDefaultSelectedBreed}
         displayValue={(item) => item.displayName}

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorSection.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorSection.tsx
@@ -22,12 +22,9 @@ export const PriceCalculatorSection = ({ section, loading, onSubmit, children }:
     const data: JSONData = {}
 
     for (const item of section.items) {
-      const formValue = formData.get(item.field.name)
-
-      if (typeof formValue === 'string') {
-        data[item.field.name] = deserializeField(item.field, formValue)
-      } else if (item.field.value === undefined && item.field.defaultValue) {
-        data[item.field.name] = item.field.defaultValue
+      const deserializedFieldValue = deserializeField(item.field, formData)
+      if (deserializedFieldValue !== undefined) {
+        data[item.field.name] = deserializedFieldValue
       }
     }
 

--- a/apps/store/src/services/PriceCalculator/Field.types.ts
+++ b/apps/store/src/services/PriceCalculator/Field.types.ts
@@ -1,6 +1,8 @@
 import { PriceIntentAnimalBreed } from '@/services/apollo/generated'
 import { Label } from './PriceCalculator.types'
 
+export const MIXED_BREED_OPTION_ID = '-1'
+
 type BaseField<ValueType> = {
   name: string
   label: Label

--- a/apps/store/src/services/PriceCalculator/PriceCalculator.helpers.ts
+++ b/apps/store/src/services/PriceCalculator/PriceCalculator.helpers.ts
@@ -108,8 +108,10 @@ export const deserializeField = (field: InputField, formData: FormData) => {
       return parseNumber(field, formData)
 
     case 'pet-dog-breeds':
+      return parseDogBreedsField(field, formData)
+
     case 'pet-cat-breeds':
-      return parsePetBreedsField(field, formData)
+      return parseCatBreedsField(field, formData)
 
     case 'text':
     case 'radio':
@@ -149,7 +151,17 @@ const parseNumber = (field: InputField, formData: FormData) => {
   return getFieldDefaultValue(field)
 }
 
-const parsePetBreedsField = (field: InputField, formData: FormData) => {
+const parseCatBreedsField = (field: InputField, formData: FormData) => {
+  const values = formData.getAll(field.name)
+
+  if (values.length > 0 && values.every(isFieldValueString)) {
+    return values
+  }
+
+  return getFieldDefaultValue(field)
+}
+
+const parseDogBreedsField = (field: InputField, formData: FormData) => {
   const values = formData.getAll(field.name)
 
   if (values.length > 0 && values.every(isFieldValueString)) {

--- a/apps/store/src/services/PriceCalculator/PriceCalculator.helpers.ts
+++ b/apps/store/src/services/PriceCalculator/PriceCalculator.helpers.ts
@@ -9,7 +9,7 @@ import { SE_HOUSE } from './data/SE_HOUSE'
 import { SE_PET_CAT } from './data/SE_PET_CAT'
 import { SE_PET_DOG } from './data/SE_PET_DOG'
 import { SE_STUDENT_APARTMENT } from './data/SE_STUDENT_APARTMENT'
-import { InputField } from './Field.types'
+import { InputField, MIXED_BREED_OPTION_ID } from './Field.types'
 import { Form, FormSection, JSONData, Template } from './PriceCalculator.types'
 
 const TEMPLATES: Record<string, Template | undefined> = {
@@ -102,18 +102,60 @@ const calculateSectionState = (section: FormSection): FormSection => {
   }
 }
 
-export const deserializeField = (field: InputField, value: string) => {
+export const deserializeField = (field: InputField, formData: FormData) => {
   switch (field.type) {
+    case 'number':
+      return parseNumber(field, formData)
+
+    case 'pet-dog-breeds':
+    case 'pet-cat-breeds':
+      return parsePetBreedsField(field, formData)
+
     case 'text':
     case 'radio':
     case 'select':
     case 'date':
-      return value
-
-    case 'number':
-      return parseInt(value, 10)
-
     default:
-      return value
+      return parseString(field, formData)
   }
+}
+
+const isFieldValueString = (value: FormDataEntryValue | null): value is string =>
+  typeof value === 'string'
+
+const getFieldDefaultValue = (field: InputField) => {
+  if (field.value === undefined && field.defaultValue) {
+    return field.defaultValue
+  }
+}
+
+const parseString = (field: InputField, formData: FormData) => {
+  const value = formData.get(field.name)
+
+  if (isFieldValueString(value)) {
+    return value
+  }
+
+  return getFieldDefaultValue(field)
+}
+
+const parseNumber = (field: InputField, formData: FormData) => {
+  const value = formData.get(field.name)
+
+  if (isFieldValueString(value)) {
+    return parseInt(value, 10)
+  }
+
+  return getFieldDefaultValue(field)
+}
+
+const parsePetBreedsField = (field: InputField, formData: FormData) => {
+  const values = formData.getAll(field.name)
+
+  if (values.length > 0 && values.every(isFieldValueString)) {
+    // Removes 'Mixed Breed' option (in case it's present) before form submission
+    return values.filter((breedId) => breedId !== MIXED_BREED_OPTION_ID)
+  }
+
+  return getFieldDefaultValue(field)
 }


### PR DESCRIPTION
## Describe your changes

* `PurchaseForm`
  * Deserialize form values based on field type
*  `Pet[Cat|Dog]tBreedsField`
  * Update them so `selectedBreed(s)` information keeps store in form controls: `input:hidden`

https://user-images.githubusercontent.com/19200662/227286529-7941e623-6f40-4744-befd-d5abe023a2cd.mov

## Justify why they are needed

For fields like `PetCatBreedsField` and `PetDogBreedsField` we don't want to make API requests every time their values are changed. A better user experience is submit them while submitting information for the whole section they are in.

## Jira issue(s): [GRW-2385](https://hedvig.atlassian.net/browse/GRW-2385)


[GRW-2385]: https://hedvig.atlassian.net/browse/GRW-2385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ