### PR TITLE
fix(ProductCard): use correct log method

### DIFF
--- a/apps/store/src/blocks/ProductCardBlock.tsx
+++ b/apps/store/src/blocks/ProductCardBlock.tsx
@@ -1,4 +1,3 @@
-import { datadogLogs } from '@datadog/browser-logs'
 import { storyblokEditable } from '@storyblok/react'
 import { useProductMetadata } from '@/components/LayoutWithMenu/ProductMetadataContext'
 import { ProductCard, type LinkType } from '@/components/ProductCard/ProductCard'
@@ -24,7 +23,7 @@ export const ProductCardBlock = ({ blok }: ProductCardBlockProps) => {
   const linkType = getLinkType(productMetadata, link)
 
   if (linkType === 'content') {
-    datadogLogs.logger.warn(
+    console.warn(
       '[ProductCardBlock]: provided "link" does not refer to a product neither a category. Skipping ProductCard render!',
     )
     return null

--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -1,5 +1,4 @@
 import { UrlObject } from 'url'
-import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
 import { motion } from 'framer-motion'
 import Link from 'next/link'
@@ -89,7 +88,7 @@ const ProductCTA = ({ link }: Pick<ProductCardProps, 'link'>) => {
 
   const priceLink = getPriceLink(link.url)
   if (!priceLink) {
-    datadogLogs.logger.warn('[ProductCard]: Unable to generate a price link. Skipping cta render!')
+    console.warn('[ProductCard]: Unable to generate a price link. Skipping cta render!')
     return null
   }
 
@@ -113,7 +112,7 @@ const CategoryCTA = ({ link }: Pick<ProductCardProps, 'link'>) => {
     }))
 
   if (productsByCategory.length < 1) {
-    datadogLogs.logger.warn(
+    console.warn(
       `[ProductCard]: No products category link ${link} were found. Skipping cta render!`,
     )
     return null


### PR DESCRIPTION
## Describe your changes

Replace `datadogLogs.logger.warn` calls for regular `console.warn`.

<img width="1251" alt="Screenshot 2023-06-21 at 16 55 01" src="https://github.com/HedvigInsurance/racoon/assets/19200662/76828667-6f1c-459d-8bd4-3c86cc4a70f2">
