### PR TITLE
[GEN-512] Always prompt Insurely when we have enough data

### DIFF
--- a/apps/store/src/components/PriceCalculator/CurrentInsuranceField/CurrentInsuranceField.tsx
+++ b/apps/store/src/components/PriceCalculator/CurrentInsuranceField/CurrentInsuranceField.tsx
@@ -1,27 +1,11 @@
 import { datadogLogs } from '@datadog/browser-logs'
-import styled from '@emotion/styled'
-import { useTranslation } from 'next-i18next'
-import { useCallback, useState } from 'react'
-import { Button, CrossIcon, Dialog, Heading, Space, theme } from 'ui'
-import { FetchInsurancePrompt } from '@/components/FetchInsurancePrompt/FetchInsurancePrompt'
 import {
   useExternalInsurersQuery,
   useExternalInsurerUpdateMutation,
-  usePriceIntentInsurelyUpdateMutation,
-  ExternalInsurer,
-  useInsurelyDataCollectionCreateMutation,
 } from '@/services/apollo/generated'
-import { InsurelyIframe, setInsurelyConfig } from '@/services/Insurely/Insurely'
-import {
-  INSURELY_IFRAME_MAX_HEIGHT,
-  INSURELY_IFRAME_MAX_WIDTH,
-} from '@/services/Insurely/Insurely.constants'
 import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
-import { Features } from '@/utils/Features'
+import { useShowFetchInsurance } from '../useFetchInsurance'
 import { InputCurrentInsurance } from './InputCurrentInsurance'
-
-const INSURELY_IS_ENABLED = Features.enabled('INSURELY')
 
 type Props = {
   label: string
@@ -31,47 +15,15 @@ type Props = {
   externalInsurer?: string
 }
 
-type State =
-  | { type: 'IDLE' }
-  | { type: 'PROMPT'; externalInsurer: ExternalInsurer; insurelyConfigName: string }
-  | { type: 'COMPARE'; externalInsurer: ExternalInsurer; insurelyConfigName: string }
-  | { type: 'SUCCESS'; externalInsurer: ExternalInsurer }
-  | { type: 'CONFIRMED'; externalInsurer: ExternalInsurer }
-
 export const CurrentInsuranceField = (props: Props) => {
   const priceIntentId = props.priceIntentId
-  const { t } = useTranslation('purchase-form')
-  const { shopSession } = useShopSession()
-  const [state, setState] = useState<State>({ type: 'IDLE' })
 
-  const showPrompt = useCallback(
-    (externalInsurer: ExternalInsurer, insurelyConfigName: string) =>
-      setState({ type: 'PROMPT', externalInsurer, insurelyConfigName }),
-    [],
-  )
-  const compare = useCallback(
-    (externalInsurer: ExternalInsurer, insurelyConfigName: string) =>
-      setState({ type: 'COMPARE', externalInsurer, insurelyConfigName }),
-    [],
-  )
-  const close = useCallback(() => setState({ type: 'IDLE' }), [])
-  const success = useCallback(
-    (externalInsurer: ExternalInsurer) => setState({ type: 'SUCCESS', externalInsurer }),
-    [],
-  )
-  const confirm = useCallback(
-    (externalInsurer: ExternalInsurer) => setState({ type: 'CONFIRMED', externalInsurer }),
-    [],
-  )
-  const isDialogOpen =
-    state.type === 'PROMPT' || state.type === 'COMPARE' || state.type === 'SUCCESS'
-
+  const showFetchInsurance = useShowFetchInsurance({ priceIntentId })
   const companyOptions = useCompanyOptions(props.productName)
   const updateExternalInsurer = useUpdateExternalInsurer({
     priceIntentId,
     onCompleted(updatedPriceIntent) {
       const externalInsurer = updatedPriceIntent.externalInsurer
-      const ssn = shopSession?.customer?.ssn
 
       if (!externalInsurer) {
         datadogLogs.logger.warn('Failed to update external insurer', {
@@ -80,15 +32,7 @@ export const CurrentInsuranceField = (props: Props) => {
         return
       }
 
-      if (INSURELY_IS_ENABLED && props.insurelyConfigName && ssn) {
-        showPrompt(externalInsurer, props.insurelyConfigName)
-        setInsurelyConfig({
-          company: externalInsurer.insurelyId ?? undefined,
-          ssn,
-        })
-      } else {
-        confirm(externalInsurer)
-      }
+      showFetchInsurance({ force: true })
     },
   })
 
@@ -96,120 +40,13 @@ export const CurrentInsuranceField = (props: Props) => {
     updateExternalInsurer(company)
   }
 
-  const [dataCollectionId, setDataCollectionId] = useState<string | null>(null)
-  const [updateDataCollectionId] = usePriceIntentInsurelyUpdateMutation({
-    onCompleted({ priceIntentInsurelyUpdate }) {
-      datadogLogs.logger.info('Updated Insurely data collection ID', {
-        priceIntentId,
-        dataCollectionId,
-      })
-
-      const updatedPriceIntent = priceIntentInsurelyUpdate.priceIntent
-      if (updatedPriceIntent && updatedPriceIntent.externalInsurer) {
-        success(updatedPriceIntent.externalInsurer)
-      } else {
-        datadogLogs.logger.error('Failed to update Insurely data collection ID', {
-          priceIntentId,
-          dataCollectionId,
-        })
-      }
-      close()
-    },
-    onError(error) {
-      console.warn(error)
-    },
-  })
-
-  const [createDataCollection] = useInsurelyDataCollectionCreateMutation({
-    onCompleted(data) {
-      const { dataCollectionId } = data.insurelyInitiateIframeDataCollection
-      if (dataCollectionId) {
-        setDataCollectionId(dataCollectionId)
-      } else {
-        datadogLogs.logger.error('Failed to create Insurely data collection', {
-          priceIntentId,
-        })
-      }
-    },
-    onError(error) {
-      datadogLogs.logger.error('Error creating Insurely data collection', {
-        priceIntentId,
-        error,
-      })
-    },
-  })
-
-  const handleInsurelyCollection = (collectionId: string) => {
-    createDataCollection({ variables: { collectionId } })
-  }
-
-  const handleInsurelyCompleted = useCallback(() => {
-    if (dataCollectionId) {
-      updateDataCollectionId({
-        variables: { priceIntentId, dataCollectionId },
-      })
-    } else {
-      datadogLogs.logger.error('Completed Insurely without creating data collection ID', {
-        priceIntentId,
-      })
-    }
-  }, [updateDataCollectionId, priceIntentId, dataCollectionId])
-
   return (
-    <>
-      <InputCurrentInsurance
-        label={props.label}
-        company={props.externalInsurer}
-        companyOptions={companyOptions}
-        onCompanyChange={handleCompanyChange}
-      />
-      {isDialogOpen && (
-        <Dialog.Root open={true} onOpenChange={close}>
-          {state.type === 'PROMPT' && (
-            <Dialog.Content onClose={close} centerContent={true}>
-              <DialogWindow>
-                <FetchInsurancePrompt
-                  company={state.externalInsurer.displayName}
-                  onClickConfirm={() => compare(state.externalInsurer, state.insurelyConfigName)}
-                  onClickSkip={close}
-                />
-              </DialogWindow>
-            </Dialog.Content>
-          )}
-
-          {state.type === 'COMPARE' && (
-            <DialogIframeContent onClose={close} centerContent={true}>
-              <DialogIframeWindow>
-                <DialogCloseButton>
-                  <CrossIcon />
-                </DialogCloseButton>
-                <InsurelyIframe
-                  configName={state.insurelyConfigName}
-                  onCollection={handleInsurelyCollection}
-                  onClose={close}
-                  onCompleted={handleInsurelyCompleted}
-                />
-              </DialogIframeWindow>
-            </DialogIframeContent>
-          )}
-
-          {state.type === 'SUCCESS' && (
-            <Dialog.Content onClose={close} centerContent={true}>
-              <DialogWindow>
-                <Space y={1.5}>
-                  <Heading as="h3" variant="standard.20">
-                    {t('INSURELY_SUCCESS_PROMPT', { company: state.externalInsurer.displayName })}
-                  </Heading>
-                  <Button onClick={() => confirm(state.externalInsurer)}>
-                    {t('INSURELY_SUCCESS_CONTINUE_BUTTON')}
-                  </Button>
-                </Space>
-              </DialogWindow>
-            </Dialog.Content>
-          )}
-        </Dialog.Root>
-      )}
-    </>
+    <InputCurrentInsurance
+      label={props.label}
+      company={props.externalInsurer}
+      companyOptions={companyOptions}
+      onCompanyChange={handleCompanyChange}
+    />
   )
 }
 
@@ -257,32 +94,3 @@ const useUpdateExternalInsurer = (params: UseUpdateExternalInsurerParams) => {
     })
   }
 }
-
-const DialogWindow = styled(Dialog.Window)({
-  padding: theme.space.md,
-  paddingTop: theme.space.lg,
-  borderRadius: theme.radius.xs,
-  width: `calc(100% - ${theme.space.xs} * 2)`,
-  maxWidth: INSURELY_IFRAME_MAX_WIDTH,
-  marginInline: 'auto',
-})
-
-const DialogIframeContent = styled(Dialog.Content)({
-  width: '100%',
-  maxWidth: INSURELY_IFRAME_MAX_WIDTH,
-})
-
-const DialogIframeWindow = styled(Dialog.Window)({
-  width: '100%',
-  maxHeight: '100%',
-  height: INSURELY_IFRAME_MAX_HEIGHT,
-  overflowY: 'auto',
-  borderRadius: theme.radius.xs,
-})
-
-const DialogCloseButton = styled(Dialog.Close)({
-  position: 'absolute',
-  top: theme.space.xs,
-  right: theme.space.xs,
-  cursor: 'pointer',
-})

--- a/apps/store/src/components/PriceCalculator/FetchInsurance.tsx
+++ b/apps/store/src/components/PriceCalculator/FetchInsurance.tsx
@@ -1,0 +1,166 @@
+import { datadogLogs } from '@datadog/browser-logs'
+import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
+import { useCallback, useState } from 'react'
+import { Button, CrossIcon, Dialog, Heading, Space, theme } from 'ui'
+import { FetchInsurancePrompt } from '@/components/FetchInsurancePrompt/FetchInsurancePrompt'
+import {
+  ExternalInsurer,
+  useInsurelyDataCollectionCreateMutation,
+  usePriceIntentInsurelyUpdateMutation,
+} from '@/services/apollo/generated'
+import { InsurelyIframe, setInsurelyConfig } from '@/services/Insurely/Insurely'
+import {
+  INSURELY_IFRAME_MAX_HEIGHT,
+  INSURELY_IFRAME_MAX_WIDTH,
+} from '@/services/Insurely/Insurely.constants'
+import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useFetchInsuranceState } from './useFetchInsurance'
+
+const logger = datadogLogs.createLogger('FetchInsurance')
+
+type Props = {
+  priceIntentId: string
+  externalInsurer: ExternalInsurer
+  insurelyConfigName: string
+}
+
+export const FetchInsurance = ({ externalInsurer, insurelyConfigName, priceIntentId }: Props) => {
+  const { t } = useTranslation('purchase-form')
+  const { shopSession } = useShopSession()
+
+  const [state, setState] = useFetchInsuranceState()
+  const isOpen = ['PROMPT', 'COMPARE', 'SUCCESS'].includes(state)
+
+  const compare = () => {
+    setState('COMPARE')
+    setInsurelyConfig({
+      company: externalInsurer.insurelyId ?? undefined,
+      ssn: shopSession?.customer?.ssn ?? undefined,
+    })
+  }
+  const skip = () => setState('SKIPPED')
+  const confirm = () => setState('SUCCESS')
+
+  const [dataCollectionId, setDataCollectionId] = useState<string | null>(null)
+  const [updateDataCollectionId] = usePriceIntentInsurelyUpdateMutation({
+    onCompleted({ priceIntentInsurelyUpdate }) {
+      logger.info('Updated Insurely data collection ID', { priceIntentId })
+
+      const updatedPriceIntent = priceIntentInsurelyUpdate.priceIntent
+      if (updatedPriceIntent && updatedPriceIntent.externalInsurer) {
+        confirm()
+      } else {
+        logger.warn('Failed to update Insurely data collection ID', { priceIntentId })
+      }
+      skip()
+    },
+    onError(error) {
+      logger.warn('Error updating Insurely data collection ID', {
+        priceIntentId,
+        error,
+      })
+    },
+  })
+
+  const [createDataCollection] = useInsurelyDataCollectionCreateMutation({
+    onCompleted(data) {
+      setDataCollectionId(data.insurelyInitiateIframeDataCollection.dataCollectionId)
+      logger.addContext('dataCollectionId', dataCollectionId)
+    },
+    onError(error) {
+      logger.warn('Error creating Insurely data collection', {
+        priceIntentId,
+        error,
+      })
+    },
+  })
+
+  const handleInsurelyCollection = (collectionId: string) => {
+    createDataCollection({ variables: { collectionId } })
+  }
+
+  const handleInsurelyCompleted = useCallback(() => {
+    if (dataCollectionId) {
+      updateDataCollectionId({
+        variables: { priceIntentId, dataCollectionId },
+      })
+    } else {
+      logger.error('Completed Insurely without creating data collection ID', { priceIntentId })
+    }
+  }, [updateDataCollectionId, priceIntentId, dataCollectionId])
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={skip}>
+      {state === 'PROMPT' && (
+        <Dialog.Content onClose={skip} centerContent={true}>
+          <DialogWindow>
+            <FetchInsurancePrompt
+              company={externalInsurer.displayName}
+              onClickConfirm={compare}
+              onClickSkip={skip}
+            />
+          </DialogWindow>
+        </Dialog.Content>
+      )}
+
+      {state === 'COMPARE' && (
+        <DialogIframeContent onClose={skip} centerContent={true}>
+          <DialogIframeWindow>
+            <DialogCloseButton>
+              <CrossIcon />
+            </DialogCloseButton>
+            <InsurelyIframe
+              configName={insurelyConfigName}
+              onCollection={handleInsurelyCollection}
+              onClose={skip}
+              onCompleted={handleInsurelyCompleted}
+            />
+          </DialogIframeWindow>
+        </DialogIframeContent>
+      )}
+
+      {state === 'SUCCESS' && (
+        <Dialog.Content onClose={skip} centerContent={true}>
+          <DialogWindow>
+            <Space y={1.5}>
+              <Heading as="h3" variant="standard.20">
+                {t('INSURELY_SUCCESS_PROMPT', { company: externalInsurer.displayName })}
+              </Heading>
+              <Button onClick={confirm}>{t('INSURELY_SUCCESS_CONTINUE_BUTTON')}</Button>
+            </Space>
+          </DialogWindow>
+        </Dialog.Content>
+      )}
+    </Dialog.Root>
+  )
+}
+
+const DialogWindow = styled(Dialog.Window)({
+  padding: theme.space.md,
+  paddingTop: theme.space.lg,
+  borderRadius: theme.radius.xs,
+  width: `calc(100% - ${theme.space.xs} * 2)`,
+  maxWidth: INSURELY_IFRAME_MAX_WIDTH,
+  marginInline: 'auto',
+})
+
+const DialogIframeContent = styled(Dialog.Content)({
+  width: '100%',
+  maxWidth: INSURELY_IFRAME_MAX_WIDTH,
+})
+
+const DialogIframeWindow = styled(Dialog.Window)({
+  width: '100%',
+  maxHeight: '100%',
+  height: INSURELY_IFRAME_MAX_HEIGHT,
+  overflowY: 'auto',
+  borderRadius: theme.radius.xs,
+})
+
+const DialogCloseButton = styled(Dialog.Close)({
+  position: 'absolute',
+  top: theme.space.xs,
+  right: theme.space.xs,
+  cursor: 'pointer',
+})

--- a/apps/store/src/components/PriceCalculator/FetchInsuranceContainer.tsx
+++ b/apps/store/src/components/PriceCalculator/FetchInsuranceContainer.tsx
@@ -1,0 +1,21 @@
+import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
+import { Features } from '@/utils/Features'
+import { FetchInsurance } from './FetchInsurance'
+
+type Props = {
+  priceIntent: PriceIntent
+}
+
+export const FetchInsuranceContainer = ({ priceIntent }: Props) => {
+  if (!Features.enabled('INSURELY')) return null
+  if (!priceIntent.externalInsurer) return null
+  if (!priceIntent.insurelyConfigName) return null
+
+  return (
+    <FetchInsurance
+      priceIntentId={priceIntent.id}
+      externalInsurer={priceIntent.externalInsurer}
+      insurelyConfigName={priceIntent.insurelyConfigName}
+    />
+  )
+}

--- a/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
@@ -10,9 +10,11 @@ import { Form } from '@/services/PriceCalculator/PriceCalculator.types'
 import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { AutomaticField } from './AutomaticField'
+import { FetchInsuranceContainer } from './FetchInsuranceContainer'
 import { FormGrid } from './FormGrid'
 import { PriceCalculatorAccordion } from './PriceCalculatorAccordion'
 import { PriceCalculatorSection } from './PriceCalculatorSection'
+import { useShowFetchInsurance } from './useFetchInsurance'
 import { useHandleSubmitPriceCalculator } from './useHandleSubmitPriceCalculator'
 
 type Props = {
@@ -44,6 +46,7 @@ export const PriceCalculator = (props: Props) => {
     return form.sections[form.sections.length - 1].id
   })
 
+  const showFetchInsurance = useShowFetchInsurance({ priceIntentId: priceIntent.id })
   const [handleSubmit, handleSubmitSection, isLoading] = useHandleSubmitPriceCalculator({
     onSuccess({ priceIntent, customer }) {
       const form = setupForm({
@@ -54,6 +57,8 @@ export const PriceCalculator = (props: Props) => {
       if (isFormReadyToConfirm({ form, priceIntent, customer })) {
         onConfirm()
       } else {
+        if (priceIntent.externalInsurer) showFetchInsurance()
+
         setActiveSectionId((prevSectionId) => {
           const currentSectionIndex = form.sections.findIndex(({ id }) => id === prevSectionId)
           // If section has both customer and priceIntent fields, we'll get two onSuccess callbacks
@@ -110,6 +115,8 @@ export const PriceCalculator = (props: Props) => {
           </PriceCalculatorSection>
         )}
       </PriceCalculatorAccordion>
+
+      <FetchInsuranceContainer priceIntent={priceIntent} />
     </>
   )
 }

--- a/apps/store/src/components/PriceCalculator/useFetchInsurance.ts
+++ b/apps/store/src/components/PriceCalculator/useFetchInsurance.ts
@@ -1,0 +1,35 @@
+import { atom, useAtom, useSetAtom } from 'jotai'
+import { useCallback } from 'react'
+
+type State = 'INITIAL' | 'PROMPT' | 'COMPARE' | 'SUCCESS' | 'SKIPPED'
+
+const STATE_ATOM = atom<State>('INITIAL')
+
+type Params = {
+  priceIntentId: string
+}
+
+export const useFetchInsuranceState = () => {
+  return useAtom(STATE_ATOM)
+}
+
+export const useShowFetchInsurance = ({ priceIntentId }: Params) => {
+  const setState = useSetAtom(STATE_ATOM)
+
+  return useCallback(
+    ({ force = false }: { force?: boolean } = {}) => {
+      const sessionStorageKey = `hedvig.fetchInsurance.${priceIntentId}.shown`
+      const hasShown = window.sessionStorage.getItem(sessionStorageKey) === 'true'
+
+      setState((currentState) => {
+        if (force || (!hasShown && currentState === 'INITIAL')) {
+          window.sessionStorage.setItem(sessionStorageKey, 'true')
+          return 'PROMPT'
+        }
+
+        return currentState
+      })
+    },
+    [setState, priceIntentId],
+  )
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Show `FetchInsurancePrompt` whenever we have collected enough data (not based on form template)

- Move `FetchInsurance` logic from `CurrentInsuranceField` to `PriceCalculator`

- Remember if user has already seen `FetchInsurancePrompt` and don't show it again

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Make Insurely work also for Car where we don't show `CurrentInsuranceField`

- We will now show the dialog as soon as the price intent is updated with relevant data.

    This is more implicit than the previous solution which I don't really like. However, since we don't need to support a lot of different products and markets, I think we are fine.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
