### PR TITLE
feat(CartEntry): added product based short summary

### DIFF
--- a/apps/store/src/components/CartInventory/CartEntryItem/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem/CartEntryItem.tsx
@@ -13,6 +13,7 @@ import { RemoveEntryDialog } from '../RemoveEntryDialog'
 import { CartEntryCollapsible } from './CartEntryCollapsible'
 import { DetailsSheet } from './DetailsSheet'
 import { EditEntryButton } from './EditEntryButton'
+import { ShortSummary } from './ShortSummary'
 
 type Props = CartEntry & {
   shopSessionId: string
@@ -23,7 +24,7 @@ type Props = CartEntry & {
 
 export const CartEntryItem = ({ defaultOpen = false, ...props }: Props) => {
   const { shopSessionId, readOnly, onRemove, ...cartEntry } = props
-  const { title: titleLabel, startDate, cost, pillow } = cartEntry
+  const { title: titleLabel, cost, pillow } = cartEntry
   const { t } = useTranslation('cart')
   const formatter = useFormatter()
 
@@ -52,11 +53,7 @@ export const CartEntryItem = ({ defaultOpen = false, ...props }: Props) => {
 
         <div>
           <Text>{titleLabel}</Text>
-          <Text color="textSecondary">
-            {startDate
-              ? t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(startDate) })
-              : t('CART_ENTRY_AUTO_SWITCH')}
-          </Text>
+          <ShortSummary cartEntry={cartEntry} />
         </div>
       </SpaceFlex>
 

--- a/apps/store/src/components/CartInventory/CartEntryItem/ShortSummary.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem/ShortSummary.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'react-i18next'
+import { Text } from 'ui'
+import { useFormatter } from '@/utils/useFormatter'
+import { CartEntry } from '../CartInventory.types'
+
+export const ShortSummary = ({ cartEntry }: { cartEntry: CartEntry }) => {
+  const { t } = useTranslation('cart')
+  const formatter = useFormatter()
+
+  const content: Array<string> = []
+
+  const productBasedSummary = getProductBasedSummary(cartEntry)
+  if (productBasedSummary) {
+    content.push(productBasedSummary)
+  }
+
+  const activationDate = cartEntry.startDate
+    ? t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(cartEntry.startDate) })
+    : t('CART_ENTRY_AUTO_SWITCH')
+  content.push(activationDate)
+
+  return <Text color="textSecondary">{content.join(' • ')}</Text>
+}
+
+// TODO: retrieve this from API or some sort of central config.
+const getProductBasedSummary = (cartEntry: CartEntry) => {
+  switch (cartEntry.productName) {
+    case 'SE_PET_DOG':
+    case 'SE_PET_CAT':
+      return cartEntry.data.name != null ? (cartEntry.data.name as string) : null
+    default:
+      return null
+  }
+}


### PR DESCRIPTION
## Describe your changes

Added product based short summary for cant entries. At the moment, we only show additional information for pet offers.

## Justify why they are needed

To match designs. It should also help migrating people to immediately see that their pet data is correct

<img width="505" alt="Screenshot 2023-05-24 at 12 00 43" src="https://github.com/HedvigInsurance/racoon/assets/19200662/e112425b-d6ee-4168-995a-e84da7c13897">

