### PR TITLE
GEN-527 - fix(Header): update menu overlay implementation so it takes banners/announcements into account

### DIFF
--- a/apps/store/src/components/Header/Header.tsx
+++ b/apps/store/src/components/Header/Header.tsx
@@ -49,10 +49,9 @@ export const Header = (props: HeaderProps) => {
   const scrollState = useScrollState({ threshold: MENU_BAR_HEIGHT_PX * 2 })
   const { t } = useTranslation('common')
 
-  const defaultPosition = overlay ? 'absolute' : 'relative'
   const backgroundColor = opaque ? theme.colors.backgroundStandard : TRANSPARENT_HSL_COLOR
 
-  const initialStyles = { position: defaultPosition, backgroundColor } as const
+  const initialStyles = { backgroundColor } as const
 
   let animate: AnimationVariant = scrollState === 'SCROLL_UP' ? 'SLIDE_IN' : undefined
   animate = scrollState === 'BELOW' ? 'HIDE' : animate
@@ -60,7 +59,7 @@ export const Header = (props: HeaderProps) => {
   animate = staticPosition ? undefined : animate
 
   return (
-    <GhostWrapper style={initialStyles}>
+    <GhostWrapper style={initialStyles} overlay={overlay}>
       <Wrapper
         initial={initialStyles}
         variants={ANIMATION_VARIANTS}
@@ -81,15 +80,20 @@ export const Header = (props: HeaderProps) => {
   )
 }
 
-const GhostWrapper = styled.div({
-  top: 0,
-  left: 0,
-  right: 0,
+const GhostWrapper = styled.div<{ overlay: boolean }>(({ overlay }) => ({
+  '--height': HEADER_HEIGHT_MOBILE,
+
+  position: 'relative',
+  height: 'var(--height)',
+  // Using negative margin to pull page's content bellow the menu causing the desired
+  // 'menu overlay' behaviour. Before that was being implemented by removing the header
+  // from doc's flow with absolute positioning. However that solution doesn't play well
+  // if we have banners/announcements on the screen.
+  marginBottom: overlay ? 'calc(-1 * var(--height))' : 'initial',
   zIndex: zIndexes.header,
 
-  height: HEADER_HEIGHT_MOBILE,
-  [mq.lg]: { height: HEADER_HEIGHT_DESKTOP },
-})
+  [mq.lg]: { '--height': HEADER_HEIGHT_DESKTOP },
+}))
 
 export const Wrapper = styled(motion.header)({
   width: '100%',


### PR DESCRIPTION
## Describe your changes

Updates _menu overlay_ implementation so it uses negative margins instead of absolute positioning.

## Justify why they are needed

Using absolute positioning to implement _menu overlay_ means to remove the menu from doc's flow which makes everything else on the page be pulled up. However that causes an issue when we have _banners/announcements_ on the screen (see image below). So what we actually want is to pull page's content by the exact menu's height. Negative margins are perfect for that use case since we don't need to do complex calculations for positioning the menu accordingly.

<img width="1118" alt="Screenshot 2023-06-12 at 09 48 24" src="https://github.com/HedvigInsurance/racoon/assets/19200662/867ad7cb-8691-4718-a473-1fe0be1e7759">

<img width="1137" alt="Screenshot 2023-06-12 at 11 52 42" src="https://github.com/HedvigInsurance/racoon/assets/19200662/0bd340c0-f353-405e-aca7-c8f81873ca6f">
