### PR TITLE
[GEN-226] Support absolute URLs for the 'next' query param

### DIFF
--- a/apps/store/src/pages/api/campaign/[code].ts
+++ b/apps/store/src/pages/api/campaign/[code].ts
@@ -7,6 +7,7 @@ import {
 } from '@/services/apollo/generated'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
+import { getPathnameFromUrl } from '@/utils/getPathnameFromUrl'
 import { getCountryByLocale } from '@/utils/l10n/countryUtils'
 import { getUrlLocale } from '@/utils/l10n/localeUtils'
 import { ORIGIN_URL, PageLink } from '@/utils/PageLink'
@@ -36,7 +37,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.redirect(...fallbackRedirect)
   }
   nextUrl.searchParams.delete(QueryParam.Next)
-  nextUrl.pathname = nextQueryParam
+  nextUrl.pathname = getPathnameFromUrl(nextQueryParam)
 
   const redirectStatus = 307
   const redirectUrl = nextUrl.toString()

--- a/apps/store/src/pages/api/redirect/recommend.ts
+++ b/apps/store/src/pages/api/redirect/recommend.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { initializeApolloServerSide } from '@/services/apollo/client'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
+import { getPathnameFromUrl } from '@/utils/getPathnameFromUrl'
 import { getCountryByLocale } from '@/utils/l10n/countryUtils'
 import { getUrlLocale } from '@/utils/l10n/localeUtils'
 import { ORIGIN_URL, PageLink } from '@/utils/PageLink'
@@ -38,7 +39,7 @@ const recommendHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     shopSessionService.saveId(shopSession.id)
 
     const targetUrl = new URL(req.url ?? '', ORIGIN_URL)
-    targetUrl.pathname = next || PageLink.home({ locale: routingLocale })
+    targetUrl.pathname = next ? getPathnameFromUrl(next) : PageLink.home({ locale: routingLocale })
     targetUrl.searchParams.delete('next')
     targetUrl.searchParams.delete('attributed_to')
     targetUrl.searchParams.delete('initiated_from')

--- a/apps/store/src/utils/getPathnameFromUrl.ts
+++ b/apps/store/src/utils/getPathnameFromUrl.ts
@@ -1,0 +1,7 @@
+export const getPathnameFromUrl = (rawUrl: string) => {
+  if (rawUrl.startsWith('https://')) {
+    return new URL(rawUrl).pathname
+  }
+
+  return rawUrl
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Support passing absolute URLs in the "next" query parameter.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

This will be used by AdTraction for affiliate links.

We will still not allow any next redirects to go to a different domain than the current one.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
