### PR TITLE
Add Blog Article List Block

### DIFF
--- a/.vscode/racoon.code-workspace
+++ b/.vscode/racoon.code-workspace
@@ -35,6 +35,7 @@
       "**/coverage": true,
       "**/storybook-static": true,
       "**/*.tsbuildinfo": true
-    }
+    },
+    "githubPullRequests.ignoredPullRequestBranches": ["main"]
   }
 }

--- a/apps/store/src/blocks/BlogArticleListBlock.tsx
+++ b/apps/store/src/blocks/BlogArticleListBlock.tsx
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled'
+import { theme } from 'ui'
+import { ArticleTeaser } from '@/components/ArticleTeaser/ArticleTeaser'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { useBlogArticleTeaserList } from '@/services/blog/blogArticleTeaserList'
+import { useFormatter } from '@/utils/useFormatter'
+
+export const BlogArticleListBlock = () => {
+  const teaserList = useBlogArticleTeaserList()
+  const formatter = useFormatter()
+
+  return (
+    <GridLayout.Root>
+      <GridLayout.Content width="1" align="center">
+        <List>
+          {teaserList.map((item) => (
+            <ArticleTeaser.Root key={item.id}>
+              <ArticleTeaser.Image {...item.image} alt={item.image.alt} />
+              <ArticleTeaser.Content
+                href="/se"
+                title={item.heading}
+                date={formatter.fromNow(new Date(item.date))}
+              >
+                {item.text}
+              </ArticleTeaser.Content>
+              <ArticleTeaser.BadgeList>
+                {item.categories.map((category) => (
+                  <ArticleTeaser.Badge key={category}>{category}</ArticleTeaser.Badge>
+                ))}
+              </ArticleTeaser.BadgeList>
+            </ArticleTeaser.Root>
+          ))}
+        </List>
+      </GridLayout.Content>
+    </GridLayout.Root>
+  )
+}
+BlogArticleListBlock.blockName = 'blogArticleList'
+
+const List = styled.div({
+  display: 'grid',
+  rowGap: theme.space.xxxl,
+  columnGap: theme.space.lg,
+  gridTemplateColumns: 'repeat(auto-fill, minmax(21rem, 1fr))',
+  gridTemplateRows: 'max-content',
+})

--- a/apps/store/src/components/ArticleTeaser/ArticleTeaser.stories.tsx
+++ b/apps/store/src/components/ArticleTeaser/ArticleTeaser.stories.tsx
@@ -1,5 +1,4 @@
 import { type Meta, type StoryObj } from '@storybook/react'
-import Image from 'next/image'
 import { ArticleTeaser } from './ArticleTeaser'
 
 const meta: Meta = {
@@ -12,18 +11,16 @@ type Story = StoryObj
 export const Primary: Story = {
   render: () => (
     <ArticleTeaser.Root>
-      <ArticleTeaser.Header>
-        <Image
-          src="https://www.hedvig.com/f/62762/800x450/42924b7dde/mimmi-thumbnail.jpg"
-          width={800}
-          height={450}
-          alt="Mimmi"
-        />
-        <ArticleTeaser.Date>2021.05.12</ArticleTeaser.Date>
-      </ArticleTeaser.Header>
+      <ArticleTeaser.Image
+        src="https://www.hedvig.com/f/62762/800x450/42924b7dde/mimmi-thumbnail.jpg"
+        width={800}
+        height={450}
+        alt="Mimmi"
+      />
       <ArticleTeaser.Content
         href="/se"
         title="Hedvig och Mimmi Blomqvist lanserar hundskålar i limiterad upplaga"
+        date="2021.05.12"
       >
         I ett nytt samarbete har Hedvig tillsammans med designern Mimmi Blomqvist ställt sig frågan
         vad som händer när en hundskål inte bara fyller en funktion, utan också blir ett

--- a/apps/store/src/components/ArticleTeaser/ArticleTeaser.tsx
+++ b/apps/store/src/components/ArticleTeaser/ArticleTeaser.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled'
+import NextImage, { type ImageProps } from 'next/image'
 import Link from 'next/link'
 import { type ReactNode } from 'react'
-import { Badge, Heading, Space, Text } from 'ui'
+import { Badge, Heading, Space, Text, theme } from 'ui'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 
 const Root = (props: { children: ReactNode }) => {
@@ -12,38 +13,39 @@ const RelativeSpace = styled(Space)({
   position: 'relative',
 })
 
-const Header = (props: { children: ReactNode }) => {
-  return <Space y={0.25}>{props.children}</Space>
-}
-
-const Date = (props: { children: ReactNode }) => {
-  return (
-    <Text size="sm" color="textSecondary">
-      {props.children}
-    </Text>
-  )
-}
+const RoundedImage = styled(NextImage)({ borderRadius: theme.radius.xl })
+const Image = (props: ImageProps) => <RoundedImage {...props} />
 
 type ContentProps = {
   children: ReactNode
   title: string
   href: string
+  date: string
 }
 
 const Content = (props: ContentProps) => {
   return (
-    <div>
-      <ExtendedLink href={props.href}>
-        <Heading as="h3" variant="standard.20">
-          {props.title}
-        </Heading>
-      </ExtendedLink>
-      <ClampedText size="lg" color="textSecondary">
-        {props.children}
-      </ClampedText>
-    </div>
+    <ContentWrapper>
+      <Space y={0.25}>
+        <Text size="sm" color="textSecondary">
+          {props.date}
+        </Text>
+        <div>
+          <ExtendedLink href={props.href}>
+            <Heading as="h3" variant="standard.20">
+              {props.title}
+            </Heading>
+          </ExtendedLink>
+          <ClampedText size="lg" color="textSecondary">
+            {props.children}
+          </ClampedText>
+        </div>
+      </Space>
+    </ContentWrapper>
   )
 }
+
+const ContentWrapper = styled.div({ paddingInline: theme.space.xs })
 
 const ExtendedLink = styled(Link)({
   // Make the whole teaser clickable
@@ -62,13 +64,16 @@ const ClampedText = styled(Text)({
 })
 
 const BadgeList = (props: { children: ReactNode }) => {
-  return <SpaceFlex space={0.25}>{props.children}</SpaceFlex>
+  return (
+    <ContentWrapper>
+      <SpaceFlex space={0.25}>{props.children}</SpaceFlex>
+    </ContentWrapper>
+  )
 }
 
 export const ArticleTeaser = {
   Root,
-  Header,
-  Date,
+  Image,
   Content,
   BadgeList,
   Badge,

--- a/apps/store/src/services/blog/articleTeaser.ts
+++ b/apps/store/src/services/blog/articleTeaser.ts
@@ -1,0 +1,46 @@
+import { getBlogArticleStories } from '@/services/storyblok/storyblok'
+import { getStoryblokImageSize } from '@/services/storyblok/Storyblok.helpers'
+
+export type BlogArticleTeaser = {
+  id: string
+  heading: string
+  date: string
+  categories: Array<string>
+  text: string
+  image: {
+    src: string
+    alt: string
+    width: number
+    height: number
+  }
+}
+
+export const getBlogArticleTeasers = async (): Promise<Array<BlogArticleTeaser>> => {
+  const blogArticles = await getBlogArticleStories()
+
+  const teasers: Array<BlogArticleTeaser> = []
+
+  for (const item of blogArticles) {
+    const sizeProps = getStoryblokImageSize(item.content.teaser_image.filename)
+    if (sizeProps === null) {
+      console.warn(`Could not get image size for ${item.content.teaser_image.filename}`)
+      console.warn(`Skipping blog article, ${item.content.page_heading}`)
+      continue
+    }
+
+    teasers.push({
+      id: item.uuid,
+      heading: item.content.page_heading,
+      date: item.content.date,
+      categories: item.content.categories,
+      text: item.content.teaser_text,
+      image: {
+        src: item.content.teaser_image.filename,
+        alt: item.content.teaser_image.alt,
+        ...sizeProps,
+      },
+    })
+  }
+
+  return teasers
+}

--- a/apps/store/src/services/blog/blog.helpers.ts
+++ b/apps/store/src/services/blog/blog.helpers.ts
@@ -1,0 +1,6 @@
+import { ISbStoryData, SbBlokData } from '@storyblok/react'
+
+export const isBlogStory = (story: ISbStoryData): boolean => {
+  const body = story.content.body as Array<SbBlokData> | undefined
+  return body?.find((item) => item.component === 'blogArticleList') !== undefined
+}

--- a/apps/store/src/services/blog/blogArticleTeaserList.ts
+++ b/apps/store/src/services/blog/blogArticleTeaserList.ts
@@ -1,0 +1,15 @@
+import { atom, useAtomValue } from 'jotai'
+import { useHydrateAtoms } from 'jotai/utils'
+import { BlogArticleTeaser } from './articleTeaser'
+
+type BlogArticleTeaserList = Array<BlogArticleTeaser>
+
+const BLOG_ARTICLE_TEASERS_ATOM = atom<BlogArticleTeaserList>([])
+
+export const useBlogArticleTeaserList = (): BlogArticleTeaserList => {
+  return useAtomValue(BLOG_ARTICLE_TEASERS_ATOM)
+}
+
+export const useHydrateBlogArticleTeaserList = (value: BlogArticleTeaserList) => {
+  useHydrateAtoms([[BLOG_ARTICLE_TEASERS_ATOM, value]])
+}

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -8,6 +8,7 @@ import {
 import { AccordionBlock } from '@/blocks/AccordionBlock'
 import { AccordionItemBlock } from '@/blocks/AccordionItemBlock'
 import { BannerBlock } from '@/blocks/BannerBlock'
+import { BlogArticleListBlock } from '@/blocks/BlogArticleListBlock'
 import { ButtonBlock } from '@/blocks/ButtonBlock'
 import { CardLinkBlock } from '@/blocks/CardLinkBlock'
 import { CardLinkListBlock } from '@/blocks/CardLinkListBlock'
@@ -59,12 +60,12 @@ import { TopPickCardBlock } from '@/blocks/TopPickCardBlock'
 import { USPBlock, USPBlockItem } from '@/blocks/USPBlock'
 import { VideoBlock } from '@/blocks/VideoBlock'
 import { VideoListBlock } from '@/blocks/VideoListBlock'
-import { fetchStory, StoryblokFetchParams } from '@/services/storyblok/Storyblok.helpers'
 import { isBrowser } from '@/utils/env'
 import { Features } from '@/utils/Features'
 import { getLocaleOrFallback, isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { Language, RoutingLocale } from '@/utils/l10n/types'
 import { GLOBAL_STORY_PROP_NAME, STORY_PROP_NAME } from './Storyblok.constant'
+import { fetchStory, StoryblokFetchParams } from './Storyblok.helpers'
 
 export type SbBaseBlockProps<T> = {
   blok: SbBlokData & T
@@ -255,6 +256,7 @@ export const initStoryblok = () => {
     CardLinkListBlock,
     SelectInsuranceGridBlock,
     QuickPurchaseBlock,
+    BlogArticleListBlock,
   ]
   const blockAliases = { reusableBlock: PageBlock }
   const components = {
@@ -355,3 +357,25 @@ export const getFilteredProductLinks = async () => {
   const allLinks = await getPageLinks()
   return allLinks.filter(({ slugParts }) => slugParts[0] === PRODUCTS_SLUG)
 }
+
+const BLOG_ARTICLE_CONTENT_TYPE = 'blog-article'
+export const getBlogArticleStories = async (): Promise<Array<BlogArticleStory>> => {
+  const response = await getStoryblokApi().getStories({
+    content_type: BLOG_ARTICLE_CONTENT_TYPE,
+    resolve_relations: 'reusableBlockReference.reference',
+  })
+
+  return response.data.stories as Array<BlogArticleStory>
+}
+
+type BlogArticleStory = ISbStoryData<
+  {
+    date: string
+    footer: Array<SbBlokData>
+    content: Array<SbBlokData>
+    categories: Array<string>
+    teaser_text: string
+    page_heading: string
+    teaser_image: StoryblokAsset
+  } & SEOData
+>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add a new block to display a list of Blog Article Teasers.

- Check if teaser block is included on page to determine if we should fetch the list of articles.

- Pass down list of teasers to the block through a Jotai atom.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Support company blog

- Use static site generation for blog pages

- I wanna avoid passing Storyblok data into React world so I create an internal representation for a "blog article teaser" which is converted from Storyblok data. This way we avoid making our solution too tightly coupled to Storyblok.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
