### PR TITLE
Add `BlogArticleCategory` support

### DIFF
--- a/apps/store/src/blocks/BlogArticleCategoryListBlock.tsx
+++ b/apps/store/src/blocks/BlogArticleCategoryListBlock.tsx
@@ -1,0 +1,23 @@
+import { ArticleCategoryList } from '@/components/ArticleCategoryList/ArticleCategoryList'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { useBlogArticleCategoryList } from '@/services/blog/blogArticleCategoryList'
+
+export const BlogArticleCategoryListBlock = () => {
+  const categoryList = useBlogArticleCategoryList()
+
+  return (
+    <GridLayout.Root>
+      <GridLayout.Content width="1" align="center">
+        <ArticleCategoryList.Root>
+          <ArticleCategoryList.ActiveItem>Alla artiklar</ArticleCategoryList.ActiveItem>
+          {categoryList.map((item) => (
+            <ArticleCategoryList.Item key={item.id} href={item.href}>
+              {item.name}
+            </ArticleCategoryList.Item>
+          ))}
+        </ArticleCategoryList.Root>
+      </GridLayout.Content>
+    </GridLayout.Root>
+  )
+}
+BlogArticleCategoryListBlock.blockName = 'blogArticleCategoryList'

--- a/apps/store/src/components/ArticleCategoryList/ArticleCategoryList.stories.tsx
+++ b/apps/store/src/components/ArticleCategoryList/ArticleCategoryList.stories.tsx
@@ -13,9 +13,7 @@ export const Primary: Story = {
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <ArticleCategoryList.Root>
         <ArticleCategoryList.Item href="/se">Alla artiklar</ArticleCategoryList.Item>
-        <ArticleCategoryList.Item href="/" active={true}>
-          Försäkringar
-        </ArticleCategoryList.Item>
+        <ArticleCategoryList.ActiveItem>Försäkringar</ArticleCategoryList.ActiveItem>
         <ArticleCategoryList.Item href="/">Insikter</ArticleCategoryList.Item>
         <ArticleCategoryList.Item href="/">På Hedvig</ArticleCategoryList.Item>
         <ArticleCategoryList.Item href="/">Lifestyle</ArticleCategoryList.Item>

--- a/apps/store/src/components/ArticleCategoryList/ArticleCategoryList.tsx
+++ b/apps/store/src/components/ArticleCategoryList/ArticleCategoryList.tsx
@@ -11,48 +11,38 @@ const Wrapper = styled.div({
   display: 'flex',
   flexWrap: 'wrap',
   gap: theme.space.xxs,
+  justifyContent: 'center',
 })
 
-type ItemProps = {
-  active?: boolean
-}
+const Item = styled(Link)({
+  borderRadius: theme.radius.sm,
+  padding: theme.space.md,
+  fontSize: theme.fontSizes.md,
+  textAlign: 'center',
+  whiteSpace: 'nowrap',
 
-const Item = styled(Link)<ItemProps>(
-  {
-    borderRadius: theme.radius.sm,
-    padding: theme.space.md,
-    fontSize: theme.fontSizes.md,
-    textAlign: 'center',
-    whiteSpace: 'nowrap',
+  ':focus-visible': {
+    backgroundColor: theme.colors.opaque1,
+  },
 
-    ':focus-visible': {
+  '@media (hover: hover)': {
+    ':hover': {
       backgroundColor: theme.colors.opaque1,
     },
-
-    '@media (hover: hover)': {
-      ':hover': {
-        backgroundColor: theme.colors.opaque1,
-      },
-    },
   },
-  ({ active }) => ({
-    ...(active && {
-      backgroundColor: theme.colors.blueFill1,
+})
 
-      ':focus-visible': {
-        backgroundColor: theme.colors.blueFill2,
-      },
-
-      '@media (hover: hover)': {
-        ':hover': {
-          backgroundColor: theme.colors.blueFill2,
-        },
-      },
-    }),
-  }),
-)
+const ActiveItem = styled.div({
+  borderRadius: theme.radius.sm,
+  padding: theme.space.md,
+  fontSize: theme.fontSizes.md,
+  textAlign: 'center',
+  whiteSpace: 'nowrap',
+  backgroundColor: theme.colors.blueFill1,
+})
 
 export const ArticleCategoryList = {
   Root,
   Item,
+  ActiveItem,
 } as const

--- a/apps/store/src/services/blog/articleCategory.ts
+++ b/apps/store/src/services/blog/articleCategory.ts
@@ -1,0 +1,12 @@
+import { getBlogArticleCategoryStories } from '@/services/storyblok/storyblok'
+import { BlogArticleCategoryList } from './blogArticleCategoryList'
+
+export const getBlogArticleCategoryList = async (): Promise<BlogArticleCategoryList> => {
+  const blogArticles = await getBlogArticleCategoryStories()
+
+  return blogArticles.map((item) => ({
+    id: item.uuid,
+    name: item.name,
+    href: item.full_slug,
+  }))
+}

--- a/apps/store/src/services/blog/articleTeaser.ts
+++ b/apps/store/src/services/blog/articleTeaser.ts
@@ -32,7 +32,7 @@ export const getBlogArticleTeasers = async (): Promise<Array<BlogArticleTeaser>>
       id: item.uuid,
       heading: item.content.page_heading,
       date: item.content.date,
-      categories: item.content.categories,
+      categories: item.content.categories.map((category) => category.name),
       text: item.content.teaser_text,
       image: {
         src: item.content.teaser_image.filename,

--- a/apps/store/src/services/blog/blogArticleCategoryList.ts
+++ b/apps/store/src/services/blog/blogArticleCategoryList.ts
@@ -1,0 +1,20 @@
+import { atom, useAtomValue } from 'jotai'
+import { useHydrateAtoms } from 'jotai/utils'
+
+type BlogArticleCategory = {
+  id: string
+  name: string
+  href: string
+}
+
+export type BlogArticleCategoryList = Array<BlogArticleCategory>
+
+const ATOM = atom<BlogArticleCategoryList>([])
+
+export const useBlogArticleCategoryList = (): BlogArticleCategoryList => {
+  return useAtomValue(ATOM)
+}
+
+export const useHydrateBlogArticleCategoryList = (value: BlogArticleCategoryList) => {
+  useHydrateAtoms([[ATOM, value]])
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add `BlogArticleCategoryListBlock` component
- Update `ArticleCategoryList` visual component
- Fetch blog article categories from Storyblok for relevant pages
- Resolve and parse categories on `blog-article` content type pages (for teaser)


![Screenshot 2023-06-02 at 10.24.16.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/1a8b512a-db68-4571-bbbe-cf2f9d7cb1b7/Screenshot%202023-06-02%20at%2010.24.16.png)


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

More support for the blog.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
