### PR TITLE
Make sure full width works on larger breakpoints

### DIFF
--- a/apps/store/src/components/GridLayout/GridLayout.helper.tsx
+++ b/apps/store/src/components/GridLayout/GridLayout.helper.tsx
@@ -40,7 +40,11 @@ export const getGridLayout = (width: ContentWidth, align: ContentAlignment = 'le
 }
 
 const RESPONSIVE_STYLES: Record<ColumnWidth, Record<ContentAlignment, CSSObject>> = {
-  '1': { left: {}, center: {}, right: {} },
+  '1': {
+    left: { gridColumn: '1 / span 12' },
+    center: { gridColumn: '1 / span 12' },
+    right: { gridColumn: '1 / span 12' },
+  },
   '2/3': {
     left: { gridColumn: 'auto / span 8' },
     center: { gridColumn: '3 / span 8' },


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
If you pick full width on a larger breakpoint after defining a smaller one, it wouldn't work since we just return an empty object

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
