### PR TITLE
feat(AnnouncementBlock): added a new block

### DIFF
--- a/apps/store/src/blocks/AnnouncementBlock.tsx
+++ b/apps/store/src/blocks/AnnouncementBlock.tsx
@@ -1,0 +1,111 @@
+import styled from '@emotion/styled'
+import { storyblokEditable, renderRichText, type ISbRichtext } from '@storyblok/react'
+import { atom, useAtom, useSetAtom } from 'jotai'
+import { createJSONStorage, atomWithStorage } from 'jotai/utils'
+import { useEffect, useCallback } from 'react'
+import { Banner } from '@/components/Banner/Banner'
+import { BannerVariant } from '@/components/Banner/Banner.types'
+import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+
+export type AnnouncementBlockProps = SbBaseBlockProps<{
+  id: string
+  content: ISbRichtext
+  variant?: BannerVariant
+}>
+
+export const AnnouncementBlock = ({ blok }: AnnouncementBlockProps) => {
+  const { announcements, addAnnouncement, dimissAnnouncement } = useAnnouncements()
+
+  const handleClose = useCallback(() => {
+    dimissAnnouncement(blok.id)
+  }, [blok.id, dimissAnnouncement])
+
+  useEffect(() => {
+    addAnnouncement({
+      id: blok.id,
+      content: renderRichText(blok.content),
+      variant: blok.variant ?? 'info',
+    })
+  }, [blok, addAnnouncement])
+
+  const matchedAnnouncement = announcements.find((announcement) => announcement.id === blok.id)
+  if (!matchedAnnouncement) return null
+
+  return (
+    <Banner
+      variant={matchedAnnouncement.variant}
+      handleClose={handleClose}
+      {...storyblokEditable(blok)}
+    >
+      <Content dangerouslySetInnerHTML={{ __html: matchedAnnouncement.content }} />
+    </Banner>
+  )
+}
+
+AnnouncementBlock.blockName = 'announcement'
+
+const Content = styled.span({
+  a: {
+    textDecoration: 'underline',
+  },
+})
+
+type Announcement = {
+  id: string
+  content: string
+  variant?: BannerVariant
+}
+
+const PERSISTED_DISMISSED_ANNOUNCEMENTS = atomWithStorage<string[]>(
+  'dismissedAnnouncements',
+  [],
+  createJSONStorage(() => sessionStorage),
+)
+
+const ANNOUNCEMENTS_ATOM = atom<Announcement[]>([])
+
+const ACTIVE_ANNOUNCEMENTS = atom(
+  (get) => {
+    const dismissedAnnouncementIds = get(PERSISTED_DISMISSED_ANNOUNCEMENTS)
+    const activeAnnouncements = get(ANNOUNCEMENTS_ATOM).filter(
+      (announcement) => !dismissedAnnouncementIds.includes(announcement.id),
+    )
+
+    return activeAnnouncements
+  },
+  (get, set, newAnnouncement: Announcement) => {
+    const allAnnouncements = get(ANNOUNCEMENTS_ATOM)
+    const isExistingAnnouncement = allAnnouncements.some(
+      (announcement) => announcement.id === newAnnouncement.id,
+    )
+
+    if (!isExistingAnnouncement) {
+      set(ANNOUNCEMENTS_ATOM, [...get(ANNOUNCEMENTS_ATOM), newAnnouncement])
+    }
+  },
+)
+
+const useAnnouncements = () => {
+  const [announcements, setAnnouncements] = useAtom(ACTIVE_ANNOUNCEMENTS)
+  const setDismissedAnnouncementIds = useSetAtom(PERSISTED_DISMISSED_ANNOUNCEMENTS)
+
+  const addAnnouncement = useCallback(
+    (announcement: Announcement) => {
+      setAnnouncements(announcement)
+    },
+    [setAnnouncements],
+  )
+
+  const dimissAnnouncement = useCallback(
+    (announcementId: string) => {
+      setDismissedAnnouncementIds((prev) => [...prev, announcementId])
+    },
+    [setDismissedAnnouncementIds],
+  )
+
+  return {
+    announcements,
+    addAnnouncement,
+    dimissAnnouncement,
+  }
+}

--- a/apps/store/src/blocks/ReusableBlockReference.tsx
+++ b/apps/store/src/blocks/ReusableBlockReference.tsx
@@ -1,7 +1,7 @@
 import { StoryblokComponent } from '@storyblok/react'
 import { ReusableStory, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
-type ReusableBlockReferenceProps = SbBaseBlockProps<{
+export type ReusableBlockReferenceProps = SbBaseBlockProps<{
   reference: Omit<ReusableStory, 'content'> & Partial<Pick<ReusableStory, 'content'>>
 }>
 

--- a/apps/store/src/components/Banner/Banner.tsx
+++ b/apps/store/src/components/Banner/Banner.tsx
@@ -19,7 +19,7 @@ export const Banner = ({ children, handleClose, variant = 'info' }: Props) => {
     <Wrapper variant={variant}>
       <Content>
         <Icon variant={variant} />
-        <Ellipsis>{children}</Ellipsis>
+        {children}
       </Content>
       <CloseButton onClick={handleClose}>
         <CrossIconSmall size="1rem" />
@@ -82,12 +82,6 @@ const CloseButton = styled.button({
   color: theme.colors.textPrimary,
   paddingLeft: theme.space.xs,
   cursor: 'pointer',
-})
-
-const Ellipsis = styled.span({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
 })
 
 const getVariantStyles = (variant: BannerVariant) => {

--- a/apps/store/src/components/GlobalBanner/GlobalBanner.tsx
+++ b/apps/store/src/components/GlobalBanner/GlobalBanner.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled'
 import { Banner } from '@/components/Banner/Banner'
 import { useDebugShopSession } from '@/utils/useDebugShopSession'
 import { useGlobalBanner } from './useGlobalBanner'
@@ -15,7 +16,13 @@ export const GlobalBanner = () => {
 
   return (
     <Banner variant={banner.variant} handleClose={handleClose}>
-      {banner.content}
+      <Ellipsis>{banner.content}</Ellipsis>
     </Banner>
   )
 }
+
+const Ellipsis = styled.span({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})

--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled'
+import { StoryblokComponent } from '@storyblok/react'
 import { type ReactElement } from 'react'
 import { FooterBlock } from '@/blocks/FooterBlock'
 import { HeaderBlock } from '@/blocks/HeaderBlock'
+import { ReusableBlockReference } from '@/blocks/ReusableBlockReference'
 import { PageStory, StoryblokPageProps } from '@/services/storyblok/storyblok'
 import { filterByBlockType, isProductStory } from '@/services/storyblok/Storyblok.helpers'
 import { useChangeLocale } from '@/utils/l10n/useChangeLocale'
@@ -33,6 +35,11 @@ export const LayoutWithMenu = (props: LayoutWithMenuProps) => {
   useHydrateProductMetadata(props.children.props[GLOBAL_PRODUCT_METADATA_PROP_NAME])
   const handleLocaleChange = useChangeLocale(story)
 
+  // Announcements are added as reusable blocks for Page and ProductPage content types
+  const reusableBlock = filterByBlockType(
+    story?.content.announcement,
+    ReusableBlockReference.blockName,
+  )
   const headerBlock = filterByBlockType(globalStory.content.header, HeaderBlock.blockName)
   const footerBlock = filterByBlockType(globalStory.content.footer, FooterBlock.blockName)
 
@@ -45,6 +52,9 @@ export const LayoutWithMenu = (props: LayoutWithMenuProps) => {
 
   return (
     <Wrapper className={className}>
+      {reusableBlock.map((referencedBlok) => (
+        <StoryblokComponent key={referencedBlok._uid} blok={referencedBlok} />
+      ))}
       {showHeader &&
         headerBlock.map((nestedBlock) => (
           <HeaderBlock

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -8,6 +8,7 @@ import {
 } from '@storyblok/react'
 import { AccordionBlock } from '@/blocks/AccordionBlock'
 import { AccordionItemBlock } from '@/blocks/AccordionItemBlock'
+import { AnnouncementBlock } from '@/blocks/AnnouncementBlock'
 import { BannerBlock } from '@/blocks/BannerBlock'
 import { BlogArticleCategoryContentType } from '@/blocks/BlogArticleCategoryContentType'
 import { BlogArticleCategoryListBlock } from '@/blocks/BlogArticleCategoryListBlock'
@@ -51,7 +52,10 @@ import { ProductPillowsBlock } from '@/blocks/ProductPillowsBlock/ProductPillows
 import { ProductSlideshowBlock } from '@/blocks/ProductSlideshowBlock'
 import { ProductVariantSelectorBlock } from '@/blocks/ProductVariantSelectorBlock'
 import { QuickPurchaseBlock } from '@/blocks/QuickPurchaseBlock'
-import { ReusableBlockReference } from '@/blocks/ReusableBlockReference'
+import {
+  ReusableBlockReference,
+  ReusableBlockReferenceProps,
+} from '@/blocks/ReusableBlockReference'
 import { RichTextBlock } from '@/blocks/RichTextBlock/RichTextBlock'
 import { SelectInsuranceGridBlock } from '@/blocks/SelectInsuranceGridBlock'
 import { SpacerBlock } from '@/blocks/SpacerBlock'
@@ -139,6 +143,8 @@ export type SEOData = {
 
 export type PageStory = ISbStoryData<
   {
+    announcement: ExpectedBlockType<ReusableBlockReferenceProps>
+    body: Array<SbBlokData>
     hideMenu?: boolean
     overlayMenu?: boolean
     hideFooter?: boolean
@@ -154,6 +160,7 @@ export type ProductStory = ISbStoryData<
     defaultProductVariant?: string
     productId: string
     priceFormTemplateId: string
+    announcement: ExpectedBlockType<ReusableBlockReferenceProps>
     body: Array<SbBlokData>
     global: Array<SbBlokData>
   } & SEOData
@@ -210,6 +217,7 @@ export const initStoryblok = () => {
   const blockComponents: Array<NamedBlock> = [
     AccordionBlock,
     AccordionItemBlock,
+    AnnouncementBlock,
     BannerBlock,
     ButtonBlock,
     CheckListBlock,


### PR DESCRIPTION
## Describe your changes

This PR is about integrating `AnnouncementBlock` for `Page` and `Product` content types. Down in the stack I also update `MigrationPage` content type so it does the same.

* Add a new block - `AnnouncementBlock` - which editors can use to display a _banner_ like message by page basis. As `GlobalBanner`, it uses `Banner` component as the UI.
* Multiple pages can share the same _announcement_ by reusing the same block.
* We use `SessionStorage` to keep opened/closed state for announcements.

<img width="1355" alt="Screenshot 2023-06-05 at 11 44 39" src="https://github.com/HedvigInsurance/racoon/assets/19200662/87aa7614-75fc-4bfb-9f14-5f779e237364">

<img width="345" alt="Screenshot 2023-06-05 at 11 43 03" src="https://github.com/HedvigInsurance/racoon/assets/19200662/c35c33ab-efcf-4d2f-8300-6537fbdbde00">

## Justify why they are needed

Editors would like to show a banner on specific pages and that by dismissing that banner in one page would also dismiss it on all pages that renders it.