### PR TITLE
fix(QuickPurchaseForm): hidden input for product name where only one product is available

### DIFF
--- a/apps/store/src/blocks/QuickPurchaseBlock.tsx
+++ b/apps/store/src/blocks/QuickPurchaseBlock.tsx
@@ -76,7 +76,7 @@ export const QuickPurchaseBlock = ({ blok, nested }: QuickPurchaseBlockProps) =>
       const formState = Object.fromEntries(formData.entries())
       const { [SSN_FIELDNAME]: ssn, [PRODUCT_FIELDNAME]: productName } = formState
 
-      // This should never happen since QuickPurchaseForm conrols are required
+      // This should never happen since QuickPurchaseForm controls are required
       if (typeof ssn !== 'string' || typeof productName !== 'string') {
         throw new Error('[QuickPurchaseBlock]: ssn and product are required')
       }

--- a/apps/store/src/components/QuickPurchaseForm/ProductSelector.tsx
+++ b/apps/store/src/components/QuickPurchaseForm/ProductSelector.tsx
@@ -21,6 +21,10 @@ type Props = {
 export const ProductSelector = ({ productOptions, ...delegated }: Props) => {
   const { t } = useTranslation('purchase-form')
 
+  if (productOptions.length === 1) {
+    return <input type="hidden" name={delegated.name} value={productOptions[0].value} />
+  }
+
   return (
     <SelectPrimitive.Root {...delegated}>
       <SelectTrigger>

--- a/apps/store/src/components/QuickPurchaseForm/QuickPurchaseForm.tsx
+++ b/apps/store/src/components/QuickPurchaseForm/QuickPurchaseForm.tsx
@@ -42,14 +42,12 @@ export const QuickPurchaseForm = ({
   return (
     <form onSubmit={onSubmit}>
       <Space y={0.25}>
-        {productOptions.length > 1 && (
-          <ProductSelector
-            productOptions={productOptions}
-            name={PRODUCT_FIELDNAME}
-            disabled={submitting}
-            required={true}
-          />
-        )}
+        <ProductSelector
+          productOptions={productOptions}
+          name={PRODUCT_FIELDNAME}
+          disabled={submitting}
+          required={true}
+        />
 
         <SsnField
           name={SSN_FIELDNAME}


### PR DESCRIPTION
## Describe your changes

* Renders a hidden input for `productName` when only one product is available;

## Justify why they are needed

By design, we shouldn't render product selector when only one option for product is available. However we still to render an input for it to be able to get that value while submitting the form.
