### PR TITLE
Display custom message for incomparable price match

### DIFF
--- a/apps/store/public/locales/en/purchase-form.json
+++ b/apps/store/public/locales/en/purchase-form.json
@@ -107,6 +107,8 @@
   "OPEN_PRICE_CALCULATOR_BUTTON": "See your price",
   "PRESENT_OFFER_EDIT_BUTTON": "Edit your info",
   "PRICE_CALCULATOR_SECTION_EDIT_BUTTON": "Edit",
+  "PRICE_MATCH_BUBBLE_INCOMPARABLE_SUBTITLE": "We couldn't match your price since you have entered a larger scope",
+  "PRICE_MATCH_BUBBLE_INCOMPARABLE_TITLE": "You pay {{amount}} at {{company}}",
   "PRICE_MATCH_BUBBLE_SUCCESS_SUBTITLE": "compared to {{company}}",
   "PRICE_MATCH_BUBBLE_SUCCESS_TITLE": "You save {{amount}}",
   "QUICK_CHECKOUT_BUTTON_LABEL": "Go to checkout",

--- a/apps/store/public/locales/sv-se/purchase-form.json
+++ b/apps/store/public/locales/sv-se/purchase-form.json
@@ -107,6 +107,8 @@
   "OPEN_PRICE_CALCULATOR_BUTTON": "Se ditt pris",
   "PRESENT_OFFER_EDIT_BUTTON": "Ändra din info",
   "PRICE_CALCULATOR_SECTION_EDIT_BUTTON": "Ändra",
+  "PRICE_MATCH_BUBBLE_INCOMPARABLE_SUBTITLE": "Vi kunde inte matcha ditt pris eftersom du har angett en större omfattning",
+  "PRICE_MATCH_BUBBLE_INCOMPARABLE_TITLE": "Du betalar {{amount}} hos {{company}}",
   "PRICE_MATCH_BUBBLE_SUCCESS_SUBTITLE": "jämfört med {{company}}",
   "PRICE_MATCH_BUBBLE_SUCCESS_TITLE": "Du sparar {{amount}}",
   "QUICK_CHECKOUT_BUTTON_LABEL": "Gå till kassan",

--- a/apps/store/src/components/ProductPage/PurchaseForm/DiscountTooltip/DiscountTooltip.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/DiscountTooltip/DiscountTooltip.tsx
@@ -4,22 +4,28 @@ import { Text, theme } from 'ui'
 type Props = {
   children: string
   subtitle?: string
+  color?: 'green' | 'gray'
 }
 
-export const DiscountTooltip = ({ children, subtitle }: Props) => {
+export const DiscountTooltip = ({ children, subtitle, color = 'green' }: Props) => {
+  const Bubble = color === 'green' ? GreenBubble : GrayBubble
+
   return (
     <Root>
       <Bubble>
-        <Text size="xs" color="textGreen" align="center">
+        <Text size="xs" color={color === 'green' ? 'textGreen' : 'textPrimary'} align="center">
           {children}
         </Text>
         {subtitle && (
-          <SecondaryText size="xs" align="center">
+          <Text
+            size="xs"
+            color={color === 'green' ? 'textGreen' : 'textSecondaryOnGray'}
+            align="center"
+          >
             {subtitle}
-          </SecondaryText>
+          </Text>
         )}
       </Bubble>
-      {/* <Tip /> */}
     </Root>
   )
 }
@@ -34,18 +40,14 @@ const Root = styled.div({
   display: 'inline-block',
 })
 
-const Bubble = styled.div({
-  backgroundColor: theme.colors.greenFill1,
-  border: `1px solid ${theme.colors.green200}`,
+const GrayBubble = styled.div({
+  backgroundColor: theme.colors.opaque1,
   paddingBlock: theme.space.xs,
   paddingInline: theme.space.sm,
   borderRadius: theme.radius.sm,
   position: 'relative',
 
-  filter: `
-    drop-shadow(0px 1px 1px rgba(51, 67, 43, 0.15))
-    drop-shadow(0px 2px 3px rgba(51, 67, 43, 0.1))
-  `,
+  filter: 'drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.15))',
 
   '::after': {
     content: '""',
@@ -58,8 +60,20 @@ const Bubble = styled.div({
     height: 0,
     borderLeft: `${HALF_TIP_WIDTH} solid transparent`,
     borderRight: `${HALF_TIP_WIDTH} solid transparent`,
-    borderTop: `${HALF_TIP_WIDTH} solid ${theme.colors.greenFill1}`,
+    borderTop: `${HALF_TIP_WIDTH} solid ${theme.colors.opaque1}`,
   },
 })
 
-const SecondaryText = styled(Text)({ color: theme.colors.green700 })
+const GreenBubble = styled(GrayBubble)({
+  backgroundColor: theme.colors.greenFill1,
+  border: `1px solid ${theme.colors.grayTranslucent200}`,
+
+  filter: `
+    drop-shadow(0px 1px 1px rgba(51, 67, 43, 0.15))
+    drop-shadow(0px 2px 3px rgba(51, 67, 43, 0.1))
+  `,
+
+  '::after': {
+    borderTopColor: theme.colors.greenFill1,
+  },
+})

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -110,15 +110,27 @@ export const OfferPresenter = (props: Props) => {
   const loading =
     loadingAddToCart || updateCancellationInfo.loading || updateStartDateResult.loading
 
-  const discountTooltiProps = useMemo(() => {
+  const discountTooltipProps = useMemo(() => {
     if (!selectedOffer.priceMatch) return null
 
-    const priceReduction = formatter.monthlyPrice(selectedOffer.priceMatch.priceReduction)
     const company = selectedOffer.priceMatch.externalInsurer.displayName
+
+    if (selectedOffer.priceMatch.priceReduction.amount < 1) {
+      // No price reduction due to incomparable offers
+      const amount = formatter.monthlyPrice(selectedOffer.priceMatch.externalPrice)
+      return {
+        children: t('PRICE_MATCH_BUBBLE_INCOMPARABLE_TITLE', { amount, company }),
+        subtitle: t('PRICE_MATCH_BUBBLE_INCOMPARABLE_SUBTITLE'),
+        color: 'gray',
+      } as const
+    }
+
+    const priceReduction = formatter.monthlyPrice(selectedOffer.priceMatch.priceReduction)
 
     return {
       children: t('PRICE_MATCH_BUBBLE_SUCCESS_TITLE', { amount: priceReduction }),
       subtitle: t('PRICE_MATCH_BUBBLE_SUCCESS_SUBTITLE', { company }),
+      color: 'green',
     } as const
   }, [selectedOffer.priceMatch, formatter, t])
 
@@ -168,7 +180,7 @@ export const OfferPresenter = (props: Props) => {
         <form ref={offerRef} onSubmit={handleSubmitAddToCart}>
           <Space y={2}>
             <SpaceFlex direction="vertical" align="center" space={1}>
-              {discountTooltiProps && <DiscountTooltip {...discountTooltiProps} />}
+              {discountTooltipProps && <DiscountTooltip {...discountTooltipProps} />}
               <Space y={0.5}>
                 <Text as="p" align="center" size="xl">
                   {displayPrice}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-06-15 at 15.58.19.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/330bec36-79c9-4930-ba07-bef1d696593a/Screenshot%202023-06-15%20at%2015.58.19.png)


- Display a custom message when the user gets price matched but with a larger scope than the competitor (e.g. 2 vs 3 co-insured)

- Update `DiscountTooltip` with option to display a gray variant

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Right now we display a confusing message like "You save -20 kr" in these cases

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
