### PR TITLE
Support attributed_to query param, use it to create new shopSession with given attribution

### DIFF
--- a/apps/store/src/graphql/ShopSessionCreate.graphql
+++ b/apps/store/src/graphql/ShopSessionCreate.graphql
@@ -1,5 +1,5 @@
-mutation ShopSessionCreate($countryCode: CountryCode!) {
-  shopSessionCreate(input: { countryCode: $countryCode }) {
+mutation ShopSessionCreate($countryCode: CountryCode!, $attributedTo: String) {
+  shopSessionCreate(input: { countryCode: $countryCode, attributedTo: $attributedTo }) {
     ...ShopSession
   }
 }

--- a/apps/store/src/services/Tracking/attributedTo.ts
+++ b/apps/store/src/services/Tracking/attributedTo.ts
@@ -1,0 +1,17 @@
+import { NextRouter } from 'next/router'
+import { isBrowser } from '@/utils/env'
+
+const PARAM_NAME = 'attributed_to'
+
+export const getAttributedToQueryParam = (): string | null => {
+  if (!isBrowser()) return null
+  return new URL(window.location.href).searchParams.get(PARAM_NAME)
+}
+
+export const removeAttributedToQueryParam = (router: NextRouter) => {
+  if (router.query[PARAM_NAME]) {
+    const target = { pathname: router.pathname, query: { ...router.query } }
+    delete target.query[PARAM_NAME]
+    router.replace(target, undefined, { shallow: true })
+  }
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Handle attributed_to query param
- initalize new shop session with proper attribution
- remove it from query to make page reload safe

We're not reading back the value from shopSession since it's not part of the schema

Will have undefined behavior if used on pages that rely on server-side created session - cart, checkout, etc.  We don't plan to use any of those in cross-sell link from our app

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Track results of cross-selling through the app

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
