### PR TITLE
Feat / Add new MediaListBlock that supports both Image and Video

### DIFF
--- a/apps/store/src/blocks/MediaListBlock.tsx
+++ b/apps/store/src/blocks/MediaListBlock.tsx
@@ -1,0 +1,57 @@
+import styled from '@emotion/styled'
+import { StoryblokComponent, storyblokEditable } from '@storyblok/react'
+import { mq } from 'ui'
+import { Slideshow } from '@/components/Slideshow/Slideshow'
+import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { ImageBlockProps } from './ImageBlock'
+import { VideoBlockProps } from './VideoBlock'
+
+const playVideoExclusively = (
+  videoList: Array<HTMLVideoElement>,
+  videoToBePlayed: HTMLVideoElement,
+) => {
+  videoList.forEach((videoNode) => {
+    if (videoNode === videoToBePlayed) return
+    if (videoNode.played.length > 0 && !videoNode.paused) {
+      videoNode.pause()
+    }
+  })
+}
+
+type MediaListBlockProps = SbBaseBlockProps<{
+  media: ExpectedBlockType<VideoBlockProps | ImageBlockProps>
+}>
+
+export const MediaListBlock = ({ blok }: MediaListBlockProps) => {
+  return (
+    <Slideshow
+      ref={(node) => {
+        const videos = Array.from(node?.querySelectorAll('video') ?? [])
+
+        videos.forEach((video) => {
+          video.addEventListener('play', () => playVideoExclusively(videos, video))
+        })
+      }}
+      alignment="center"
+      {...storyblokEditable(blok)}
+    >
+      {blok.media.map((nestedBlok) => (
+        <Wrapper key={nestedBlok._uid}>
+          <StoryblokComponent blok={nestedBlok} nested={true} />
+        </Wrapper>
+      ))}
+    </Slideshow>
+  )
+}
+MediaListBlock.blockName = 'mediaList'
+
+const Wrapper = styled.div({
+  paddingInline: 0,
+  width: '90vw',
+  [mq.sm]: {
+    maxWidth: '20.75rem',
+  },
+  [mq.lg]: {
+    paddingInline: 0,
+  },
+})

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -36,6 +36,7 @@ import { ImageTextBlock } from '@/blocks/ImageTextBlock'
 import { InlineSpaceBlock } from '@/blocks/InlineSpaceBlock'
 import { InsurableLimitsBlock } from '@/blocks/InsurableLimitsBlock'
 import { ManyPetsMigrationPageBlock } from '@/blocks/ManyPetsMigrationPageBlock'
+import { MediaListBlock } from '@/blocks/MediaListBlock'
 import { ModalBlock } from '@/blocks/ModalBlock'
 import { PageBlock } from '@/blocks/PageBlock'
 import { PerilsBlock } from '@/blocks/PerilsBlock'
@@ -239,6 +240,7 @@ export const initStoryblok = () => {
     ImageTextBlock,
     InlineSpaceBlock,
     InsurableLimitsBlock,
+    MediaListBlock,
     ModalBlock,
     ManyPetsMigrationPageBlock,
     NavItemBlock,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Extend VideoListBlock to support ImageBlock as well. 
Instead of trying to rename existing block I created a new block called MediaListBlock.
Once migrated, we can remove VideoListBlock

https://github.com/HedvigInsurance/racoon/assets/6661511/a377df19-86a4-41bf-a592-f100bd90a15e

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
We wanted to support images in VideoListBlock

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
