### PR TITLE
fix(ManyPetsMigrationPage): make announcements optional

### DIFF
--- a/apps/store/src/blocks/ManyPetsMigrationPageBlock.tsx
+++ b/apps/store/src/blocks/ManyPetsMigrationPageBlock.tsx
@@ -10,7 +10,7 @@ export const ManyPetsMigrationPageBlock = ({ blok }: Props) => {
   return (
     <ManyPetsMigrationPage
       migrationSessionId={'empty-placeholder'}
-      announcement={blok.announcement.map((blok) => (
+      announcement={blok.announcement?.map((blok) => (
         <StoryblokComponent key={blok._uid} blok={blok} />
       ))}
       // We can't preview this on storyblok since there will be no migration shopping session

--- a/apps/store/src/pages/manypets/migration/[shopSessionId].tsx
+++ b/apps/store/src/pages/manypets/migration/[shopSessionId].tsx
@@ -54,7 +54,7 @@ const NextManyPetsMigrationPage: NextPage<Props> = ({
       <HeadSeoInfo story={story} />
       <ManyPetsMigrationPage
         migrationSessionId={migrationSessionId}
-        announcement={announcement.map((blok) => (
+        announcement={announcement?.map((blok) => (
           <StoryblokComponent key={blok._uid} blok={blok} />
         ))}
         preOfferContent={preOfferContent?.map((blok) => (

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -143,7 +143,7 @@ export type SEOData = {
 
 export type PageStory = ISbStoryData<
   {
-    announcement: ExpectedBlockType<ReusableBlockReferenceProps>
+    announcement?: ExpectedBlockType<ReusableBlockReferenceProps>
     body: Array<SbBlokData>
     hideMenu?: boolean
     overlayMenu?: boolean
@@ -160,7 +160,7 @@ export type ProductStory = ISbStoryData<
     defaultProductVariant?: string
     productId: string
     priceFormTemplateId: string
-    announcement: ExpectedBlockType<ReusableBlockReferenceProps>
+    announcement?: ExpectedBlockType<ReusableBlockReferenceProps>
     body: Array<SbBlokData>
     global: Array<SbBlokData>
   } & SEOData
@@ -193,7 +193,7 @@ export type ConfirmationStory = ISbStoryData & {
 
 export type ManyPetsMigrationStory = ISbStoryData<
   {
-    announcement: ExpectedBlockType<ReusableBlockReferenceProps>
+    announcement?: ExpectedBlockType<ReusableBlockReferenceProps>
     preOfferContent?: Array<SbBlokData>
     postOfferContent: Array<SbBlokData>
   } & SEOData


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix an issue while trying to render Many Pets Migration page when no announcements are configured for that page. 

## Justify why they are needed

I've forgot to properly type/check for the presence of announcements for Many Pets Migration page so trying to render it without giving it an announcement would break the code - cannot map over underfined.

https://hedviginsurance.slack.com/archives/C054YL76SSU/p1686218003173419
