### PR TITLE
Include asset prefix for next/image URLs

### DIFF
--- a/apps/onboarding/next.config.js
+++ b/apps/onboarding/next.config.js
@@ -8,6 +8,8 @@ const nextConfig = {
   i18n,
   images: {
     domains: ['promise.hedvig.com'],
+    // Required to work with "assetPrefix": https://github.com/vercel/next.js/issues/20968#issuecomment-1015328088
+    path: isProd ? `${process.env.ASSET_PREFIX}/_next/image` : undefined,
   },
   compiler: {
     emotion: true,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Include asset prefix for next/image URLs

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

The global asset prefix doesn't automatically apply to "next/image"

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
