### PR TITLE
feat: enable Storyblok preview for Manypets Migration Page content type

### DIFF
--- a/apps/store/src/blocks/ManyPetsMigrationPageBlock.tsx
+++ b/apps/store/src/blocks/ManyPetsMigrationPageBlock.tsx
@@ -1,0 +1,21 @@
+import { StoryblokComponent } from '@storyblok/react'
+import { ManyPetsMigrationPage } from '@/components/ManyPetsMigrationPage/ManyPetsMigrationPage'
+import { SbBaseBlockProps, ManyPetsMigrationStory } from '@/services/storyblok/storyblok'
+
+type Props = SbBaseBlockProps<ManyPetsMigrationStory['content']>
+
+// Storyblok Content Type
+export const ManyPetsMigrationPageBlock = ({ blok }: Props) => {
+  return (
+    <ManyPetsMigrationPage
+      preOfferContent={blok.preOfferContent?.map((blok) => (
+        <StoryblokComponent key={blok._uid} blok={blok} />
+      ))}
+      postOfferContent={blok.postOfferContent.map((blok) => (
+        <StoryblokComponent key={blok._uid} blok={blok} />
+      ))}
+    />
+  )
+}
+
+ManyPetsMigrationPageBlock.blockName = 'ManypetsMigrationPage'

--- a/apps/store/src/components/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
+++ b/apps/store/src/components/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
@@ -1,6 +1,5 @@
 import { isApolloError, useApolloClient } from '@apollo/client'
 import { datadogLogs } from '@datadog/browser-logs'
-import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { FormEventHandler, ReactNode, useCallback, useEffect, useMemo } from 'react'
 import { Button } from 'ui'
@@ -80,17 +79,11 @@ export const ManyPetsMigrationPage = ({
   }
 
   return (
-    <>
-      <Head>
-        <title>TODO: Take from CMS</title>
-        <meta name="robots" content="none" />
-      </Head>
-      <main>
-        {preOfferContent}
-        {offersSection}
-        {postOfferContent}
-      </main>
-    </>
+    <main>
+      {preOfferContent}
+      {offersSection}
+      {postOfferContent}
+    </main>
   )
 }
 

--- a/apps/store/src/pages/manypets/[[...slug]].tsx
+++ b/apps/store/src/pages/manypets/[[...slug]].tsx
@@ -1,5 +1,6 @@
 import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
 import { GetStaticPaths, GetStaticProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
 import {
   getStoryBySlug,
@@ -37,12 +38,17 @@ export const getStaticProps: GetStaticProps<
 
   const slug = `${MANYPETS_FOLDER_SLUG}/${(params?.slug ?? []).join('/')}`
 
-  const pageStory = await getStoryBySlug<PageStory>(slug, { version, locale })
-  if (!pageStory) return { notFound: true }
+  const [story, translations] = await Promise.all([
+    getStoryBySlug<PageStory>(slug, { version, locale }),
+    serverSideTranslations(locale),
+  ])
+
+  if (!story) return { notFound: true }
 
   return {
     props: {
-      [STORY_PROP_NAME]: pageStory,
+      [STORY_PROP_NAME]: story,
+      ...translations,
     },
     revalidate: process.env.VERCEL_ENV === 'preview' ? 1 : false,
   }

--- a/apps/store/src/pages/manypets/migration/[shopSessionId].tsx
+++ b/apps/store/src/pages/manypets/migration/[shopSessionId].tsx
@@ -2,6 +2,7 @@ import { StoryblokComponent } from '@storyblok/react'
 import type { NextPage } from 'next'
 import { GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
 import { ManyPetsMigrationPage } from '@/components/ManyPetsMigrationPage/ManyPetsMigrationPage'
 import { addApolloState, initializeApolloServerSide } from '@/services/apollo/client'
 import { resetAuthTokens } from '@/services/authApi/persist'
@@ -20,17 +21,21 @@ type Props = { [SHOP_SESSION_PROP_NAME]: string; [STORY_PROP_NAME]: ManyPetsMigr
 type Params = { shopSessionId: string }
 
 const NextManyPetsMigrationPage: NextPage<Props> = (props) => {
-  const { preOfferContent, postOfferContent } = props[STORY_PROP_NAME].content
+  const story = props[STORY_PROP_NAME]
+  const { preOfferContent, postOfferContent } = story.content
 
   return (
-    <ManyPetsMigrationPage
-      preOfferContent={preOfferContent?.map((blok) => (
-        <StoryblokComponent key={blok._uid} blok={blok} />
-      ))}
-      postOfferContent={postOfferContent.map((blok) => (
-        <StoryblokComponent key={blok._uid} blok={blok} />
-      ))}
-    />
+    <>
+      <HeadSeoInfo story={story} />
+      <ManyPetsMigrationPage
+        preOfferContent={preOfferContent?.map((blok) => (
+          <StoryblokComponent key={blok._uid} blok={blok} />
+        ))}
+        postOfferContent={postOfferContent.map((blok) => (
+          <StoryblokComponent key={blok._uid} blok={blok} />
+        ))}
+      />
+    </>
   )
 }
 

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -33,6 +33,7 @@ import { ImageBlock } from '@/blocks/ImageBlock'
 import { ImageTextBlock } from '@/blocks/ImageTextBlock'
 import { InlineSpaceBlock } from '@/blocks/InlineSpaceBlock'
 import { InsurableLimitsBlock } from '@/blocks/InsurableLimitsBlock'
+import { ManyPetsMigrationPageBlock } from '@/blocks/ManyPetsMigrationPageBlock'
 import { ModalBlock } from '@/blocks/ModalBlock'
 import { PageBlock } from '@/blocks/PageBlock'
 import { PerilsBlock } from '@/blocks/PerilsBlock'
@@ -177,6 +178,13 @@ export type ConfirmationStory = ISbStoryData & {
   }
 }
 
+export type ManyPetsMigrationStory = ISbStoryData<
+  {
+    preOfferContent?: Array<SbBlokData>
+    postOfferContent: Array<SbBlokData>
+  } & SEOData
+>
+
 type LinkData = Pick<
   ISbStoryData,
   'id' | 'slug' | 'name' | 'parent_id' | 'position' | 'uuid' | 'is_startpage'
@@ -219,6 +227,7 @@ export const initStoryblok = () => {
     InlineSpaceBlock,
     InsurableLimitsBlock,
     ModalBlock,
+    ManyPetsMigrationPageBlock,
     NavItemBlock,
     NestedNavContainerBlock,
     PageBlock,


### PR DESCRIPTION
## Describe your changes

Enables Storyblok preview for Manypets migration page by:

* Adding a block por _Manypets Migtation Page_ Content Type --> `ManyPetsMigrationPageBlock`
* Make sure `migration/[shopSessionId]` and `ManyPetsMigrationPageBlock` renders the same component: `ManyPetsMigrationPage`

Additionally I've also changed `migration/[[...slug]]` file so it supports translations.

## Justify why they are needed

Enabling editors to construct the migration will make us move faster and avoid back and forth when it comes about design tweaks. 