### PR TITLE
Fix broken link decoration

### DIFF
--- a/apps/store/src/blocks/RichTextBlock/RichTextBlock.styles.tsx
+++ b/apps/store/src/blocks/RichTextBlock/RichTextBlock.styles.tsx
@@ -26,19 +26,13 @@ export const GlobalLinkStyles = () => {
 
 export const linkStyles = css({
   a: {
-    position: 'relative',
-    '&::after': {
-      content: '""',
-      position: 'absolute',
-      bottom: -2,
-      left: 0,
-      width: '100%',
-      height: 2,
-      backgroundColor: theme.colors.borderOpaque2,
-    },
+    textDecorationLine: 'underline',
+    textDecorationColor: theme.colors.borderOpaque2,
+    textDecorationThickness: 'clamp(1px, 0.07em, 2px);',
+    textUnderlineOffset: 5,
 
-    '&:hover::after': {
-      backgroundColor: 'var(--random-hover-color)',
+    '&:hover': {
+      textDecorationColor: 'var(--random-hover-color)',
     },
   },
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Use native underline decoration. Didn't know you could tweak the offset and other settings 🙏
Use `clamp` to make line height a dynamic value between 1px and 2px depending on `font-size`

### Before
![Screenshot_2023-04-05_at_20_27_12](https://user-images.githubusercontent.com/6661511/230181863-b6173c88-7b7f-492c-a421-8c5e110371f3.jpg)

### After


https://user-images.githubusercontent.com/6661511/230182295-18eccc1c-d022-460e-b86a-a3ac81b577fd.mov





<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Underline styling was broken when a link spanned over multiple lines. 

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
