### PR TITLE
fix(DetailsSheet): sanitize rows

### DIFF
--- a/apps/store/src/components/CartInventory/CartEntryItem/DetailsSheet.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem/DetailsSheet.tsx
@@ -13,15 +13,20 @@ export const DetailsSheet = (props: CartEntry) => {
   const dataTableRows = getDataTable(productName)
   const getDataTableValue = useGetDataTableValue()
 
+  const allRows =
+    dataTableRows?.map((item) => ({
+      title: t(item.label, { defaultValue: `${item.label} MISSING` }),
+      value: getDataTableValue(item, data),
+    })) ?? []
+  const rowsWithValues = allRows.filter((item) => item.value !== null)
+
   return (
     <Root y={1}>
       <Table>
-        {dataTableRows?.map((item) => (
-          <Row key={item.label}>
-            <Text color="textSecondary">
-              {t(item.label, { defaultValue: `${item.label} MISSING` })}
-            </Text>
-            <Text>{getDataTableValue(item, data)}</Text>
+        {rowsWithValues.map(({ title, value }) => (
+          <Row key={title}>
+            <Text color="textSecondary">{title}</Text>
+            <Text>{value}</Text>
           </Row>
         ))}
         {props.tierLevelDisplayName && (


### PR DESCRIPTION
## Describe your changes

'Sanitize' details sheet offer related rows by not showing rows that doesn't contain values associated with it. 

## Justify why they are needed

For hedvig-com created pet offers we want to display 'Boyta' (living space) row but for many pets offers we don't have that info and therefore want to hide from the table.

**Before**

<img width="574" alt="Screenshot 2023-05-29 at 14 03 22" src="https://github.com/HedvigInsurance/racoon/assets/19200662/9753632a-0a18-400e-95b3-d4de076f7142">

**After**

<img width="524" alt="Screenshot 2023-05-29 at 14 03 44" src="https://github.com/HedvigInsurance/racoon/assets/19200662/dba488ac-daa4-4f36-95e4-9d3ead71d3a4">

