### PR TITLE
fix: campaign api route

### DIFF
--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -76,9 +76,9 @@ export const PageLink = {
 
   apiSessionReset: () => '/api/session/reset',
   apiSessionCreate: (ssn: string) => `/api/session/create/?ssn=${ssn}`,
-  apiCampaignAdd: ({ code, next }: CampaignAddRoute) => {
+  apiCampaign: ({ code, next }: CampaignAddRoute) => {
     const nextQueryParam = next ? `?next=${next}` : ''
-    return `/api/campaign/add/${code}${nextQueryParam}`
+    return `/api/campaign/${code}${nextQueryParam}`
   },
 } as const
 


### PR DESCRIPTION
## Justify why they are needed

Went through this the other day. It seems not to be used anywhere but it was wrong before since we don't have `api/campaign/add/<code>` api route.