### PR TITLE
Fallback to cached_url if linked story is missing

### DIFF
--- a/apps/store/src/components/ContactSupport/ContactSupport.stories.tsx
+++ b/apps/store/src/components/ContactSupport/ContactSupport.stories.tsx
@@ -16,6 +16,7 @@ const linkField: LinkField = {
   id: '1234',
   url: 'https://hedvigapp.typeform.com/to/p0m0QakI',
   linktype: 'url',
+  cached_url: 'https://hedvigapp.typeform.com/to/p0m0QakI',
 }
 
 export const Default = Template.bind({})

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -58,18 +58,19 @@ export const fetchStory = async <StoryData extends ISbStoryData | undefined>(
   return story as StoryData
 }
 
-const missingLinks = new Set()
+const MISSING_LINKS = new Set()
 export const getLinkFieldURL = (link: LinkField, linkText?: string) => {
   if (link.story) return makeAbsolute(link.story.url)
 
   if (link.linktype === 'url') return makeAbsolute(link.url)
 
   // Warn about CMS links without target. This could be either reference to something not yet created or misconfiguration
-  if (!missingLinks.has(link.id)) {
-    missingLinks.add(link.id)
+  if (!MISSING_LINKS.has(link.id)) {
+    MISSING_LINKS.add(link.id)
     console.log('Did not see story field in link, returning empty URL.', linkText, link)
   }
-  return '/'
+
+  return makeAbsolute(link.cached_url)
 }
 
 const makeAbsolute = (url: string) => {

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -105,6 +105,7 @@ export type LinkField = {
   url: string
   linktype: 'multilink' | 'story' | 'url'
   target?: string
+  cached_url: string
   story?: {
     id: number
     uuid: string


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

See title.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

1. This should be more accurate than simply falling back to `/`, right?

2. I'm not sure why we are not seeing getting the link in the first place 🤔 we should ask Storyblok so we make sure we understand it correctly.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
