### PR TITLE
Fix duplicated strucutred data

### DIFF
--- a/apps/store/src/blocks/AccordionBlock.tsx
+++ b/apps/store/src/blocks/AccordionBlock.tsx
@@ -9,6 +9,7 @@ import * as Accordion from '@/components/Accordion/Accordion'
 import { GridLayout, TEXT_CONTENT_MAX_WIDTH } from '@/components/GridLayout/GridLayout'
 import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
+import { isBrowser } from '@/utils/env'
 
 type Props = SbBaseBlockProps<{
   items: ExpectedBlockType<AccordionItemBlockProps>
@@ -25,6 +26,7 @@ export const AccordionBlock = ({ blok, nested }: Props) => {
   const enableFAQStructuredData = blok.isFAQ ?? false
   const displayTitleDescriptionSection = blok.title || blok.description
   const isCentered = blok.centerLayout || !displayTitleDescriptionSection
+  const FAQStructuredData = getFAQStructuredData(accordionItems)
 
   const handleValueChange = useCallback((value: string) => {
     setOpenItem(value)
@@ -73,13 +75,14 @@ export const AccordionBlock = ({ blok, nested }: Props) => {
 
   return (
     <>
-      {enableFAQStructuredData && (
+      {isBrowser() && enableFAQStructuredData && (
+        // isBrowser check is needed due to bug in Next where script tag is inserted twice despite having a key
         <Head>
           <script
             key="accordion-faq-sctructured-data"
             type="application/ld+json"
             dangerouslySetInnerHTML={{
-              __html: JSON.stringify(getFAQStructuredData(accordionItems)),
+              __html: JSON.stringify(FAQStructuredData),
             }}
           />
         </Head>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Avoid structured data script being rendered twice in <head>. There's seem to be a bug with next/head since it should [not render duplicates if you add a key prop](https://nextjs.org/docs/pages/api-reference/components/head#:~:text=To%20avoid%20duplicate,the%20following%20example%3A)

Seems to be an hydration issue so this makes sure it's only rendered once, validated with [Rich Result Test](https://search.google.com/test/rich-results/result?id=NtRRH13hlxCG3pPyGxsCFg)

<img width="1853" alt="Screenshot 2023-05-10 at 17 43 43" src="https://github.com/HedvigInsurance/racoon/assets/6661511/310bd91d-0a87-4d95-aaaa-280d23a57f69">
 
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Warning from Google Search Console that content is duplicated

<img width="1025" alt="Screenshot 2023-05-10 at 17 47 23" src="https://github.com/HedvigInsurance/racoon/assets/6661511/b360d385-b46f-4df4-963a-dac93aad66a9">

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
