### PR TITLE
GRW-2420 - feat(AccordionContent): keep content mounted for SEO purposes

### DIFF
--- a/apps/store/src/blocks/AccordionBlock.tsx
+++ b/apps/store/src/blocks/AccordionBlock.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import { storyblokEditable, renderRichText } from '@storyblok/react'
 import Head from 'next/head'
+import { useState, useCallback } from 'react'
 import { Heading, Text, theme, mq } from 'ui'
 import { AccordionItemBlock, AccordionItemBlockProps } from '@/blocks/AccordionItemBlock'
 import { Wrapper as TabsBlockWrapper } from '@/blocks/TabsBlock'
@@ -18,19 +19,30 @@ type Props = SbBaseBlockProps<{
 }>
 
 export const AccordionBlock = ({ blok, nested }: Props) => {
+  const [openedItem, setOpenedItem] = useState<string>()
+
   const accordionItems = filterByBlockType(blok.items, AccordionItemBlock.blockName)
   const enableFAQStructuredData = blok.isFAQ ?? false
   const displayTitleDescriptionSection = blok.title || blok.description
   const isCentered = blok.centerLayout || !displayTitleDescriptionSection
+
+  const handleValueChange = useCallback((value: string) => {
+    setOpenedItem(value)
+  }, [])
 
   let content: React.ReactNode = null
   if (nested) {
     content = (
       <>
         {displayTitleDescriptionSection && <AccodrionTitleDescription blok={blok} />}
-        <StyledAccordionRoot type="single" collapsible>
+        <StyledAccordionRoot
+          type="single"
+          collapsible
+          value={openedItem}
+          onValueChange={handleValueChange}
+        >
           {accordionItems.map((nestedBlock) => (
-            <AccordionItemBlock key={nestedBlock._uid} blok={nestedBlock} />
+            <AccordionItemBlock key={nestedBlock._uid} blok={nestedBlock} openedItem={openedItem} />
           ))}
         </StyledAccordionRoot>
       </>
@@ -44,9 +56,18 @@ export const AccordionBlock = ({ blok, nested }: Props) => {
           </GridLayout.Content>
         )}
         <GridLayout.Content width="1/2" align={isCentered ? 'center' : 'right'}>
-          <Accordion.Root type="single" collapsible>
+          <Accordion.Root
+            type="single"
+            collapsible
+            value={openedItem}
+            onValueChange={handleValueChange}
+          >
             {accordionItems.map((nestedBlock) => (
-              <AccordionItemBlock key={nestedBlock._uid} blok={nestedBlock} />
+              <AccordionItemBlock
+                key={nestedBlock._uid}
+                blok={nestedBlock}
+                openedItem={openedItem}
+              />
             ))}
           </Accordion.Root>
         </GridLayout.Content>

--- a/apps/store/src/blocks/AccordionBlock.tsx
+++ b/apps/store/src/blocks/AccordionBlock.tsx
@@ -19,7 +19,7 @@ type Props = SbBaseBlockProps<{
 }>
 
 export const AccordionBlock = ({ blok, nested }: Props) => {
-  const [openedItem, setOpenedItem] = useState<string>()
+  const [openItem, setOpenItem] = useState<string>()
 
   const accordionItems = filterByBlockType(blok.items, AccordionItemBlock.blockName)
   const enableFAQStructuredData = blok.isFAQ ?? false
@@ -27,7 +27,7 @@ export const AccordionBlock = ({ blok, nested }: Props) => {
   const isCentered = blok.centerLayout || !displayTitleDescriptionSection
 
   const handleValueChange = useCallback((value: string) => {
-    setOpenedItem(value)
+    setOpenItem(value)
   }, [])
 
   let content: React.ReactNode = null
@@ -38,11 +38,11 @@ export const AccordionBlock = ({ blok, nested }: Props) => {
         <StyledAccordionRoot
           type="single"
           collapsible
-          value={openedItem}
+          value={openItem}
           onValueChange={handleValueChange}
         >
           {accordionItems.map((nestedBlock) => (
-            <AccordionItemBlock key={nestedBlock._uid} blok={nestedBlock} openedItem={openedItem} />
+            <AccordionItemBlock key={nestedBlock._uid} blok={nestedBlock} openItem={openItem} />
           ))}
         </StyledAccordionRoot>
       </>
@@ -59,15 +59,11 @@ export const AccordionBlock = ({ blok, nested }: Props) => {
           <Accordion.Root
             type="single"
             collapsible
-            value={openedItem}
+            value={openItem}
             onValueChange={handleValueChange}
           >
             {accordionItems.map((nestedBlock) => (
-              <AccordionItemBlock
-                key={nestedBlock._uid}
-                blok={nestedBlock}
-                openedItem={openedItem}
-              />
+              <AccordionItemBlock key={nestedBlock._uid} blok={nestedBlock} openItem={openItem} />
             ))}
           </Accordion.Root>
         </GridLayout.Content>

--- a/apps/store/src/blocks/AccordionItemBlock.tsx
+++ b/apps/store/src/blocks/AccordionItemBlock.tsx
@@ -9,9 +9,9 @@ import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 export type AccordionItemBlockProps = SbBaseBlockProps<{
   title: string
   body: ISbRichtext
-}> & { openedItem?: string }
+}> & { openItem?: string }
 
-export const AccordionItemBlock = ({ blok, openedItem }: AccordionItemBlockProps) => {
+export const AccordionItemBlock = ({ blok, openItem }: AccordionItemBlockProps) => {
   const defaultId = useId()
   const contentHtml = renderRichText(blok.body)
   const value = blok._uid || defaultId
@@ -21,7 +21,7 @@ export const AccordionItemBlock = ({ blok, openedItem }: AccordionItemBlockProps
       <Accordion.HeaderWithTrigger>
         <Text size={{ _: 'md', md: 'lg' }}>{blok.title}</Text>
       </Accordion.HeaderWithTrigger>
-      <Accordion.Content opened={openedItem === value}>
+      <Accordion.Content open={openItem === value}>
         <ContentWrapper>
           <RichTextContent dangerouslySetInnerHTML={{ __html: contentHtml }} />
         </ContentWrapper>

--- a/apps/store/src/blocks/AccordionItemBlock.tsx
+++ b/apps/store/src/blocks/AccordionItemBlock.tsx
@@ -9,17 +9,19 @@ import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 export type AccordionItemBlockProps = SbBaseBlockProps<{
   title: string
   body: ISbRichtext
-}>
+}> & { openedItem?: string }
 
-export const AccordionItemBlock = ({ blok }: AccordionItemBlockProps) => {
+export const AccordionItemBlock = ({ blok, openedItem }: AccordionItemBlockProps) => {
   const defaultId = useId()
   const contentHtml = renderRichText(blok.body)
+  const value = blok._uid || defaultId
+
   return (
-    <Accordion.Item value={blok._uid || defaultId} {...storyblokEditable(blok)}>
+    <Accordion.Item value={value} {...storyblokEditable(blok)}>
       <Accordion.HeaderWithTrigger>
         <Text size={{ _: 'md', md: 'lg' }}>{blok.title}</Text>
       </Accordion.HeaderWithTrigger>
-      <Accordion.Content>
+      <Accordion.Content opened={openedItem === value}>
         <ContentWrapper>
           <RichTextContent dangerouslySetInnerHTML={{ __html: contentHtml }} />
         </ContentWrapper>

--- a/apps/store/src/components/Accordion/Accordion.stories.tsx
+++ b/apps/store/src/components/Accordion/Accordion.stories.tsx
@@ -1,24 +1,20 @@
 import { Meta, StoryFn } from '@storybook/react'
+import { useState } from 'react'
 import { Heading } from 'ui'
 import * as Accordion from './Accordion'
 
-export default {
-  title: 'Accordion',
-  component: Accordion.Root,
-} as Meta<typeof Accordion.Root>
-
-const Template: StoryFn<typeof Accordion.Root> = () => (
-  <Accordion.Root type="single" collapsible>
-    <Accordion.Item value="item-1">
-      <Accordion.HeaderWithTrigger>Header 1</Accordion.HeaderWithTrigger>
-      <Accordion.Content>
-        Lorem ipsum dolor sit amet, florrum plorrum klufs grufs glufs. Nufs ep trop. Nufs ep trop.
-        Lorem ipsum dolor sit amet, florrum plorrum.
-      </Accordion.Content>
-    </Accordion.Item>
-    <Accordion.Item value="item-2">
-      <Accordion.HeaderWithTrigger>Header 2</Accordion.HeaderWithTrigger>
-      <Accordion.Content>
+const ACCORDION_ITEMS = [
+  {
+    value: 'item-1',
+    title: 'Header 1',
+    content:
+      'Lorem ipsum dolor sit amet, florrum plorrum klufs grufs glufs. Nufs ep trop. Nufs ep trop. Lorem ipsum dolor sit amet, florrum plorrum.',
+  },
+  {
+    value: 'item-2',
+    title: 'Header 2',
+    content: (
+      <>
         Lorem ipsum dolor sit amet, florrum plorrum klufs grufs glufs. Nufs ep trop. Nufs ep trop.
         Lorem ipsum dolor sit amet, florrum plorrum.
         <Heading variant="serif.20" as="h4">
@@ -29,19 +25,53 @@ const Template: StoryFn<typeof Accordion.Root> = () => (
           <li>Ipsum dolor</li>
           <li>Ipsum dolor</li>
         </ul>
-      </Accordion.Content>
-    </Accordion.Item>
-    <Accordion.Item value="item-3">
-      <Accordion.HeaderWithTrigger>
-        Header 3 which is really long and wraps
-      </Accordion.HeaderWithTrigger>
-      <Accordion.Content>
+      </>
+    ),
+  },
+  {
+    value: 'item-3',
+    title: 'Header 3 which is really long and wraps',
+    content: (
+      <>
         Lorem ipsum dolor sit amet, florrum plorrum klufs grufs glufs. Nufs ep trop. Nufs ep trop.
         Lorem ipsum dolor sit amet, florrum plorrum.
-      </Accordion.Content>
-    </Accordion.Item>
-  </Accordion.Root>
-)
+        <Heading variant="serif.20" as="h4">
+          Covered
+        </Heading>
+        <ul>
+          <li>Lorem ploran</li>
+          <li>Ipsum dolor</li>
+          <li>Ipsum dolor</li>
+        </ul>
+      </>
+    ),
+  },
+]
+
+export default {
+  title: 'Accordion',
+  component: Accordion.Root,
+} as Meta<typeof Accordion.Root>
+
+const Template: StoryFn<typeof Accordion.Root> = () => {
+  const [openedItem, setOpenedItem] = useState<string>()
+
+  return (
+    <Accordion.Root
+      type="single"
+      collapsible
+      value={openedItem}
+      onValueChange={(value) => setOpenedItem(value)}
+    >
+      {ACCORDION_ITEMS.map((item) => (
+        <Accordion.Item key={item.value} value={item.value}>
+          <Accordion.HeaderWithTrigger>{item.title}</Accordion.HeaderWithTrigger>
+          <Accordion.Content opened={openedItem === item.value}>{item.content}</Accordion.Content>
+        </Accordion.Item>
+      ))}
+    </Accordion.Root>
+  )
+}
 
 export const Default = Template.bind({})
 Default.args = {}

--- a/apps/store/src/components/Accordion/Accordion.stories.tsx
+++ b/apps/store/src/components/Accordion/Accordion.stories.tsx
@@ -66,7 +66,7 @@ const Template: StoryFn<typeof Accordion.Root> = () => {
       {ACCORDION_ITEMS.map((item) => (
         <Accordion.Item key={item.value} value={item.value}>
           <Accordion.HeaderWithTrigger>{item.title}</Accordion.HeaderWithTrigger>
-          <Accordion.Content opened={openedItem === item.value}>{item.content}</Accordion.Content>
+          <Accordion.Content open={openedItem === item.value}>{item.content}</Accordion.Content>
         </Accordion.Item>
       ))}
     </Accordion.Root>

--- a/apps/store/src/components/Accordion/Accordion.tsx
+++ b/apps/store/src/components/Accordion/Accordion.tsx
@@ -82,14 +82,14 @@ const CloseIcon = styled(MinusIcon)({
   '[data-state=open] &': { display: 'block' },
 })
 
-type ContentProps = AccordionPrimitives.AccordionContentProps & { opened: boolean }
+type ContentProps = AccordionPrimitives.AccordionContentProps & { open: boolean }
 
 export const Content = forwardRef<HTMLDivElement, ContentProps>(
-  ({ children, opened, ...props }, forwardedRef) => {
+  ({ children, open, ...props }, forwardedRef) => {
     return (
       <StyledContent {...props} ref={forwardedRef} forceMount>
         <motion.div
-          initial={opened ? 'opened' : 'closed'}
+          initial={open ? 'opened' : 'closed'}
           transition={{
             ease: [0.65, 0.05, 0.36, 1],
             duration: 0.4,
@@ -102,7 +102,7 @@ export const Content = forwardRef<HTMLDivElement, ContentProps>(
               height: 0,
             },
           }}
-          animate={opened ? 'opened' : 'closed'}
+          animate={open ? 'opened' : 'closed'}
         >
           {children}
         </motion.div>

--- a/apps/store/src/components/Accordion/Accordion.tsx
+++ b/apps/store/src/components/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
-import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as AccordionPrimitives from '@radix-ui/react-accordion'
+import { motion } from 'framer-motion'
 import { forwardRef, PropsWithChildren, ReactElement } from 'react'
 import { MinusIcon, mq, PlusIcon, theme } from 'ui'
 
@@ -82,47 +82,39 @@ const CloseIcon = styled(MinusIcon)({
   '[data-state=open] &': { display: 'block' },
 })
 
-const slideDown = keyframes({
-  from: {
-    height: 0,
-  },
-  to: {
-    // custom property reference: https://www.radix-ui.com/docs/primitives/components/accordion
-    height: 'var(--radix-accordion-content-height)',
-  },
-})
-const slideUp = keyframes({
-  from: {
-    height: 'var(--radix-accordion-content-height)',
-  },
-  to: {
-    height: 0,
-  },
-})
+type ContentProps = AccordionPrimitives.AccordionContentProps & { opened: boolean }
 
-export const StyledContent = styled(AccordionPrimitives.Content)({
+export const Content = forwardRef<HTMLDivElement, ContentProps>(
+  ({ children, opened, ...props }, forwardedRef) => {
+    return (
+      <StyledContent {...props} ref={forwardedRef} forceMount>
+        <motion.div
+          initial={opened ? 'opened' : 'closed'}
+          transition={{
+            ease: [0.65, 0.05, 0.36, 1],
+            duration: 0.4,
+          }}
+          variants={{
+            opened: {
+              height: 'var(--radix-accordion-content-height)',
+            },
+            closed: {
+              height: 0,
+            },
+          }}
+          animate={opened ? 'opened' : 'closed'}
+        >
+          {children}
+        </motion.div>
+      </StyledContent>
+    )
+  },
+)
+Content.displayName = 'AccordionContent'
+
+const StyledContent = styled(AccordionPrimitives.Content)({
   fontSize: theme.fontSizes.md,
   color: theme.colors.textSecondary,
   lineHeight: 1.32,
   overflow: 'hidden',
-
-  '[data-state=open] &': {
-    animation: `${slideDown} 400ms cubic-bezier(0.65,0.05,0.36,1) forwards`,
-  },
-  '[data-state=closed] &': {
-    animation: `${slideUp} 400ms cubic-bezier(0.65,0.05,0.36,1) forwards`,
-  },
 })
-
-type ContentProps = React.ForwardRefExoticComponent<
-  AccordionPrimitives.AccordionContentProps & React.RefAttributes<HTMLDivElement>
->
-
-export const Content = forwardRef<ContentProps>(({ children, ...props }: any, forwardedRef) => {
-  return (
-    <StyledContent {...props} ref={forwardedRef} forceMount>
-      {children}
-    </StyledContent>
-  )
-})
-Content.displayName = 'AccordionContent'

--- a/apps/store/src/components/Accordion/Accordion.tsx
+++ b/apps/store/src/components/Accordion/Accordion.tsx
@@ -1,7 +1,7 @@
 import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as AccordionPrimitives from '@radix-ui/react-accordion'
-import { PropsWithChildren, ReactElement } from 'react'
+import { forwardRef, PropsWithChildren, ReactElement } from 'react'
 import { MinusIcon, mq, PlusIcon, theme } from 'ui'
 
 export const Root = styled(AccordionPrimitives.Root)({
@@ -100,16 +100,29 @@ const slideUp = keyframes({
   },
 })
 
-export const Content = styled(AccordionPrimitives.Content)({
+export const StyledContent = styled(AccordionPrimitives.Content)({
   fontSize: theme.fontSizes.md,
   color: theme.colors.textSecondary,
   lineHeight: 1.32,
   overflow: 'hidden',
 
   '[data-state=open] &': {
-    animation: `${slideDown} 400ms cubic-bezier(0.65,0.05,0.36,1)`,
+    animation: `${slideDown} 400ms cubic-bezier(0.65,0.05,0.36,1) forwards`,
   },
   '[data-state=closed] &': {
-    animation: `${slideUp} 400ms cubic-bezier(0.65,0.05,0.36,1)`,
+    animation: `${slideUp} 400ms cubic-bezier(0.65,0.05,0.36,1) forwards`,
   },
 })
+
+type ContentProps = React.ForwardRefExoticComponent<
+  AccordionPrimitives.AccordionContentProps & React.RefAttributes<HTMLDivElement>
+>
+
+export const Content = forwardRef<ContentProps>(({ children, ...props }: any, forwardedRef) => {
+  return (
+    <StyledContent {...props} ref={forwardedRef} forceMount>
+      {children}
+    </StyledContent>
+  )
+})
+Content.displayName = 'AccordionContent'

--- a/apps/store/src/components/Perils/Perils.tsx
+++ b/apps/store/src/components/Perils/Perils.tsx
@@ -82,7 +82,7 @@ const PerilsAccordion = ({ peril }: { peril: PerilFragment }) => {
             <TriggerText size="lg">{title}</TriggerText>
           </HeaderWrapper>
         </Accordion.HeaderWithTrigger>
-        <Accordion.Content>
+        <Accordion.Content opened={(openedItems ?? []).includes(title)}>
           <ContentWrapper>
             <Text as="p" size="xs" color="textPrimary">
               {description}

--- a/apps/store/src/components/Perils/Perils.tsx
+++ b/apps/store/src/components/Perils/Perils.tsx
@@ -67,14 +67,14 @@ const PerilColumnFlex = styled.div({
 
 const PerilsAccordion = ({ peril }: { peril: PerilFragment }) => {
   const { title, description, covered, colorCode } = peril
-  const [openedItems, setOpenedItems] = useState<Array<string>>()
+  const [openItems, setOpenItems] = useState<Array<string>>()
 
   const handleValueChange = useCallback((value: Array<string>) => {
-    setOpenedItems(value)
+    setOpenItems(value)
   }, [])
 
   return (
-    <Accordion.Root type="multiple" value={openedItems} onValueChange={handleValueChange}>
+    <Accordion.Root type="multiple" value={openItems} onValueChange={handleValueChange}>
       <Accordion.Item key={title} value={title}>
         <Accordion.HeaderWithTrigger>
           <HeaderWrapper>
@@ -82,7 +82,7 @@ const PerilsAccordion = ({ peril }: { peril: PerilFragment }) => {
             <TriggerText size="lg">{title}</TriggerText>
           </HeaderWrapper>
         </Accordion.HeaderWithTrigger>
-        <Accordion.Content opened={(openedItems ?? []).includes(title)}>
+        <Accordion.Content open={(openItems ?? []).includes(title)}>
           <ContentWrapper>
             <Text as="p" size="xs" color="textPrimary">
               {description}


### PR DESCRIPTION
## Describe your changes

* Keep `AccordionContent`'s content mounted so it can be used for SEO purposes
* Replace Accordion's CSS animations with JS based animations with _framer motion_

https://user-images.githubusercontent.com/19200662/229769745-a4a49b1e-d30b-4f6e-937d-993f822d2e26.mov

## Justify why they are needed

As discussed [here](https://github.com/radix-ui/primitives/discussions/1481) the purpose of `forceMount` is to hand over lifecycle to javascript animations libraries. By using it, we solve the SEO issue but as consequence radix built in animation handler will not properly work. With that said, I've replaced the CSS animations with framer motion ones so we can have both. 

## Jira issue(s): [GRW-2420](https://hedvig.atlassian.net/browse/GRW-2420)

[GRW-2420]: https://hedvig.atlassian.net/browse/GRW-2420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ