### PR TITLE
Allow initiated_from to be specified via /api/redirect/recommend

### DIFF
--- a/apps/store/src/graphql/ShopSessionCreate.graphql
+++ b/apps/store/src/graphql/ShopSessionCreate.graphql
@@ -1,5 +1,11 @@
-mutation ShopSessionCreate($countryCode: CountryCode!, $attributedTo: String) {
-  shopSessionCreate(input: { countryCode: $countryCode, attributedTo: $attributedTo }) {
+mutation ShopSessionCreate(
+  $countryCode: CountryCode!
+  $attributedTo: String
+  $initiatedFrom: String
+) {
+  shopSessionCreate(
+    input: { countryCode: $countryCode, attributedTo: $attributedTo, initiatedFrom: $initiatedFrom }
+  ) {
     ...ShopSession
   }
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Allow initiated_from to be specificed the same way as attributed_to, so we can do things like
- initiated_from=CROSS_SELL for app cross-sell
- attributed_to=BENIFY for partners
- no use cases for both at the same time, but I allow it to do less work

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Properly support car cross-sales with relaxed pricing guidelines in Eir

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
