### PR TITLE
GEN-406: fix(RichTextBlock): append anchor id if provided

### DIFF
--- a/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
+++ b/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
@@ -12,35 +12,45 @@ export type RichTextBlockProps = SbBaseBlockProps<{
   largeText?: boolean
 }>
 
-export const richTextRenderOptions: RenderOptions = {
+const richTextRenderOptions: RenderOptions = {
   blokResolvers: {
     image: (props) => <ImageBlock blok={props as ImageBlockProps['blok']} nested={true} />,
   },
   markResolvers: {
     [MARK_LINK]: (children, props) => {
-      const { linktype, href, target } = props
+      const { linktype, target, anchor } = props
+
+      let href = ''
+      if (props.href) {
+        href = props.href
+      } else {
+        console.warn(
+          "[RichTextBlock]: No 'href' provided to link. This is probably a configuration issue. Using '' as placholder",
+        )
+      }
+
       if (linktype === 'email') {
         return <a href={`mailto:${href}`}>{children}</a>
       }
 
       // External links
-      if (href?.match(/^(https?:)?\/\//)) {
+      if (isExternalLink(href)) {
         return (
-          <a href={href} target={target}>
+          <a href={appendAnchor(href, anchor)} target={target}>
             {children}
           </a>
         )
       }
 
       // Internal links
-      if (href) {
-        return <Link href={href}>{children}</Link>
-      }
-
-      return null
+      return <Link href={appendAnchor(href, anchor)}>{children}</Link>
     },
   },
 }
+
+const isExternalLink = (href?: string) => href?.match(/^(https?:)?\/\//)
+
+const appendAnchor = (href: string, anchor?: string) => (anchor ? `${href}#${anchor}` : href)
 
 export const RichTextBlock = ({ blok }: RichTextBlockProps) => {
   return (


### PR DESCRIPTION
## Describe your changes

* `RichTextBlock`: make sure anchors are append into `href` when provided.

<img width="1311" alt="Screenshot 2023-06-26 at 14 11 29" src="https://github.com/HedvigInsurance/racoon/assets/19200662/bd125f9b-1346-4dd0-8b34-2da7bb1796a3">

## Justify why they are needed

Without it, anchor definitions are being ignored:

<img width="559" alt="Screenshot 2023-06-26 at 14 10 11" src="https://github.com/HedvigInsurance/racoon/assets/19200662/1337d91d-91aa-41ee-8de9-bc7eeabd9e39">

<img width="1309" alt="Screenshot 2023-06-26 at 14 10 55" src="https://github.com/HedvigInsurance/racoon/assets/19200662/2bc3b4ed-8e30-4549-b98e-509d581c2adb">
