### PR TITLE
Payment Connect: make it safe to reload page

### DIFF
--- a/apps/store/public/locales/en/common.json
+++ b/apps/store/public/locales/en/common.json
@@ -29,6 +29,7 @@
   "NAV_MENU_DIALOG_CLOSE": "Close",
   "NAV_MENU_DIALOG_OPEN": "Menu",
   "PAYMENT_CONNECT_FAILURE": "Could not connect direct debit",
+  "PAYMENT_CONNECT_IFRAME_LOAD_BUTTON": "Press here to begin",
   "PAYMENT_CONNECT_RETRY": "Try again",
   "PAYMENT_CONNECT_SUCCESS": "Success! You can close this page now :)",
   "PAYMENT_CONNECT_TITLE": "Connect direct debit",

--- a/apps/store/public/locales/sv-se/common.json
+++ b/apps/store/public/locales/sv-se/common.json
@@ -26,6 +26,7 @@
   "NAV_MENU_DIALOG_CLOSE": "Stäng",
   "NAV_MENU_DIALOG_OPEN": "Meny",
   "PAYMENT_CONNECT_FAILURE": "Autogirokopplingen misslyckades tyvärr",
+  "PAYMENT_CONNECT_IFRAME_LOAD_BUTTON": "Tryck här för att börja",
   "PAYMENT_CONNECT_RETRY": "Försök igen",
   "PAYMENT_CONNECT_SUCCESS": "Autogiro kopplat! Du kan stänga sidan nu :)",
   "PAYMENT_CONNECT_TITLE": "Koppla autogiro",

--- a/apps/store/src/components/PaymentConnectPage/ErrorDialog.tsx
+++ b/apps/store/src/components/PaymentConnectPage/ErrorDialog.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from 'next-i18next'
+import { Button, Text, WarningTriangleIcon, theme } from 'ui'
+import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
+import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
+
+type Props = {
+  open: boolean
+  onRetry: () => void
+}
+
+export const ErrorDialog = (props: Props) => {
+  const { t } = useTranslation()
+
+  return (
+    <FullscreenDialog.Root open={props.open}>
+      <FullscreenDialog.Modal
+        center={true}
+        Footer={
+          <Button onClick={props.onRetry} variant="primary">
+            {t('PAYMENT_CONNECT_RETRY')}
+          </Button>
+        }
+      >
+        <SpaceFlex direction="vertical" align="center">
+          <WarningTriangleIcon color={theme.colors.amberElement} />
+          <Text size={{ _: 'md', lg: 'lg' }}>{t('PAYMENT_CONNECT_FAILURE')}</Text>
+        </SpaceFlex>
+      </FullscreenDialog.Modal>
+    </FullscreenDialog.Root>
+  )
+}

--- a/apps/store/src/components/PaymentConnectPage/IdleState.tsx
+++ b/apps/store/src/components/PaymentConnectPage/IdleState.tsx
@@ -1,0 +1,79 @@
+import { useApolloClient } from '@apollo/client'
+import { datadogRum } from '@datadog/browser-rum'
+import styled from '@emotion/styled'
+import { type NextRouter, useRouter } from 'next/router'
+import { type FormEventHandler, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button, Space, Text, theme } from 'ui'
+import { exchangeAuthorizationCode } from '@/services/authApi/oauth'
+import { saveAuthTokens } from '@/services/authApi/persist'
+import { createTrustlyUrl } from '@/services/trustly/createTrustlyUrl'
+import { trustlyIframeStyles } from '@/services/trustly/TrustlyIframe'
+import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { Layout } from './Layout'
+
+type Props = {
+  onCompleted: (trustlyUrl: string) => void
+  onFailed: () => void
+}
+
+export const IdleState = (props: Props) => {
+  const [state, setState] = useState<'idle' | 'loading'>('idle')
+  const { t } = useTranslation(['common', 'checkout'])
+  const router = useRouter()
+  const apolloClient = useApolloClient()
+  const { routingLocale } = useCurrentLocale()
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault()
+    setState('loading')
+    datadogRum.addAction('Payment Connect Init')
+
+    try {
+      await consumeAuthorizationCode(router)
+      const trustlyUrl = await createTrustlyUrl({ apolloClient, locale: routingLocale })
+      props.onCompleted(trustlyUrl)
+    } catch (error) {
+      datadogRum.addError(error)
+      props.onFailed()
+    }
+  }
+
+  return (
+    <Layout>
+      <Space y={0.75}>
+        <form onSubmit={handleSubmit}>
+          <IframePlaceholder data-state={state}>
+            <Button loading={state === 'loading'}>{t('PAYMENT_CONNECT_IFRAME_LOAD_BUTTON')}</Button>
+          </IframePlaceholder>
+        </form>
+        <Text size="xs" align="center">
+          {t('PAYMENT_TRUSTLY_FOOTNOTE', { ns: 'checkout' })}
+        </Text>
+      </Space>
+    </Layout>
+  )
+}
+
+const IframePlaceholder = styled.div(trustlyIframeStyles, {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: theme.colors.white,
+  paddingInline: theme.space.xl,
+})
+
+const AUTHORIZATION_CODE_QUERY_PARAM = 'authorization_code'
+
+const consumeAuthorizationCode = async (router: NextRouter) => {
+  const authorizationCode = router.query[AUTHORIZATION_CODE_QUERY_PARAM]
+
+  if (typeof authorizationCode === 'string') {
+    const reponse = await exchangeAuthorizationCode(authorizationCode)
+    saveAuthTokens(reponse)
+
+    const target = { pathname: router.pathname, query: { ...router.query } }
+    delete target.query[AUTHORIZATION_CODE_QUERY_PARAM]
+    await router.replace(target, undefined, { shallow: true })
+  }
+}

--- a/apps/store/src/components/PaymentConnectPage/Layout.tsx
+++ b/apps/store/src/components/PaymentConnectPage/Layout.tsx
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
+import Link from 'next/link'
+import { type ReactNode } from 'react'
+import { Heading, HedvigLogo, Space, mq, theme } from 'ui'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { PageLink } from '@/utils/PageLink'
+import { MENU_BAR_HEIGHT_DESKTOP, MENU_BAR_HEIGHT_MOBILE } from '../Header/HeaderStyles'
+
+export const Layout = ({ children }: { children: ReactNode }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Space y={2}>
+      <Header>
+        <Link href={PageLink.home()}>
+          <HedvigLogo width={78} />
+        </Link>
+      </Header>
+      <GridLayout.Root>
+        <GridLayout.Content width="1/3" align="center">
+          <Space y={{ base: 2, lg: 3.5 }}>
+            <Heading as="h1" variant="standard.24" align="center" balance={true}>
+              {t('PAYMENT_CONNECT_TITLE')}
+            </Heading>
+            {children}
+          </Space>
+        </GridLayout.Content>
+      </GridLayout.Root>
+    </Space>
+  )
+}
+
+const Header = styled(GridLayout.Root)({
+  paddingInline: theme.space.md,
+  display: 'flex',
+  alignItems: 'center',
+  height: MENU_BAR_HEIGHT_MOBILE,
+
+  [mq.md]: {
+    paddingInline: theme.space.xl,
+    gridTemplateRows: MENU_BAR_HEIGHT_DESKTOP,
+  },
+})

--- a/apps/store/src/components/PaymentConnectPage/ReadyState.tsx
+++ b/apps/store/src/components/PaymentConnectPage/ReadyState.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from 'next-i18next'
+import { Space, Text } from 'ui'
+import { TrustlyIframe } from '@/services/trustly/TrustlyIframe'
+import { Layout } from './Layout'
+
+type Props = {
+  trustlyUrl: string
+  onSuccess: () => void
+  onFail: () => void
+}
+
+export const ReadyState = (props: Props) => {
+  const { t } = useTranslation('checkout')
+
+  return (
+    <Layout>
+      <Space y={0.75}>
+        <TrustlyIframe url={props.trustlyUrl} onSuccess={props.onSuccess} onFail={props.onFail} />
+        <Text size="xs" align="center">
+          {t('PAYMENT_TRUSTLY_FOOTNOTE')}
+        </Text>
+      </Space>
+    </Layout>
+  )
+}

--- a/apps/store/src/components/PaymentConnectPage/SuccessState.tsx
+++ b/apps/store/src/components/PaymentConnectPage/SuccessState.tsx
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
+import { CheckIcon, Text, theme } from 'ui'
+import { trustlyIframeStyles } from '@/services/trustly/TrustlyIframe'
+import { Layout } from './Layout'
+
+export const SuccessState = () => {
+  const { t } = useTranslation()
+
+  return (
+    <Layout>
+      <IframePlaceholder>
+        <CheckIcon color={theme.colors.greenElement} />
+        <Text size={{ _: 'md', lg: 'lg' }}>{t('PAYMENT_CONNECT_SUCCESS')}</Text>
+      </IframePlaceholder>
+    </Layout>
+  )
+}
+
+const IframePlaceholder = styled.div(trustlyIframeStyles, {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexDirection: 'column',
+  gap: theme.space.xs,
+})

--- a/apps/store/src/services/trustly/TrustlyIframe.tsx
+++ b/apps/store/src/services/trustly/TrustlyIframe.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import { useEffect, type ReactEventHandler } from 'react'
 import { theme } from 'ui'
@@ -31,7 +32,6 @@ export const TrustlyIframe = ({ url, onSuccess, onFail }: Props) => {
   const handleLoad: ReactEventHandler<HTMLIFrameElement> = (event) => {
     try {
       const url = event.currentTarget.contentWindow?.location.href
-      console.log('Iframe location', url)
       if (url === PageLink.paymentSuccess({ locale: routingLocale })) {
         onSuccess()
       } else if (url === PageLink.paymentFailure({ locale: routingLocale })) {
@@ -46,9 +46,7 @@ export const TrustlyIframe = ({ url, onSuccess, onFail }: Props) => {
   return <Iframe src={url} onLoad={handleLoad} />
 }
 
-const Iframe = styled.iframe({
-  display: 'block',
-
+export const trustlyIframeStyles = css({
   width: '100%',
   maxWidth: 600,
 
@@ -56,8 +54,12 @@ const Iframe = styled.iframe({
   height: '60vh',
   maxHeight: 800,
 
-  border: 'none',
   boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.15)',
   marginInline: 'auto',
   backgroundColor: theme.colors.white,
+})
+
+const Iframe = styled.iframe(trustlyIframeStyles, {
+  display: 'block',
+  border: 'none',
 })

--- a/apps/store/src/services/trustly/createTrustlyUrl.ts
+++ b/apps/store/src/services/trustly/createTrustlyUrl.ts
@@ -1,4 +1,4 @@
-import { type ApolloClient, type NormalizedCacheObject } from '@apollo/client'
+import { type ApolloClient } from '@apollo/client'
 import {
   TrustlyInitDocument,
   TrustlyInitMutation,
@@ -8,7 +8,7 @@ import { RoutingLocale } from '@/utils/l10n/types'
 import { PageLink } from '@/utils/PageLink'
 
 type Params = {
-  apolloClient: ApolloClient<NormalizedCacheObject>
+  apolloClient: ApolloClient<unknown>
   locale: RoutingLocale
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Update payment connect page to require user to explicitly initiate the flow.


![localhost_8040_se_payment_connect_authorization_code=3ea88bec-e96b-4021-89c0-28eed73e0ca7(iPhone 12 Pro).png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/91d7f376-1054-4451-bc0f-79d049092b21/localhost_8040_se_payment_connect_authorization_code=3ea88bec-e96b-4021-89c0-28eed73e0ca7(iPhone%2012%20Pro).png)


![localhost_8040_se_payment_connect_authorization_code=3ea88bec-e96b-4021-89c0-28eed73e0ca7(iPhone 12 Pro) (1).png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/0110dc82-602e-43f7-b9df-987c46d4aaf4/localhost_8040_se_payment_connect_authorization_code=3ea88bec-e96b-4021-89c0-28eed73e0ca7(iPhone%2012%20Pro)%20(1).png)


![localhost_8040_se_payment_connect_authorization_code=9b9fa759-1bee-4de3-a289-e531d38b8fd6(iPhone 12 Pro).png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/040a6447-dd0f-4324-aec0-b5f504a6ff73/localhost_8040_se_payment_connect_authorization_code=9b9fa759-1bee-4de3-a289-e531d38b8fd6(iPhone%2012%20Pro).png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

This makes it safe to send the payment link and for users to load the page any number of times. The authorization code is not used up until the user initiates the flow.

I'm not really sure what the design of the page should look like.

I'm not really sure if we should use a query parameter or a path parameter for the authorization code.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
