### PR TITLE
Unify date formatting across blog

### DIFF
--- a/apps/store/src/features/blog/ArticleTeaser/ArticleTeaser.tsx
+++ b/apps/store/src/features/blog/ArticleTeaser/ArticleTeaser.tsx
@@ -30,7 +30,7 @@ const Content = (props: ContentProps) => {
   return (
     <ContentWrapper>
       <Space y={0.25}>
-        <Text size="sm" color="textSecondary">
+        <Text size="sm" color="textSecondary" uppercase={true}>
           {props.date}
         </Text>
         <div>

--- a/apps/store/src/features/blog/BlogArticleBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleBlock.tsx
@@ -5,7 +5,7 @@ import { Heading, Space, Text, mq, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { type SbBaseBlockProps } from '@/services/storyblok/storyblok'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useFormatter } from '@/utils/useFormatter'
 import { ArticleTeaser } from './ArticleTeaser/ArticleTeaser'
 import { BLOG_ARTICLE_CONTENT_TYPE } from './blog.constants'
 import { convertToBlogArticleCategory } from './blog.helpers'
@@ -15,7 +15,7 @@ type Props = SbBaseBlockProps<BlogArticleContentType['content']>
 
 export const BlogArticleBlock = (props: Props) => {
   const categories = props.blok.categories.map(convertToBlogArticleCategory)
-  const { locale } = useCurrentLocale()
+  const formatter = useFormatter()
 
   return (
     <>
@@ -35,7 +35,7 @@ export const BlogArticleBlock = (props: Props) => {
                 {props.blok.page_heading}
               </Heading>
               <UppercaseText size="sm" color="textSecondary">
-                {formatDate(props.blok.date, locale)}
+                {formatter.dateFull(new Date(props.blok.date))}
               </UppercaseText>
             </Space>
           </Space>
@@ -57,11 +57,3 @@ const TopPadding = styled.div({
 const UppercaseText = styled(Text)({
   textTransform: 'uppercase',
 })
-
-const formatDate = (date: string, locale = 'sv-SE') => {
-  return new Date(date).toLocaleDateString(locale, {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
-}

--- a/apps/store/src/features/blog/BlogArticleListBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleListBlock.tsx
@@ -35,7 +35,7 @@ export const BlogArticleListBlock = (props: Props) => {
               <ArticleTeaser.Content
                 href={item.href}
                 title={item.heading}
-                date={formatter.fromNow(new Date(item.date))}
+                date={formatter.dateFull(new Date(item.date))}
               >
                 {item.text}
               </ArticleTeaser.Content>

--- a/apps/store/src/utils/formatter.ts
+++ b/apps/store/src/utils/formatter.ts
@@ -90,6 +90,12 @@ export class Formatter {
   public money = (money: Money) => formatMoney(money, this.options)
   public monthlyPrice = (price: Money) => formatMonthlyPrice(price, this.options)
   public fromNow = (date: Date) => formatDateFromNow(date, this.options)
+  public dateFull = (date: Date) =>
+    date.toLocaleDateString(this.options.locale, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
   public titleCase = (str: string) => formatTitleCase(str)
   public ssn = formatSsn
   public carRegistrationNumber = formatCarRegistrationNumber

--- a/packages/ui/src/components/Text/Text.tsx
+++ b/packages/ui/src/components/Text/Text.tsx
@@ -28,6 +28,7 @@ export type TextProps = {
   size?: FontSizeProps
   children?: ReactNode
   className?: string
+  uppercase?: boolean
 }
 
 const elementConfig = {
@@ -37,10 +38,11 @@ const elementConfig = {
 export const TextBase = styled(
   Space,
   elementConfig,
-)<TextProps>(({ align, color, size = 'md' }) => ({
+)<TextProps>(({ align, color, size = 'md', uppercase = false }) => ({
   color: color ? theme.colors[color] : 'inherit',
   ...getFontSize(size),
   ...(align && { textAlign: align }),
+  ...(uppercase && { textTransform: 'uppercase' }),
 }))
 
 export const Text = ({ as, balance, children, className, ...rest }: TextProps) => (


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

![Screenshot 2023-06-29 at 14.00.30.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/7320c64b-f64c-4fae-ac0c-06c08d88a576/Screenshot%202023-06-29%20at%2014.00.30.png)

- Display dates in the same way across the blog pages

- Use localized dates; add new `dateFull` formatter utility

- Add "uppercase" prop to `Text` component

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Peter wants dates to be displayed in the same way across the blog pages

- Uppercasing text is a common design pattern

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
