### PR TITLE
Avoid resize error in media query hook

### DIFF
--- a/packages/ui/src/lib/media-query.test.ts
+++ b/packages/ui/src/lib/media-query.test.ts
@@ -2,6 +2,19 @@ import { renderHook } from '@testing-library/react'
 import { Level, useBreakpoint } from './media-query'
 
 describe('media-query', () => {
+  let spy: jest.SpyInstance
+
+  beforeEach(() => {
+    spy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0)
+      return 0
+    })
+  })
+
+  afterEach(() => {
+    spy.mockRestore()
+  })
+
   describe('useBreakpoint', () => {
     it('should return true when window is larger than breakpoint', () => {
       // align


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Wrap resize callback in request animation frame.

Source: https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded/58701523#58701523

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Prevent resize error:

```
ResizeObserver loop limit exceeded
```

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
