### PR TITLE
fix(QuickPurchaseForm): avoid flashing UI

### DIFF
--- a/apps/store/src/components/QuickPurchaseForm/ProductSelector.tsx
+++ b/apps/store/src/components/QuickPurchaseForm/ProductSelector.tsx
@@ -21,10 +21,6 @@ type Props = {
 export const ProductSelector = ({ productOptions, ...delegated }: Props) => {
   const { t } = useTranslation('purchase-form')
 
-  if (productOptions.length === 1) {
-    return <input type="hidden" name={delegated.name} value={productOptions[0].value} />
-  }
-
   return (
     <SelectPrimitive.Root {...delegated}>
       <SelectTrigger>

--- a/apps/store/src/components/QuickPurchaseForm/QuickPurchaseForm.tsx
+++ b/apps/store/src/components/QuickPurchaseForm/QuickPurchaseForm.tsx
@@ -22,7 +22,6 @@ export type FormError = Partial<Record<typeof SSN_FIELDNAME | 'general', string>
 type Props = {
   productOptions: Array<ProductOption>
   onSubmit?: FormEventHandler<HTMLFormElement>
-  loading?: boolean
   submitting?: boolean
   showSsnField?: boolean
   ssnDefaultValue?: string
@@ -32,7 +31,7 @@ type Props = {
 export const QuickPurchaseForm = ({
   productOptions,
   onSubmit,
-  submitting,
+  submitting = false,
   ssnDefaultValue = '',
   showSsnField = false,
   error,
@@ -42,13 +41,17 @@ export const QuickPurchaseForm = ({
   return (
     <form onSubmit={onSubmit}>
       <Space y={0.25}>
-        <ProductSelector
-          productOptions={productOptions}
-          name={PRODUCT_FIELDNAME}
-          disabled={submitting}
-          required={true}
-        />
-
+        {productOptions.length === 1 && (
+          <input type="hidden" name={PRODUCT_FIELDNAME} value={productOptions[0].value} />
+        )}
+        {productOptions.length > 1 && (
+          <ProductSelector
+            productOptions={productOptions}
+            name={PRODUCT_FIELDNAME}
+            disabled={submitting}
+            required={true}
+          />
+        )}
         <SsnField
           name={SSN_FIELDNAME}
           defaultValue={ssnDefaultValue}
@@ -58,11 +61,9 @@ export const QuickPurchaseForm = ({
           message={error?.ssn}
           hidden={!showSsnField}
         />
-
         <Button type="submit" loading={submitting}>
           {t('BUTTON_LABEL_GET_PRICE')}
         </Button>
-
         {error?.general && <GeneralErrorMessage>{error.general}</GeneralErrorMessage>}
       </Space>
     </form>


### PR DESCRIPTION
## Describe your changes

Don't render `ProductSelector` if no `productOptions` list is empty.

## Justify why they are needed

To avoid "flashing UI"

https://github.com/HedvigInsurance/racoon/assets/19200662/5c6183fc-4dda-4d92-8b5e-8d20d2d9c69d

**Disclaimer**

It will happen when more than one `productOption` is available. But adding UI pieces after something gets loaded seems less disruptive then removing it. 

https://github.com/HedvigInsurance/racoon/assets/19200662/1e23a595-ad49-4573-80b0-87eb024184a7

## Relates with

https://github.com/HedvigInsurance/racoon/pull/2446
