### PR TITLE
GEN-576 - refact(ProductCard): increase specificity on 'read more' button focus styling

### DIFF
--- a/apps/store/public/locales/en/common.json
+++ b/apps/store/public/locales/en/common.json
@@ -38,5 +38,6 @@
   "PAYMENT_CONNECT_SUCCESS": "Success! You can close this page now :)",
   "PAYMENT_CONNECT_TITLE": "Connect direct debit",
   "READ_MORE": "Read more",
+  "SELECT_INSURANCE": "Select insurance",
   "UNKNOWN_ERROR_MESSAGE": "Something went wrong, please try again."
 }

--- a/apps/store/public/locales/sv-se/common.json
+++ b/apps/store/public/locales/sv-se/common.json
@@ -35,5 +35,6 @@
   "PAYMENT_CONNECT_SUCCESS": "Autogiro kopplat! Du kan stänga sidan nu :)",
   "PAYMENT_CONNECT_TITLE": "Koppla autogiro",
   "READ_MORE": "Läs mer",
+  "SELECT_INSURANCE": "Välj försäkring",
   "UNKNOWN_ERROR_MESSAGE": "Något gick fel, försök igen."
 }

--- a/apps/store/src/blocks/SelectInsuranceGridBlock.tsx
+++ b/apps/store/src/blocks/SelectInsuranceGridBlock.tsx
@@ -5,7 +5,7 @@ import { useProductMetadata } from '@/components/LayoutWithMenu/ProductMetadataC
 import { OPEN_PRICE_CALCULATOR_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam'
 import { SelectInsuranceGrid } from '@/components/SelectInsuranceGrid/SelectInsuranceGrid'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
-import { ORIGIN_URL } from '@/utils/PageLink'
+import { getParameterizedLink } from '@/utils/getParameterizedLink'
 
 type Props = SbBaseBlockProps<{
   title?: string
@@ -18,7 +18,9 @@ export const SelectInsuranceGridBlock = ({ blok, nested }: Props) => {
 
   const parsedProducts = (products ?? []).map((product) => ({
     ...product,
-    pageLink: getProductLink(product.pageLink, openPriceCalculator),
+    pageLink: openPriceCalculator
+      ? getParameterizedLink(product.pageLink, [[OPEN_PRICE_CALCULATOR_QUERY_PARAM, '1']])
+      : product.pageLink,
   }))
 
   return (
@@ -44,17 +46,5 @@ const StyledSelectInsuranceGrid = styled(SelectInsuranceGrid)({
     },
   },
 })
-
-const getProductLink = (pageLink: string, openPriceCalculator: boolean) => {
-  return openPriceCalculator
-    ? addSearchParam(pageLink, OPEN_PRICE_CALCULATOR_QUERY_PARAM, '1')
-    : pageLink
-}
-
-const addSearchParam = (url: string, param: string, value: string) => {
-  const urlObj = new URL(url, ORIGIN_URL)
-  urlObj.searchParams.set(param, value)
-  return urlObj.toString()
-}
 
 SelectInsuranceGridBlock.blockName = 'selectInsuranceGrid'

--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -54,6 +54,7 @@ export const ProductCard = ({
         <Subtitle>{subtitle}</Subtitle>
         <CallToAction>
           <Button
+            id="read-more-btn"
             onClick={() => router.push(link.url)}
             tabIndex={-1}
             aria-hidden={true}
@@ -203,7 +204,7 @@ const MainLink = styled(Link)({
     left: 0,
   },
 
-  [`&:focus-visible ~ ${CallToAction} button`]: {
+  [`&:focus-visible ~ ${CallToAction} #read-more-btn`]: {
     boxShadow: `0 0 0 2px ${theme.colors.textPrimary}`,
   },
 })

--- a/apps/store/src/components/ProductGrid/ProductGrid.stories.tsx
+++ b/apps/store/src/components/ProductGrid/ProductGrid.stories.tsx
@@ -22,7 +22,7 @@ Default.args = {
       title: 'Hedvig Home',
       subtitle: 'Flexible and simple, for both renters and owners.',
       image: { src: 'https://via.placeholder.com/336x400' },
-      link: { url: '/', type: 'content' },
+      link: { url: '/', type: 'product' },
     },
     {
       key: '2',

--- a/apps/store/src/graphql/ProductMetadata.graphql
+++ b/apps/store/src/graphql/ProductMetadata.graphql
@@ -6,6 +6,7 @@ query ProductMetadata {
     displayNameFull
     tagline
     pageLink
+    categoryPageLink
     pillowImage {
       id
       alt

--- a/apps/store/src/utils/getParameterizedLink.ts
+++ b/apps/store/src/utils/getParameterizedLink.ts
@@ -1,0 +1,15 @@
+import { ORIGIN_URL } from '@/utils/PageLink'
+
+type Parameter = [param: string, value: string]
+
+export const getParameterizedLink = (link: string, parameters: Array<Parameter>) => {
+  return parameters.reduce((result, [param, value]) => {
+    return addSearchParam(result, param, value)
+  }, link)
+}
+
+const addSearchParam = (url: string, param: string, value: string) => {
+  const urlObj = new URL(url, ORIGIN_URL)
+  urlObj.searchParams.set(param, value)
+  return urlObj.toString()
+}


### PR DESCRIPTION
## Describe your changes

* Changes how focus styling is applied to [Read more] button by increasing the specificity of the selector.

## Justify why they are needed

Which the specificity we had [before](https://github.com/HedvigInsurance/racoon/pull/2595/files#diff-cb843ebd121aa7a1c934583700ae1d2e7501e359f8c95e0c052d5618c055e3f8L207) pretty much any button rendered as a `ProductCard` _call to action container's_ children would receive focus styling when the link represented by the `ProductCard` get's focused. That caused some issues with the addition of [See your price] button for product categories:

 https://github.com/HedvigInsurance/racoon/assets/19200662/6ece83fe-25ec-4b07-a0d9-17de061bf455

