### PR TITLE
Add close button to Insurely modal

### DIFF
--- a/apps/store/src/components/PriceCalculator/CurrentInsuranceField/CurrentInsuranceField.tsx
+++ b/apps/store/src/components/PriceCalculator/CurrentInsuranceField/CurrentInsuranceField.tsx
@@ -2,7 +2,7 @@ import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { useCallback, useState } from 'react'
-import { Button, Dialog, Heading, Space, theme } from 'ui'
+import { Button, CrossIcon, Dialog, Heading, Space, theme } from 'ui'
 import { PURCHASE_FORM_MAX_WIDTH } from '@/components/ProductPage/PurchaseForm/PurchaseForm.constants'
 import {
   useExternalInsurersQuery,
@@ -158,9 +158,12 @@ export const CurrentInsuranceField = (props: Props) => {
       />
       {isDialogOpen && (
         <Dialog.Root open={true} onOpenChange={close}>
-          <StyledDialogContent>
+          <DialogContent onClose={close} centerContent={true}>
             {state.type === 'COMPARE' ? (
               <DialogIframeWindow>
+                <DialogCloseButton>
+                  <CrossIcon />
+                </DialogCloseButton>
                 <InsurelyIframe
                   configName={state.insurelyConfigName}
                   onCollection={handleInsurelyCollection}
@@ -180,7 +183,7 @@ export const CurrentInsuranceField = (props: Props) => {
                 </Space>
               </DialogSuccessWindow>
             )}
-          </StyledDialogContent>
+          </DialogContent>
         </Dialog.Root>
       )}
     </>
@@ -232,19 +235,15 @@ const useUpdateExternalInsurer = (params: UseUpdateExternalInsurerParams) => {
   }
 }
 
-const StyledDialogContent = styled(Dialog.Content)({
-  height: '100%',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  padding: theme.space.xs,
+const DialogContent = styled(Dialog.Content)({
+  width: '100%',
+  maxWidth: INSURELY_IFRAME_MAX_WIDTH,
 })
 
 const DialogIframeWindow = styled(Dialog.Window)({
   width: '100%',
-  maxWidth: INSURELY_IFRAME_MAX_WIDTH,
-  height: '100%',
-  maxHeight: INSURELY_IFRAME_MAX_HEIGHT,
+  maxHeight: '100%',
+  height: INSURELY_IFRAME_MAX_HEIGHT,
   overflowY: 'auto',
   borderRadius: theme.radius.xs,
 })
@@ -254,4 +253,11 @@ const DialogSuccessWindow = styled(Dialog.Window)({
   borderRadius: theme.radius.xs,
   width: '100%',
   maxWidth: `calc(${PURCHASE_FORM_MAX_WIDTH} + 1rem)`,
+})
+
+const DialogCloseButton = styled(Dialog.Close)({
+  position: 'absolute',
+  top: theme.space.xs,
+  right: theme.space.xs,
+  cursor: 'pointer',
 })

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -47,32 +47,41 @@ type ContentProps = {
   onClose?: () => void
   className?: string
   frostedOverlay?: boolean
+  centerContent?: boolean
 }
 
-export const Content = ({ children, onClose, className, frostedOverlay }: ContentProps) => {
-  const handleClose = () => onClose?.()
+export const Content = (props: ContentProps) => {
+  const handleClose = () => props.onClose?.()
 
   return (
     <DialogPrimitive.Portal>
-      <StyledOverlay frosted={frostedOverlay} />
+      <StyledOverlay frosted={props.frostedOverlay} />
 
-      <StyledContentWrapper>
+      <StyledContentWrapper center={props.centerContent ?? false}>
         <DialogPrimitive.Content
-          className={className}
+          className={props.className}
           onEscapeKeyDown={handleClose}
           onInteractOutside={handleClose}
         >
-          {children}
+          {props.children}
         </DialogPrimitive.Content>
       </StyledContentWrapper>
     </DialogPrimitive.Portal>
   )
 }
 
-const StyledContentWrapper = styled.div({
-  position: 'fixed',
-  inset: 0,
-})
+const StyledContentWrapper = styled.div<{ center: boolean }>(
+  {
+    position: 'fixed',
+    inset: 0,
+  },
+  ({ center }) =>
+    center && {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+)
 
 export const Root = DialogPrimitive.Root
 export const Trigger = DialogPrimitive.Trigger


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add close button to Insurely dialog

- Add option to center content inside a `Dialog`

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Make it clear how to close Insurely dialog

- Make it possible to click outside a Dialog to close it while also centering the content

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
