### PR TITLE
chore(pr-template): removes 'Jira Ticket' section.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,13 +12,6 @@ If it makes sense, add screenshots and/or screen recordings here.
 
 ## Justify why they are needed
 
-## Jira issue(s): []
-
-<!--
-If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
-A link to that issue will automatically be created.
--->
-
 ## Checklist before requesting a review
 
 - [ ] I have performed a self-review of my code


### PR DESCRIPTION
Disclaimer: Maybe we don't need to get this merged now. We can wait until we actually "pull the plug".

## Describe your changes

Removes 'Jira Ticket' section from PR Template

## Justify why they are needed

We're moving away from Jira.