### PR TITLE
feat(CartEntry): use same date format in CartEntry - summary and detaisl sheet

### DIFF
--- a/apps/store/src/utils/useFormatter.ts
+++ b/apps/store/src/utils/useFormatter.ts
@@ -15,6 +15,7 @@ const FORMAT_CONFIG: Record<string, AutoFormatOption> = {
   ssn: 'ssn',
   registrationNumber: 'carRegistrationNumber',
   zipCode: 'zipCode',
+  birthDate: 'date',
 }
 
 export const useAutoFormat = () => {
@@ -36,6 +37,9 @@ export const useAutoFormat = () => {
 
           case 'zipCode':
             return typeof value === 'string' ? formatter.zipCode(value) : String(value)
+
+          case 'date':
+            return typeof value === 'string' ? formatter.fromNow(new Date(value)) : String(value)
 
           default:
             return String(value)


### PR DESCRIPTION
## Describe your changes

Use same date format in CartEntry - summary and details sheet

## Justify why they are needed

Requested by design.

### Before

<img width="586" alt="before" src="https://github.com/HedvigInsurance/racoon/assets/19200662/d1f61172-c785-489a-a2f7-c27d2e671b88">

### After

<img width="581" alt="after" src="https://github.com/HedvigInsurance/racoon/assets/19200662/2846e218-675b-4bad-b5e7-0e5134f158f1">
