### PR TITLE
chore(ProductRecomendations): handle cache update warning

### DIFF
--- a/apps/store/src/graphql/ProductRecommendations.graphql
+++ b/apps/store/src/graphql/ProductRecommendations.graphql
@@ -1,5 +1,6 @@
 query ProductRecommendations($shopSessionId: UUID!) {
   shopSession(id: $shopSessionId) {
+    id
     recommendations {
       product {
         ...ProductRecommendation


### PR DESCRIPTION
## Describe your changes

* Update `ProductRecommendations` Query so it also requests `shoppingSession.id`

## Justify why they are needed

By not doing so, we get a warning from Apollo notifying that we might be losing some shopping session data from the cache when executing `ProductRecommendations` query. That's because both `ShoppingSession` and `ProductRecommendations` queries refer to same cache object - `shoppingSession` -  but since the later wasn't including the `shoppingSession.id` all of existing `shoppingSession` cached data gets lost.

By including the id, Apollo knows that `ProductRecommendations` query means updating existing `shoppingSession` object in cache by adding a `recommendations` list into it instead of replace the whole thing.

Obs: It was working before because something in code triggers the refetch of `ShoppingSession` query whenever `ProductRecommendations` get executed, which means we only have inconsistent cache momentarily. But it's nice to proper solve the issue if we can and get rid of the warning.

<img width="784" alt="Screenshot 2023-03-28 at 13 58 06" src="https://user-images.githubusercontent.com/19200662/228233066-94357e69-5029-4bd3-af87-c0f488d7e7ad.png">
