### PR TITLE
Re-create price intent after adding to cart

### DIFF
--- a/apps/store/src/components/ProductPage/PriceIntentContext.tsx
+++ b/apps/store/src/components/ProductPage/PriceIntentContext.tsx
@@ -1,5 +1,4 @@
 import { useApolloClient } from '@apollo/client'
-import { useRouter } from 'next/router'
 import {
   createContext,
   PropsWithChildren,
@@ -68,14 +67,18 @@ const usePriceIntentContextValue = () => {
     },
   })
 
-  const router = useRouter()
   const createNewPriceIntent = useCallback(
     async (shopSession: ShopSession) => {
       const service = priceIntentServiceInitClientSide(apolloClient)
       service.clear(priceTemplate.name, shopSession.id)
-      await router.replace(router.asPath)
+      const priceIntent = await service.getOrCreate({
+        priceTemplate,
+        productName: productData.name,
+        shopSessionId: shopSession.id,
+      })
+      setPriceIntentId(priceIntent.id)
     },
-    [apolloClient, priceTemplate, router],
+    [apolloClient, priceTemplate, productData.name],
   )
 
   useEffect(


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Create a new price intent after adding to cart and refresh price calculator

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We had a bug before where we didn't create a new price intent after adding to cart.

Instead we just removed the cookie and "refreshed" the page. But since it's now a static page nothing really happened. This is now fixed.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
