### PR TITLE
GRW-2444  - feat(ImageTextBlock): better integrate with QuickPurchaseBlock

### DIFF
--- a/apps/store/src/blocks/ImageTextBlock.tsx
+++ b/apps/store/src/blocks/ImageTextBlock.tsx
@@ -20,6 +20,7 @@ type ImageTextBlockProps = SbBaseBlockProps<{
   image: ExpectedBlockType<ImageBlockProps>
   body?: SbBlokData[]
   orientation?: Orientation
+  // TODO: rename this to 'textVerticalAlignment'
   textAlignment?: TextAlignment
   textHorizontalAlignment?: TextHorizontalAlignment
   imagePlacement?: ImagePlacement

--- a/apps/store/src/blocks/ImageTextBlock.tsx
+++ b/apps/store/src/blocks/ImageTextBlock.tsx
@@ -8,10 +8,12 @@ import { ImageBlock, ImageBlockProps } from './ImageBlock'
 
 type Orientation = 'vertical' | 'fluid'
 type TextAlignment = 'top' | 'center' | 'bottom'
+type TextHorizontalAlignment = 'left' | 'center' | 'right'
 type ImagePlacement = 'left' | 'right'
 
 const DEFAULT_ORIENTATION: Orientation = 'vertical'
 const DEFAULT_TEXT_ALIGNMENT: TextAlignment = 'top'
+const DEFAULT_TEXT_HORIZONTAL_ALIGNMENT: TextHorizontalAlignment = 'left'
 const DEFAULT_IMAGE_PLACEMENT: ImagePlacement = 'right'
 
 type ImageTextBlockProps = SbBaseBlockProps<{
@@ -19,6 +21,7 @@ type ImageTextBlockProps = SbBaseBlockProps<{
   body?: SbBlokData[]
   orientation?: Orientation
   textAlignment?: TextAlignment
+  textHorizontalAlignment?: TextHorizontalAlignment
   imagePlacement?: ImagePlacement
 }>
 
@@ -36,6 +39,7 @@ export const ImageTextBlock = ({ blok }: ImageTextBlockProps) => {
           imageBlock={imageBlock}
           body={blok.body}
           textAlignment={blok.textAlignment}
+          textHorizontalAlignment={blok.textHorizontalAlignment}
           imagePlacement={blok.imagePlacement}
         />
       )
@@ -83,13 +87,14 @@ const VerticalBodyWrapper = styled.div({
 
 type FluidImageTextBlockProps = Pick<
   ImageTextBlockProps['blok'],
-  'body' | 'textAlignment' | 'imagePlacement'
+  'body' | 'textAlignment' | 'textHorizontalAlignment' | 'imagePlacement'
 > & { imageBlock?: ImageBlockProps['blok'] }
 
 const FluidImageTextBlock = ({
   imageBlock,
   body,
   textAlignment = DEFAULT_TEXT_ALIGNMENT,
+  textHorizontalAlignment = DEFAULT_TEXT_HORIZONTAL_ALIGNMENT,
   imagePlacement = DEFAULT_IMAGE_PLACEMENT,
 }: FluidImageTextBlockProps) => {
   return (
@@ -99,12 +104,16 @@ const FluidImageTextBlock = ({
           <ImageBlock key={imageBlock._uid} blok={imageBlock} nested={true} />
         </GridLayout.Content>
       )}
-      <FluidBodyWrapper textAlignment={textAlignment} imagePlacement={imagePlacement}>
-        <div>
+      <FluidBodyWrapper
+        imagePlacement={imagePlacement}
+        textAlignment={textAlignment}
+        textHorizontalAlignment={textHorizontalAlignment}
+      >
+        <FluidBodyInnerWrapper>
           {body?.map((nestedBlock) => (
             <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} nested={true} />
           ))}
-        </div>
+        </FluidBodyInnerWrapper>
       </FluidBodyWrapper>
     </FluidImageTextBlockWrapper>
   )
@@ -112,41 +121,52 @@ const FluidImageTextBlock = ({
 
 const FluidImageTextBlockWrapper = styled(GridLayout.Root)({
   paddingInline: theme.space.xs,
+  rowGap: theme.space.md,
 
   [mq.md]: {
     paddingInline: theme.space.md,
+  },
+  [mq.lg]: {
+    columnGap: theme.space.xxxl,
   },
 })
 
 export const FluidBodyWrapper = styled.div<{
   textAlignment: TextAlignment
+  textHorizontalAlignment: TextHorizontalAlignment
   imagePlacement: ImagePlacement
-}>(({ textAlignment, imagePlacement }) => ({
-  paddingBlock: theme.space.md,
-  paddingInline: theme.space.xs,
+}>(({ textAlignment, textHorizontalAlignment, imagePlacement }) => ({
   gridColumn: '1 / -1',
 
   [mq.lg]: {
+    gridColumn: 'span 6',
     display: 'flex',
     flexDirection: 'column',
     justifyContent: getTextAlignmentStyles(textAlignment),
-    gridColumn: 'span 6',
+    alignItems: getTextAlignmentStyles(textHorizontalAlignment),
     order: imagePlacement === 'right' ? -1 : 'initial',
-    maxWidth: '37.5rem',
-    paddingInline:
-      imagePlacement === 'right'
-        ? `${theme.space.xs} ${theme.space.xxl}`
-        : `${theme.space.xxl} ${theme.space.xs}`,
   },
 }))
 
-const getTextAlignmentStyles = (textAlignment: TextAlignment) => {
-  switch (textAlignment) {
+const FluidBodyInnerWrapper = styled.div({
+  paddingInline: theme.space.xs,
+  maxWidth: '37.5rem',
+
+  [mq.md]: {
+    paddingInline: 0,
+    maxWidth: 'initial',
+  },
+})
+
+const getTextAlignmentStyles = (alignment: TextAlignment | TextHorizontalAlignment) => {
+  switch (alignment) {
     case 'top':
+    case 'left':
       return 'flex-start'
     case 'center':
       return 'center'
     case 'bottom':
+    case 'right':
       return 'flex-end'
     default:
       return 'initial'

--- a/apps/store/src/blocks/QuickPurchaseBlock.tsx
+++ b/apps/store/src/blocks/QuickPurchaseBlock.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 import { useRouter } from 'next/router'
 import { useState, useMemo, type FormEventHandler } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ConditionalWrapper, theme } from 'ui'
+import { theme } from 'ui'
 import { OPEN_PRICE_CALCULATOR_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam'
 import {
   QuickPurchaseForm,
@@ -26,7 +26,7 @@ type QuickPurchaseBlockProps = SbBaseBlockProps<{
   campaignCode?: string
 }>
 
-export const QuickPurchaseBlock = ({ blok, nested }: QuickPurchaseBlockProps) => {
+export const QuickPurchaseBlock = ({ blok }: QuickPurchaseBlockProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<FormError>()
 
@@ -140,7 +140,7 @@ export const QuickPurchaseBlock = ({ blok, nested }: QuickPurchaseBlockProps) =>
   }
 
   return (
-    <ConditionalWrapper condition={!nested} wrapWith={(children) => <Wrapper>{children}</Wrapper>}>
+    <Wrapper>
       <QuickPurchaseForm
         productOptions={productOptions}
         onSubmit={handleSubmit}
@@ -150,13 +150,13 @@ export const QuickPurchaseBlock = ({ blok, nested }: QuickPurchaseBlockProps) =>
         ssnDefaultValue={shopSession?.customer?.ssn ?? ''}
         error={error}
       />
-    </ConditionalWrapper>
+    </Wrapper>
   )
 }
 QuickPurchaseBlock.blockName = 'quickPurchase'
 
 const Wrapper = styled.div({
-  width: 'min(25rem, 100%)',
-  margin: '0 auto',
+  width: 'min(24rem, 100%)',
+  marginInline: 'auto',
   paddingInline: theme.space.md,
 })

--- a/apps/store/src/components/QuickPurchaseForm/ProductSelector.tsx
+++ b/apps/store/src/components/QuickPurchaseForm/ProductSelector.tsx
@@ -33,9 +33,9 @@ export const ProductSelector = ({ productOptions, ...delegated }: Props) => {
       <SelectPrimitive.Portal>
         <SelectContent position="popper" sideOffset={4}>
           <SelectPrimitive.Viewport>
-            {productOptions.map((option) => (
+            {productOptions.map((option, index) => (
               <Fragment key={option.value}>
-                <Separator />
+                {index !== 0 && <Separator />}
                 <SelectItem value={option.value}>
                   <SelectPrimitive.ItemText asChild={true}>
                     <ItemDisplay>
@@ -72,10 +72,6 @@ const SelectTrigger = styled(SelectPrimitive.Trigger)({
 
   '&[data-placeholder]': {
     color: theme.colors.textSecondary,
-  },
-
-  '&:focus-visible': {
-    boxShadow: `0 0 0 2px ${theme.colors.textPrimary}`,
   },
 
   '&:invalid, &:disabled': {

--- a/apps/store/src/components/QuickPurchaseForm/QuickPurchaseForm.tsx
+++ b/apps/store/src/components/QuickPurchaseForm/QuickPurchaseForm.tsx
@@ -41,27 +41,25 @@ export const QuickPurchaseForm = ({
 
   return (
     <form onSubmit={onSubmit}>
-      <Space y={0.75}>
-        <Space y={0.5}>
-          <SsnField
-            name={SSN_FIELDNAME}
-            defaultValue={ssnDefaultValue}
-            required={true}
-            disabled={submitting}
-            warning={!!error?.ssn}
-            message={error?.ssn}
-            hidden={!showSsnField}
-          />
+      <Space y={0.25}>
+        <SsnField
+          name={SSN_FIELDNAME}
+          defaultValue={ssnDefaultValue}
+          required={true}
+          disabled={submitting}
+          warning={!!error?.ssn}
+          message={error?.ssn}
+          hidden={!showSsnField}
+        />
 
-          {productOptions.length > 1 && (
-            <ProductSelector
-              productOptions={productOptions}
-              name={PRODUCT_FIELDNAME}
-              disabled={submitting}
-              required={true}
-            />
-          )}
-        </Space>
+        {productOptions.length > 1 && (
+          <ProductSelector
+            productOptions={productOptions}
+            name={PRODUCT_FIELDNAME}
+            disabled={submitting}
+            required={true}
+          />
+        )}
 
         <Button type="submit" loading={submitting}>
           {t('BUTTON_LABEL_GET_PRICE')}


### PR DESCRIPTION
## Describe your changes

* Update `ImageTextBlock` so it became possible to configure horizontal alignment for its body content. This is intended to be used with `QuickPurchaseBlock`

<img width="2010" alt="image" src="https://user-images.githubusercontent.com/19200662/234318379-2a37a382-2199-4c82-bef3-7816f89346a2.png">

## Justify why they are needed

Requested by design.

## Jira issue(s): [GRW-2444](https://hedvig.atlassian.net/browse/GRW-2444)

[GRW-2444]: https://hedvig.atlassian.net/browse/GRW-2444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ