### PR TITLE
GEN-606 - fix(RichTextBlock): pass down link custom attributes

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -55,7 +55,7 @@
     "react-dom": "18.2.0",
     "react-i18next": "12.3.1",
     "react-wrap-balancer": "1.0.0",
-    "storyblok-rich-text-react-renderer": "2.8.0",
+    "storyblok-rich-text-react-renderer": "2.9.0",
     "tss-react": "4.8.6",
     "ui": "workspace:",
     "uuid": "9.0.0",

--- a/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
+++ b/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
@@ -6,12 +6,6 @@ import { RichText } from '@/components/RichText/RichText'
 import { type GridColumnsField, type SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { ImageBlock, ImageBlockProps } from '../ImageBlock'
 
-type LinkCustomAttributes = {
-  rel?: string
-  title?: string
-  [key: string]: any
-}
-
 export type RichTextBlockProps = SbBaseBlockProps<{
   content: ISbRichtext
   layout?: GridColumnsField
@@ -23,11 +17,7 @@ const richTextRenderOptions: RenderOptions = {
     image: (props) => <ImageBlock blok={props as ImageBlockProps['blok']} nested={true} />,
   },
   markResolvers: {
-    [MARK_LINK]: (children, _props) => {
-      // This is a workaround while we don't get 'storyblok-rich-text-react-renderer' library types
-      // updated. Refer to https://github.com/claus/storyblok-rich-text-react-renderer/issues/41
-      // for more info.
-      const props: typeof _props & { custom?: LinkCustomAttributes } = { ..._props }
+    [MARK_LINK]: (children, props) => {
       const { linktype, target, anchor, custom } = props
 
       let href = ''

--- a/yarn.lock
+++ b/yarn.lock
@@ -22188,7 +22188,7 @@ __metadata:
     react-dom: 18.2.0
     react-i18next: 12.3.1
     react-wrap-balancer: 1.0.0
-    storyblok-rich-text-react-renderer: 2.8.0
+    storyblok-rich-text-react-renderer: 2.9.0
     storybook: 7.0.23
     storybook-addon-apollo-client: 4.1.4
     subscriptions-transport-ws: 0.11.0
@@ -22210,12 +22210,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"storyblok-rich-text-react-renderer@npm:2.8.0":
-  version: 2.8.0
-  resolution: "storyblok-rich-text-react-renderer@npm:2.8.0"
+"storyblok-rich-text-react-renderer@npm:2.9.0":
+  version: 2.9.0
+  resolution: "storyblok-rich-text-react-renderer@npm:2.9.0"
   peerDependencies:
     react: ">=16.0.0"
-  checksum: d671d76791302f72c75613dce3d2fb81b229702f99e542876f409cede2cca8e65383e5b9234413ed13bcb0676def71ea5584a369210e1e2f1e5cad012182185a
+  checksum: 4af7d6275450cc011a475b0e33cafceede06b0b670d1a6e8709c09d39444e75f378d754931874e306e239953d4e1cb16795091e46ba05d0c84452647e53770b7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Update**: `storyblok-rich-text-react-renderer` got updated so no workaround is required anymore.

## Describe your changes

Update `RichTextBlock` so link's `custom` attributes like `rel` and `title` get included in the rendered ancho tag.

<img width="559" alt="Screenshot 2023-06-27 at 09 57 29" src="https://github.com/HedvigInsurance/racoon/assets/19200662/e0caa0c0-aa0a-43df-9d8e-57ff6bb290c0">
<img width="924" alt="Screenshot 2023-06-27 at 09 58 28" src="https://github.com/HedvigInsurance/racoon/assets/19200662/dab76dc5-d320-43aa-9713-0e846fdb227f">


## Justify why they are needed

Before they were being ignored even though we proper get from them _Storyblok_. Observe tho that this solution  has a workaround as the ideal solution would be the one where `[storyblok-rich-text-react-renderer](https://github.com/claus/storyblok-rich-text-react-renderer)` - a library we're using for resolving rich text content into React components - get its types updated. Link's custom attributes are already available for the link resolver function, so it's just about a type mismatch. I've created an [issue](https://github.com/claus/storyblok-rich-text-react-renderer/issues/41).
 
![Untitled](https://github.com/HedvigInsurance/racoon/assets/19200662/8bd1eb62-2c8b-4a0a-aea4-14773c732603)
![Untitled (1)](https://github.com/HedvigInsurance/racoon/assets/19200662/69eb9fb1-fd25-4ddb-9df8-239a33ecff6f)


