### PR TITLE
Add support for adding ImageBlock in RichTextBlock

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -55,6 +55,7 @@
     "react-dom": "18.2.0",
     "react-i18next": "12.3.1",
     "react-wrap-balancer": "0.5.0",
+    "storyblok-rich-text-react-renderer": "2.8.0",
     "tss-react": "4.8.6",
     "ui": "workspace:",
     "uuid": "9.0.0",

--- a/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
+++ b/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
@@ -1,8 +1,9 @@
-import { ISbRichtext, renderRichText, storyblokEditable } from '@storyblok/react'
-import { useMemo } from 'react'
+import { ISbRichtext, storyblokEditable } from '@storyblok/react'
+import { render, RenderOptions } from 'storyblok-rich-text-react-renderer'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { RichText } from '@/components/RichText/RichText'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { ImageBlock, ImageBlockProps } from '../ImageBlock'
 import { Layout } from '../TextContentBlock'
 
 export type RichTextBlockProps = SbBaseBlockProps<{
@@ -11,16 +12,22 @@ export type RichTextBlockProps = SbBaseBlockProps<{
   largeText?: boolean
 }>
 
-export const RichTextBlock = ({ blok }: RichTextBlockProps) => {
-  const contentHtml = useMemo(() => renderRichText(blok.content), [blok.content])
+export const richTextRenderOptions: RenderOptions = {
+  blokResolvers: {
+    image: (props) => <ImageBlock blok={props as ImageBlockProps['blok']} nested={true} />,
+  },
+}
 
+export const RichTextBlock = ({ blok }: RichTextBlockProps) => {
   return (
     <GridLayout.Root {...storyblokEditable(blok)}>
       <GridLayout.Content
         width={blok.layout?.widths ?? { base: '1', md: '2/3', xl: '1/2' }}
         align={blok.layout?.alignment ?? 'center'}
       >
-        <RichText contentHTML={contentHtml} largeText={blok.largeText} />
+        <RichText largeText={blok.largeText}>
+          {render(blok.content, richTextRenderOptions)}
+        </RichText>
       </GridLayout.Content>
     </GridLayout.Root>
   )

--- a/apps/store/src/components/RichText/RichText.styles.tsx
+++ b/apps/store/src/components/RichText/RichText.styles.tsx
@@ -160,7 +160,8 @@ export const richTextStyles = css(
       backgroundColor: theme.colors.borderOpaque2,
     },
 
-    img: {
+    // Differentiate between inlined images and ImageBlock
+    'p > img': {
       maxWidth: `calc(100% + ${theme.space.md})`,
       marginBlock: '4.5rem',
       marginInline: `-${theme.space.xs}`,
@@ -168,7 +169,7 @@ export const richTextStyles = css(
     },
 
     [mq.md]: {
-      img: {
+      'p > img': {
         maxWidth: '100%',
         marginBlock: theme.space[9],
         marginInline: 0,

--- a/apps/store/src/components/RichText/RichText.tsx
+++ b/apps/store/src/components/RichText/RichText.tsx
@@ -1,13 +1,15 @@
 import styled from '@emotion/styled'
+import { ReactNode } from 'react'
 import { richTextStyles } from '@/components/RichText/RichText.styles'
 
 type RichTextProps = {
-  contentHTML: string
+  children: ReactNode
+  contentHTML?: string
   largeText?: boolean
 }
 
-export const RichText = ({ contentHTML, largeText }: RichTextProps) => {
-  return <Content dangerouslySetInnerHTML={{ __html: contentHTML }} data-large-text={largeText} />
+export const RichText = ({ largeText, children }: RichTextProps) => {
+  return <Content data-large-text={largeText}>{children}</Content>
 }
 
 const Content = styled.div(richTextStyles)

--- a/apps/store/src/features/blog/BlogArticleBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleBlock.tsx
@@ -1,7 +1,8 @@
-import { StoryblokComponent, renderRichText, storyblokEditable } from '@storyblok/react'
+import { StoryblokComponent, storyblokEditable } from '@storyblok/react'
 import Link from 'next/link'
-import { useMemo } from 'react'
+import { render } from 'storyblok-rich-text-react-renderer'
 import { Heading, Space, Text } from 'ui'
+import { richTextRenderOptions } from '@/blocks/RichTextBlock/RichTextBlock'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { RichText } from '@/components/RichText/RichText'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
@@ -16,7 +17,6 @@ type Props = SbBaseBlockProps<BlogArticleContentType['content']>
 
 export const BlogArticleBlock = (props: Props) => {
   const formatter = useFormatter()
-  const contentHtml = useMemo(() => renderRichText(props.blok.content), [props.blok.content])
   const categories = props.blok.categories.map(convertToBlogArticleCategory)
 
   return (
@@ -38,7 +38,7 @@ export const BlogArticleBlock = (props: Props) => {
               {formatter.fromNow(new Date(props.blok.date))}
             </Text>
           </Space>
-          <RichText contentHTML={contentHtml} />
+          <RichText>{render(props.blok.content, richTextRenderOptions)}</RichText>
         </GridLayout.Content>
       </GridLayout.Root>
       {props.blok.body.map((item) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -22179,6 +22179,7 @@ __metadata:
     react-dom: 18.2.0
     react-i18next: 12.3.1
     react-wrap-balancer: 0.5.0
+    storyblok-rich-text-react-renderer: 2.8.0
     storybook: 7.0.21
     storybook-addon-apollo-client: 4.1.4
     subscriptions-transport-ws: 0.11.0
@@ -22197,6 +22198,15 @@ __metadata:
   version: 5.10.6
   resolution: "storyblok-js-client@npm:5.10.6"
   checksum: a89ae01f060b04850648de200659be8681a35304bc77b5fba89f22adc5c2a9286135e8f68921906223f2c2b654108b555d5aa761916ab2a56b934bacbfb86f92
+  languageName: node
+  linkType: hard
+
+"storyblok-rich-text-react-renderer@npm:2.8.0":
+  version: 2.8.0
+  resolution: "storyblok-rich-text-react-renderer@npm:2.8.0"
+  peerDependencies:
+    react: ">=16.0.0"
+  checksum: d671d76791302f72c75613dce3d2fb81b229702f99e542876f409cede2cca8e65383e5b9234413ed13bcb0676def71ea5584a369210e1e2f1e5cad012182185a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add support for using blocks inside RichText
- Being able to use ImageBlock and render with NextImage

We want to have the same image capabilities in RichText and also add support for rendering links as NextLinks (upcoming change)

As [suggested by Storyblok](https://github.com/storyblok/storyblok-react#rendering-rich-text:~:text=We%20also%20recommend%20using%20the%20Storyblok%20Rich%20Text%20Renderer%20for%20React%20by%20Claus%20for%20rendering%20your%20Storyblok%20rich%20text%20content%20to%20React%20elements%20and%20Next.js%20applications.) we can use https://github.com/claus/storyblok-rich-text-react-renderer 


https://github.com/HedvigInsurance/racoon/assets/6661511/a1035234-f122-43b7-ae27-b4a76076f79b



<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
The default Storyblok render function doesn't support rendering React components

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
