### PR TITLE
Group components in Storybook

### DIFF
--- a/apps/store/src/components/Accordion/Accordion.stories.tsx
+++ b/apps/store/src/components/Accordion/Accordion.stories.tsx
@@ -49,7 +49,6 @@ const ACCORDION_ITEMS = [
 ]
 
 export default {
-  title: 'Accordion',
   component: Accordion.Root,
 } as Meta<typeof Accordion.Root>
 

--- a/apps/store/src/components/Banner/Banner.stories.tsx
+++ b/apps/store/src/components/Banner/Banner.stories.tsx
@@ -4,7 +4,6 @@ import { Banner } from './Banner'
 type Story = StoryObj<typeof Banner>
 
 const meta: Meta<typeof Banner> = {
-  title: 'Banner',
   component: Banner,
   parameters: {
     layout: 'fullscreen',

--- a/apps/store/src/components/CartNotification/CartNotification.stories.tsx
+++ b/apps/store/src/components/CartNotification/CartNotification.stories.tsx
@@ -3,7 +3,7 @@ import { Button, Dialog } from 'ui'
 import { CartNotificationContent } from './CartToast'
 
 const config = {
-  title: 'Cart Notification',
+  title: 'Cart / Cart Notification',
 }
 
 export const Open: StoryFn<typeof CartNotificationContent> = (props) => (

--- a/apps/store/src/components/CheckList/CheckList.stories.tsx
+++ b/apps/store/src/components/CheckList/CheckList.stories.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryFn } from '@storybook/react'
 import * as CheckList from './CheckList'
 
 export default {
-  title: 'Check List',
   component: CheckList.Root,
   argTypes: {},
 } as Meta<typeof CheckList.Root>

--- a/apps/store/src/components/Combobox/Combobox.stories.tsx
+++ b/apps/store/src/components/Combobox/Combobox.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { Combobox } from './Combobox'
 
 export default {
-  title: 'Combobox',
+  title: 'Inputs / Combobox',
   component: Combobox,
   argTypes: {},
 } as Meta<typeof Combobox>

--- a/apps/store/src/components/ComparisonTable/ComparisonTable.stories.tsx
+++ b/apps/store/src/components/ComparisonTable/ComparisonTable.stories.tsx
@@ -2,7 +2,6 @@ import { Meta } from '@storybook/react'
 import * as ComparisonTable from './ComparisonTable'
 
 export default {
-  title: 'Comparison Table',
   component: ComparisonTable.Root,
 } as Meta<typeof ComparisonTable.Root>
 

--- a/apps/store/src/components/ContactSupport/ContactSupport.stories.tsx
+++ b/apps/store/src/components/ContactSupport/ContactSupport.stories.tsx
@@ -3,7 +3,6 @@ import { LinkField } from '@/services/storyblok/storyblok'
 import { ContactSupport, ContactSupportProps } from './ContactSupport'
 
 export default {
-  title: 'Contact Support',
   component: ContactSupport,
   argTypes: {},
 } as Meta<typeof ContactSupport>

--- a/apps/store/src/components/Header/Header.stories.tsx
+++ b/apps/store/src/components/Header/Header.stories.tsx
@@ -19,7 +19,6 @@ import { TopMenuDesktop } from './TopMenuDesktop/TopMenuDesktop'
 import { TopMenuMobile } from './TopMenuMobile/TopMenuMobile'
 
 export default {
-  title: 'Header',
   component: Header,
 } as Meta<typeof Header>
 

--- a/apps/store/src/components/HeroVideo/HeroVideo.stories.tsx
+++ b/apps/store/src/components/HeroVideo/HeroVideo.stories.tsx
@@ -3,7 +3,6 @@ import { Meta, StoryFn } from '@storybook/react'
 import { HeroVideo } from './HeroVideo'
 
 export default {
-  title: 'HeroVideo',
   component: HeroVideo,
   parameters: {
     viewport: {

--- a/apps/store/src/components/HeroVideoVimeo/HeroVideoVimeo.stories.tsx
+++ b/apps/store/src/components/HeroVideoVimeo/HeroVideoVimeo.stories.tsx
@@ -3,7 +3,6 @@ import { Meta, StoryFn } from '@storybook/react'
 import { HeroVideoVimeo } from './HeroVideoVimeo'
 
 export default {
-  title: 'HeroVideoVimeo',
   component: HeroVideoVimeo,
   parameters: {
     viewport: {

--- a/apps/store/src/components/InsurableLimits/InsurableLimits.stories.tsx
+++ b/apps/store/src/components/InsurableLimits/InsurableLimits.stories.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryFn } from '@storybook/react'
 import { InsurableLimits } from './InsurableLimits'
 
 export default {
-  title: 'InsurableLimits',
   component: InsurableLimits,
 } as Meta<typeof InsurableLimits>
 

--- a/apps/store/src/components/LoadingDots/LoadingDots.stories.tsx
+++ b/apps/store/src/components/LoadingDots/LoadingDots.stories.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import { LoadingDots, LoadingDotsProps } from './LoadingDots'
 
 export default {
-  title: 'Loading Dots',
   component: LoadingDots,
   parameters: {
     layout: 'centered',

--- a/apps/store/src/components/Perils/Perils.stories.tsx
+++ b/apps/store/src/components/Perils/Perils.stories.tsx
@@ -40,7 +40,6 @@ const createNewPeril = (): PerilFragment => ({
 // Story
 
 export default {
-  title: 'Accordion/Perils',
   component: Perils,
 } as Meta<typeof Perils>
 

--- a/apps/store/src/components/ProductCard/ProductCard.stories.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.stories.tsx
@@ -3,7 +3,6 @@ import { Meta, StoryFn } from '@storybook/react'
 import { ProductCard, ProductCardProps } from './ProductCard'
 
 export default {
-  title: 'Product Card',
   component: ProductCard,
   argTypes: {},
   parameters: {

--- a/apps/store/src/components/ProductGrid/ProductGrid.stories.tsx
+++ b/apps/store/src/components/ProductGrid/ProductGrid.stories.tsx
@@ -3,7 +3,6 @@ import { ProductCard, ProductCardProps } from '@/components/ProductCard/ProductC
 import { ProductGrid, ProductGridProps } from './ProductGrid'
 
 export default {
-  title: 'Product Grid',
   component: ProductGrid,
   argTypes: {},
 } as Meta<typeof ProductGrid>

--- a/apps/store/src/components/QuickPurchaseForm/QuickPurchaseForm.stories.tsx
+++ b/apps/store/src/components/QuickPurchaseForm/QuickPurchaseForm.stories.tsx
@@ -3,7 +3,6 @@ import { Meta, StoryFn } from '@storybook/react'
 import { QuickPurchaseForm, type ProductOption } from './QuickPurchaseForm'
 
 export default {
-  title: 'QuickPurchaseForm',
   component: QuickPurchaseForm,
   parameters: {
     viewport: {

--- a/apps/store/src/components/SelectInsuranceGrid/SelectInsuranceGrid.stories.tsx
+++ b/apps/store/src/components/SelectInsuranceGrid/SelectInsuranceGrid.stories.tsx
@@ -3,7 +3,6 @@ import { ProductItem } from './ProductItem'
 import { SelectInsuranceGrid } from './SelectInsuranceGrid'
 
 export default {
-  title: 'Select Insurance Grid',
   component: SelectInsuranceGrid,
 } as Meta<typeof SelectInsuranceGrid>
 

--- a/apps/store/src/components/Slideshow/Slideshow.stories.tsx
+++ b/apps/store/src/components/Slideshow/Slideshow.stories.tsx
@@ -7,7 +7,6 @@ const Item = () => (
 )
 
 export default {
-  title: 'Slideshow',
   component: Slideshow,
   parameters: {
     viewport: {

--- a/apps/store/src/components/TierSelector/TierSelector.stories.tsx
+++ b/apps/store/src/components/TierSelector/TierSelector.stories.tsx
@@ -4,7 +4,7 @@ import * as TierLevelRadioGroup from './TierLevelRadioGroup'
 import * as TierSelector from './TierSelector'
 
 export default {
-  title: 'Tier Selector',
+  title: 'Purchase Form / Tier Selector',
   component: TierSelector.Root,
 } as Meta<typeof TierSelector.Root>
 

--- a/apps/store/src/components/Timeline/Timeline.stories.tsx
+++ b/apps/store/src/components/Timeline/Timeline.stories.tsx
@@ -4,7 +4,6 @@ import { Heading } from 'ui'
 import * as Timeline from './Timeline'
 
 export default {
-  title: 'Timeline',
   component: Timeline.Root,
   parameters: {
     viewport: {

--- a/apps/store/src/components/TopPickCard/TopPickCard.stories.tsx
+++ b/apps/store/src/components/TopPickCard/TopPickCard.stories.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryFn } from '@storybook/react'
 import { TopPickCard } from './TopPickCard'
 
 export default {
-  title: 'TopPickCard',
   component: TopPickCard,
 } as Meta<typeof TopPickCard>
 

--- a/apps/store/src/components/Video/Video.stories.tsx
+++ b/apps/store/src/components/Video/Video.stories.tsx
@@ -3,7 +3,6 @@ import { Meta, StoryFn } from '@storybook/react'
 import { Video } from './Video'
 
 export default {
-  title: 'Video',
   component: Video,
   parameters: {
     viewport: {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Storybook automatically groups components based on it's name and folder. So removing the title will group it under `components`. 

Let me know if this is better or not :D 

Before: 
<img width="766" alt="Screenshot 2023-06-15 at 11 35 29" src="https://github.com/HedvigInsurance/racoon/assets/6661511/0ae17dbf-2d22-449d-94f0-2941a462af44">

After:
<img width="652" alt="Screenshot 2023-06-15 at 11 35 03" src="https://github.com/HedvigInsurance/racoon/assets/6661511/96da0e65-6907-418e-92ac-014b336e70fd">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
