### PR TITLE
chore(codegen): treate UUID scalar as string

### DIFF
--- a/apps/store/codegen.yml
+++ b/apps/store/codegen.yml
@@ -2,6 +2,9 @@ schema: ${NEXT_PUBLIC_GRAPHQL_ENDPOINT}
 documents: './src/graphql/*.graphql'
 generates:
   ./src/services/apollo/generated.ts:
+    config:
+      scalars:
+        UUID: string
     plugins:
       - typescript
       - typescript-operations

--- a/apps/store/src/components/ProductRecommendationList/useProductRecommendations.ts
+++ b/apps/store/src/components/ProductRecommendationList/useProductRecommendations.ts
@@ -4,7 +4,7 @@ import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 export const useProductRecommendations = () => {
   const { shopSession } = useShopSession()
 
-  const shopSessionId = typeof shopSession?.id === 'string' ? shopSession.id : undefined
+  const shopSessionId = shopSession?.id
   const result = useProductRecommendationsQuery({
     variables: shopSessionId ? { shopSessionId } : undefined,
     skip: !shopSessionId,


### PR DESCRIPTION
## Describe your changes

Treat UUID scalar as string on graphql types generation.

## Justify why they are needed

Then we don't need to cast `shoppingSession.id` type from `any` into `string`
