### PR TITLE
GRW-2432 - feat(PurchaseForm): display error messages form API

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/usePurchaseFormState.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/usePurchaseFormState.ts
@@ -1,0 +1,31 @@
+import { useReducer } from 'react'
+
+type FormState = {
+  state: 'IDLE' | 'EDIT' | 'ERROR'
+  errorMsg?: string
+}
+
+type ActionErrorWithPayload = { state: 'ERROR'; errorMsg?: string }
+
+type FormStateReducerAction = FormState['state'] | ActionErrorWithPayload
+
+export const usePurchaseFormState = (initialState?: FormState) => {
+  const [state, dispatch] = useReducer(reducer, initialState ?? { state: 'IDLE' })
+
+  return [state, dispatch] as const
+}
+
+const reducer = (state: FormState, action: FormStateReducerAction): FormState => {
+  const actionType = typeof action === 'string' ? action : action.state
+
+  switch (actionType) {
+    case 'IDLE':
+      return { state: 'IDLE' }
+    case 'EDIT':
+      return { state: 'EDIT' }
+    case 'ERROR':
+      return { state: 'ERROR', errorMsg: (action as ActionErrorWithPayload)?.errorMsg }
+    default:
+      return state
+  }
+}


### PR DESCRIPTION
## Describe your changes

* Display ApolloError messages while trying to confirm _PriceIntent_

<img width="1904" alt="image" src="https://user-images.githubusercontent.com/19200662/230360759-65bd2542-91a2-4759-93ac-87fd378402b2.png">

## Justify why they are needed

Better guide user on what's going on.

## Jira issue(s): [GRW-2432](https://hedvig.atlassian.net/browse/GRW-2432)

[GRW-2432]: https://hedvig.atlassian.net/browse/GRW-2432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ