### PR TITLE
Prevent payment success -> connect payment redirect

### DIFF
--- a/apps/store/src/pages/checkout/[shopSessionId]/payment/[status].tsx
+++ b/apps/store/src/pages/checkout/[shopSessionId]/payment/[status].tsx
@@ -39,9 +39,10 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
 
   if (status === 'success') {
     try {
-      const checkoutSteps = await fetchCheckoutSteps({ apolloClient, shopSession })
+      const checkoutSteps = await fetchCheckoutSteps({ apolloClient, req, res, shopSession })
       const currentStepIndex = checkoutSteps.findIndex((item) => item === CheckoutStep.Checkout)
       const nextStep = checkoutSteps[currentStepIndex + 1]
+
       const link = getCheckoutStepLink({ step: nextStep, shopSession, locale })
       return { redirect: { destination: link, permanent: false } }
     } catch (error) {

--- a/apps/store/src/pages/checkout/[shopSessionId]/payment/trustly.tsx
+++ b/apps/store/src/pages/checkout/[shopSessionId]/payment/trustly.tsx
@@ -30,7 +30,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async ({
     setupShopSessionServiceServerSide({ apolloClient, req, res }).fetchById(shopSessionId),
   ])
 
-  const checkoutSteps = await fetchCheckoutSteps({ apolloClient, shopSession })
+  const checkoutSteps = await fetchCheckoutSteps({ apolloClient, req, res, shopSession })
 
   return {
     props: {

--- a/apps/store/src/pages/checkout/[shopSessionId]/switching-assistant.tsx
+++ b/apps/store/src/pages/checkout/[shopSessionId]/switching-assistant.tsx
@@ -46,7 +46,7 @@ export const getServerSideProps: GetServerSideProps<NextPageProps, Params> = asy
   }
 
   const [checkoutSteps, translations] = await Promise.all([
-    fetchCheckoutSteps({ apolloClient, shopSession }),
+    fetchCheckoutSteps({ apolloClient, req, res, shopSession }),
     serverSideTranslations(locale),
   ])
 

--- a/apps/store/src/pages/checkout/index.tsx
+++ b/apps/store/src/pages/checkout/index.tsx
@@ -98,7 +98,7 @@ export const getServerSideProps: GetServerSideProps<NextPageProps> = async (cont
   let checkoutSteps: Array<CheckoutStep>, shopSessionSigning: ShopSessionSigning | null
   try {
     ;[checkoutSteps, shopSessionSigning] = await Promise.all([
-      fetchCheckoutSteps({ apolloClient, shopSession }),
+      fetchCheckoutSteps({ apolloClient, req, res, shopSession }),
       fetchCurrentShopSessionSigning({ apolloClient, req }),
     ])
   } catch (error) {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Ensure we don't redirect payment success -> payment connection when storefront returns unexpected authenticationStatus

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

This is a workaround for production issue.  Proper fix would involve not relying on shopSession after signing and using shopSessionOutcome instead

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
