### PR TITLE
Reset any previous authToken on Manypets migration page

### DIFF
--- a/apps/store/src/pages/manypets/migration/[shopSessionId].tsx
+++ b/apps/store/src/pages/manypets/migration/[shopSessionId].tsx
@@ -3,6 +3,7 @@ import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { ManyPetsMigrationPage } from '@/components/ManyPetsMigrationPage/ManyPetsMigrationPage'
 import { addApolloState, initializeApolloServerSide } from '@/services/apollo/client'
+import { resetAuthTokens } from '@/services/authApi/persist'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { getStoryBySlug, MANYPETS_FOLDER_SLUG, PageStory } from '@/services/storyblok/storyblok'
@@ -29,6 +30,9 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
     console.error('No shop session in URL')
     return { notFound: true }
   }
+
+  // Make sure we don't identify different member based on accessToken - this breaks signing
+  resetAuthTokens({ req, res })
 
   const apolloClient = await initializeApolloServerSide({ req, res, locale })
   const shopSessionService = setupShopSessionServiceServerSide({ apolloClient, req, res })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Reset auth tokens on  Manypets migration page to ensure we sign new member, instead of possibly different member based on previous token

As a side effect, reloading the page will clear token from that same page, but we can probably live with ti

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
