### PR TITLE
Use resolved relations for blog article categories

### DIFF
--- a/apps/store/src/blocks/BlogArticleContentType.tsx
+++ b/apps/store/src/blocks/BlogArticleContentType.tsx
@@ -1,15 +1,16 @@
 import styled from '@emotion/styled'
 import { StoryblokComponent, renderRichText, storyblokEditable } from '@storyblok/react'
+import Link from 'next/link'
 import { useMemo } from 'react'
 import { Heading, Space, Text } from 'ui'
 import { ArticleTeaser } from '@/components/ArticleTeaser/ArticleTeaser'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
-import { RawBlogArticleStory, SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { BlogArticleStory, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { useFormatter } from '@/utils/useFormatter'
 import { richTextStyles } from './RichTextBlock/RichTextBlock.styles'
 
-type Props = SbBaseBlockProps<RawBlogArticleStory['content']>
+type Props = SbBaseBlockProps<BlogArticleStory['content']>
 
 export const BlogArticleContentType = (props: Props) => {
   const formatter = useFormatter()
@@ -21,7 +22,11 @@ export const BlogArticleContentType = (props: Props) => {
         <GridLayout.Content width={{ lg: '2/3', xl: '1/2', xxl: '1/3' }} align="center">
           <Space y={1}>
             <SpaceFlex space={0.25}>
-              <ArticleTeaser.Badge>Lifestyle</ArticleTeaser.Badge>
+              {props.blok.categories.map((item) => (
+                <Link key={item.uuid} href={item.full_slug}>
+                  <ArticleTeaser.Badge>{item.name}</ArticleTeaser.Badge>
+                </Link>
+              ))}
             </SpaceFlex>
             <Heading as="h1" variant={{ _: 'serif.32', lg: 'serif.48' }}>
               {props.blok.page_heading}

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -1,5 +1,5 @@
 import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
-import type { GetStaticPaths, GetStaticProps, NextPageWithLayout } from 'next'
+import { type GetStaticPaths, type GetStaticProps, type NextPageWithLayout } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
 import { fetchBreadcrumbs } from '@/components/LayoutWithMenu/fetchBreadcrumbs'
@@ -10,13 +10,13 @@ import {
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
 import { ProductPage } from '@/components/ProductPage/ProductPage'
 import { getProductData } from '@/components/ProductPage/ProductPage.helpers'
-import { ProductPageProps } from '@/components/ProductPage/ProductPage.types'
+import { type ProductPageProps } from '@/components/ProductPage/ProductPage.types'
 import { initializeApollo } from '@/services/apollo/client'
 import { getBlogArticleCategoryList } from '@/services/blog/articleCategory'
 import { BlogArticleTeaser, getBlogArticleTeasers } from '@/services/blog/articleTeaser'
 import { hasBlogArticleList } from '@/services/blog/blog.helpers'
 import {
-  BlogArticleCategoryList,
+  type BlogArticleCategoryList,
   useHydrateBlogArticleCategoryList,
 } from '@/services/blog/blogArticleCategoryList'
 import { useHydrateBlogArticleTeaserList } from '@/services/blog/blogArticleTeaserList'
@@ -28,8 +28,8 @@ import {
   StoryblokQueryParams,
   getFilteredPageLinks,
   StoryblokPreviewData,
-  PageStory,
-  ProductStory,
+  type PageStory,
+  type ProductStory,
 } from '@/services/storyblok/storyblok'
 import { GLOBAL_STORY_PROP_NAME, STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
 import { isProductStory } from '@/services/storyblok/Storyblok.helpers'
@@ -98,11 +98,6 @@ export const getStaticProps: GetStaticProps<
     fetchBreadcrumbs(slug, { version, locale }),
   ])
   console.timeEnd('getStoryblokData')
-
-  if (story === undefined) {
-    console.warn(`Page not found: ${slug}, locale: ${locale}`)
-    return { notFound: true }
-  }
 
   const props = {
     ...translations,

--- a/apps/store/src/pages/api/preview.ts
+++ b/apps/store/src/pages/api/preview.ts
@@ -15,9 +15,6 @@ const preview = async (req: NextApiRequest, res: NextApiResponse) => {
   })
   const { version, pageId } = getPreviewParams(req)
   const story = await fetchStory(storyblokClient, pageId, { version })
-  if (!story) {
-    throw new Error(`Couldn't find story slug=${pageId}, version=${version}`)
-  }
 
   res.setPreviewData({ version })
 

--- a/apps/store/src/pages/confirmation/[shopSessionId].tsx
+++ b/apps/store/src/pages/confirmation/[shopSessionId].tsx
@@ -49,11 +49,6 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
   //   return { redirect: { destination: PageLink.store({ locale }), permanent: false } }
   // }
 
-  if (story === undefined) {
-    console.warn(`Page not found: ${CONFIRMATION_PAGE_SLUG}, locale: ${locale}`)
-    return { notFound: true }
-  }
-
   return addApolloState(apolloClient, {
     props: {
       ...translations,

--- a/apps/store/src/pages/manypets/[[...slug]].tsx
+++ b/apps/store/src/pages/manypets/[[...slug]].tsx
@@ -44,8 +44,6 @@ export const getStaticProps: GetStaticProps<
     serverSideTranslations(locale),
   ])
 
-  if (!story) return { notFound: true }
-
   return {
     props: {
       [STORY_PROP_NAME]: story,

--- a/apps/store/src/pages/manypets/migration/[shopSessionId].tsx
+++ b/apps/store/src/pages/manypets/migration/[shopSessionId].tsx
@@ -111,10 +111,6 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
     return { notFound: true }
   }
 
-  if (!pageStory) {
-    return { notFound: true }
-  }
-
   const { data, errors } = await apolloClient.query<
     ManyPetsMigrationOffersQuery,
     ManyPetsMigrationOffersQueryVariables

--- a/apps/store/src/pages/reusable-blocks/[...slug].tsx
+++ b/apps/store/src/pages/reusable-blocks/[...slug].tsx
@@ -37,18 +37,13 @@ export const getServerSideProps: GetServerSideProps<
 
   const slug = (params?.slug ?? []).join('/')
 
-  const story = await getStoryBySlug(`/reusable-blocks/${slug}`, {
+  const story = await getStoryBySlug<ReusableStory>(`/reusable-blocks/${slug}`, {
     locale,
     version,
   })
-  if (!story) {
-    return { notFound: true }
-  }
 
   return {
-    props: {
-      story: story as ReusableStory,
-    },
+    props: { story },
   }
 }
 

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -1,8 +1,8 @@
 import { StoryblokClient } from '@storyblok/js'
-import { SbBlokData, ISbStoryData } from '@storyblok/react'
+import { type SbBlokData, type ISbStoryData } from '@storyblok/react'
 import { get as getFromConfig } from '@vercel/edge-config'
 import { fetchJson } from '@/services/authApi/fetchJson'
-import { Language } from '@/utils/l10n/types'
+import { type Language } from '@/utils/l10n/types'
 import { LinkField, ProductStory, StoryblokVersion } from './storyblok'
 
 export const filterByBlockType = <BlockData extends SbBlokData>(
@@ -37,7 +37,7 @@ export type StoryblokFetchParams = {
   resolve_relations?: string
 }
 
-export const fetchStory = async <StoryData extends ISbStoryData | undefined>(
+export const fetchStory = async <StoryData extends ISbStoryData>(
   storyblokClient: StoryblokClient,
   slug: string,
   params: StoryblokFetchParams,
@@ -46,16 +46,13 @@ export const fetchStory = async <StoryData extends ISbStoryData | undefined>(
   // if (params.version === 'published') {
   //   cv = await getStoryblokCacheVersion()
   // }
-  const response = await storyblokClient.get(`cdn/stories/${slug}`, {
+  const response = await storyblokClient.getStory(slug, {
     ...params,
     // cv,
     resolve_links: 'url',
   })
 
-  const {
-    data: { story },
-  } = response
-  return story as StoryData
+  return response.data.story as StoryData
 }
 
 const MISSING_LINKS = new Set()


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Use [resolved relations](https://www.storyblok.com/tp/using-relationship-resolving-to-include-other-content-entries) to fetch related categories per article

- Remove check if "story" is undefined => pretty sure the API will throw an error if the story doesn't exist

![Screenshot 2023-06-07 at 16.54.35.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/46fb7bb3-fcbb-4ecd-a079-ca55c9e6dcdf/Screenshot%202023-06-07%20at%2016.54.35.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We need to fetch the resolved categories on Blog Article content type

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
