### PR TITLE
Insurely: use native close button

### DIFF
--- a/apps/store/src/components/PriceCalculator/FetchInsurance.tsx
+++ b/apps/store/src/components/PriceCalculator/FetchInsurance.tsx
@@ -2,7 +2,7 @@ import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
 import { type ComponentProps, useCallback, useState, useMemo } from 'react'
-import { CrossIcon, Dialog, Text, mq, theme } from 'ui'
+import { Dialog, Text, theme } from 'ui'
 import { FetchInsurancePrompt } from '@/components/FetchInsurancePrompt/FetchInsurancePrompt'
 import {
   ExternalInsurer,
@@ -131,9 +131,6 @@ export const FetchInsurance = ({
       {state === 'COMPARE' && (
         <DialogIframeContent onClose={dismiss} centerContent={true}>
           <DialogIframeWindow>
-            <DialogCloseButton>
-              <CrossIcon />
-            </DialogCloseButton>
             <InsurelyIframe
               configName={insurelyConfigName}
               onCollection={handleInsurelyCollection}
@@ -180,7 +177,9 @@ const DialogIframeContent = styled(Dialog.Content)({
   width: '100%',
   maxWidth: INSURELY_IFRAME_MAX_WIDTH,
 
-  [mq.lg]: { alignSelf: 'center' },
+  [`@media (min-height: ${INSURELY_IFRAME_MAX_HEIGHT}px)`]: {
+    alignSelf: 'center',
+  },
 })
 
 const DialogIframeWindow = styled(Dialog.Window)({
@@ -189,11 +188,4 @@ const DialogIframeWindow = styled(Dialog.Window)({
   height: INSURELY_IFRAME_MAX_HEIGHT,
   overflowY: 'auto',
   borderRadius: theme.radius.xs,
-})
-
-const DialogCloseButton = styled(Dialog.Close)({
-  position: 'absolute',
-  top: theme.space.xs,
-  right: theme.space.xs,
-  cursor: 'pointer',
 })

--- a/apps/store/src/services/Insurely/Insurely.tsx
+++ b/apps/store/src/services/Insurely/Insurely.tsx
@@ -94,7 +94,7 @@ export const setInsurelyConfig = (config: InsurelyConfig) => {
       ...(config.configName && { configName: config.configName }),
       ...(config.language && { language: config.language }),
 
-      // showCloseButton: true,
+      showCloseButton: true,
       dataAggregation: {
         hideResultsView: true,
       },


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

![Screenshot 2023-06-19 at 11.56.41.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/03654bde-6e65-4246-85e6-6120ff38dad7/Screenshot%202023-06-19%20at%2011.56.41.png)

- Use native Insurely close button instead of overlaying our own

- Center Insurely iframe on small devices based on screen height

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- The native close button looks more native we don't need to worry about
  positioning it correctly

- We can't always center the iframe since the content might be longer than the
  screen height. But if the content is shorter than the screen height, we should center it.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
