### PR TITLE
fix(pet-insurance-comparison-table): only display 'Livförsäkring' and 'Tidigare besvär”' attributes when they are present and equals true

### DIFF
--- a/apps/store/src/services/manypets/data/SE_PET_INSURANCE_COMPARISON_TABLE.ts
+++ b/apps/store/src/services/manypets/data/SE_PET_INSURANCE_COMPARISON_TABLE.ts
@@ -6,8 +6,8 @@ const getDeductibleData: DataGetter = (offerData) => {
 
 const getLifeInsuranceData: DataGetter = (offerData) => {
   const { deathOption } = offerData.priceIntentData
-  if (deathOption != null) {
-    return Boolean(deathOption)
+  if (deathOption) {
+    return true
   }
 
   return null
@@ -15,8 +15,8 @@ const getLifeInsuranceData: DataGetter = (offerData) => {
 
 const getPreviousComplaintsData: DataGetter = (offerData) => {
   const { preExistingOption } = offerData.priceIntentData
-  if (preExistingOption != null) {
-    return Boolean(preExistingOption)
+  if (preExistingOption) {
+    return true
   }
 
   return null


### PR DESCRIPTION
## Describe your changes

* Updates Pet Insurance Comparison Table template

## Justify why they are needed

* 'Livförsäkring' and 'Tidigare besvär”' attributes should only be displayed when they are present and equals `true`
