### PR TITLE
Make only Hedvig-logo clickable in header

### DIFF
--- a/apps/store/src/components/Header/Header.tsx
+++ b/apps/store/src/components/Header/Header.tsx
@@ -67,9 +67,11 @@ export const Header = (props: HeaderProps) => {
         animate={animate}
         transition={TRANSITION}
       >
-        <LogoWrapper href={PageLink.home()} aria-label={t('HOME_PAGE_LINK_LABEL')}>
-          <HedvigLogo />
-        </LogoWrapper>
+        <div style={{ flex: 1 }}>
+          <LogoWrapper href={PageLink.home()} aria-label={t('HOME_PAGE_LINK_LABEL')}>
+            <HedvigLogo />
+          </LogoWrapper>
+        </div>
         <ContentWrapper>
           {children}
           <ShoppingCartMenuItem />
@@ -107,8 +109,10 @@ export const Wrapper = styled(motion.header)({
 })
 
 const LogoWrapper = styled(Link)({
-  flex: 1,
   ':active': { opacity: 0.75 },
+  '> svg': {
+    display: 'inline-block',
+  },
 })
 
 const ContentWrapper = styled.div({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Update Hedvig-logo styles in Header so that it the clickable area is only under the icon itself.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
