### PR TITLE
Make Insurely optional in Current Insurance picker

### DIFF
--- a/apps/store/src/components/PriceCalculator/AutomaticField.tsx
+++ b/apps/store/src/components/PriceCalculator/AutomaticField.tsx
@@ -145,16 +145,15 @@ export const AutomaticField = ({ field, priceIntent, onSubmit, loading, autoFocu
       return <CarMileageField field={field} />
 
     case 'current-insurance':
-      return productData.insurelyClientId ? (
+      return (
         <CurrentInsuranceField
           label={translateLabel(field.label)}
           productName={productData.name}
           priceIntentId={priceIntent.id}
-          insurelyClientId={productData.insurelyClientId}
+          insurelyClientId={productData.insurelyClientId ?? undefined}
           externalInsurer={priceIntent.externalInsurer?.id}
         />
-      ) : // TODO: Add a fallback for when we don't have an insurelyClientId
-      null
+      )
 
     case 'stepper':
       return (


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Make it possible to edit current insurer without an Insurely client ID.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We currently just skip that section if there is no Insurely client ID. However, it should still be possible to get help with cancellation even if we don't perform price matching.

Now we always let the user pick their insurer, and if there is an Insurely client ID we will perform price matching.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
