### PR TITLE
[GEN-422] Add option to toggle display of video controls

### DIFF
--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -10,6 +10,7 @@ export type VideoBlockProps = SbBaseBlockProps<
     video: StoryblokAsset
     poster?: StoryblokAsset
     fullBleed?: boolean
+    controls?: boolean
   } & Pick<
     VideoProps,
     | 'autoPlay'
@@ -20,7 +21,7 @@ export type VideoBlockProps = SbBaseBlockProps<
   >
 > & { className?: string }
 
-export const VideoBlock = ({ className, blok }: VideoBlockProps) => {
+export const VideoBlock = ({ className, blok, nested = false }: VideoBlockProps) => {
   const posterUrl = blok.poster?.filename
     ? getOptimizedImageUrl(blok.poster.filename, {
         maxWidth: breakpoints.xxl,
@@ -28,7 +29,7 @@ export const VideoBlock = ({ className, blok }: VideoBlockProps) => {
     : undefined
   return (
     <ConditionalWrapper
-      condition={!blok.fullBleed}
+      condition={!(blok.fullBleed || nested)}
       wrapWith={(children) => <Wrapper className={className}>{children}</Wrapper>}
     >
       <Video
@@ -40,6 +41,7 @@ export const VideoBlock = ({ className, blok }: VideoBlockProps) => {
         maxHeightLandscape={blok.maxHeightLandscape}
         maxHeightPortrait={blok.maxHeightPortrait}
         roundedCorners={!blok.fullBleed}
+        showControls={blok.controls}
       />
     </ConditionalWrapper>
   )

--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -27,6 +27,7 @@ export type VideoProps = React.ComponentPropsWithoutRef<'video'> & {
    */
   sources: VideoSource[]
   poster?: string
+  showControls?: boolean
 } & VideoSize
 
 const autoplaySettings = {
@@ -46,6 +47,7 @@ export const Video = ({
   roundedCorners,
   onPlaying,
   onPause,
+  showControls = true,
   ...delegated
 }: VideoProps) => {
   const videoRef = useRef<HTMLVideoElement | null>(null)
@@ -166,22 +168,24 @@ export const Video = ({
           )
         })}
       </StyledVideo>
-      <VideoControls data-state={state} onClick={() => playPauseButtonRef.current?.click()}>
-        <Controls>
-          <PlayPauseButton
-            ref={playPauseButtonRef}
-            onClick={togglePlay}
-            variant="secondary"
-            size="small"
-            aria-labelledby={playButtonId}
-          >
-            {state === State.Paused ? <PlayIcon size="1rem" /> : <PauseIcon size="1rem" />}
-            <span id={playButtonId} hidden>
-              {state === State.Paused ? 'Play' : 'Pause'}
-            </span>
-          </PlayPauseButton>
-        </Controls>
-      </VideoControls>
+      {showControls && (
+        <VideoControls data-state={state} onClick={() => playPauseButtonRef.current?.click()}>
+          <Controls>
+            <PlayPauseButton
+              ref={playPauseButtonRef}
+              onClick={togglePlay}
+              variant="secondary"
+              size="small"
+              aria-labelledby={playButtonId}
+            >
+              {state === State.Paused ? <PlayIcon size="1rem" /> : <PauseIcon size="1rem" />}
+              <span id={playButtonId} hidden>
+                {state === State.Paused ? 'Play' : 'Pause'}
+              </span>
+            </PlayPauseButton>
+          </Controls>
+        </VideoControls>
+      )}
     </VideoWrapper>
   )
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Show video controls based on setting in Storyblok

- Fix padding in nested video block


![Screenshot 2023-06-01 at 15.31.06.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/29f0ab52-29a2-43af-8557-a28a766b48e2/Screenshot%202023-06-01%20at%2015.31.06.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Feedback from Peter

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
