### PR TITLE
Remember to hide cart offer after user dismisses it

### DIFF
--- a/apps/store/src/components/CartInventory/CartEntryOfferItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryOfferItem.tsx
@@ -1,7 +1,8 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
-import { SyntheticEvent, useState } from 'react'
+import { atom, useAtom } from 'jotai'
+import { SyntheticEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button, theme, Text, Space, mq } from 'ui'
 import { Pillow } from '@/components/Pillow/Pillow'
@@ -22,7 +23,7 @@ type CartOfferItemProps = {
   offer: OfferRecommendationFragment
 }
 export const CartEntryOfferItem = ({ cartId, product, offer }: CartOfferItemProps) => {
-  const [show, setShow] = useState(true)
+  const [show, setShow] = useShowCartEntryOffer()
   const { t } = useTranslation('cart')
   const formatter = useFormatter()
 
@@ -152,3 +153,9 @@ const GhostButton = styled(Button)({
     },
   },
 })
+
+const SHOW_CART_OFFER_ATOM = atom(true)
+
+const useShowCartEntryOffer = () => {
+  return useAtom(SHOW_CART_OFFER_ATOM)
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Store whether to show cart offer in global jotai atom

[Screen Recording 2023-04-26 at 16.23.44.mov](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/0aea08ca-1aeb-4d8d-9f00-4375f6e1d8dc/Screen%20Recording%202023-04-26%20at%2016.23.44.mov)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Remember to hide cart offer in cart/checkout after user has dismissed it. Right now you can dismiss it and then it appears after navigating to the checkout page.

- This solution only supports hiding none/all cart offers, not individual ones. When we support that we can come up with a more robust solution perhaps.

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
