### PR TITLE
GEN-392 - feat(GlobalBanner): make usage of SessionStorage to keep banner opened/closed state

### DIFF
--- a/apps/store/src/components/GlobalBanner/useGlobalBanner.tsx
+++ b/apps/store/src/components/GlobalBanner/useGlobalBanner.tsx
@@ -1,9 +1,13 @@
 import { useAtom, useSetAtom } from 'jotai'
-import { atomWithReset, atomWithStorage } from 'jotai/utils'
+import { atomWithReset, atomWithStorage, createJSONStorage } from 'jotai/utils'
 
 const GLOBAL_BANNER_ATOM = atomWithReset<string | null>(null)
 
-const GLOBAL_BANNER_CLOSED_ATOM = atomWithStorage<boolean>('closedBanner', false)
+const GLOBAL_BANNER_CLOSED_ATOM = atomWithStorage<boolean>(
+  'closedBanner',
+  false,
+  createJSONStorage(() => sessionStorage),
+)
 
 export const useGlobalBanner = () => {
   return useAtom(GLOBAL_BANNER_ATOM)


### PR DESCRIPTION
## Describe your changes

* Make usage of SessionStorage to keep banner opened/closed state

## Justify why they are needed

When it comes about `atomWithStorage`:

> If not specified, the default storage implementation uses localStorage for storage/retrieval, JSON.stringify()/JSON.parse() for serialization/deserialization, and subscribes to storage events for cross-tab synchronization.

Then Peter mentioned this:

> How is the cache for closed/removed banner configured? I closed a discount banner in my browser two weeks ago. Now it never shows up again, only in incognito. Could we cache it only during the user session.

So I guess it would be better to keep that temporary state into `SessionStorage` despite the tradeoff of not having it shared between multiple tabs.
