### PR TITLE
Fix reset/renew ShopSession after sign

### DIFF
--- a/apps/store/src/components/ChangeSsnWarningDialog/ChangeSsnWarningDialog.tsx
+++ b/apps/store/src/components/ChangeSsnWarningDialog/ChangeSsnWarningDialog.tsx
@@ -20,8 +20,8 @@ export const ChangeSsnWarningDialog = ({ open, onAccept, onDecline }: Props) => 
   const handleAccept = useCallback(async () => {
     setLoading(true)
 
-    await resetShopSession()
     resetAuthTokens()
+    await resetShopSession()
 
     if (onAccept) {
       if (onAccept instanceof Promise) {

--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -25,7 +25,6 @@ import {
   CurrentMemberQueryVariables,
   ShopSessionAuthenticationStatus,
 } from '@/services/apollo/generated'
-import { setupShopSessionServiceClientSide } from '@/services/shopSession/ShopSession.helpers'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { useTracking } from '@/services/Tracking/useTracking'
 import { PageLink } from '@/utils/PageLink'
@@ -48,7 +47,7 @@ const CheckoutPage = (props: CheckoutPageProps) => {
   const { t } = useTranslation('checkout')
 
   const [showSignError, setShowSignError] = useState(false)
-  const { shopSession } = useShopSession()
+  const { shopSession, reset: resetShopSession } = useShopSession()
   const router = useRouter()
   const apolloClient = useApolloClient()
   const tracking = useTracking()
@@ -72,7 +71,7 @@ const CheckoutPage = (props: CheckoutPageProps) => {
         memberId,
         customerAuthenticationStatus === ShopSessionAuthenticationStatus.None,
       )
-      setupShopSessionServiceClientSide(apolloClient).reset()
+      resetShopSession()
 
       const checkoutStepIndex = checkoutSteps.findIndex((item) => item === CheckoutStep.Checkout)
       const nextCheckoutStep = checkoutSteps[checkoutStepIndex + 1]

--- a/apps/store/src/graphql/ShopSessionOutcome.graphql
+++ b/apps/store/src/graphql/ShopSessionOutcome.graphql
@@ -1,5 +1,6 @@
 query ShopSessionOutcome($shopSessionId: UUID!) {
   shopSession(id: $shopSessionId) {
+    id
     outcome {
       id
       createdContracts {

--- a/apps/store/src/services/shopSession/ShopSessionContext.tsx
+++ b/apps/store/src/services/shopSession/ShopSessionContext.tsx
@@ -10,7 +10,6 @@ import {
   useState,
 } from 'react'
 import { ShopSessionQueryResult, useShopSessionQuery } from '@/services/apollo/generated'
-import { resetAuthTokens } from '@/services/authApi/persist'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { isBrowser } from '@/utils/env'
 import { useCurrentCountry } from '@/utils/l10n/useCurrentCountry'
@@ -76,7 +75,6 @@ const useShopSessionContextValue = (initialShopSessionId?: string) => {
 
   queryResult.reset = useCallback(() => {
     shopSessionServiceClientSide.reset()
-    resetAuthTokens()
     return shopSessionServiceClientSide.getOrCreate({ countryCode }).then((shopSession) => {
       setShopSessionId(shopSession.id)
     })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix refresh of shop session after signing

Refactor reset function from shop session hook to not worry about resetting auth tokens.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Currently, we don't update the cart after signing the shop session.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
