### PR TITLE
Add /api/redriect/recommend route to force session creation with given attributed_to value

### DIFF
--- a/apps/store/src/graphql/ShopSessionCreate.graphql
+++ b/apps/store/src/graphql/ShopSessionCreate.graphql
@@ -1,5 +1,5 @@
-mutation ShopSessionCreate($countryCode: CountryCode!) {
-  shopSessionCreate(input: { countryCode: $countryCode }) {
+mutation ShopSessionCreate($countryCode: CountryCode!, $attributedTo: String) {
+  shopSessionCreate(input: { countryCode: $countryCode, attributedTo: $attributedTo }) {
     ...ShopSession
   }
 }

--- a/apps/store/src/pages/api/redirect/recommend.ts
+++ b/apps/store/src/pages/api/redirect/recommend.ts
@@ -1,0 +1,40 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { initializeApolloServerSide } from '@/services/apollo/client'
+import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
+import { getCountryByLocale } from '@/utils/l10n/countryUtils'
+import { getUrlLocale } from '@/utils/l10n/localeUtils'
+import { ORIGIN_URL, PageLink } from '@/utils/PageLink'
+
+const recommendHandler = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const { query = {} } = req
+    const { attributed_to: attributedTo, next = '' } = query
+
+    if (typeof attributedTo !== 'string') {
+      return res.status(400).send('Expected attributed_to query param with single value')
+    }
+    if (typeof next !== 'string') {
+      return res.status(400).send('Multiple next values not supported')
+    }
+
+    const routingLocale = getUrlLocale(next)
+    const { countryCode } = getCountryByLocale(routingLocale)
+
+    const apolloClient = await initializeApolloServerSide({ req, res })
+    const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })
+    const shopSession = await shopSessionService.create({ countryCode, attributedTo })
+    shopSessionService.saveId(shopSession.id)
+
+    const targetUrl = new URL(req.url ?? '', ORIGIN_URL)
+    targetUrl.pathname = next || PageLink.home({ locale: routingLocale })
+    targetUrl.searchParams.delete('next')
+    targetUrl.searchParams.delete('attributed_to')
+
+    return res.redirect(307, targetUrl.toString())
+  } catch (err) {
+    console.log('Error when handling recommend redirect, redirecting to index page', err)
+    return res.redirect(307, PageLink.home())
+  }
+}
+
+export default recommendHandler


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

Alternative approach to setting attributed_to - make a special API route to force session creation

## Justify why they are needed

More stable solution than relying on query param when starting the app (https://github.com/HedvigInsurance/racoon/pull/2151?no-redirect=1) 

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
