### PR TITLE
styles(ProductPage): update purchase form wrapper's max height

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -200,7 +200,7 @@ const PurchaseFormWrapper = styled.div({
     position: 'sticky',
     top: HEADER_HEIGHT_DESKTOP,
     // Scroll independently if content is too long
-    maxHeight: '100vh',
+    maxHeight: `calc(100vh - ${HEADER_HEIGHT_DESKTOP})`,
     overflow: 'auto',
     paddingBottom: theme.space.xl,
     paddingTop: '6vw',


### PR DESCRIPTION
## Describe your changes

* Updates purchase form wrapper's max height 

https://user-images.githubusercontent.com/19200662/227301790-1b856d26-03cf-4e9d-a623-5e2017c615c2.mov

## Justify why they are needed

Container should not discount header's height since we scrollable container can't use that space.

Requested [here](https://hedviginsurance.slack.com/archives/C041SD67G82/p1679587742204349).