### PR TITLE
Add breadcrumb list above footer

### DIFF
--- a/apps/store/src/blocks/RichTextBlock/RichTextBlock.styles.tsx
+++ b/apps/store/src/blocks/RichTextBlock/RichTextBlock.styles.tsx
@@ -24,18 +24,20 @@ export const GlobalLinkStyles = () => {
 }
 
 export const linkStyles = css({
-  a: {
-    textDecorationLine: 'underline',
-    textDecorationColor: theme.colors.gray400,
-    textDecorationThickness: 'clamp(1px, 0.07em, 2px);',
-    textUnderlineOffset: 5,
+  textDecorationLine: 'underline',
+  textDecorationColor: theme.colors.gray400,
+  textDecorationThickness: 'clamp(1px, 0.07em, 2px);',
+  textUnderlineOffset: 5,
 
-    '@media (hover: hover)': {
-      '&:hover': {
-        textDecorationColor: 'var(--random-hover-color)',
-      },
+  '@media (hover: hover)': {
+    '&:hover': {
+      textDecorationColor: 'var(--random-hover-color)',
     },
   },
+})
+
+export const nestedLinkStyles = css({
+  a: linkStyles,
 })
 
 export const listStyles = css({

--- a/apps/store/src/blocks/TextBlock.tsx
+++ b/apps/store/src/blocks/TextBlock.tsx
@@ -3,7 +3,7 @@ import { ISbRichtext, renderRichText, storyblokEditable } from '@storyblok/react
 import { useMemo } from 'react'
 import { UIColors, Text, FontSizes, Space } from 'ui'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
-import { linkStyles } from './RichTextBlock/RichTextBlock.styles'
+import { nestedLinkStyles } from './RichTextBlock/RichTextBlock.styles'
 
 type TextColor = keyof Pick<UIColors, 'textPrimary' | 'textSecondary' | 'textTertiary'>
 
@@ -36,6 +36,6 @@ export const TextBlock = ({ blok }: TextBlockProps) => {
   )
 }
 
-const StyledText = styled(Text)(linkStyles)
+const StyledText = styled(Text)(nestedLinkStyles)
 
 TextBlock.blockName = 'text'

--- a/apps/store/src/components/ForeverPage/ForeverPage.tsx
+++ b/apps/store/src/components/ForeverPage/ForeverPage.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { FormEventHandler, useState } from 'react'
 import { Button, Space, Text, mq, theme } from 'ui'
-import { linkStyles } from '@/blocks/RichTextBlock/RichTextBlock.styles'
+import { nestedLinkStyles } from '@/blocks/RichTextBlock/RichTextBlock.styles'
 import { useRedeemCampaign } from '@/components/CartInventory/useCampaign'
 import { useSetGlobalBanner } from '@/components/GlobalBanner/useGlobalBanner'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
@@ -109,4 +109,4 @@ const UppercaseTextField = styled(TextField)({
   textTransform: 'uppercase',
 })
 
-const TextWithLink = styled(Text)(linkStyles)
+const TextWithLink = styled(Text)(nestedLinkStyles)

--- a/apps/store/src/components/LayoutWithMenu/BreadcrumbList.tsx
+++ b/apps/store/src/components/LayoutWithMenu/BreadcrumbList.tsx
@@ -1,0 +1,49 @@
+import Head from 'next/head'
+import { Text } from 'ui'
+import { Breadcrumbs } from './Breadcrumbs'
+
+export type BreadcrumbListItem = {
+  label: string
+  href?: string
+}
+
+type Props = { items: Array<BreadcrumbListItem> }
+
+export const BreadcrumbList = (props: Props) => {
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: props.items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.label,
+      ...(item.href && { item: item.href }),
+    })),
+  }
+
+  return (
+    <>
+      <Breadcrumbs.Root>
+        {props.items.map((item) =>
+          item.href ? (
+            <Breadcrumbs.Link key={item.href} href={item.href}>
+              {item.label}
+            </Breadcrumbs.Link>
+          ) : (
+            <Text size="sm" color="textSecondaryOnGray" key={item.label}>
+              {item.label}
+            </Text>
+          ),
+        )}
+      </Breadcrumbs.Root>
+
+      <Head>
+        <script
+          key="structured-data-breadcrumb-list"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
+      </Head>
+    </>
+  )
+}

--- a/apps/store/src/components/LayoutWithMenu/Breadcrumbs.tsx
+++ b/apps/store/src/components/LayoutWithMenu/Breadcrumbs.tsx
@@ -1,0 +1,55 @@
+import styled from '@emotion/styled'
+import Link from 'next/link'
+import { Children, type ReactNode } from 'react'
+import { Text, theme } from 'ui'
+import { linkStyles } from '@/blocks/RichTextBlock/RichTextBlock.styles'
+
+const BreadcrumbList = ({ children }: { children: ReactNode }) => {
+  const count = Children.count(children)
+
+  return (
+    <>
+      <StyledBreadcrumbList>
+        {Children.map(children, (child, index) => (
+          <BreadcumbItem>
+            {child}
+            {index < count - 1 && <Text color="textSecondaryOnGray">&middot;</Text>}
+          </BreadcumbItem>
+        ))}
+      </StyledBreadcrumbList>
+    </>
+  )
+}
+
+const StyledBreadcrumbList = styled.ul({
+  display: 'flex',
+  flexFlow: 'row nowrap',
+  gap: theme.space.xxs,
+  overflowX: 'auto',
+
+  padding: theme.space.sm,
+  backgroundColor: theme.colors.opaque2,
+
+  '::before, ::after': {
+    content: '""',
+    margin: 'auto',
+  },
+})
+
+const BreadcumbItem = styled.li({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.space.xxs,
+  flexShrink: 0,
+})
+
+const BreadcrumbLink = styled(Link)(linkStyles, {
+  fontSize: theme.fontSizes.sm,
+  color: theme.colors.textPrimary,
+  textDecorationColor: 'transparent',
+})
+
+export const Breadcrumbs = {
+  Root: BreadcrumbList,
+  Link: BreadcrumbLink,
+}

--- a/apps/store/src/components/LayoutWithMenu/fetchBreadcrumbs.ts
+++ b/apps/store/src/components/LayoutWithMenu/fetchBreadcrumbs.ts
@@ -1,0 +1,28 @@
+import { getStoriesBySlug, type StoryOptions } from '@/services/storyblok/storyblok'
+import { ORIGIN_URL } from '@/utils/PageLink'
+import { BreadcrumbListItem } from './BreadcrumbList'
+
+export const fetchBreadcrumbs = async (
+  slug: string,
+  options: StoryOptions,
+): Promise<Array<BreadcrumbListItem>> => {
+  const absoluteSlug = slug.startsWith('/') ? slug : `/${slug}`
+
+  const parentSlugs = absoluteSlug
+    .split('/')
+    .slice(0, -1)
+    .map((_, index, array) => array.slice(0, index + 1).join('/'))
+    .map((item) => `${options.locale}${item}/`)
+
+  // No point in fetching breadcrumbs for root page
+  if (parentSlugs.length < 2) return []
+
+  const stories = await getStoriesBySlug(parentSlugs, { version: options.version })
+
+  return stories
+    .sort((a, b) => a.full_slug.length - b.full_slug.length)
+    .map((item) => ({
+      label: item.name,
+      href: `${ORIGIN_URL}/${item.full_slug}`,
+    }))
+}

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -2,6 +2,7 @@ import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
 import type { GetStaticPaths, GetStaticProps, NextPageWithLayout } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
+import { fetchBreadcrumbs } from '@/components/LayoutWithMenu/fetchBreadcrumbs'
 import {
   fetchGlobalProductMetadata,
   GLOBAL_PRODUCT_METADATA_PROP_NAME,
@@ -87,12 +88,14 @@ export const getStaticProps: GetStaticProps<
   const slug = (params?.slug ?? []).join('/')
 
   const apolloClient = initializeApollo({ locale })
+
   console.time('getStoryblokData')
-  const [story, globalStory, translations, productMetadata] = await Promise.all([
+  const [story, globalStory, translations, productMetadata, breadcrumbs] = await Promise.all([
     getStoryBySlug<PageStory | ProductStory>(slug, { version, locale }),
     getGlobalStory({ version, locale }),
     serverSideTranslations(locale),
     fetchGlobalProductMetadata({ apolloClient }),
+    fetchBreadcrumbs(slug, { version, locale }),
   ])
   console.timeEnd('getStoryblokData')
 
@@ -106,6 +109,7 @@ export const getStaticProps: GetStaticProps<
     [STORY_PROP_NAME]: story,
     [GLOBAL_STORY_PROP_NAME]: globalStory,
     [GLOBAL_PRODUCT_METADATA_PROP_NAME]: productMetadata,
+    breadcrumbs,
   }
   const revalidate = process.env.VERCEL_ENV === 'preview' ? 1 : false
 

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -142,6 +142,7 @@ export type PageStory = ISbStoryData<
     hideMenu?: boolean
     overlayMenu?: boolean
     hideFooter?: boolean
+    hideBreadcrumbs?: boolean
   } & SEOData
 >
 
@@ -300,12 +301,12 @@ export const initStoryblok = () => {
   })
 }
 
-type StoryOptions = {
+export type StoryOptions = {
   locale: string
   version?: StoryblokVersion
 }
 
-export const getStoryBySlug = async <StoryData extends ISbStoryData | undefined>(
+export const getStoryBySlug = <StoryData extends ISbStoryData | undefined>(
   slug: string,
   { version, locale }: StoryOptions,
 ) => {
@@ -313,7 +314,8 @@ export const getStoryBySlug = async <StoryData extends ISbStoryData | undefined>
     version: version ?? USE_DRAFT_CONTENT ? 'draft' : 'published',
     resolve_relations: 'reusableBlockReference.reference',
   }
-  return await fetchStory<StoryData | undefined>(getStoryblokApi(), `${locale}/${slug}`, params)
+
+  return fetchStory<StoryData | undefined>(getStoryblokApi(), `${locale}/${slug}`, params)
 }
 
 export const getPageLinks = async (): Promise<PageLink[]> => {
@@ -421,3 +423,16 @@ export const getBlogArticleCategoryStories = async (): Promise<Array<BlogArticle
 }
 
 type BlogArticleCategoryStory = ISbStoryData
+
+export const getStoriesBySlug = async (
+  slugs: Array<string>,
+  options: Pick<StoryOptions, 'version'>,
+) => {
+  const response = await getStoryblokApi().getStories({
+    by_slugs: slugs.join(','),
+    ...options,
+    ...(USE_DRAFT_CONTENT && { version: 'draft' }),
+  })
+
+  return response.data.stories
+}

--- a/packages/ui/src/components/Text/Text.tsx
+++ b/packages/ui/src/components/Text/Text.tsx
@@ -11,6 +11,7 @@ type TextColor = Pick<
   UIColors,
   | 'textPrimary'
   | 'textSecondary'
+  | 'textSecondaryOnGray'
   | 'textTertiary'
   | 'textDisabled'
   | 'textNegative'


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add Breadcrumb List above the page footer (and option to hide from Storyblok)

- Include structured data based on the breadcrumb list

- Add helper function to generate breadcrumb list

- Add new text color to Text-component: "textSecondaryOnGray"

- Make link styles more re-usable


![Screenshot 2023-06-05 at 14.09.47.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/f25d83ed-ccc3-415d-b176-086f738a100c/Screenshot%202023-06-05%20at%2014.09.47.png)


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

SEO and site improvements

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
