### PR TITLE
GEN-610 / Add DownloadableContentItemBlock

### DIFF
--- a/apps/store/public/locales/en/common.json
+++ b/apps/store/public/locales/en/common.json
@@ -14,6 +14,7 @@
   "DATE_TOO_LATE": "Date can't be later than {{maxValue}}",
   "DIALOG_BUTTON_CANCEL": "Cancel",
   "DIALOG_CLOSE": "Close",
+  "DOWNLOAD_ASSET": "Download",
   "ERROR_DIALOG_CLOSE": "Close",
   "FOREVER_PAGE_BTN_LABEL": "Next",
   "FOREVER_PAGE_FOOTER_TEXT": "This is an exclusive site only intended for invited individuals. If you currently are not in possession of a code please do continue to our [[regular website.]]",

--- a/apps/store/public/locales/sv-se/common.json
+++ b/apps/store/public/locales/sv-se/common.json
@@ -13,6 +13,7 @@
   "DATE_TOO_LATE": "Datum kan inte vara senare än {{maxValue}}",
   "DIALOG_BUTTON_CANCEL": "Avbryt",
   "DIALOG_CLOSE": "Stäng",
+  "DOWNLOAD_ASSET": "Ladda ner",
   "ERROR_DIALOG_CLOSE": "Stäng",
   "FOREVER_PAGE_BTN_LABEL": "Nästa",
   "FOREVER_PAGE_FOOTER_TEXT": "Denna sida är avsedd för inbjudna personer. Om du inte har en kod kan du fortsätta till vår vanliga [[webbplats.]]",

--- a/apps/store/src/blocks/DownloadableContentItemBlock.tsx
+++ b/apps/store/src/blocks/DownloadableContentItemBlock.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { DownloadableContentItem } from '@/components/DownloadableContentItem/DownloadableContentItem'
+import { LinkField, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
+
+export type DownloadableContentItemBlockProps = SbBaseBlockProps<{
+  thumbnail: StoryblokAsset
+  fileLink: LinkField
+}>
+
+export const DownloadableContentItemBlock = ({ blok }: DownloadableContentItemBlockProps) => {
+  return <DownloadableContentItem thumbnail={blok.thumbnail} url={blok.fileLink.url} />
+}
+
+DownloadableContentItemBlock.blockName = 'downloadableContentItem'

--- a/apps/store/src/components/DownloadableContentItem/DownloadableContentItem.stories.tsx
+++ b/apps/store/src/components/DownloadableContentItem/DownloadableContentItem.stories.tsx
@@ -1,0 +1,69 @@
+import styled from '@emotion/styled'
+import type { Meta, StoryObj } from '@storybook/react'
+import { mq, theme } from 'ui'
+import { DownloadableContentItem } from './DownloadableContentItem'
+import { type DownloadableContentProps } from './DownloadableContentItem'
+
+const meta: Meta<typeof DownloadableContentItem> = {
+  component: DownloadableContentItem,
+  parameters: {
+    paddings: [{ name: 'Large', value: '64px', default: true }],
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof DownloadableContentItem>
+
+export const Default: Story = {
+  render: () => (
+    <Root>
+      {items.map((item) => (
+        <DownloadableContentItem key={item.thumbnail.id} {...item} />
+      ))}
+    </Root>
+  ),
+}
+
+const items: DownloadableContentProps[] = [
+  {
+    thumbnail: {
+      id: 10046027,
+      alt: '',
+      name: '',
+      focus: '',
+      title: '',
+      filename: 'https://a.storyblok.com/f/165473/3840x2584/ef9bf2f1f9/hedvig-press-car.jpg',
+      copyright: '',
+      fieldtype: 'asset',
+      is_external_url: false,
+    },
+    url: 'https://a.storyblok.com/f/165473/3840x2584/ef9bf2f1f9/hedvig-press-car.jpg',
+  },
+  {
+    thumbnail: {
+      id: 10046029,
+      alt: '',
+      name: '',
+      focus: '',
+      title: '',
+      filename: 'https://a.storyblok.com/f/165473/1920x1081/a24e5c11ed/burnout-thumbnail.jpg',
+      copyright: '',
+      fieldtype: 'asset',
+      is_external_url: false,
+    },
+    url: 'https://a.storyblok.com/f/165473/x/0e3c9a3779/car-burnout-hedvig-test.mov',
+  },
+]
+
+const Root = styled.div({
+  display: 'grid',
+  columnGap: theme.space.md,
+  rowGap: theme.space.lg,
+  marginInline: 'auto',
+  width: '100%',
+
+  [mq.md]: {
+    maxWidth: '800px',
+    gridTemplateColumns: 'repeat(2, 1fr)',
+  },
+})

--- a/apps/store/src/components/DownloadableContentItem/DownloadableContentItem.tsx
+++ b/apps/store/src/components/DownloadableContentItem/DownloadableContentItem.tsx
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { theme } from 'ui'
+import { StoryblokAsset } from '@/services/storyblok/storyblok'
+import { ImageWithPlaceholder } from '../ImageWithPlaceholder/ImageWithPlaceholder'
+import { linkStyles } from '../RichText/RichText.styles'
+
+export type DownloadableContentProps = {
+  url: string
+  thumbnail: StoryblokAsset
+}
+
+export const DownloadableContentItem = ({ thumbnail, url }: DownloadableContentProps) => {
+  const { t } = useTranslation('common')
+  return (
+    <div>
+      <Wrapper>
+        <Image src={thumbnail.filename} alt={thumbnail.alt} fill />
+      </Wrapper>
+      <Link href={url}>{t('DOWNLOAD_ASSET')}</Link>
+    </div>
+  )
+}
+
+const Wrapper = styled.div({
+  position: 'relative',
+  aspectRatio: '6 / 4',
+})
+
+const Image = styled(ImageWithPlaceholder)({
+  objectFit: 'cover',
+  borderRadius: theme.radius.sm,
+})
+
+const Link = styled.a(linkStyles, {
+  display: 'inline-block',
+  marginBlock: theme.space.xs,
+  marginInline: theme.space.xs,
+})

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -18,6 +18,7 @@ import { ComparisonTableBlock } from '@/blocks/ComparisonTableBlock'
 import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
 import { ContactSupportBlock } from '@/blocks/ContactSupportBlock'
 import { ContentBlock } from '@/blocks/ContentBlock'
+import { DownloadableContentItemBlock } from '@/blocks/DownloadableContentItemBlock'
 import { FooterBlock, FooterBlockProps, FooterLink, FooterSection } from '@/blocks/FooterBlock'
 import { GridBlock } from '@/blocks/GridBlock'
 import {
@@ -240,6 +241,7 @@ export const initStoryblok = () => {
     ContactSupportBlock,
     ContentBlock,
     ConfirmationPageBlock,
+    DownloadableContentItemBlock,
     FooterBlock,
     FooterLink,
     FooterSection,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add new block for uploading a thumbnail and adding a link to the asset.
- Supports video, image and documents
- Will be used inside `GridBlock` as decided with Peter


https://github.com/HedvigInsurance/racoon/assets/6661511/f6a51239-469e-4799-90e9-1c70e700f00e



<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Press material 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
