### PR TITLE
Set 308 status on root redirect

### DIFF
--- a/apps/store/src/middleware.ts
+++ b/apps/store/src/middleware.ts
@@ -44,12 +44,10 @@ const countrySelectorMiddleware = (req: NextRequest): NextResponse => {
     case countries.DK.id:
       nextURL.pathname = toRoutingLocale(countries.DK.defaultLocale)
       break
-    case countries.SE.id:
-      nextURL.pathname = toRoutingLocale(countries.SE.defaultLocale)
-      break
     default:
+      // Default routing to /se with a permanent status of 308
       nextURL.pathname = toRoutingLocale(countries.SE.defaultLocale)
-      console.log(`Routing undefined country to fallback ${nextURL}`)
+      console.log(`Default routing to ${nextURL}`)
       return NextResponse.redirect(nextURL, 308)
   }
 

--- a/apps/store/src/middleware.ts
+++ b/apps/store/src/middleware.ts
@@ -49,11 +49,12 @@ const countrySelectorMiddleware = (req: NextRequest): NextResponse => {
       break
     default:
       nextURL.pathname = toRoutingLocale(countries.SE.defaultLocale)
-      break
+      console.log(`Routing undefined country to fallback ${nextURL}`)
+      return NextResponse.redirect(nextURL, 308)
   }
 
   console.log(`Routing visitor from ${country} to ${nextURL}`)
-  return NextResponse.redirect(nextURL, 308)
+  return NextResponse.redirect(nextURL)
 }
 
 type Redirect = {

--- a/apps/store/src/middleware.ts
+++ b/apps/store/src/middleware.ts
@@ -53,7 +53,7 @@ const countrySelectorMiddleware = (req: NextRequest): NextResponse => {
   }
 
   console.log(`Routing visitor from ${country} to ${nextURL}`)
-  return NextResponse.redirect(nextURL)
+  return NextResponse.redirect(nextURL, 308)
 }
 
 type Redirect = {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Set 308 status (permanent) for fallback redirect
- Remove SE geo redirect and use the fallback redirect instead (input from Peter)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Default is 307. Needed for crawlers to properly index /se 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
