### PR TITLE
Move switching assistant to confirmation page

### DIFF
--- a/apps/store/src/components/CheckoutHeader/CheckoutHeader.helpers.ts
+++ b/apps/store/src/components/CheckoutHeader/CheckoutHeader.helpers.ts
@@ -3,7 +3,6 @@ import {
   CurrentMemberDocument,
   CurrentMemberQuery,
   CurrentMemberQueryVariables,
-  ExternalInsuranceCancellationOption as CancellationOption,
 } from '@/services/apollo/generated'
 import { getAccessToken } from '@/services/authApi/persist'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
@@ -17,12 +16,7 @@ type Params = {
   shopSession: Pick<ShopSession, 'cart'>
 } & CookieParams
 
-export const fetchCheckoutSteps = async ({ apolloClient, req, res, shopSession }: Params) => {
-  const switchingEntry = shopSession.cart.entries.find(
-    ({ cancellation }) => cancellation.option === CancellationOption.Banksignering,
-  )
-  const showSwitchingAssistant = !!switchingEntry
-
+export const fetchCheckoutSteps = async ({ apolloClient, req, res }: Params) => {
   let showPayment = true
   // NOTE: Cannot rely on shopSession.customer.authenticationStatus if session is complete (we'd NONE for new members)
   const isAuthenticated = !!getAccessToken({ req, res })
@@ -37,7 +31,6 @@ export const fetchCheckoutSteps = async ({ apolloClient, req, res, shopSession }
   const steps: Array<CheckoutStep> = [CheckoutStep.Checkout]
 
   if (showPayment) steps.push(CheckoutStep.Payment)
-  if (showSwitchingAssistant) steps.push(CheckoutStep.SwitchingAssistant)
   if (steps.length < 3) steps.push(CheckoutStep.Confirmation)
   if (steps.length < 3) steps.push(CheckoutStep.Done)
   return steps

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -16,6 +16,7 @@ import { CheckList, CheckListItem } from './CheckList'
 import { ConfirmationPageProps } from './ConfirmationPage.types'
 import qrCodeImage from './download-app-qrcode.png'
 import { ImageSection } from './ImageSection'
+import { SwitchingAssistantSection } from './SwitchingAssistantSection'
 
 type Props = ConfirmationPageProps & {
   story: ConfirmationStory
@@ -41,7 +42,14 @@ export const ConfirmationPage = (props: Props) => {
                 <CartInventory shopSessionId={props.shopSessionId} cart={cart} readOnly />
               </Space>
 
-              <Space y={1}>
+              {props.switching && (
+                <SwitchingAssistantSection
+                  shopSessionId={props.shopSessionId}
+                  {...props.switching}
+                />
+              )}
+
+              <Space y={{ base: 1.5, lg: 2 }}>
                 <div>
                   <Heading as="h2" variant="standard.24">
                     {story.content.checklistTitle}

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
@@ -6,4 +6,7 @@ export type ConfirmationPageProps = Pick<StoryblokPageProps, 'globalStory'> & {
   platform: 'apple' | 'google' | null
   cart: CartFragmentFragment
   shopSessionId: string
+  switching?: {
+    companyDisplayName: string
+  }
 }

--- a/apps/store/src/components/ConfirmationPage/ContractCard.tsx
+++ b/apps/store/src/components/ConfirmationPage/ContractCard.tsx
@@ -4,7 +4,7 @@ import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Button, Space, Text, theme } from 'ui'
+import { Button, Space, Text, mq, theme } from 'ui'
 import { useBankSigneringInitMutation } from '@/services/apollo/generated'
 import { useAppErrorHandleContext } from '@/services/appErrors/AppErrorContext'
 import { useFormatter } from '@/utils/useFormatter'
@@ -22,13 +22,7 @@ export const ContractCard = (props: BankSigneringContract) => {
   )
 }
 
-const PendingContractCard = ({
-  id,
-  status,
-  displayName,
-  company,
-  approveByDate,
-}: ContractCardProps) => {
+const PendingContractCard = ({ id, status, displayName, approveByDate }: ContractCardProps) => {
   const { t } = useTranslation('checkout')
   const formatter = useFormatter()
   const windowRef = useRef<Window | null>(null)
@@ -64,12 +58,12 @@ const PendingContractCard = ({
   }
 
   return (
-    <Card>
+    <PendingCard>
       <Space y={1}>
         <PendingStatusPill>{status.message}</PendingStatusPill>
         <Space y={1}>
           <div>
-            <Text>{[displayName, company].join(' · ')}</Text>
+            <Text>{displayName}</Text>
             <Text color="textSecondary">
               {t('SWITCHING_ASSISTANT_BANK_SIGNERING_MESSAGE', {
                 date: formatter.fromNow(approveByDate),
@@ -81,11 +75,11 @@ const PendingContractCard = ({
           </Button>
         </Space>
       </Space>
-    </Card>
+    </PendingCard>
   )
 }
 
-const CompletedContractCard = ({ status, displayName, company }: ContractCardProps) => {
+const CompletedContractCard = ({ status, displayName }: ContractCardProps) => {
   const { t } = useTranslation('checkout')
 
   return (
@@ -93,7 +87,7 @@ const CompletedContractCard = ({ status, displayName, company }: ContractCardPro
       <Space y={1}>
         <CompletedStatusPill>{status.message}</CompletedStatusPill>
         <div>
-          <Text>{[displayName, company].join(' · ')}</Text>
+          <Text>{displayName}</Text>
           <Text color="textSecondary">
             {t('SWITCHING_ASSISTANT_BANK_SIGNERING_MESSAGE_COMPLETED')}
           </Text>
@@ -103,11 +97,19 @@ const CompletedContractCard = ({ status, displayName, company }: ContractCardPro
   )
 }
 
+const CARD_HEIGHT = '9.75rem'
+
 const Card = styled.div({
   padding: theme.space.md,
   backgroundColor: theme.colors.gray100,
   borderRadius: theme.radius.md,
+
+  [mq.lg]: {
+    padding: theme.space.lg,
+  },
 })
+
+const PendingCard = styled(Card)({ backgroundColor: theme.colors.amberFill1 })
 
 const pulsingAnimation = keyframes({
   '0%': {
@@ -122,8 +124,12 @@ const pulsingAnimation = keyframes({
 })
 
 export const CardSkeleton = styled(Card)({
-  height: '11.75rem',
+  height: `calc(${CARD_HEIGHT} + ${theme.space.md} * 2)`,
   animation: `${pulsingAnimation} 1.5s ease-in-out infinite`,
+
+  [mq.lg]: {
+    height: `calc(${CARD_HEIGHT} + ${theme.space.lg} * 2)`,
+  },
 })
 
 const Pill = styled.div({
@@ -136,21 +142,25 @@ const Pill = styled.div({
   alignItems: 'center',
 })
 
+const PendingPill = styled(Pill)({
+  backgroundColor: theme.colors.amber200,
+})
+
 const PillStatus = styled.div({
-  height: theme.space.xs,
-  width: theme.space.xs,
+  height: theme.space.sm,
+  width: theme.space.sm,
   borderRadius: '50%',
-  backgroundColor: theme.colors.amber600,
+  backgroundColor: theme.colors.amberElement,
 })
 
 type StatusPillProps = { children: string }
 
 const PendingStatusPill = ({ children }: StatusPillProps) => {
   return (
-    <Pill>
+    <PendingPill>
       <PillStatus color={theme.colors.amber600} />
       <Text size="xs">{children}</Text>
-    </Pill>
+    </PendingPill>
   )
 }
 

--- a/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection.tsx
+++ b/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from 'next-i18next'
+import { Heading, Space, Text } from 'ui'
+import { CardSkeleton, ContractCard } from './ContractCard'
+import { useSwitchingContracts } from './useSwitchingContracts'
+
+type Props = {
+  shopSessionId: string
+  companyDisplayName: string
+}
+
+export const SwitchingAssistantSection = (props: Props) => {
+  const { t } = useTranslation('checkout')
+  const switchingContracts = useSwitchingContracts({ shopSessionId: props.shopSessionId })
+
+  return (
+    <Space y={{ base: 1.5, lg: 2 }}>
+      <div>
+        <Heading as="h2" variant="standard.24">
+          {t('CONFIRMATION_SWITCHING_TITLE')}
+        </Heading>
+        <Text as="p" color="textSecondary" size="xl">
+          {t('CONFIRMATION_SWITCHING_SUBTITLE', { company: props.companyDisplayName })}
+        </Text>
+      </div>
+      {switchingContracts.length === 0 ? <CardSkeleton /> : switchingContracts.map(ContractCard)}
+    </Space>
+  )
+}

--- a/apps/store/src/components/ConfirmationPage/useSwitchingContracts.ts
+++ b/apps/store/src/components/ConfirmationPage/useSwitchingContracts.ts
@@ -12,7 +12,6 @@ export type BankSigneringContract = {
     type: 'PENDING' | 'COMPLETED'
     message: string
   }
-  company: string
   approveByDate: Date
 }
 
@@ -20,7 +19,7 @@ type Params = { shopSessionId: string }
 
 export const useSwitchingContracts = ({ shopSessionId }: Params) => {
   const { data, refetch } = useShopSessionOutcomeQuery({
-    variables: { id: shopSessionId },
+    variables: { shopSessionId },
     pollInterval: 10000,
   })
   const getStatus = useGetStatus()
@@ -31,7 +30,7 @@ export const useSwitchingContracts = ({ shopSessionId }: Params) => {
     return () => window.removeEventListener('focus', handler)
   }, [refetch])
 
-  return useMemo(() => {
+  return useMemo<Array<BankSigneringContract>>(() => {
     const contracts = data?.shopSession.outcome?.createdContracts ?? []
     const switchingContracts: Array<BankSigneringContract> = []
 
@@ -52,9 +51,10 @@ export const useSwitchingContracts = ({ shopSessionId }: Params) => {
 
       switchingContracts.push({
         id: contract.id,
-        displayName: contract.variant.displayName,
+        displayName: [contract.variant.displayName, cancellation.externalInsurer.displayName].join(
+          ' · ',
+        ),
         status: getStatus(cancellation.status),
-        company: cancellation.externalInsurer.displayName,
         approveByDate,
       })
     })

--- a/apps/store/src/components/SwitchingAssistantPage/SwitchingAssistantPage.tsx
+++ b/apps/store/src/components/SwitchingAssistantPage/SwitchingAssistantPage.tsx
@@ -1,3 +1,5 @@
+// TODO: No longer used; remove.
+
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import Link from 'next/link'
@@ -5,10 +7,10 @@ import { Heading, mq, Space, theme } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { CheckoutStep } from '@/components/CheckoutHeader/Breadcrumbs'
 import { CheckoutHeader } from '@/components/CheckoutHeader/CheckoutHeader'
+import { CardSkeleton, ContractCard } from '@/components/ConfirmationPage/ContractCard'
+import { useSwitchingContracts } from '@/components/ConfirmationPage/useSwitchingContracts'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { PageLink } from '@/utils/PageLink'
-import { CardSkeleton, ContractCard } from './ContractCard'
-import { useSwitchingContracts } from './useSwitchingContracts'
 
 export type SwitchingAssistantPageProps = {
   checkoutSteps: Array<CheckoutStep>

--- a/apps/store/src/graphql/ShopSessionOutcome.graphql
+++ b/apps/store/src/graphql/ShopSessionOutcome.graphql
@@ -1,5 +1,5 @@
-query ShopSessionOutcome($id: UUID!) {
-  shopSession(id: $id) {
+query ShopSessionOutcome($shopSessionId: UUID!) {
+  shopSession(id: $shopSessionId) {
     outcome {
       id
       createdContracts {

--- a/apps/store/src/pages/checkout/[shopSessionId]/switching-assistant.tsx
+++ b/apps/store/src/pages/checkout/[shopSessionId]/switching-assistant.tsx
@@ -1,3 +1,5 @@
+// TODO: No longer used; remove.
+
 import type { GetServerSideProps, NextPage } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { fetchCheckoutSteps } from '@/components/CheckoutHeader/CheckoutHeader.helpers'

--- a/apps/store/src/services/shopSession/ShopSessionService.ts
+++ b/apps/store/src/services/shopSession/ShopSessionService.ts
@@ -4,6 +4,9 @@ import {
   ShopSessionCreateMutation,
   ShopSessionCreateMutationVariables,
   ShopSessionDocument,
+  ShopSessionOutcomeDocument,
+  ShopSessionOutcomeQuery,
+  ShopSessionOutcomeQueryVariables,
   ShopSessionQuery,
   ShopSessionQueryVariables,
 } from '@/services/apollo/generated'
@@ -94,5 +97,18 @@ export class ShopSessionService {
     this.saveId(shopSession.id)
 
     return shopSession
+  }
+
+  public async fetchOutcome(
+    shopSessionId: string,
+  ): Promise<ShopSessionOutcomeQuery['shopSession']['outcome']> {
+    const { data } = await this.apolloClient.query<
+      ShopSessionOutcomeQuery,
+      ShopSessionOutcomeQueryVariables
+    >({
+      query: ShopSessionOutcomeDocument,
+      variables: { shopSessionId },
+    })
+    return data.shopSession.outcome
   }
 }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -168,13 +168,10 @@ export type ConfirmationStory = ISbStoryData & {
   content: ISbStoryData['content'] & {
     body: Array<SbBlokData>
     title: string
-    subtitle: string
-    footerTitle: string
-    footerSubtitle: string
-    footerImage: StoryblokAsset
     checklistTitle: string
     checklistSubtitle: string
     checklist: string
+    footerImage: StoryblokAsset
     seoTitle: string
   }
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Move switching assistant module to the confirmation page.

- Skip "switching assistant" step during checkout flow.


![Screenshot 2023-05-03 at 09.14.29.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/f9de29eb-3039-40c5-99b7-192422f45587/Screenshot%202023-05-03%20at%2009.14.29.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Updates from design.

- I didn't remove all of the code related to switching assistant page in this PR to make it easier to revert if needed.

- I haven't been able to test it out end-2-end since I don't have a car 😛

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
 