### PR TITLE
GRW-2440 - fix(useHandleSubmitAddToCart): refetch recommendations after adding a poduct into cart

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/useHandleSubmitAddToCart.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/useHandleSubmitAddToCart.ts
@@ -1,6 +1,11 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { SyntheticEvent, useCallback } from 'react'
-import { CartEntryAddMutation, useCartEntryAddMutation } from '@/services/apollo/generated'
+import { useProductRecommendations } from '@/components/ProductRecommendationList/useProductRecommendations'
+import {
+  CartEntryAddMutation,
+  useCartEntryAddMutation,
+  ProductRecommendationsDocument,
+} from '@/services/apollo/generated'
 import { useAppErrorHandleContext } from '@/services/appErrors/AppErrorContext'
 import { getOrThrowFormValue } from '@/utils/getOrThrowFormValue'
 import { FormElement } from './PurchaseForm.constants'
@@ -12,9 +17,13 @@ type Params = {
 }
 
 export const useHandleSubmitAddToCart = ({ cartId, onSuccess }: Params) => {
+  // ProductRecommendationsQuery needs to be an active query
+  // before we can "re"fetch it after adding a new product into
+  // the cart
+  useProductRecommendations()
+
   const [addEntry, { loading }] = useCartEntryAdd({
-    // Refetch recommendations
-    refetchQueries: 'active',
+    refetchQueries: [ProductRecommendationsDocument],
     awaitRefetchQueries: true,
   })
 


### PR DESCRIPTION
# Describe your changes

* Make sure _ProductRecommendations_ query gets refetched after adding a product into the cart.

## Justify why they are needed

### The problem

_ProductRecommendations_ query doesn't get refetched when a product get's added into the cart, which makes Cart Page product recommendations list be built with stale data - the famous cache invalidation issue. One can reproduce it by following the steps described in the video below:

https://user-images.githubusercontent.com/19200662/231446212-4a6e1af3-0726-4bb2-8e54-bce580e47d36.mov

### Why does it happen?

As one might notice, we have code in place with the function of refetching that list when cart gets mutated [adding](https://github.com/HedvigInsurance/racoon/blob/main/apps/store/src/components/ProductPage/PurchaseForm/useHandleSubmitAddToCart.ts#L17)/[removing](https://github.com/HedvigInsurance/racoon/blob/main/apps/store/src/components/CartInventory/useRemoveCartEntry.ts#L25) products. Both implementations make usage of _apollo client_'s declarative API for updating the cache after a mutation: `refetchQueries`. That property accepts a list of _active_ queries that should be refetched after the mutation gets executed. The "active" word here is important and it's the reason why it's working for when products get removed from the cart but not when products get added - _ProductRecommentations_ query is not active when we add a product to the cart.

Based on their docs, the only way to refetch a _non-active_ query is doing it programmatically with the `refetch` method returned by `useQuery` hook. Weirdly enough, just calling that method would also not solve the issue because, by default,  the query that should be refetched reads from the cache. In our situation we need to make sure that it gets data from the network, that's why I'm calling it with `fetchPolicy: 'network-only'`. In other words, I needed to replace a declarative solution with an imperative one because of the level of control I'm offered to.

## Jira issue(s): [GRW-2440](https://hedvig.atlassian.net/browse/GRW-2440)


[GRW-2440]: https://hedvig.atlassian.net/browse/GRW-2440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ