### PR TITLE
feat(Banner): added banner component

### DIFF
--- a/apps/store/src/components/Banner/Banner.stories.tsx
+++ b/apps/store/src/components/Banner/Banner.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Banner } from './Banner'
+
+type Story = StoryObj<typeof Banner>
+
+const meta: Meta<typeof Banner> = {
+  title: 'Banner',
+  component: Banner,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+const noopHandleClose = () => {}
+
+export const Info: Story = {
+  render: () => (
+    <Banner handleClose={noopHandleClose}>
+      <span>
+        Here’s a message with random information ·{' '}
+        <a style={{ textDecoration: 'underline' }} href="#">
+          Read more
+        </a>
+      </span>
+    </Banner>
+  ),
+}
+
+export const Campaign: Story = {
+  render: () => (
+    <Banner variant="campaign" handleClose={noopHandleClose}>
+      Campaign code applied
+    </Banner>
+  ),
+}
+
+export const Warning: Story = {
+  render: () => (
+    <Banner variant="warning" handleClose={noopHandleClose}>
+      Price quote unavailable
+    </Banner>
+  ),
+}
+
+export const Error: Story = {
+  render: () => (
+    <Banner variant="error" handleClose={noopHandleClose}>
+      An unknown error has occured
+    </Banner>
+  ),
+}
+
+export const LongText: Story = {
+  render: () => (
+    <Banner handleClose={noopHandleClose}>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eget nunc cursus, laoreet leo
+      ut, mollis odio. Nunc egestas, nisi ac lobortis bibendum, libero
+    </Banner>
+  ),
+}
+
+export default meta

--- a/apps/store/src/components/Banner/Banner.tsx
+++ b/apps/store/src/components/Banner/Banner.tsx
@@ -1,0 +1,118 @@
+import styled from '@emotion/styled'
+import { type ReactNode } from 'react'
+import { InfoIcon, CampaignIcon, WarningTriangleIcon, CrossIconSmall, mq, theme } from 'ui'
+import { BannerVariant } from './Banner.types'
+
+const Area = {
+  Content: 'content',
+  CloseBtn: 'close-btn',
+}
+
+type Props = {
+  children: ReactNode
+  handleClose: () => void
+  variant?: BannerVariant
+}
+
+export const Banner = ({ children, handleClose, variant = 'info' }: Props) => {
+  return (
+    <Wrapper variant={variant}>
+      <Content>
+        <Icon variant={variant} />
+        <Ellipsis>{children}</Ellipsis>
+      </Content>
+      <CloseButton onClick={handleClose}>
+        <CrossIconSmall size="1rem" />
+      </CloseButton>
+    </Wrapper>
+  )
+}
+
+const Icon = ({ variant }: { variant: BannerVariant }) => {
+  const size = '1rem'
+
+  let icon: ReactNode = null
+  switch (variant) {
+    case 'info':
+      icon = <InfoIcon color={theme.colors.blue600} size={size} />
+      break
+    case 'campaign':
+      icon = <CampaignIcon color={theme.colors.greenElement} size={size} />
+      break
+    case 'warning':
+      icon = <WarningTriangleIcon color={theme.colors.amberElement} size={size} />
+      break
+    case 'error':
+      icon = <WarningTriangleIcon color={theme.colors.redElement} size={size} />
+      break
+  }
+
+  return icon
+}
+
+const Wrapper = styled.div<{ variant: BannerVariant }>(({ variant }) => ({
+  display: 'grid',
+  // Using grid here to perfect center align banner's content, excluding close button
+  gridTemplateAreas: `
+    ". ${Area.Content} ${Area.CloseBtn}"
+  `,
+  gridTemplateColumns: '1fr auto 1fr',
+  alignItems: 'center',
+  paddingBlock: theme.space.sm,
+  paddingInline: theme.space.md,
+  fontSize: theme.fontSizes.xs,
+  ...getVariantStyles(variant),
+
+  [mq.lg]: {
+    paddingInline: theme.space.xl,
+  },
+}))
+
+const Content = styled.div({
+  gridArea: Area.Content,
+  display: 'grid',
+  gridTemplateColumns: 'auto 1fr',
+  alignItems: 'center',
+  gap: theme.space.xs,
+})
+
+const CloseButton = styled.button({
+  gridArea: Area.CloseBtn,
+  justifySelf: 'end',
+  color: theme.colors.textPrimary,
+  paddingLeft: theme.space.xs,
+  cursor: 'pointer',
+})
+
+const Ellipsis = styled.span({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
+const getVariantStyles = (variant: BannerVariant) => {
+  switch (variant) {
+    case 'info':
+      return {
+        color: theme.colors.blue800,
+        backgroundColor: theme.colors.blueFill1,
+      }
+    case 'campaign':
+      return {
+        color: theme.colors.textGreen,
+        backgroundColor: theme.colors.greenFill1,
+      }
+    case 'warning':
+      return {
+        color: theme.colors.textAmber,
+        backgroundColor: theme.colors.amberFill1,
+      }
+    case 'error':
+      return {
+        color: theme.colors.textRed,
+        backgroundColor: theme.colors.redFill1,
+      }
+    default:
+      return {}
+  }
+}

--- a/apps/store/src/components/Banner/Banner.types.ts
+++ b/apps/store/src/components/Banner/Banner.types.ts
@@ -1,0 +1,1 @@
+export type BannerVariant = 'info' | 'campaign' | 'warning' | 'error'


### PR DESCRIPTION
## Describe your changes

* Extract `GlobalBanner` UI into it's own component. Down in the stack I'm gonna reuse that component - `Banner` - within `GlobalBanner` and `AnnouncementBlock`

Changes:

* It supports 4 variants: _info_, _campaign_, _warning_ and _error_ 
* It's content is now perfectly centered in the screen as it's not taking the _close button_ into account while aligning as it was before.

<img width="927" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/459b18ed-bf41-4df1-af15-18d3910f8d09">


## Justify why they are needed

We need to provide a way for editors to render an _announcement_ (I've named it this while lacking a better name - we already have a banner block) by page. Despite looking exactly the same as the `GlobalBanner` it should function differently. That's why I thought about extracting the UI into a separate component and reuse it between `GlobalBanner` and `AnnouncementBlock`.