### PR TITLE
Support blog article category *pages*

### DIFF
--- a/apps/store/src/blocks/BlogArticleCategoryContentType.tsx
+++ b/apps/store/src/blocks/BlogArticleCategoryContentType.tsx
@@ -1,0 +1,7 @@
+import { type ComponentProps } from 'react'
+import { PageBlock } from './PageBlock'
+
+export const BlogArticleCategoryContentType = (props: ComponentProps<typeof PageBlock>) => {
+  return <PageBlock {...props} />
+}
+BlogArticleCategoryContentType.blockName = 'blog-article-category'

--- a/apps/store/src/blocks/BlogArticleCategoryListBlock.tsx
+++ b/apps/store/src/blocks/BlogArticleCategoryListBlock.tsx
@@ -1,20 +1,31 @@
 import { ArticleCategoryList } from '@/components/ArticleCategoryList/ArticleCategoryList'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { useBlogArticleCategoryList } from '@/services/blog/blogArticleCategoryList'
+import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
-export const BlogArticleCategoryListBlock = () => {
+type Props = SbBaseBlockProps<{
+  active?: string
+}>
+
+export const BlogArticleCategoryListBlock = (props: Props) => {
   const categoryList = useBlogArticleCategoryList()
+  const activeCategoryId = props.blok.active ?? 'all'
 
   return (
     <GridLayout.Root>
       <GridLayout.Content width="1" align="center">
         <ArticleCategoryList.Root>
-          <ArticleCategoryList.ActiveItem>Alla artiklar</ArticleCategoryList.ActiveItem>
-          {categoryList.map((item) => (
-            <ArticleCategoryList.Item key={item.id} href={item.href}>
-              {item.name}
-            </ArticleCategoryList.Item>
-          ))}
+          {categoryList.map((item) =>
+            item.id === activeCategoryId ? (
+              <ArticleCategoryList.ActiveItem key={item.id}>
+                {item.name}
+              </ArticleCategoryList.ActiveItem>
+            ) : (
+              <ArticleCategoryList.Item key={item.id} href={item.href}>
+                {item.name}
+              </ArticleCategoryList.Item>
+            ),
+          )}
         </ArticleCategoryList.Root>
       </GridLayout.Content>
     </GridLayout.Root>

--- a/apps/store/src/blocks/BlogArticleListBlock.tsx
+++ b/apps/store/src/blocks/BlogArticleListBlock.tsx
@@ -1,19 +1,34 @@
 import styled from '@emotion/styled'
+import { useMemo } from 'react'
 import { theme } from 'ui'
 import { ArticleTeaser } from '@/components/ArticleTeaser/ArticleTeaser'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { useBlogArticleTeaserList } from '@/services/blog/blogArticleTeaserList'
+import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { useFormatter } from '@/utils/useFormatter'
 
-export const BlogArticleListBlock = () => {
+type Props = SbBaseBlockProps<{
+  categories?: Array<string>
+}>
+
+export const BlogArticleListBlock = (props: Props) => {
   const teaserList = useBlogArticleTeaserList()
   const formatter = useFormatter()
+
+  const filteredTeaserList = useMemo(() => {
+    if (!props.blok.categories?.length) return teaserList
+
+    const categorySet = new Set(props.blok.categories)
+    return teaserList.filter((item) => {
+      return item.categories.some((category) => categorySet.has(category.id))
+    })
+  }, [teaserList, props.blok.categories])
 
   return (
     <GridLayout.Root>
       <GridLayout.Content width="1" align="center">
         <List>
-          {teaserList.map((item) => (
+          {filteredTeaserList.map((item) => (
             <ArticleTeaser.Root key={item.id}>
               <ArticleTeaser.Image {...item.image} alt={item.image.alt} />
               <ArticleTeaser.Content
@@ -25,7 +40,7 @@ export const BlogArticleListBlock = () => {
               </ArticleTeaser.Content>
               <ArticleTeaser.BadgeList>
                 {item.categories.map((category) => (
-                  <ArticleTeaser.Badge key={category}>{category}</ArticleTeaser.Badge>
+                  <ArticleTeaser.Badge key={category.id}>{category.name}</ArticleTeaser.Badge>
                 ))}
               </ArticleTeaser.BadgeList>
             </ArticleTeaser.Root>

--- a/apps/store/src/components/ArticleTeaser/ArticleTeaser.tsx
+++ b/apps/store/src/components/ArticleTeaser/ArticleTeaser.tsx
@@ -13,7 +13,10 @@ const RelativeSpace = styled(Space)({
   position: 'relative',
 })
 
-const RoundedImage = styled(NextImage)({ borderRadius: theme.radius.xl })
+const RoundedImage = styled(NextImage)({
+  borderRadius: theme.radius.xl,
+  aspectRatio: '16 / 9',
+})
 const Image = (props: ImageProps) => <RoundedImage {...props} />
 
 type ContentProps = {

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -13,7 +13,7 @@ import { ProductPageProps } from '@/components/ProductPage/ProductPage.types'
 import { initializeApollo } from '@/services/apollo/client'
 import { getBlogArticleCategoryList } from '@/services/blog/articleCategory'
 import { BlogArticleTeaser, getBlogArticleTeasers } from '@/services/blog/articleTeaser'
-import { isBlogStory } from '@/services/blog/blog.helpers'
+import { hasBlogArticleList } from '@/services/blog/blog.helpers'
 import {
   BlogArticleCategoryList,
   useHydrateBlogArticleCategoryList,
@@ -111,7 +111,7 @@ export const getStaticProps: GetStaticProps<
 
   let blogArticleTeasers: Array<BlogArticleTeaser> | undefined
   let blogArticleCategoryList: BlogArticleCategoryList | undefined
-  if (isBlogStory(story)) {
+  if (hasBlogArticleList(story)) {
     blogArticleTeasers = await getBlogArticleTeasers()
     blogArticleCategoryList = await getBlogArticleCategoryList()
   }

--- a/apps/store/src/services/blog/articleTeaser.ts
+++ b/apps/store/src/services/blog/articleTeaser.ts
@@ -5,7 +5,10 @@ export type BlogArticleTeaser = {
   id: string
   heading: string
   date: string
-  categories: Array<string>
+  categories: Array<{
+    id: string
+    name: string
+  }>
   text: string
   image: {
     src: string
@@ -32,7 +35,10 @@ export const getBlogArticleTeasers = async (): Promise<Array<BlogArticleTeaser>>
       id: item.uuid,
       heading: item.content.page_heading,
       date: item.content.date,
-      categories: item.content.categories.map((category) => category.name),
+      categories: item.content.categories.map((category) => ({
+        id: category.uuid,
+        name: category.name,
+      })),
       text: item.content.teaser_text,
       image: {
         src: item.content.teaser_image.filename,

--- a/apps/store/src/services/blog/blog.helpers.ts
+++ b/apps/store/src/services/blog/blog.helpers.ts
@@ -1,6 +1,6 @@
 import { ISbStoryData, SbBlokData } from '@storyblok/react'
 
-export const isBlogStory = (story: ISbStoryData): boolean => {
+export const hasBlogArticleList = (story: ISbStoryData): boolean => {
   const body = story.content.body as Array<SbBlokData> | undefined
-  return body?.find((item) => item.component === 'blogArticleList') !== undefined
+  return body?.some((item) => item.component === 'blogArticleList') ?? false
 }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -8,6 +8,7 @@ import {
 import { AccordionBlock } from '@/blocks/AccordionBlock'
 import { AccordionItemBlock } from '@/blocks/AccordionItemBlock'
 import { BannerBlock } from '@/blocks/BannerBlock'
+import { BlogArticleCategoryContentType } from '@/blocks/BlogArticleCategoryContentType'
 import { BlogArticleCategoryListBlock } from '@/blocks/BlogArticleCategoryListBlock'
 import { BlogArticleListBlock } from '@/blocks/BlogArticleListBlock'
 import { ButtonBlock } from '@/blocks/ButtonBlock'
@@ -261,6 +262,7 @@ export const initStoryblok = () => {
     QuickPurchaseBlock,
     BlogArticleListBlock,
     BlogArticleCategoryListBlock,
+    BlogArticleCategoryContentType,
   ]
   const blockAliases = { reusableBlock: PageBlock }
   const components = {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add support for rendering blog article category pages (content type: `blog-article-category`)

- Use same underlying block as `page` content type

- Add support for filtering blog articles by categories defined in `blogArticleList` block


![Screenshot 2023-06-02 at 13.21.18.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/17bf5e29-36e7-4b3d-86ef-3a9e190ee42e/Screenshot%202023-06-02%20at%2013.21.18.png)


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Blog support

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
