### PR TITLE
Update type to catch undefined reusable stories

### DIFF
--- a/apps/store/src/blocks/ReusableBlockReference.tsx
+++ b/apps/store/src/blocks/ReusableBlockReference.tsx
@@ -2,13 +2,13 @@ import { StoryblokComponent } from '@storyblok/react'
 import { ReusableStory, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
 type ReusableBlockReferenceProps = SbBaseBlockProps<{
-  reference: ReusableStory
+  reference: Omit<ReusableStory, 'content'> & Partial<Pick<ReusableStory, 'content'>>
 }>
 
 export const ReusableBlockReference = ({ blok }: ReusableBlockReferenceProps) => {
   return (
     <>
-      {blok.reference.content.body.map((nestedBlock) => (
+      {blok.reference.content?.body.map((nestedBlock) => (
         <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
       ))}
     </>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
See thread here https://hedviginsurance.slack.com/archives/G01MARCFUUW/p1682600497217479

Quick solution proposed by @alebedev 

Couldn't update the `ReusableStory` type since that would cause this error:
```
Property 'content' is optional in type 'ReusableStory' but required in type 
'ISbStoryData<(ISbComponentType<string> & { [index: string]: any; } & { body: SbBlokData[]; }) | undefined>'.
```

This fixes the error in the browser. But the cause is when you edit something on a page in storyblok and enter preview mode, the content from reusable blocks disappear. So I wonder if we need to resolve relations properly when entering preview mode 🧐  https://www.storyblok.com/tp/using-relationship-resolving-to-include-other-content-entries#using-the-storyblok-bridge
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Crashes storyblok when editing pages using reusable stories

## Jira issue(s): []

<!--
If there is a Jira issue, add the key (e.g. GRW-123) between the brackets.
A link to that issue will automatically be created.
-->

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
