### PR TITLE
[GEN-573] Show GDPR link before calculating price

### DIFF
--- a/apps/store/public/locales/en/purchase-form.json
+++ b/apps/store/public/locales/en/purchase-form.json
@@ -93,6 +93,7 @@
   "FIELD_SUB_TYPE_APARTMENT_OPTION_RENT": "Rent it",
   "FIELD_YEAR_OF_CONSTRUCTION_LABEL": "Year of construction",
   "FIELD_ZIP_CODE_LABEL": "Postal code",
+  "GDPR_LINK_BEFORE_OFFER": "How we handle personal data",
   "GENERAL_ERROR_DIALOG_PRIMARY_BUTTON": "Try again",
   "GENERAL_ERROR_DIALOG_PROMPT": "Something went wrong. We can't calculate your price at the moment.",
   "HOUSEHOLD_SIZE_VALUE_one": "You + {{count}}",

--- a/apps/store/public/locales/sv-se/purchase-form.json
+++ b/apps/store/public/locales/sv-se/purchase-form.json
@@ -93,6 +93,7 @@
   "FIELD_SUB_TYPE_APARTMENT_OPTION_RENT": "Hyr den",
   "FIELD_YEAR_OF_CONSTRUCTION_LABEL": "Byggår",
   "FIELD_ZIP_CODE_LABEL": "Postnr.",
+  "GDPR_LINK_BEFORE_OFFER": "Så hanterar vi personuppgifter",
   "GENERAL_ERROR_DIALOG_PRIMARY_BUTTON": "Försök igen",
   "GENERAL_ERROR_DIALOG_PROMPT": "Något gick fel. Vi kan inte beräkna ditt pris för tillfället.",
   "HOUSEHOLD_SIZE_VALUE_one": "Du + {{count}}",

--- a/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
@@ -6,9 +6,9 @@ import {
   setupForm,
   updateFormState,
 } from '@/services/PriceCalculator/PriceCalculator.helpers'
-import { Form } from '@/services/PriceCalculator/PriceCalculator.types'
-import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
-import { ShopSession } from '@/services/shopSession/ShopSession.types'
+import { type Form } from '@/services/PriceCalculator/PriceCalculator.types'
+import { type PriceIntent } from '@/services/priceIntent/priceIntent.types'
+import { type ShopSession } from '@/services/shopSession/ShopSession.types'
 import { AutomaticField } from './AutomaticField'
 import { FetchInsuranceContainer } from './FetchInsuranceContainer'
 import { FormGrid } from './FormGrid'
@@ -96,6 +96,7 @@ export const PriceCalculator = (props: Props) => {
             section={section}
             onSubmit={handleSubmitSection}
             loading={isLoading}
+            last={sectionIndex === form.sections.length - 1}
           >
             <FormGrid items={section.items}>
               {(field, index) => (

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorSection.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorSection.tsx
@@ -1,17 +1,26 @@
-import { FormEventHandler, ReactNode } from 'react'
-import { Button, Space } from 'ui'
+import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
+import NextLink from 'next/link'
+import { type FormEventHandler, type ReactNode } from 'react'
+import { Button, Space, Text } from 'ui'
+import { linkStyles } from '@/components/RichText/RichText.styles'
 import { deserializeField } from '@/services/PriceCalculator/PriceCalculator.helpers'
-import { FormSection, JSONData } from '@/services/PriceCalculator/PriceCalculator.types'
+import { type FormSection, type JSONData } from '@/services/PriceCalculator/PriceCalculator.types'
+import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { PageLink } from '@/utils/PageLink'
 import { useTranslateFieldLabel } from './useTranslateFieldLabel'
 
 type Props = {
   section: FormSection
   loading: boolean
   onSubmit: (data: JSONData) => void
+  last: boolean
   children: ReactNode
 }
 
-export const PriceCalculatorSection = ({ section, loading, onSubmit, children }: Props) => {
+export const PriceCalculatorSection = ({ section, loading, onSubmit, last, children }: Props) => {
+  const { routingLocale } = useCurrentLocale()
+  const { t } = useTranslation('purchase-form')
   const translateLabel = useTranslateFieldLabel()
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
@@ -40,8 +49,21 @@ export const PriceCalculatorSection = ({ section, loading, onSubmit, children }:
           <Button type="submit" disabled={loading} loading={loading}>
             {translateLabel(section.submitLabel)}
           </Button>
+
+          {last && (
+            <Link href={PageLink.privacyPolicy({ locale: routingLocale })} target="_blank">
+              <Text as="span" size="xs">
+                {t('GDPR_LINK_BEFORE_OFFER')}
+              </Text>
+            </Link>
+          )}
         </Space>
       </Space>
     </form>
   )
 }
+
+const Link = styled(NextLink)(linkStyles, {
+  display: 'block',
+  textAlign: 'center',
+})

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -64,6 +64,15 @@ export const PageLink = {
     return url
   },
 
+  privacyPolicy: ({ locale }: Required<BaseParams>) => {
+    const url = PRIVACY_POLICY_URL[locale]
+    if (!url) {
+      datadogLogs.logger.error('Missing privacy policy link for locale', { locale })
+      return PageLink.home({ locale })
+    }
+    return url
+  },
+
   apiSessionReset: () => '/api/session/reset',
   apiSessionCreate: (ssn: string) => `/api/session/create/?ssn=${ssn}`,
   apiCampaign: ({ code, next }: CampaignAddRoute) => {
@@ -80,4 +89,9 @@ const CUSTOMER_SERVICE_URL: Partial<Record<RoutingLocale, string>> = {
 const DEDUCTIBLE_HELP_URL: Partial<Record<RoutingLocale, string>> = {
   se: '/se/forsakringar/djurforsakring/sjalvrisk',
   'se-en': '/se-en/insurances/pet-insurance/deductible',
+}
+
+const PRIVACY_POLICY_URL: Partial<Record<RoutingLocale, string>> = {
+  se: '/se/hedvig/personuppgifter',
+  'se-en': '/se-en/hedvig/privacy-policy',
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-06-21 at 17.20.00.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/212ca4e8-63db-4df4-9196-9c3face567dd/Screenshot%202023-06-21%20at%2017.20.00.png)


- Show a link to privacy policy in price calculator before showing price

  - Only show the link on the last step of the price calculator

- Add PageLink function to get privacy policy link

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Be compliant with GDPR

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
