### PR TITLE
feat(ContentBlock): add support for heading level

### DIFF
--- a/apps/store/src/blocks/ContentBlock.tsx
+++ b/apps/store/src/blocks/ContentBlock.tsx
@@ -9,6 +9,7 @@ type Alignment = 'left' | 'center' | 'right' | 'justify'
 export type Props = SbBaseBlockProps<{
   body: ISbRichtext
   heading?: string
+  headingLevel?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
   alignment?: Alignment
 }>
 
@@ -17,7 +18,7 @@ export const ContentBlock = ({ blok }: Props) => {
 
   return (
     <Wrapper {...storyblokEditable(blok)} y={1}>
-      {blok.heading && <Badge>{blok.heading}</Badge>}
+      {blok.heading && <Badge as={blok.headingLevel ?? 'h2'}>{blok.heading}</Badge>}
       <TextWrapper alignment={blok.alignment ?? 'left'}>
         <Space y={1} dangerouslySetInnerHTML={{ __html: contentHtml }} />
       </TextWrapper>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Adds a property to `ContentBlock` where editors could configure the heading level. `h2` will be the one used in case none is provided.

## Justify why they are needed

It's necessary for the full merge of hedvig-dot-com.

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

