### PR TITLE
Add GridBlock component 

### DIFF
--- a/apps/store/src/blocks/GridBlock.tsx
+++ b/apps/store/src/blocks/GridBlock.tsx
@@ -65,6 +65,7 @@ const Wrapper = styled.div({
   display: 'grid',
   gridTemplateColumns: 'repeat(12, 1fr)',
   columnGap: theme.space.md,
+  rowGap: theme.space.xxl,
 })
 
 const Column = styled.div<ColumnProps>(({ columns }) => ({

--- a/apps/store/src/blocks/GridBlock.tsx
+++ b/apps/store/src/blocks/GridBlock.tsx
@@ -63,12 +63,15 @@ GridBlock.blockName = 'grid'
 
 const Wrapper = styled.div({
   display: 'grid',
-  gridTemplateColumns: 'repeat(12, 1fr)',
   columnGap: theme.space.md,
   rowGap: theme.space.xxl,
+  marginInline: 'auto',
+
+  [mq.md]: {
+    gridTemplateColumns: 'repeat(12, 1fr)',
+  },
 })
 
 const Column = styled.div<ColumnProps>(({ columns }) => ({
-  gridColumn: '1 / span 12',
   ...COLUMN_STYLES[columns],
 }))

--- a/apps/store/src/blocks/GridBlock.tsx
+++ b/apps/store/src/blocks/GridBlock.tsx
@@ -1,0 +1,73 @@
+import styled, { CSSObject } from '@emotion/styled'
+import { StoryblokComponent, storyblokEditable } from '@storyblok/react'
+import { mq, theme } from 'ui'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { ImageTextBlockProps } from './ImageTextBlock'
+import { Layout } from './TextContentBlock'
+
+type ColumnBloks = ExpectedBlockType<ImageTextBlockProps>
+
+type ColumnProps = { columns: 2 | 3 | 4 }
+
+type GridBlockProps = SbBaseBlockProps<{
+  title?: string
+  columns: ColumnBloks
+  layout?: Layout
+}>
+
+const COLUMN_STYLES: Record<number, CSSObject> = {
+  2: {
+    [mq.md]: { gridColumn: 'auto / span 6' },
+  },
+  3: {
+    [mq.md]: { gridColumn: 'auto / span 4' },
+  },
+  4: {
+    [mq.md]: { gridColumn: 'auto / span 6' },
+    [mq.lg]: { gridColumn: 'auto / span 3' },
+  },
+}
+
+const getColumns = (items: ColumnBloks) => {
+  const noOfItems = items.length
+  switch (noOfItems) {
+    case 1:
+    case 2:
+      return 2
+    case 3:
+      return 3
+    default:
+      return 4
+  }
+}
+
+export const GridBlock = ({ blok }: GridBlockProps) => {
+  const columns = getColumns(blok.columns)
+  return (
+    <GridLayout.Root {...storyblokEditable(blok)}>
+      <GridLayout.Content width={blok.layout?.widths ?? { base: '1' }} align="center">
+        <Wrapper>
+          {blok.columns.map((nestedBlock) => (
+            <Column key={nestedBlock._uid} columns={columns}>
+              <StoryblokComponent blok={nestedBlock} nested={true} />
+            </Column>
+          ))}
+        </Wrapper>
+      </GridLayout.Content>
+    </GridLayout.Root>
+  )
+}
+
+GridBlock.blockName = 'grid'
+
+const Wrapper = styled.div({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(12, 1fr)',
+  columnGap: theme.space.md,
+})
+
+const Column = styled.div<ColumnProps>(({ columns }) => ({
+  gridColumn: '1 / span 12',
+  ...COLUMN_STYLES[columns],
+}))

--- a/apps/store/src/blocks/ImageTextBlock.tsx
+++ b/apps/store/src/blocks/ImageTextBlock.tsx
@@ -16,7 +16,7 @@ const DEFAULT_TEXT_ALIGNMENT: TextAlignment = 'top'
 const DEFAULT_TEXT_HORIZONTAL_ALIGNMENT: TextHorizontalAlignment = 'left'
 const DEFAULT_IMAGE_PLACEMENT: ImagePlacement = 'right'
 
-type ImageTextBlockProps = SbBaseBlockProps<{
+export type ImageTextBlockProps = SbBaseBlockProps<{
   image: ExpectedBlockType<ImageBlockProps>
   body?: SbBlokData[]
   orientation?: Orientation

--- a/apps/store/src/blocks/ImageTextBlock.tsx
+++ b/apps/store/src/blocks/ImageTextBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { SbBlokData, StoryblokComponent } from '@storyblok/react'
-import { mq, theme } from 'ui'
+import { ConditionalWrapper, mq, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { SbBaseBlockProps, ExpectedBlockType } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
@@ -26,7 +26,7 @@ export type ImageTextBlockProps = SbBaseBlockProps<{
   imagePlacement?: ImagePlacement
 }>
 
-export const ImageTextBlock = ({ blok }: ImageTextBlockProps) => {
+export const ImageTextBlock = ({ blok, nested }: ImageTextBlockProps) => {
   const { orientation = DEFAULT_ORIENTATION } = blok
   // We expect only one image from Storyblok
   const imageBlock = Array.isArray(blok.image)
@@ -42,10 +42,11 @@ export const ImageTextBlock = ({ blok }: ImageTextBlockProps) => {
           textAlignment={blok.textAlignment}
           textHorizontalAlignment={blok.textHorizontalAlignment}
           imagePlacement={blok.imagePlacement}
+          nested={nested}
         />
       )
     case 'vertical':
-      return <VerticalImageTextBlock imageBlock={imageBlock} body={blok.body} />
+      return <VerticalImageTextBlock imageBlock={imageBlock} body={blok.body} nested={nested} />
     default:
       console.warn(`orientation type '${orientation}' is not valid`)
       return null
@@ -53,30 +54,25 @@ export const ImageTextBlock = ({ blok }: ImageTextBlockProps) => {
 }
 ImageTextBlock.blockName = 'imageText'
 
-type VerticalImageTextBlockProps = Pick<ImageTextBlockProps['blok'], 'body'> & {
+type VerticalImageTextBlockProps = Pick<ImageTextBlockProps['blok'], 'body' | 'nested'> & {
   imageBlock?: ImageBlockProps['blok']
 }
 
-const VerticalImageTextBlock = ({ imageBlock, body }: VerticalImageTextBlockProps) => {
+const VerticalImageTextBlock = ({ imageBlock, body, nested }: VerticalImageTextBlockProps) => {
   return (
-    <VerticalImageTextBlockWrapper>
+    <ConditionalWrapper
+      condition={!nested}
+      wrapWith={(children) => <ImageTextBlockWrapper>{children}</ImageTextBlockWrapper>}
+    >
       {imageBlock && <ImageBlock key={imageBlock._uid} blok={imageBlock} nested={true} />}
       <VerticalBodyWrapper>
         {body?.map((nestedBlock) => (
           <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} nested={true} />
         ))}
       </VerticalBodyWrapper>
-    </VerticalImageTextBlockWrapper>
+    </ConditionalWrapper>
   )
 }
-
-const VerticalImageTextBlockWrapper = styled.div({
-  paddingInline: theme.space.xs,
-
-  [mq.md]: {
-    paddingInline: theme.space.md,
-  },
-})
 
 const VerticalBodyWrapper = styled.div({
   padding: theme.space.xs,
@@ -88,7 +84,7 @@ const VerticalBodyWrapper = styled.div({
 
 type FluidImageTextBlockProps = Pick<
   ImageTextBlockProps['blok'],
-  'body' | 'textAlignment' | 'textHorizontalAlignment' | 'imagePlacement'
+  'body' | 'textAlignment' | 'textHorizontalAlignment' | 'imagePlacement' | 'nested'
 > & { imageBlock?: ImageBlockProps['blok'] }
 
 const FluidImageTextBlock = ({
@@ -97,38 +93,48 @@ const FluidImageTextBlock = ({
   textAlignment = DEFAULT_TEXT_ALIGNMENT,
   textHorizontalAlignment = DEFAULT_TEXT_HORIZONTAL_ALIGNMENT,
   imagePlacement = DEFAULT_IMAGE_PLACEMENT,
+  nested,
 }: FluidImageTextBlockProps) => {
   return (
-    <FluidImageTextBlockWrapper>
-      {imageBlock && (
-        <GridLayout.Content width="1/2">
-          <ImageBlock key={imageBlock._uid} blok={imageBlock} nested={true} />
-        </GridLayout.Content>
-      )}
-      <FluidBodyWrapper
-        imagePlacement={imagePlacement}
-        textAlignment={textAlignment}
-        textHorizontalAlignment={textHorizontalAlignment}
-      >
-        <FluidBodyInnerWrapper>
-          {body?.map((nestedBlock) => (
-            <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} nested={true} />
-          ))}
-        </FluidBodyInnerWrapper>
-      </FluidBodyWrapper>
-    </FluidImageTextBlockWrapper>
+    <ConditionalWrapper
+      condition={!nested}
+      wrapWith={(children) => <ImageTextBlockWrapper>{children}</ImageTextBlockWrapper>}
+    >
+      <FluidImageTextBlockGrid>
+        {imageBlock && (
+          <GridLayout.Content width="1/2">
+            <ImageBlock key={imageBlock._uid} blok={imageBlock} nested={true} />
+          </GridLayout.Content>
+        )}
+        <FluidBodyWrapper
+          imagePlacement={imagePlacement}
+          textAlignment={textAlignment}
+          textHorizontalAlignment={textHorizontalAlignment}
+        >
+          <FluidBodyInnerWrapper>
+            {body?.map((nestedBlock) => (
+              <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} nested={true} />
+            ))}
+          </FluidBodyInnerWrapper>
+        </FluidBodyWrapper>
+      </FluidImageTextBlockGrid>
+    </ConditionalWrapper>
   )
 }
 
-const FluidImageTextBlockWrapper = styled(GridLayout.Root)({
-  paddingInline: theme.space.xs,
+const FluidImageTextBlockGrid = styled(GridLayout.Root)({
   rowGap: theme.space.md,
+
+  [mq.lg]: {
+    columnGap: theme.space.xxxl,
+  },
+})
+
+const ImageTextBlockWrapper = styled.div({
+  paddingInline: theme.space.xs,
 
   [mq.md]: {
     paddingInline: theme.space.md,
-  },
-  [mq.lg]: {
-    columnGap: theme.space.xxxl,
   },
 })
 

--- a/apps/store/src/components/GridLayout/GridLayout.helper.tsx
+++ b/apps/store/src/components/GridLayout/GridLayout.helper.tsx
@@ -3,7 +3,7 @@ import { mq, Level } from 'ui'
 
 type PartialRecord<K extends keyof any, T> = Partial<Record<K, T>>
 
-export type ColumnWidth = '1' | '2/3' | '1/2' | '1/3'
+export type ColumnWidth = '1' | '5/6' | '2/3' | '1/2' | '1/3'
 export type ContentAlignment = 'left' | 'center' | 'right'
 export type ContentWidth = ColumnWidth | PartialRecord<Level | 'base', ColumnWidth>
 
@@ -44,6 +44,11 @@ const RESPONSIVE_STYLES: Record<ColumnWidth, Record<ContentAlignment, CSSObject>
     left: { gridColumn: '1 / span 12' },
     center: { gridColumn: '1 / span 12' },
     right: { gridColumn: '1 / span 12' },
+  },
+  '5/6': {
+    left: { gridColumn: '1 / span 10' },
+    center: { gridColumn: '2 / span 10' },
+    right: { gridColumn: '3 / span 10' },
   },
   '2/3': {
     left: { gridColumn: 'auto / span 8' },
@@ -91,8 +96,13 @@ const thirdLeftStyles: CSSObject = {
   [mq.xl]: { gridColumn: 'auto / span 4' },
 }
 
+const fiveSixthsCenterStyles: CSSObject = {
+  [mq.lg]: { gridColumn: '2 / span 10' },
+}
+
 const STYLES: Record<ColumnWidth, Record<ContentAlignment, CSSObject>> = {
   '1': { left: {}, center: {}, right: {} },
+  '5/6': { left: {}, center: fiveSixthsCenterStyles, right: {} },
   '2/3': {
     left: {},
     center: twoThirdsCenterStyles,

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -16,6 +16,7 @@ import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
 import { ContactSupportBlock } from '@/blocks/ContactSupportBlock'
 import { ContentBlock } from '@/blocks/ContentBlock'
 import { FooterBlock, FooterBlockProps, FooterLink, FooterSection } from '@/blocks/FooterBlock'
+import { GridBlock } from '@/blocks/GridBlock'
 import {
   HeaderBlock,
   HeaderBlockProps,
@@ -205,6 +206,7 @@ export const initStoryblok = () => {
     FooterSection,
     ReusableBlockReference,
     // TODO: Header vs Heading is easy to confuse.  Discuss with team if we should rename one of these
+    GridBlock,
     HeaderBlock,
     HeadingBlock,
     HeadingLabelBlock,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
A block where you can add a number of blocks in a grid/column layout. 
To start with only ImageTextBlock. 
The layout is defined based on how many items you add to the grid and you can set the max width on the wrapper with the layout settings in Storyblok

[Review app](https://hedvig-dot-com-git-feat-add-grid-block-hedvig.vercel.app/api/preview?secret=DWafxGrY6M8&slug=se/hedvig/legal-information-copy&_storyblok=266110806&_storyblok_c=page&_storyblok_version=&_storyblok_lang=default&_storyblok_release=0&_storyblok_rl=1683276629798&_storyblok_tk[space_id]=165473&_storyblok_tk[timestamp]=1683276629&_storyblok_tk[token]=41ef9b590ea7ddeca679f9b6c3f313d76654e5c1)

https://user-images.githubusercontent.com/6661511/236397454-9e284a29-38d1-4faa-b16c-29a7f0f5ec2e.mov



<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Needed for hedvig.com to go live

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
