### PR TITLE
Add Storybook Apollo addon

### DIFF
--- a/apps/store/.storybook/main.ts
+++ b/apps/store/.storybook/main.ts
@@ -3,7 +3,11 @@ import babelConfig from './babelConfig'
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(ts|tsx)'],
-  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    'storybook-addon-apollo-client',
+  ],
   framework: {
     name: '@storybook/nextjs',
     options: {},

--- a/apps/store/.storybook/preview.tsx
+++ b/apps/store/.storybook/preview.tsx
@@ -2,10 +2,14 @@ import { ThemeProvider } from 'ui'
 import { storybookFontStyles } from 'ui/src/lib/storybookFontStyles'
 import { Global } from '@emotion/react'
 import { RouterContext } from 'next/dist/shared/lib/router-context'
+import { MockedProvider } from '@apollo/client/testing'
 import './i18next'
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
+  apolloClient: {
+    MockedProvider,
+  },
   controls: {
     matchers: {
       color: /(background|color)$/i,

--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -94,6 +94,7 @@
     "next-router-mock": "0.9.3",
     "prettier": "2.8.7",
     "storybook": "7.0.5",
+    "storybook-addon-apollo-client": "4.1.4",
     "subscriptions-transport-ws": "0.11.0",
     "ts-jest": "29.1.0",
     "tsconfig": "workspace:",

--- a/apps/store/src/components/CartInventory/CartEntryItem/CartEntryItem.stories.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem/CartEntryItem.stories.tsx
@@ -1,6 +1,8 @@
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
 import type { Meta, StoryObj } from '@storybook/react'
 import { CurrencyCode, InsuranceDocumentType } from '@/services/apollo/generated'
+import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
+import { ShopSessionProvider } from '@/services/shopSession/ShopSessionContext'
 import { CartEntryItem } from './CartEntryItem'
 
 const meta: Meta<typeof CartEntryItem> = {
@@ -17,12 +19,20 @@ const meta: Meta<typeof CartEntryItem> = {
 export default meta
 type Story = StoryObj<typeof CartEntryItem>
 
-export const ReadOnly: Story = {
+const Template: Story = {
   render: (args) => (
-    <div style={{ maxWidth: '29rem', width: '100%' }}>
-      <CartEntryItem {...args} />
-    </div>
+    <ShopSessionProvider shopSessionId="1e517b18-fd77-4384-aee1-17481da3781a">
+      <AppErrorProvider>
+        <div style={{ maxWidth: '29rem', width: '100%' }}>
+          <CartEntryItem {...args} />
+        </div>
+      </AppErrorProvider>
+    </ShopSessionProvider>
   ),
+}
+
+export const ReadOnly = {
+  ...Template,
   args: {
     readOnly: true,
     cartId: 'cart',
@@ -40,19 +50,16 @@ export const ReadOnly: Story = {
     startDate: new Date(),
     documents: [
       {
-        __typename: 'InsuranceDocument',
         type: InsuranceDocumentType.GeneralTerms,
         displayName: 'Olycksfall Försäkringsvillkor',
         url: 'https://promise.hedvig.com/swe_terms_conditions_accident_47228b7079.pdf',
       },
       {
-        __typename: 'InsuranceDocument',
         type: InsuranceDocumentType.PreSaleInfo,
         displayName: 'Produktfaktablad Olycksfallsförsäkring',
         url: 'https://promise.hedvig.com/Hedvig_OLYCKSFALL_SE_IPID_1_7e7640efa2.pdf',
       },
       {
-        __typename: 'InsuranceDocument',
         type: InsuranceDocumentType.TermsAndConditions,
         displayName: 'Olycksfallsförsäkring Ärrtabell',
         url: 'https://promise.hedvig.com/se_arrtabell_olycksfall_66dbff4975.pdf',
@@ -64,5 +71,13 @@ export const ReadOnly: Story = {
       livingSpace: 70,
       numberCoInsured: '2',
     },
+  },
+}
+
+export const Editable = {
+  ...Template,
+  args: {
+    ...ReadOnly.args,
+    readOnly: false,
   },
 }

--- a/apps/store/src/components/CartInventory/CartEntryItem/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem/CartEntryItem.tsx
@@ -112,7 +112,12 @@ const Main = styled.li({
 
 const Layout = {
   Main,
-  Pillow: styled.div({ gridArea: GRID_AREAS.Pillow }),
+  Pillow: styled.div({
+    gridArea: GRID_AREAS.Pillow,
+    [mq.md]: {
+      marginBottom: theme.space.xs,
+    },
+  }),
   Title: styled.div({ gridArea: GRID_AREAS.Title }),
   Details: styled.div({
     gridArea: GRID_AREAS.Details,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5408,6 +5408,56 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/addons@npm:~6.5.12":
+  version: 6.5.16
+  resolution: "@storybook/addons@npm:6.5.16"
+  dependencies:
+    "@storybook/api": 6.5.16
+    "@storybook/channels": 6.5.16
+    "@storybook/client-logger": 6.5.16
+    "@storybook/core-events": 6.5.16
+    "@storybook/csf": 0.0.2--canary.4566f4d.1
+    "@storybook/router": 6.5.16
+    "@storybook/theming": 6.5.16
+    "@types/webpack-env": ^1.16.0
+    core-js: ^3.8.2
+    global: ^4.4.0
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 0463150e4cf7bd2b2aaafdbaadfb4420e4e0a31eb651cfc1a2d7f4b4974caf67878712602474585dfa18f583000608598045594909959d2e9e2ec32ba004392d
+  languageName: node
+  linkType: hard
+
+"@storybook/api@npm:6.5.16":
+  version: 6.5.16
+  resolution: "@storybook/api@npm:6.5.16"
+  dependencies:
+    "@storybook/channels": 6.5.16
+    "@storybook/client-logger": 6.5.16
+    "@storybook/core-events": 6.5.16
+    "@storybook/csf": 0.0.2--canary.4566f4d.1
+    "@storybook/router": 6.5.16
+    "@storybook/semver": ^7.3.2
+    "@storybook/theming": 6.5.16
+    core-js: ^3.8.2
+    fast-deep-equal: ^3.1.3
+    global: ^4.4.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    regenerator-runtime: ^0.13.7
+    store2: ^2.12.0
+    telejson: ^6.0.8
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: c873189ac1e501825d647903baa125899c492cee962cb86ebb7455110bd09194eeb6943f5c58a1f808ce4ee2e20e305f5604a4e60b07003c82a6fc6ceaee5ea9
+  languageName: node
+  linkType: hard
+
 "@storybook/api@npm:7.0.5":
   version: 7.0.5
   resolution: "@storybook/api@npm:7.0.5"
@@ -5566,6 +5616,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/channels@npm:6.5.16":
+  version: 6.5.16
+  resolution: "@storybook/channels@npm:6.5.16"
+  dependencies:
+    core-js: ^3.8.2
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  checksum: 3d7f7bc19ed7b250976e00e02ab544408806b439106bed18a5db9815612f6c5df9bdf7c1a97b5a40ba3194184ebe7e4c75e2bca5496025d6b26afefa95cfccbd
+  languageName: node
+  linkType: hard
+
 "@storybook/channels@npm:7.0.5":
   version: 7.0.5
   resolution: "@storybook/channels@npm:7.0.5"
@@ -5632,6 +5693,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/client-logger@npm:6.5.16":
+  version: 6.5.16
+  resolution: "@storybook/client-logger@npm:6.5.16"
+  dependencies:
+    core-js: ^3.8.2
+    global: ^4.4.0
+  checksum: 0a86959b1bacb1b893e282173b48afe9c857b8cdc67a47ad87a7f11ba7dbc15ebc4f0d05c07dffb988e0cd3e1de0f09f300ee06c66afe4c50e9be83aaed75971
+  languageName: node
+  linkType: hard
+
 "@storybook/client-logger@npm:7.0.5":
   version: 7.0.5
   resolution: "@storybook/client-logger@npm:7.0.5"
@@ -5681,6 +5752,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/components@npm:~6.5.12":
+  version: 6.5.16
+  resolution: "@storybook/components@npm:6.5.16"
+  dependencies:
+    "@storybook/client-logger": 6.5.16
+    "@storybook/csf": 0.0.2--canary.4566f4d.1
+    "@storybook/theming": 6.5.16
+    core-js: ^3.8.2
+    memoizerific: ^1.11.3
+    qs: ^6.10.0
+    regenerator-runtime: ^0.13.7
+    util-deprecate: ^1.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 1caf822bf1293ca043822f1c77f05c0f01631e8a61adad6bc4651ba9be78c8f4822ba0905e39c8feaa3fb44ae10422e9ccd3004348b18531fb82c54cfcea4fa9
+  languageName: node
+  linkType: hard
+
 "@storybook/core-client@npm:7.0.5":
   version: 7.0.5
   resolution: "@storybook/core-client@npm:7.0.5"
@@ -5715,6 +5805,15 @@ __metadata:
     resolve-from: ^5.0.0
     ts-dedent: ^2.0.0
   checksum: df90dce70a91b325130059a697543d87820774b295b95c4ce8cd72f49bfd5b13febe594e2ed4676e7561853160260fd24bb89edf931de5997f80dee84e163380
+  languageName: node
+  linkType: hard
+
+"@storybook/core-events@npm:6.5.16":
+  version: 6.5.16
+  resolution: "@storybook/core-events@npm:6.5.16"
+  dependencies:
+    core-js: ^3.8.2
+  checksum: 1844bdabfb7828af7ddd54129fbb321bf65d8b65459eaac99c8f3f94c7c2f0ee000468362758076444083f863a3bc835ecd1e4f2128524eb5c00c8a576473bc9
   languageName: node
   linkType: hard
 
@@ -5812,6 +5911,15 @@ __metadata:
     recast: ^0.23.1
     ts-dedent: ^2.0.0
   checksum: 066715c6c7f5aa84fdc3453cabd4e31d5b9da35f4e71e0ed9f74194af634b834546e2a173b77a65071863f3de51f435719b599e802160a1a9c51e511f0e34d2a
+  languageName: node
+  linkType: hard
+
+"@storybook/csf@npm:0.0.2--canary.4566f4d.1":
+  version: 0.0.2--canary.4566f4d.1
+  resolution: "@storybook/csf@npm:0.0.2--canary.4566f4d.1"
+  dependencies:
+    lodash: ^4.17.15
+  checksum: afac948e1eae72f020b3708538dd2553524f291bc129ecb2941983668fd62b17448e52f9c9be5b8edeea7a64d96f620bbac78b8acc10ece11b8279930a1deb03
   languageName: node
   linkType: hard
 
@@ -6121,6 +6229,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/router@npm:6.5.16":
+  version: 6.5.16
+  resolution: "@storybook/router@npm:6.5.16"
+  dependencies:
+    "@storybook/client-logger": 6.5.16
+    core-js: ^3.8.2
+    memoizerific: ^1.11.3
+    qs: ^6.10.0
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 2812b93997026b1d85f02072d04f18e98e24de288efb73402f8d15ececd390e13dc620ef011268e09986c629f497ffa03230c2431e89b4e37c01b70761be2c6d
+  languageName: node
+  linkType: hard
+
 "@storybook/router@npm:7.0.5":
   version: 7.0.5
   resolution: "@storybook/router@npm:7.0.5"
@@ -6132,6 +6256,18 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: bc6cea36f66a1a05e0a33cadb0a61a6da1081fd8949f32688b00d638a9d1b22949093e1510fbd5c9a6cc6227d3fbdc7ef74eb96e11a87d9021f3f71a8f5bdf53
+  languageName: node
+  linkType: hard
+
+"@storybook/semver@npm:^7.3.2":
+  version: 7.3.2
+  resolution: "@storybook/semver@npm:7.3.2"
+  dependencies:
+    core-js: ^3.6.5
+    find-up: ^4.1.0
+  bin:
+    semver: bin/semver.js
+  checksum: c98225817af5539654ef547e33e4496edccc04a88b6091d4a5601f81b71743109074dc71cc444813f43c112273c9d54d5f99416e9ad08ee89b4913318e6aea90
   languageName: node
   linkType: hard
 
@@ -6159,6 +6295,21 @@ __metadata:
     nanoid: ^3.3.1
     read-pkg-up: ^7.0.1
   checksum: ae65956920db986d61bd112f96c0aedda71e9a5ccb56496833c470b804cda05de107ca5573650e9850b86b7919f5524b20eae79c3ca4b452c047caf5c50a4c12
+  languageName: node
+  linkType: hard
+
+"@storybook/theming@npm:6.5.16":
+  version: 6.5.16
+  resolution: "@storybook/theming@npm:6.5.16"
+  dependencies:
+    "@storybook/client-logger": 6.5.16
+    core-js: ^3.8.2
+    memoizerific: ^1.11.3
+    regenerator-runtime: ^0.13.7
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 349affa5c5208240291a5d24c73d852e220bfaf36b8fda70564aec1cac6070248ce7566ccb755c55a6ce0844ab2bbfd55881f6f788240b38cb407714e393c6f3
   languageName: node
   linkType: hard
 
@@ -6538,6 +6689,13 @@ __metadata:
   version: 6.1.0
   resolution: "@types/html-minifier-terser@npm:6.1.0"
   checksum: eb843f6a8d662d44fb18ec61041117734c6aae77aa38df1be3b4712e8e50ffaa35f1e1c92fdd0fde14a5675fecf457abcd0d15a01fae7506c91926176967f452
+  languageName: node
+  linkType: hard
+
+"@types/is-function@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@types/is-function@npm:1.0.1"
+  checksum: dfbb591936dfebd4686b109603bc3e2d23a17087d6ec913fb35cd6b5a4ef908ed68ab93cb27d508f1546d312edf03e663cb6738d3b67d420c68da961ac2b3d1f
   languageName: node
   linkType: hard
 
@@ -6985,6 +7143,13 @@ __metadata:
   version: 9.0.1
   resolution: "@types/uuid@npm:9.0.1"
   checksum: c472b8a77cbeded4bc529220b8611afa39bd64677f507838f8083d8aac8033b1f88cb9ddaa2f8589e0dcd2317291d0f6e1379f82d5ceebd6f74f3b4825288e00
+  languageName: node
+  linkType: hard
+
+"@types/webpack-env@npm:^1.16.0":
+  version: 1.18.0
+  resolution: "@types/webpack-env@npm:1.18.0"
+  checksum: ecf4daa31cb37d474ac0ce058d83a3cadeb9881ca8107ae93c2299eaa9954943aae09b43e143c62ccbe4288a14db00c918c9debd707afe17c3998f873eaabc59
   languageName: node
   linkType: hard
 
@@ -9620,6 +9785,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js@npm:^3.6.5, core-js@npm:^3.8.2":
+  version: 3.30.1
+  resolution: "core-js@npm:3.30.1"
+  checksum: 6d4a00b488694d4c715c424e15dfef31433ac7aa395c39c518a0cfacec918ada1c716fed74682033197e0164e23bbf38bfd598ee9a239c4aaa590ab1ba862ac8
+  languageName: node
+  linkType: hard
+
 "core-util-is@npm:1.0.2":
   version: 1.0.2
   resolution: "core-util-is@npm:1.0.2"
@@ -10253,6 +10425,13 @@ __metadata:
     domhandler: ^5.0.2
     entities: ^4.2.0
   checksum: cd1810544fd8cdfbd51fa2c0c1128ec3a13ba92f14e61b7650b5de421b88205fd2e3f0cc6ace82f13334114addb90ed1c2f23074a51770a8e9c1273acbc7f3e6
+  languageName: node
+  linkType: hard
+
+"dom-walk@npm:^0.1.0":
+  version: 0.1.2
+  resolution: "dom-walk@npm:0.1.2"
+  checksum: 19eb0ce9c6de39d5e231530685248545d9cd2bd97b2cb3486e0bfc0f2a393a9addddfd5557463a932b52fdfcf68ad2a619020cd2c74a5fe46fbecaa8e80872f3
   languageName: node
   linkType: hard
 
@@ -12372,6 +12551,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"global@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "global@npm:4.4.0"
+  dependencies:
+    min-document: ^2.19.0
+    process: ^0.11.10
+  checksum: 9c057557c8f5a5bcfbeb9378ba4fe2255d04679452be504608dd5f13b54edf79f7be1db1031ea06a4ec6edd3b9f5f17d2d172fb47e6c69dae57fd84b7e72b77f
+  languageName: node
+  linkType: hard
+
 "globals@npm:^11.1.0, globals@npm:^11.12.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
@@ -13305,6 +13494,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-function@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "is-function@npm:1.0.2"
+  checksum: 7d564562e07b4b51359547d3ccc10fb93bb392fd1b8177ae2601ee4982a0ece86d952323fc172a9000743a3971f09689495ab78a1d49a9b14fc97a7e28521dc0
+  languageName: node
+  linkType: hard
+
 "is-generator-fn@npm:^2.0.0":
   version: 2.1.0
   resolution: "is-generator-fn@npm:2.1.0"
@@ -13470,7 +13666,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-regex@npm:^1.1.4":
+"is-regex@npm:^1.1.2, is-regex@npm:^1.1.4":
   version: 1.1.4
   resolution: "is-regex@npm:1.1.4"
   dependencies:
@@ -13632,6 +13828,13 @@ __metadata:
   version: 3.0.1
   resolution: "isobject@npm:3.0.1"
   checksum: db85c4c970ce30693676487cca0e61da2ca34e8d4967c2e1309143ff910c207133a969f9e4ddb2dc6aba670aabce4e0e307146c310350b298e74a31f7d464703
+  languageName: node
+  linkType: hard
+
+"isobject@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "isobject@npm:4.0.0"
+  checksum: bbcb522e46d54fb22418ba49fb9a82057ffa201c8401fb6e018c042e2c98cf7d9c7b185aff88e035ec8adea0814506dc2aeff2d08891bbc158e1671a49e99c06
   languageName: node
   linkType: hard
 
@@ -15418,6 +15621,15 @@ __metadata:
   version: 4.0.0
   resolution: "mimic-fn@npm:4.0.0"
   checksum: 995dcece15ee29aa16e188de6633d43a3db4611bcf93620e7e62109ec41c79c0f34277165b8ce5e361205049766e371851264c21ac64ca35499acb5421c2ba56
+  languageName: node
+  linkType: hard
+
+"min-document@npm:^2.19.0":
+  version: 2.19.0
+  resolution: "min-document@npm:2.19.0"
+  dependencies:
+    dom-walk: ^0.1.0
+  checksum: da6437562ea2228041542a2384528e74e22d1daa1a4ec439c165abf0b9d8a63e17e3b8a6dc6e0c731845e85301198730426932a0e813d23f932ca668340c9623
   languageName: node
   linkType: hard
 
@@ -17654,7 +17866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:^0.13.11":
+"regenerator-runtime@npm:^0.13.11, regenerator-runtime@npm:^0.13.7":
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
@@ -18770,7 +18982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"store2@npm:^2.14.2":
+"store2@npm:^2.12.0, store2@npm:^2.14.2":
   version: 2.14.2
   resolution: "store2@npm:2.14.2"
   checksum: 6f270fc5bab99b63f45fcc7bd8b99c2714b4adf880f557ed7ffb5ed3987131251165bccde425a00928aaf044870aee79ddeef548576d093c68703ed2edec45d7
@@ -18850,6 +19062,7 @@ __metadata:
     react-i18next: 12.2.0
     react-wrap-balancer: 0.4.0
     storybook: 7.0.5
+    storybook-addon-apollo-client: 4.1.4
     subscriptions-transport-ws: 0.11.0
     ts-jest: 29.1.0
     tsconfig: "workspace:"
@@ -18865,6 +19078,20 @@ __metadata:
   version: 5.10.2
   resolution: "storyblok-js-client@npm:5.10.2"
   checksum: 5236cdaa0f7b318136d9d1fc011fd86b9be475e2611293a3c874ccd4b02f04925561cdc44b697a91406ee02543075dec9fb6e82d47984aca4ae781894be295ee
+  languageName: node
+  linkType: hard
+
+"storybook-addon-apollo-client@npm:4.1.4":
+  version: 4.1.4
+  resolution: "storybook-addon-apollo-client@npm:4.1.4"
+  dependencies:
+    "@storybook/addons": ~6.5.12
+    "@storybook/components": ~6.5.12
+    tslib: ^2.4.0
+  peerDependencies:
+    graphql: "*"
+    react: ">=16.8.0"
+  checksum: 881e676a48a943f0a72caaedcfeb3b235f3fde780c32d6deaf9855506def7834d96d2406f5d1fb1bb4204825827c0607769d0d69fdb4760dace3f41707e6dc1d
   languageName: node
   linkType: hard
 
@@ -19294,6 +19521,22 @@ __metadata:
   dependencies:
     streamx: ^2.12.5
   checksum: 36bf7ce8bb5eb428ad7b14b695ee7fb0a02f09c1a9d8181cc42531208543a920b299d711bf78dad4ff9bcf36ac437ae8e138053734746076e3e0e7d6d76eef64
+  languageName: node
+  linkType: hard
+
+"telejson@npm:^6.0.8":
+  version: 6.0.8
+  resolution: "telejson@npm:6.0.8"
+  dependencies:
+    "@types/is-function": ^1.0.0
+    global: ^4.4.0
+    is-function: ^1.0.2
+    is-regex: ^1.1.2
+    is-symbol: ^1.0.3
+    isobject: ^4.0.0
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+  checksum: 7411a5e78a35720bd0654a544409d3ce467b1dbb2073c73f36476b4c0905d97dbf539d6cbae737bb1fd8c872c2058f2a5450163a15117ed3fa031b2a2b8b33f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add Storybook [Apollo addon](https://storybook.js.org/addons/storybook-addon-apollo-client). This way we can create stories for components thats dependent on Apollo and mock data.
In this case I added a story for `CartEntryItem` with the remove button. 





https://user-images.githubusercontent.com/6661511/232733701-c2ccd788-4ad2-4bc0-9e99-0a0bedd3a898.mov






<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
To enable us to build components in isolation that's dependent on Apollo

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
