### PR TITLE
Fix issue in dialog where content was hidden

### DIFF
--- a/apps/store/src/components/PriceCalculator/FetchInsurance.tsx
+++ b/apps/store/src/components/PriceCalculator/FetchInsurance.tsx
@@ -2,7 +2,7 @@ import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
 import { type ComponentProps, useCallback, useState, useMemo } from 'react'
-import { CrossIcon, Dialog, Text, theme } from 'ui'
+import { CrossIcon, Dialog, Text, mq, theme } from 'ui'
 import { FetchInsurancePrompt } from '@/components/FetchInsurancePrompt/FetchInsurancePrompt'
 import {
   ExternalInsurer,
@@ -170,11 +170,16 @@ const DialogWindow = styled(Dialog.Window)({
   marginInline: 'auto',
 })
 
-const DialogContent = styled(Dialog.Content)({ width: '100%' })
+const DialogContent = styled(Dialog.Content)({
+  width: '100%',
+  alignSelf: 'center',
+})
 
-const DialogIframeContent = styled(DialogContent)({
+const DialogIframeContent = styled(Dialog.Content)({
   width: '100%',
   maxWidth: INSURELY_IFRAME_MAX_WIDTH,
+
+  [mq.lg]: { alignSelf: 'center' },
 })
 
 const DialogIframeWindow = styled(Dialog.Window)({

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -78,8 +78,8 @@ const StyledContentWrapper = styled.div<{ center: boolean }>(
   ({ center }) =>
     center && {
       display: 'flex',
-      alignItems: 'center',
       justifyContent: 'center',
+      overflowY: 'auto',
     },
 )
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix issue with Fetch Insurance dialog on small screens where content gets hidden if it's being centered.


![Screenshot 2023-06-14 at 15.47.59.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/d0ed91be-71c6-48df-80c1-46542f33db94/Screenshot%202023-06-14%20at%2015.47.59.png)


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Fix the bug

Make sure the content scrolls properly on small screens if there is overflow

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
