### PR TITLE
Improve ProductCard SEO and accessibility

### DIFF
--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -1,8 +1,9 @@
 import { UrlObject } from 'url'
 import styled from '@emotion/styled'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import { useTranslation } from 'react-i18next'
-import { mq, Space, theme } from 'ui'
+import { Button, mq, Space, theme } from 'ui'
 import { ImageSize } from '@/blocks/ProductCardBlock'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { ImageWithPlaceholder } from '@/components/ImageWithPlaceholder/ImageWithPlaceholder'
@@ -32,30 +33,35 @@ export const ProductCard = ({
   link,
 }: ProductCardProps) => {
   const { t } = useTranslation('common')
+  const router = useRouter()
   const priceLink = link.type === 'product' ? getPriceLink(link.url) : undefined
 
   return (
-    <Space y={1.5}>
-      <Link href={link.url} tabIndex={-1} aria-hidden={true}>
-        <ImageWrapper aspectRatio={aspectRatio}>
-          <Image {...imageProps} alt={alt} fill sizes="100vw" />
-        </ImageWrapper>
-        <ContentWrapper>
-          <Title>{title}</Title>
-          <Subtitle>{subtitle}</Subtitle>
-        </ContentWrapper>
-      </Link>
-      <CallToAction>
-        <ButtonNextLink href={link.url} size="medium" variant="secondary">
-          {t('READ_MORE')}
-        </ButtonNextLink>
-        {priceLink && (
-          <ButtonNextLink href={priceLink} size="medium" variant="primary-alt">
-            {t('GET_PRICE_LINK')}
-          </ButtonNextLink>
-        )}
-      </CallToAction>
-    </Space>
+    <Container y={1}>
+      <ImageWrapper aspectRatio={aspectRatio}>
+        <Image {...imageProps} alt={alt} fill sizes="100vw" />
+      </ImageWrapper>
+      <ContentWrapper>
+        <MainLink href={link.url}>{title}</MainLink>
+        <Subtitle>{subtitle}</Subtitle>
+        <CallToAction>
+          <Button
+            onClick={() => router.push(link.url)}
+            tabIndex={-1}
+            aria-hidden={true}
+            size="medium"
+            variant="secondary"
+          >
+            {t('READ_MORE')}
+          </Button>
+          {priceLink && (
+            <ButtonNextLink href={priceLink} size="medium" variant="primary-alt">
+              {t('GET_PRICE_LINK')}
+            </ButtonNextLink>
+          )}
+        </CallToAction>
+      </ContentWrapper>
+    </Container>
   )
 }
 
@@ -71,6 +77,12 @@ const getPriceLink = (productLink: string): LinkHref | undefined => {
     query: { [OPEN_PRICE_CALCULATOR_QUERY_PARAM]: 1 },
   } as const
 }
+
+const CALL_TO_ACTION_HEIGHT = '2.5rem'
+
+const Container = styled(Space)({
+  position: 'relative',
+})
 
 const ImageWrapper = styled.div<ImageSize>(({ aspectRatio }) => ({
   display: 'block',
@@ -103,10 +115,6 @@ const ContentWrapper = styled.div({
   marginInline: theme.space.xs,
 })
 
-const Title = styled.p({
-  fontSize: theme.fontSizes.md,
-})
-
 const Subtitle = styled.p({
   fontSize: theme.fontSizes.md,
   color: theme.colors.gray600,
@@ -114,6 +122,24 @@ const Subtitle = styled.p({
 
 const CallToAction = styled.div({
   display: 'flex',
+  height: CALL_TO_ACTION_HEIGHT,
   gap: theme.space.sm,
-  marginInline: theme.space.xs,
+  marginTop: theme.space.lg,
+})
+
+const MainLink = styled(Link)({
+  fontSize: theme.fontSizes.md,
+  // Make the whole card clickable - CallToAction height
+  '&::after': {
+    content: '""',
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: CALL_TO_ACTION_HEIGHT,
+    left: 0,
+  },
+
+  [`&:focus-visible ~ ${CallToAction} button`]: {
+    boxShadow: `0 0 0 2px ${theme.colors.textPrimary}`,
+  },
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Currently we have two links in the same ProductCard which we should avoid if possible for SEO reasons. Having the "Read more" button as the main link is also bad practise for screenreaders and SEO since it's the same on all cards.

- Make the title of the Card the main link to get a descriptive link text
- Add an `:after` element to the link to cover the card and make it clickable
- Add a focus state to "Read More" button when the main link is focused
- Navigate with router to the product page when "Read More" button is clicked

https://user-images.githubusercontent.com/6661511/229752222-35f818b8-d9aa-41a2-ba36-030989ec85b9.mov

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Improve ProductCard SEO and accessibility

Good resource I found on the topic https://inclusive-components.design/cards/

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
