### PR TITLE
Trustly Iframe: add initial loading state

### DIFF
--- a/apps/store/src/services/trustly/TrustlyIframe.tsx
+++ b/apps/store/src/services/trustly/TrustlyIframe.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/react'
+import { css, keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
-import { useEffect, type ReactEventHandler } from 'react'
+import { useEffect, type ReactEventHandler, useState } from 'react'
 import { theme } from 'ui'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { PageLink } from '@/utils/PageLink'
@@ -29,6 +29,7 @@ export const TrustlyIframe = ({ url, onSuccess, onFail }: Props) => {
     return () => window.removeEventListener('message', handler)
   }, [url])
 
+  const [loading, setLoading] = useState(true)
   const handleLoad: ReactEventHandler<HTMLIFrameElement> = (event) => {
     try {
       const url = event.currentTarget.contentWindow?.location.href
@@ -41,9 +42,11 @@ export const TrustlyIframe = ({ url, onSuccess, onFail }: Props) => {
       // This is a cross-origin error, which is expected
       console.debug('Unable to read iframe location', error)
     }
+
+    setLoading(false)
   }
 
-  return <Iframe src={url} onLoad={handleLoad} />
+  return <Iframe src={url} onLoad={handleLoad} data-loading={loading} />
 }
 
 export const trustlyIframeStyles = css({
@@ -59,7 +62,18 @@ export const trustlyIframeStyles = css({
   backgroundColor: theme.colors.white,
 })
 
+const pulseAnimation = keyframes({
+  '0%': { opacity: 1 },
+  '50%': { opacity: 0.5 },
+  '100%': { opacity: 1 },
+})
+
 const Iframe = styled.iframe(trustlyIframeStyles, {
   display: 'block',
   border: 'none',
+
+  '&[data-loading=true]': {
+    backgroundColor: theme.colors.gray200,
+    animation: `${pulseAnimation} 2s infinite`,
+  },
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Show loading state before Trustly iframe has loaded


![Screenshot 2023-06-12 at 15.15.22.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/07ac2376-7a6f-4e61-8f44-07e455b1d09a/Screenshot%202023-06-12%20at%2015.15.22.png)


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Indicate to user that something is happening so they don't reload the page

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
