### PR TITLE
[GEN-571] Add Grid layout to USPBlock

### DIFF
--- a/apps/store/src/blocks/GridBlock.tsx
+++ b/apps/store/src/blocks/GridBlock.tsx
@@ -2,9 +2,12 @@ import styled, { CSSObject } from '@emotion/styled'
 import { StoryblokComponent, storyblokEditable } from '@storyblok/react'
 import { mq, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
-import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import {
+  type ExpectedBlockType,
+  type GridColumnsField,
+  type SbBaseBlockProps,
+} from '@/services/storyblok/storyblok'
 import { ImageTextBlockProps } from './ImageTextBlock'
-import { Layout } from './TextContentBlock'
 
 type ColumnBloks = ExpectedBlockType<ImageTextBlockProps>
 
@@ -13,7 +16,7 @@ type ColumnProps = { columns: number }
 type GridBlockProps = SbBaseBlockProps<{
   title?: string
   columns: ColumnBloks
-  layout?: Layout
+  layout?: GridColumnsField
 }>
 
 export const GridBlock = ({ blok }: GridBlockProps) => {

--- a/apps/store/src/blocks/ImageBlock.tsx
+++ b/apps/store/src/blocks/ImageBlock.tsx
@@ -5,9 +5,13 @@ import { ConditionalWrapper, mq, theme } from 'ui'
 import { HeadingBlock, HeadingBlockProps } from '@/blocks/HeadingBlock'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { ImageWithPlaceholder } from '@/components/ImageWithPlaceholder/ImageWithPlaceholder'
-import { ExpectedBlockType, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
+import {
+  type ExpectedBlockType,
+  type GridColumnsField,
+  type SbBaseBlockProps,
+  type StoryblokAsset,
+} from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
-import { Layout } from './TextContentBlock'
 
 export type ImageAspectRatio = '1 / 1' | '2 / 1' | '3 / 2' | '4 / 3' | '5 / 4' | '16 / 9'
 
@@ -18,7 +22,7 @@ export type ImageBlockProps = SbBaseBlockProps<{
   fullBleed?: boolean
   body?: ExpectedBlockType<HeadingBlockProps>
   priority?: boolean
-  layout?: Layout
+  layout?: GridColumnsField
 }>
 
 export const ImageBlock = ({ blok, nested }: ImageBlockProps) => {

--- a/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
+++ b/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
@@ -3,13 +3,12 @@ import Link from 'next/link'
 import { render, RenderOptions, MARK_LINK } from 'storyblok-rich-text-react-renderer'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { RichText } from '@/components/RichText/RichText'
-import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { type GridColumnsField, type SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { ImageBlock, ImageBlockProps } from '../ImageBlock'
-import { Layout } from '../TextContentBlock'
 
 export type RichTextBlockProps = SbBaseBlockProps<{
   content: ISbRichtext
-  layout?: Layout
+  layout?: GridColumnsField
   largeText?: boolean
 }>
 

--- a/apps/store/src/blocks/TextContentBlock.tsx
+++ b/apps/store/src/blocks/TextContentBlock.tsx
@@ -2,21 +2,19 @@ import styled from '@emotion/styled'
 import { StoryblokComponent, storyblokEditable } from '@storyblok/react'
 import { theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
-import { ContentAlignment, ContentWidth } from '@/components/GridLayout/GridLayout.helper'
-import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import {
+  type ExpectedBlockType,
+  type GridColumnsField,
+  type SbBaseBlockProps,
+} from '@/services/storyblok/storyblok'
 import { HeadingBlockProps } from './HeadingBlock'
 import { HeadingLabelBlockProps } from './HeadingLabelBlock'
 import { TextBlockProps } from './TextBlock'
 
-export type Layout = {
-  widths: ContentWidth
-  alignment: ContentAlignment
-}
-
 export type Props = SbBaseBlockProps<{
   heading?: ExpectedBlockType<HeadingBlockProps | HeadingLabelBlockProps>
   body: ExpectedBlockType<TextBlockProps>
-  layout?: Layout
+  layout?: GridColumnsField
 }>
 
 export const TextContentBlock = ({ blok }: Props) => {

--- a/apps/store/src/blocks/USPBlock.tsx
+++ b/apps/store/src/blocks/USPBlock.tsx
@@ -1,21 +1,39 @@
 import styled from '@emotion/styled'
-import { Badge, Text, Space, theme, mq } from 'ui'
-import { SbBaseBlockProps, ExpectedBlockType } from '@/services/storyblok/storyblok'
+import { storyblokEditable } from '@storyblok/react'
+import { Badge, Text, theme, mq } from 'ui'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+import {
+  type SbBaseBlockProps,
+  type ExpectedBlockType,
+  type GridColumnsField,
+} from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 
 type USPBlockProps = SbBaseBlockProps<{
   items: ExpectedBlockType<USPItemBlockProps>
+  layout?: GridColumnsField
 }>
 
 export const USPBlock = ({ blok }: USPBlockProps) => {
   const uspItems = filterByBlockType(blok.items, USPBlockItem.blockName)
 
   return (
-    <Wrapper numberOfItems={uspItems.length}>
-      {uspItems.map((nestedBlock) => (
-        <USPBlockItem key={nestedBlock._uid} blok={nestedBlock} />
-      ))}
-    </Wrapper>
+    <GridLayout.Root {...storyblokEditable(blok)}>
+      <GridLayout.Content
+        width={blok.layout?.widths ?? '1'}
+        align={blok.layout?.alignment ?? 'center'}
+      >
+        <List>
+          {uspItems.map((nestedBlock) => (
+            <USPBlockItem
+              key={nestedBlock._uid}
+              blok={nestedBlock}
+              numberOfItems={uspItems.length}
+            />
+          ))}
+        </List>
+      </GridLayout.Content>
+    </GridLayout.Root>
   )
 }
 USPBlock.blockName = 'usp'
@@ -23,32 +41,39 @@ USPBlock.blockName = 'usp'
 type USPItemBlockProps = SbBaseBlockProps<{
   title: string
   content: string
-}>
+}> & { numberOfItems: number }
 
-export const USPBlockItem = ({ blok }: USPItemBlockProps) => {
+export const USPBlockItem = ({ blok, numberOfItems }: USPItemBlockProps) => {
   return (
-    <li>
-      <Space y={{ base: 1, md: 1.5 }}>
-        <Badge>{blok.title}</Badge>
-        <Text size={{ _: 'xl' }}>{blok.content}</Text>
-      </Space>
-    </li>
+    <ListItem numberOfItems={numberOfItems}>
+      <Badge>{blok.title}</Badge>
+      <Text size={{ _: 'xl' }}>{blok.content}</Text>
+    </ListItem>
   )
 }
 USPBlockItem.blockName = 'uspItem'
 
-const Wrapper = styled.ul<{ numberOfItems: number }>(({ numberOfItems }) => ({
+const List = styled.ul({
   display: 'grid',
   gridTemplateColumns: 'repeat(auto-fit, minmax(21.875rem, 1fr))',
   gap: theme.space.xxl,
-  paddingInline: theme.space.md,
 
   [mq.md]: {
-    gap: theme.space.md,
-    paddingInline: theme.space.lg,
+    columnGap: theme.space.md,
+  },
+})
+
+const ListItem = styled.li<{ numberOfItems: number }>(({ numberOfItems }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  gap: theme.space.md,
+
+  [mq.md]: {
+    gap: theme.space.lg,
   },
 
-  '& > li': {
+  [`${List.toString()} > &`]: {
     maxWidth: numberOfItems >= 3 ? '28.125rem' : '40.625rem',
   },
 }))

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -65,6 +65,7 @@ import { TopPickCardBlock } from '@/blocks/TopPickCardBlock'
 import { USPBlock, USPBlockItem } from '@/blocks/USPBlock'
 import { VideoBlock } from '@/blocks/VideoBlock'
 import { VideoListBlock } from '@/blocks/VideoListBlock'
+import { type ContentWidth, type ContentAlignment } from '@/components/GridLayout/GridLayout.helper'
 import { BLOG_ARTICLE_CONTENT_TYPE } from '@/features/blog/blog.constants'
 import { blogBlocks } from '@/features/blog/blogBlocks'
 // TODO: get rid of this import, services should avoid feature-imports
@@ -102,6 +103,11 @@ export type StoryblokVersion = 'draft' | 'published'
 
 export type StoryblokPreviewData = {
   version?: StoryblokVersion
+}
+
+export type GridColumnsField = {
+  widths: ContentWidth
+  alignment: ContentAlignment
 }
 
 export type StoryblokAsset = {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-06-22 at 10.36.04.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/7d10a33b-fc81-4686-98b8-ddc810bd6984/Screenshot%202023-06-22%20at%2010.36.04.png)


- Add the grid layout to the USP Block

- Create shared `GridColumnsField` type based on "HedvigGridColumns" storyblok plugin

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Make USP Block match the layout of the rest of the page

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
