### PR TITLE
styles(ComparisonTable): general updates for beter UI

### DIFF
--- a/apps/store/src/components/ManyPetsMigrationPage/LatestAdoptionNote.tsx
+++ b/apps/store/src/components/ManyPetsMigrationPage/LatestAdoptionNote.tsx
@@ -26,11 +26,15 @@ const Wrapper = styled.div({
   display: 'flex',
   gap: theme.space.xs,
   alignItems: 'baseline',
-  backgroundColor: theme.colors.blue200,
+  backgroundColor: theme.colors.blueFill1,
+  border: `1px solid ${theme.colors.blue200}`,
   borderRadius: theme.radius.sm,
   padding: theme.space.md,
 })
 
 const StyledInfoIcon = styled(InfoIcon)({
   flex: '0 0 auto',
+  // Optical alignment with text
+  position: 'relative',
+  top: 3,
 })

--- a/apps/store/src/components/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
+++ b/apps/store/src/components/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
@@ -107,7 +107,8 @@ export const ManyPetsMigrationPage = ({
                   </ComparisonTable.Header>
                   <ComparisonTable.Header active>
                     <Centered>
-                      <HedvigLogo />
+                      {/* Both icons are composed differently. For optical sizing, they should diff 2px in width/height */}
+                      <HedvigLogo width={76} height={22} />
                     </Centered>
                   </ComparisonTable.Header>
                 </ComparisonTable.Row>
@@ -228,7 +229,7 @@ const parseTableValue = (value: string | boolean): ReactNode => {
 
 const OfferSection = styled(Space)({
   paddingInline: theme.space.md,
-  maxWidth: '28.5rem',
+  maxWidth: '31.5rem',
   marginInline: 'auto',
 
   [mq.lg]: {

--- a/apps/store/src/components/ManyPetsMigrationPage/ManypetsLogo.tsx
+++ b/apps/store/src/components/ManyPetsMigrationPage/ManypetsLogo.tsx
@@ -1,15 +1,16 @@
 export type Props = {
+  color?: string
   width?: number
   height?: number
 }
 
-export const ManypetsLogo = ({ width = 78, height = 24 }: Props) => {
+export const ManypetsLogo = ({ color = 'currentColor', width = 78, height = 24 }: Props) => {
   return (
     <svg
       width={width}
       height={height}
       viewBox="0 0 58 13"
-      fill="none"
+      fill={color}
       xmlns="http://www.w3.org/2000/svg"
       aria-label="Manypets logo"
     >

--- a/apps/store/src/components/ProductPage/PurchaseForm/ComparisonTable/ComparisonTable.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ComparisonTable/ComparisonTable.tsx
@@ -39,9 +39,11 @@ export const Header = ({ children, active, ...props }: HeaderProps) => {
 
 const TableHeader = styled.th({
   paddingBlock: theme.space.sm,
+  paddingInline: theme.space.xs,
 
   [mq.lg]: {
     paddingBlock: theme.space.md,
+    paddingInline: theme.space.sm,
   },
 })
 
@@ -55,9 +57,9 @@ type TitleDataCellProps = { children: React.ReactNode; className?: string }
 
 export const TitleDataCell = ({ children, ...props }: TitleDataCellProps) => {
   return (
-    <TableDataCell {...props}>
+    <StyledTitleDataCell {...props}>
       <Text size={{ _: 'sm', lg: 'md' }}>{children}</Text>
-    </TableDataCell>
+    </StyledTitleDataCell>
   )
 }
 
@@ -74,13 +76,19 @@ export const DataCell = ({ children, active, ...props }: DataCellProps) => {
 
 const TableDataCell = styled.td({
   paddingBlock: theme.space.sm,
+  paddingInline: theme.space.xs,
   verticalAlign: 'middle',
   minWidth: '2.5rem',
 
   [mq.lg]: {
     minWidth: '4rem',
     paddingBlock: theme.space.md,
+    paddingInline: theme.space.sm,
   },
+})
+
+const StyledTitleDataCell = styled(TableDataCell)({
+  minWidth: 'revert',
 })
 
 const ActiveTableDataCell = styled(TableDataCell)({
@@ -90,6 +98,8 @@ const ActiveTableDataCell = styled(TableDataCell)({
 const Centered = styled.div({
   display: 'flex',
   justifyContent: 'center',
+  // Make sure text gets centered when wrapped into multiple lines
+  textAlign: 'center',
 })
 
 export const CheckIcon = () => <PerilsCheckIcon size="1rem" />

--- a/apps/store/src/services/manypets/data/SE_PET_INSURANCE_COMPARISON_TABLE.ts
+++ b/apps/store/src/services/manypets/data/SE_PET_INSURANCE_COMPARISON_TABLE.ts
@@ -22,9 +22,14 @@ const getPreviousComplaintsData: DataGetter = (offerData) => {
   return null
 }
 
+// Unicode for &nbsp; HTML entity: non-breaking space
+// We use it to make sure number values get spaced but don't get broken down
+// into multiple lines when no space is available.
+const nbsp = '\u00A0'
+
 export const TableDataTemplate: ComparisonTableTemplateByTierLevelMap = {
   BASIC: {
-    Veterinärvård: '30 000',
+    Veterinärvård: `30${nbsp}000`,
     Självrisk: getDeductibleData,
     'Dolda fel': true,
     Livförsäkring: getLifeInsuranceData,
@@ -33,7 +38,7 @@ export const TableDataTemplate: ComparisonTableTemplateByTierLevelMap = {
     'Ingen bindningstid': true,
   },
   STANDARD: {
-    Veterinärvård: '60 000',
+    Veterinärvård: `60${nbsp}000`,
     Självrisk: getDeductibleData,
     'Dolda fel': true,
     Medicin: true,
@@ -42,14 +47,14 @@ export const TableDataTemplate: ComparisonTableTemplateByTierLevelMap = {
     'Strålning och kemoterapi': true,
     Rehabilitering: true,
     Specialkost: true,
-    'Förlossning/Kejsarsnitt': true,
+    'Förlossning / Kejsarsnitt': true,
     Livförsäkring: getLifeInsuranceData,
     'Tidigare besvär': getPreviousComplaintsData,
     'Fria vårdsamtal': true,
     'Ingen bindningstid': true,
   },
   PREMIUM: {
-    Veterinärvård: '140 000',
+    Veterinärvård: `140${nbsp}000`,
     Självrisk: getDeductibleData,
     'Dolda fel': true,
     Medicin: true,
@@ -58,7 +63,7 @@ export const TableDataTemplate: ComparisonTableTemplateByTierLevelMap = {
     'Strålning och kemoterapi': true,
     Rehabilitering: true,
     Specialkost: true,
-    'Förlossning/Kejsarsnitt': true,
+    'Förlossning / Kejsarsnitt': true,
     Livförsäkring: getLifeInsuranceData,
     'Tidigare besvär': getPreviousComplaintsData,
     'Fria vårdsamtal': true,


### PR DESCRIPTION
## Describe your changes

Improve _ComparisonTable_ design.

<img width="377" alt="Screenshot 2023-05-25 at 17 55 45" src="https://github.com/HedvigInsurance/racoon/assets/19200662/49765cf7-85ed-471f-b344-c29327daadce">
<img width="631" alt="Screenshot 2023-05-25 at 17 55 24" src="https://github.com/HedvigInsurance/racoon/assets/19200662/87b16f9d-2bed-4533-aac5-30d1059f5650">

## Justify why they are needed

To match designs.