### PR TITLE
Show preview in price calculator sections

### DIFF
--- a/apps/store/src/components/PriceCalculator/Accordion.tsx
+++ b/apps/store/src/components/PriceCalculator/Accordion.tsx
@@ -3,11 +3,7 @@ import * as Accordion from '@radix-ui/react-accordion'
 import { ReactNode } from 'react'
 import { theme } from 'ui'
 
-export const Header = styled(Accordion.Header)(() => ({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-}))
+export const Header = Accordion.Header
 
 export const Content = styled(Accordion.Content)({
   paddingTop: theme.space.sm,

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorAccordion.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorAccordion.tsx
@@ -1,13 +1,9 @@
-import styled from '@emotion/styled'
-import { useTranslation } from 'next-i18next'
 import { ReactNode } from 'react'
-import { Heading, Text } from 'ui'
 import { SsnSeSection } from '@/components/PriceCalculator/SsnSeSection'
-import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { Form, FormSection } from '@/services/PriceCalculator/PriceCalculator.types'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import * as Accordion from './Accordion'
-import { StepIcon } from './StepIcon'
+import { PriceCalculatorAccordionSection } from './PriceCalculatorAccordionSection'
 import { useTranslateFieldLabel } from './useTranslateFieldLabel'
 
 type Props = {
@@ -20,7 +16,6 @@ type Props = {
 
 export const PriceCalculatorAccordion = (props: Props) => {
   const { form, children, activeSectionId, onActiveSectionChange } = props
-  const { t } = useTranslation('purchase-form')
   const translateLabel = useTranslateFieldLabel()
 
   const handleSsnSectionCompleted = () => {
@@ -37,15 +32,9 @@ export const PriceCalculatorAccordion = (props: Props) => {
       type="single"
       value={activeSectionId}
       onValueChange={onActiveSectionChange}
-      collapsible
+      collapsible={true}
     >
       {form.sections.map((section, index) => {
-        const isActive = section.id === activeSectionId
-        const isValid = section.state === 'valid'
-        const showMutedHeading = !(isActive || isValid)
-        const showEditButton = isValid && !isActive
-        const stepIconState = isValid ? 'valid' : 'muted'
-
         let content
         if (section.id === SsnSeSection.sectionId) {
           content = (
@@ -56,33 +45,20 @@ export const PriceCalculatorAccordion = (props: Props) => {
         }
 
         return (
-          <Accordion.Item key={section.id} value={section.id}>
-            <Accordion.Header>
-              <SpaceFlex space={0.5} align="center">
-                <StepIcon state={isActive ? 'filled' : stepIconState} />
-                <StyledHeading
-                  as="h3"
-                  variant="standard.18"
-                  color={showMutedHeading ? 'textSecondary' : 'textPrimary'}
-                >
-                  {translateLabel(section.title)}
-                </StyledHeading>
-              </SpaceFlex>
-              {showEditButton && (
-                <Accordion.Trigger>
-                  <StyledText size="md" color="textPrimary">
-                    {t('PRICE_CALCULATOR_SECTION_EDIT_BUTTON')}
-                  </StyledText>
-                </Accordion.Trigger>
-              )}
-            </Accordion.Header>
-            <Accordion.Content>{content}</Accordion.Content>
-          </Accordion.Item>
+          <PriceCalculatorAccordionSection
+            key={section.id}
+            active={section.id === activeSectionId}
+            valid={section.state === 'valid'}
+            title={translateLabel(section.title)}
+            value={section.id}
+            previewFieldName={section.preview?.fieldName}
+            previewLabel={section.preview?.label}
+            items={section.items}
+          >
+            {content}
+          </PriceCalculatorAccordionSection>
         )
       })}
     </Accordion.Root>
   )
 }
-
-const StyledHeading = styled(Heading)({ lineHeight: 1 })
-const StyledText = styled(Text)({ lineHeight: 1 })

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorAccordionSection.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorAccordionSection.tsx
@@ -1,0 +1,114 @@
+import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
+import { ReactNode, useMemo } from 'react'
+import { Heading, Text, theme } from 'ui'
+import { Label, SectionItem } from '@/services/PriceCalculator/PriceCalculator.types'
+import * as Accordion from './Accordion'
+import { StepIcon } from './StepIcon'
+import { useTranslateFieldLabel } from './useTranslateFieldLabel'
+
+type Props = {
+  children: ReactNode
+  active: boolean
+  valid: boolean
+  title: string
+  value: string
+  previewFieldName?: string
+  previewLabel?: Label
+  items: Array<SectionItem>
+}
+
+export const PriceCalculatorAccordionSection = (props: Props) => {
+  const { t } = useTranslation('purchase-form')
+  const translateLabel = useTranslateFieldLabel()
+
+  const showMutedHeading = !(props.active || props.valid)
+  const showEditButton = props.valid && !props.active
+
+  const stepIconState = useMemo(() => {
+    if (props.active) return 'filled'
+    if (props.valid) return 'valid'
+    return 'muted'
+  }, [props.active, props.valid])
+
+  const previewText = useMemo(() => {
+    if (!props.previewFieldName) return
+
+    const item = props.items.find((item) => item.field.name === props.previewFieldName)
+    const value = item?.field.value
+    if (value === undefined) return
+
+    if (!props.previewLabel) {
+      return value.toString()
+    }
+
+    return translateLabel(props.previewLabel, parseTranslateOptions(value))
+  }, [props.previewFieldName, props.items, props.previewLabel, translateLabel])
+
+  return (
+    <Accordion.Item value={props.value}>
+      <Accordion.Header>
+        <Grid>
+          <GridIcon>
+            <StepIcon state={stepIconState} />
+          </GridIcon>
+
+          <GridTitle>
+            <Heading
+              as="h3"
+              variant="standard.18"
+              color={showMutedHeading ? 'textSecondary' : 'textPrimary'}
+            >
+              {props.title}
+            </Heading>
+          </GridTitle>
+
+          <GridEdit hidden={!showEditButton}>
+            <Accordion.Trigger>
+              <Text size="md" color="textPrimary">
+                {t('PRICE_CALCULATOR_SECTION_EDIT_BUTTON')}
+              </Text>
+            </Accordion.Trigger>
+          </GridEdit>
+
+          <GridPreview hidden={props.active || !previewText}>
+            <Text color="textSecondary">{previewText}</Text>
+          </GridPreview>
+        </Grid>
+      </Accordion.Header>
+      <Accordion.Content>{props.children}</Accordion.Content>
+    </Accordion.Item>
+  )
+}
+
+const parseTranslateOptions = (value: unknown) => {
+  if (typeof value === 'number') return { count: value }
+  if (typeof value === 'string') {
+    const intValue = parseInt(value)
+    if (!isNaN(intValue)) return { count: intValue }
+  }
+}
+
+enum Area {
+  Icon = 'icon',
+  Title = 'title',
+  Edit = 'edit',
+  Preview = 'preview',
+}
+
+const Grid = styled.div({
+  display: 'grid',
+  gridTemplateColumns: 'auto 1fr auto',
+  gridTemplateRows: 'auto auto',
+  gridTemplateAreas: `
+    "${Area.Icon} ${Area.Title}   ${Area.Edit}"
+    ".            ${Area.Preview} ${Area.Preview}"
+  `,
+  columnGap: theme.space.xs,
+  alignItems: 'center',
+})
+
+const GridIcon = styled.div({ gridArea: Area.Icon, paddingTop: 1 })
+const GridTitle = styled.div({ gridArea: Area.Title })
+const GridEdit = styled.div({ gridArea: Area.Edit })
+const GridPreview = styled.div({ gridArea: Area.Preview })

--- a/apps/store/src/services/PriceCalculator/PriceCalculator.types.ts
+++ b/apps/store/src/services/PriceCalculator/PriceCalculator.types.ts
@@ -34,6 +34,10 @@ export type TemplateSection = {
   title: Label
   submitLabel: Label
   items: Array<SectionItem>
+  preview?: {
+    fieldName: string
+    label?: Label
+  }
 }
 
 export type JSONData = Record<string, JSONValue>

--- a/apps/store/src/services/PriceCalculator/data/SE_ACCIDENT.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_ACCIDENT.ts
@@ -33,6 +33,9 @@ export const SE_ACCIDENT: Template = {
           layout: LAYOUT.HALF_WIDTH,
         },
       ],
+      preview: {
+        fieldName: streetAddressField.name,
+      },
     },
     yourFamilySection,
   ],

--- a/apps/store/src/services/PriceCalculator/data/SE_CAR.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_CAR.ts
@@ -28,6 +28,9 @@ export const SE_CAR: Template = {
           layout: LAYOUT.FULL_WIDTH,
         },
       ],
+      preview: {
+        fieldName: carRegistrationNumberField.name,
+      },
     },
     yourAddressSection,
   ],

--- a/apps/store/src/services/PriceCalculator/data/SE_HOUSE.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_HOUSE.ts
@@ -49,6 +49,9 @@ export const SE_HOUSE: Template = {
           layout: LAYOUT.FULL_WIDTH,
         },
       ],
+      preview: {
+        fieldName: streetAddressField.name,
+      },
     },
 
     {
@@ -126,6 +129,10 @@ export const SE_HOUSE: Template = {
           layout: LAYOUT.FULL_WIDTH,
         },
       ],
+      preview: {
+        fieldName: 'numberOfBathrooms',
+        label: { key: tKey('FIELD_NUMBER_OF_BATHROOMS_VALUE') },
+      },
     },
     yourFamilySection,
   ],

--- a/apps/store/src/services/PriceCalculator/data/SE_PET_CAT.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_PET_CAT.ts
@@ -100,6 +100,9 @@ export const SE_PET_CAT: Template = {
           layout: LAYOUT.FULL_WIDTH,
         },
       ],
+      preview: {
+        fieldName: 'name',
+      },
     },
     yourAddressSectionWithlivingSpace,
   ],

--- a/apps/store/src/services/PriceCalculator/data/SE_PET_DOG.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_PET_DOG.ts
@@ -85,6 +85,9 @@ export const SE_PET_DOG: Template = {
           layout: LAYOUT.FULL_WIDTH,
         },
       ],
+      preview: {
+        fieldName: 'name',
+      },
     },
     yourAddressSectionWithlivingSpace,
   ],

--- a/apps/store/src/services/PriceCalculator/formFragments.ts
+++ b/apps/store/src/services/PriceCalculator/formFragments.ts
@@ -92,6 +92,13 @@ export const apartmentSubTypeField: InputField = {
   required: true,
 }
 
+const ssnSeField: InputField = {
+  type: 'text',
+  name: 'ssn',
+  label: { key: tKey('FIELD_SSN_SE_LABEL') },
+  required: true,
+}
+
 export const ssnSeSection: TemplateSection = {
   id: 'ssn-se',
   title: { key: tKey('SECTION_TITLE_PERSONAL_NUMBER') },
@@ -99,18 +106,16 @@ export const ssnSeSection: TemplateSection = {
   submitLabel: { key: tKey('SUBMIT_LABEL_PROCEED') },
   items: [
     {
-      field: {
-        type: 'text',
-        name: 'ssn',
-        label: { key: tKey('FIELD_SSN_SE_LABEL') },
-        required: true,
-      },
+      field: ssnSeField,
       layout: LAYOUT.FULL_WIDTH,
     },
   ],
+  preview: {
+    fieldName: ssnSeField.name,
+  },
 }
 
-export const yourApartmentSection = {
+export const yourApartmentSection: TemplateSection = {
   id: 'your-home',
   title: { key: tKey('SECTION_TITLE_YOUR_HOME') },
   submitLabel: { key: tKey('SUBMIT_LABEL_PROCEED') },
@@ -132,9 +137,12 @@ export const yourApartmentSection = {
       layout: LAYOUT.FULL_WIDTH,
     },
   ],
+  preview: {
+    fieldName: streetAddressField.name,
+  },
 }
 
-export const yourFamilySection = {
+export const yourFamilySection: TemplateSection = {
   id: 'your-family',
   title: { key: tKey('SECTION_TITLE_YOUR_FAMILY') },
   submitLabel: { key: tKey('SUBMIT_LABEL_FINISH') },
@@ -142,9 +150,13 @@ export const yourFamilySection = {
     { field: householdSizeField, layout: LAYOUT.FULL_WIDTH },
     { field: emailField, layout: LAYOUT.FULL_WIDTH },
   ],
+  preview: {
+    fieldName: householdSizeField.name,
+    label: { key: tKey('HOUSEHOLD_SIZE_VALUE') },
+  },
 }
 
-export const yourAddressSection = {
+export const yourAddressSection: TemplateSection = {
   id: 'your-address',
   title: { key: tKey('SECTION_TITLE_YOUR_ADDRESS') },
   submitLabel: { key: tKey('SUBMIT_LABEL_FINISH') },
@@ -153,9 +165,12 @@ export const yourAddressSection = {
     { field: postalCodeField, layout: LAYOUT.FULL_WIDTH },
     { field: emailField, layout: LAYOUT.FULL_WIDTH },
   ],
+  preview: {
+    fieldName: streetAddressField.name,
+  },
 }
 
-export const yourAddressSectionWithlivingSpace = {
+export const yourAddressSectionWithlivingSpace: TemplateSection = {
   id: 'your-address',
   title: { key: tKey('SECTION_TITLE_YOUR_ADDRESS') },
   submitLabel: { key: tKey('SUBMIT_LABEL_FINISH') },
@@ -165,4 +180,7 @@ export const yourAddressSectionWithlivingSpace = {
     { field: livingSpaceField, layout: LAYOUT.HALF_WIDTH },
     { field: emailField, layout: LAYOUT.FULL_WIDTH },
   ],
+  preview: {
+    fieldName: streetAddressField.name,
+  },
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add support to show a preview label for each completed section in the price calculator.

Refactor the price calculator accordion slightly.


![Screenshot 2023-04-24 at 11.40.44.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/f4efb532-bde2-42c9-adfa-12c0bb55cb0b/Screenshot%202023-04-24%20at%2011.40.44.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Improve UX, especially when user needs to edit things about the price intent.

Just supports a single preview label for now. Let's discuss if we should support multiple labels in the future. Another discussion would be if we should move the form template to the backend.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
