### PR TITLE
Filter blog articles per locale

### DIFF
--- a/apps/store/src/features/blog/fetchAricleCategories.ts
+++ b/apps/store/src/features/blog/fetchAricleCategories.ts
@@ -1,12 +1,17 @@
 import { fetchStories } from '@/services/storyblok/storyblok'
+import { RoutingLocale } from '@/utils/l10n/types'
 import { BLOG_ARTICLE_CATEGORY_CONTENT_TYPE } from './blog.constants'
 import { type BlogArticleCategory } from './blog.types'
 
-export const fetchArticleCategories = async (
-  draft = false,
-): Promise<Array<BlogArticleCategory>> => {
+type Params = { locale: RoutingLocale; draft?: boolean }
+
+export const fetchArticleCategories = async ({
+  locale,
+  draft,
+}: Params): Promise<Array<BlogArticleCategory>> => {
   const response = await fetchStories({
     content_type: BLOG_ARTICLE_CATEGORY_CONTENT_TYPE,
+    starts_with: `${locale}/`,
     ...(draft && { version: 'draft' }),
   })
 

--- a/apps/store/src/features/blog/fetchArticleTeasers.ts
+++ b/apps/store/src/features/blog/fetchArticleTeasers.ts
@@ -1,12 +1,17 @@
 import { type SbBlokData, type ISbStoryData, type ISbRichtext } from '@storyblok/react'
 import { type SEOData, type StoryblokAsset, fetchStories } from '@/services/storyblok/storyblok'
 import { getStoryblokImageSize } from '@/services/storyblok/Storyblok.helpers'
+import { RoutingLocale } from '@/utils/l10n/types'
 import { BLOG_ARTICLE_CONTENT_TYPE } from './blog.constants'
 import { convertToBlogArticleCategory } from './blog.helpers'
 import { type BlogArticleTeaser } from './blog.types'
 
-export const fetchArticleTeasers = async (draft = false): Promise<Array<BlogArticleTeaser>> => {
-  const stories = await fetchArticles(draft)
+type FetchArticlesParams = { locale: RoutingLocale; draft?: boolean }
+
+export const fetchArticleTeasers = async (
+  params: FetchArticlesParams,
+): Promise<Array<BlogArticleTeaser>> => {
+  const stories = await fetchArticles(params)
 
   const teasers: Array<BlogArticleTeaser> = []
 
@@ -49,11 +54,14 @@ type BlogArticleContentType = ISbStoryData<
   } & SEOData
 >
 
-const fetchArticles = async (draft = false): Promise<Array<BlogArticleContentType>> => {
+const fetchArticles = async (
+  params: FetchArticlesParams,
+): Promise<Array<BlogArticleContentType>> => {
   const response = await fetchStories({
     content_type: BLOG_ARTICLE_CONTENT_TYPE,
+    starts_with: `${params.locale}/`,
     resolve_relations: `${BLOG_ARTICLE_CONTENT_TYPE}.categories`,
-    ...(draft && { version: 'draft' }),
+    ...(params.draft && { version: 'draft' }),
   })
 
   return response.data.stories as Array<BlogArticleContentType>

--- a/apps/store/src/features/blog/fetchBlogPageProps.ts
+++ b/apps/store/src/features/blog/fetchBlogPageProps.ts
@@ -1,4 +1,5 @@
 import { type ISbStoryData, type SbBlokData } from '@storyblok/react'
+import { RoutingLocale } from '@/utils/l10n/types'
 import {
   BLOG_ARTICLE_CATEGORIES_PAGE_PROP,
   BLOG_ARTICLE_CATEGORY_LIST_BLOCK,
@@ -8,10 +9,16 @@ import {
 import { fetchArticleCategories } from './fetchAricleCategories'
 import { fetchArticleTeasers } from './fetchArticleTeasers'
 
-export const fetchBlogPageProps = async (story: ISbStoryData) => {
+type Params = {
+  locale: RoutingLocale
+  story: ISbStoryData
+  draft: boolean
+}
+
+export const fetchBlogPageProps = async (params: Params) => {
   const [teasers, categories] = await Promise.all([
-    fetchArticleTeasersIfNeeded(story),
-    fetchArticleCategoriesIfNeeded(story),
+    fetchArticleTeasersIfNeeded(params),
+    fetchArticleCategoriesIfNeeded(params),
   ])
 
   return {
@@ -20,14 +27,14 @@ export const fetchBlogPageProps = async (story: ISbStoryData) => {
   }
 }
 
-const fetchArticleTeasersIfNeeded = async (story: ISbStoryData) => {
+const fetchArticleTeasersIfNeeded = async ({ story, locale, draft }: Params) => {
   if (!findBlock(story, BLOG_ARTICLE_LIST_BLOCK)) return
-  return fetchArticleTeasers()
+  return fetchArticleTeasers({ locale, draft })
 }
 
-const fetchArticleCategoriesIfNeeded = async (story: ISbStoryData) => {
+const fetchArticleCategoriesIfNeeded = async ({ story, locale, draft }: Params) => {
   if (!findBlock(story, BLOG_ARTICLE_CATEGORY_LIST_BLOCK)) return
-  return fetchArticleCategories()
+  return fetchArticleCategories({ locale, draft })
 }
 
 const findBlock = (story: ISbStoryData, component: string) => {

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -127,7 +127,7 @@ export const getStaticProps: GetStaticProps<
   return {
     props: {
       type: 'content',
-      ...(await fetchBlogPageProps(story)),
+      ...(await fetchBlogPageProps({ story, locale, draft: version === 'draft' })),
       ...props,
     },
     revalidate,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Filter blog articles and categories by the current locale

- Use `start_with` filter query in Storyblok API

- Pass down "draft" mode parameter from Next.js when fetching blog content

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Now all blog contnet is mixed (swedish + english)

- Unpublished articles don't show up on category pages even if you are in draft mode

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
