### PR TITLE
Override i18next html lang to correct format

### DIFF
--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -33,6 +33,7 @@ import { contentFontClassName } from '@/utils/fonts'
 import { getCountryByLocale } from '@/utils/l10n/countryUtils'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
 import { useDebugTranslationKeys } from '@/utils/l10n/useDebugTranslationKeys'
+import { useForceHtmlLangAttribute } from '@/utils/l10n/useForceHtmlLangAttribute'
 import { useAllowActiveStylesInSafari } from '@/utils/useAllowActiveStylesInSafari'
 import { useReloadOnCountryChange } from '@/utils/useReloadOnCountryChange'
 
@@ -70,6 +71,8 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
   useDebugTranslationKeys()
   useReloadOnCountryChange()
   useAllowActiveStylesInSafari()
+  // Override to correct html lang set by i18next
+  useForceHtmlLangAttribute()
 
   const apolloClient = useApollo(pageProps)
   const getLayout = Component.getLayout || ((page) => page)

--- a/apps/store/src/utils/l10n/useForceHtmlLangAttribute.ts
+++ b/apps/store/src/utils/l10n/useForceHtmlLangAttribute.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+import { useCurrentLocale } from './useCurrentLocale'
+
+export const useForceHtmlLangAttribute = () => {
+  const { htmlLang } = useCurrentLocale()
+
+  useEffect(() => {
+    document.documentElement.lang = htmlLang
+
+    const langObserver = new MutationObserver(() => {
+      if (document.documentElement.lang !== htmlLang) {
+        document.documentElement.lang = htmlLang
+      }
+    })
+
+    langObserver.observe(document.documentElement, {
+      attributeFilter: ['lang'],
+    })
+
+    return () => {
+      langObserver.disconnect()
+    }
+  }, [htmlLang])
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Override i18next html lang to correct format

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Since i18next automatically sets html lang based on the locales in `next-i18next.config` (and those are not in the correct format), we need to listen for that change and override the value

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
