### PR TITLE
Use exact path for Edge config redirects

### DIFF
--- a/apps/store/src/middleware.ts
+++ b/apps/store/src/middleware.ts
@@ -80,7 +80,7 @@ const redirectMiddleware = async (req: NextRequest): Promise<NextResponse | unde
     }
     // Cannot use req.nextUrl, it removes locale prefix
     const reqUrl = new URL(req.url)
-    if (reqUrl.pathname.startsWith(redirect.from)) {
+    if (reqUrl.pathname === redirect.from) {
       console.log(
         `Applying ${redirect.temporary ? 'temporary' : 'permanent'} redirect ${redirect.from} -> ${
           redirect.to


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Use exact path for Edge config redirects

For these types of redirects it makes more sense to use exact paths

An example:
We want `/se-en/forever` to redirect to `se-en/hedvig/discount` but not catch `/se-en/forever/[code]`

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Make it easier to add custom redirects in Edge Config. If we want to use wildcard redirects it makes more sense to put it in next config

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
