### PR TITLE
[GEN-607] Pre-select price matched offers

### DIFF
--- a/apps/store/public/locales/en/purchase-form.json
+++ b/apps/store/public/locales/en/purchase-form.json
@@ -108,7 +108,7 @@
   "OPEN_PRICE_CALCULATOR_BUTTON": "See your price",
   "PRESENT_OFFER_EDIT_BUTTON": "Edit your info",
   "PRICE_CALCULATOR_SECTION_EDIT_BUTTON": "Edit",
-  "PRICE_MATCH_BUBBLE_INCOMPARABLE_SUBTITLE": "We couldn't match your price since you have entered a larger scope",
+  "PRICE_MATCH_BUBBLE_INCOMPARABLE_SUBTITLE": "We could unfortunately not match your current price",
   "PRICE_MATCH_BUBBLE_INCOMPARABLE_TITLE": "You pay {{amount}} at {{company}}",
   "PRICE_MATCH_BUBBLE_SUCCESS_SUBTITLE": "compared to {{company}}",
   "PRICE_MATCH_BUBBLE_SUCCESS_TITLE": "You save {{amount}}",

--- a/apps/store/public/locales/sv-se/purchase-form.json
+++ b/apps/store/public/locales/sv-se/purchase-form.json
@@ -108,7 +108,7 @@
   "OPEN_PRICE_CALCULATOR_BUTTON": "Se ditt pris",
   "PRESENT_OFFER_EDIT_BUTTON": "Ändra din info",
   "PRICE_CALCULATOR_SECTION_EDIT_BUTTON": "Ändra",
-  "PRICE_MATCH_BUBBLE_INCOMPARABLE_SUBTITLE": "Vi kunde inte matcha ditt pris eftersom du har angett en större omfattning",
+  "PRICE_MATCH_BUBBLE_INCOMPARABLE_SUBTITLE": "Vi kunde tyvärr inte matcha ditt nuvarande pris",
   "PRICE_MATCH_BUBBLE_INCOMPARABLE_TITLE": "Du betalar {{amount}} hos {{company}}",
   "PRICE_MATCH_BUBBLE_SUCCESS_SUBTITLE": "jämfört med {{company}}",
   "PRICE_MATCH_BUBBLE_SUCCESS_TITLE": "Du sparar {{amount}}",

--- a/apps/store/src/components/ProductPage/PriceIntentContext.tsx
+++ b/apps/store/src/components/ProductPage/PriceIntentContext.tsx
@@ -62,6 +62,9 @@ const usePriceIntentContextValue = () => {
           if (matchingReplaceOffer) return matchingReplaceOffer
         }
 
+        const priceMatchedOffer = data.priceIntent.offers.find((item) => item.priceMatch)
+        if (priceMatchedOffer) return priceMatchedOffer
+
         return getOffersByPrice(data.priceIntent.offers)[0]
       })
     },


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Pre-select offers that have been price matched in the offer presenter

- Update translations for when we are not able to match a competitor price

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We intend to control which offers are pre-selected (and/or highlighted) in the API, however, we are not able to do this yet. This is a temporary solution to launch Insurely for Car.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
