### PR TITLE
Blog: clean up alignment in article teaser layout

### DIFF
--- a/apps/store/src/features/blog/ArticleTeaser/ArticleTeaser.stories.tsx
+++ b/apps/store/src/features/blog/ArticleTeaser/ArticleTeaser.stories.tsx
@@ -10,23 +10,21 @@ type Story = StoryObj
 
 export const Primary: Story = {
   render: () => (
-    <ArticleTeaser.Root>
+    <ArticleTeaser.Root
+      href="/se"
+      title="Hedvig och Mimmi Blomqvist lanserar hundskålar i limiterad upplaga"
+      ingress="I ett nytt samarbete har Hedvig tillsammans med designern Mimmi Blomqvist ställt sig frågan
+        vad som händer när en hundskål inte bara fyller en funktion, utan också blir ett
+        designobjekt. Resultatet är en limiterad upplaga handgjorda hundskålar i porslin med Mimmi
+        Blomqvists karaktäristiska formspråk."
+      date="2021.05.12"
+    >
       <ArticleTeaser.Image
         src="https://www.hedvig.com/f/62762/800x450/42924b7dde/mimmi-thumbnail.jpg"
         width={800}
         height={450}
         alt="Mimmi"
       />
-      <ArticleTeaser.Content
-        href="/se"
-        title="Hedvig och Mimmi Blomqvist lanserar hundskålar i limiterad upplaga"
-        date="2021.05.12"
-      >
-        I ett nytt samarbete har Hedvig tillsammans med designern Mimmi Blomqvist ställt sig frågan
-        vad som händer när en hundskål inte bara fyller en funktion, utan också blir ett
-        designobjekt. Resultatet är en limiterad upplaga handgjorda hundskålar i porslin med Mimmi
-        Blomqvists karaktäristiska formspråk.
-      </ArticleTeaser.Content>
     </ArticleTeaser.Root>
   ),
 }

--- a/apps/store/src/features/blog/ArticleTeaser/ArticleTeaser.tsx
+++ b/apps/store/src/features/blog/ArticleTeaser/ArticleTeaser.tsx
@@ -4,17 +4,52 @@ import Link from 'next/link'
 import { type ReactNode } from 'react'
 import { Heading, Space, Text, theme } from 'ui'
 
-const Root = (props: { children: ReactNode }) => {
-  return <RelativeSpace y={1}>{props.children}</RelativeSpace>
+type Props = {
+  children: ReactNode
+  title: string
+  ingress: string
+  href: string
+  date: string
 }
 
-const RelativeSpace = styled(Space)({
+const Root = (props: Props) => {
+  return (
+    <Wrapper y={1}>
+      <Space y={1}>
+        {props.children}
+        <ContentWrapper>
+          <Space y={0.75}>
+            <Text size="sm" color="textSecondary" uppercase={true}>
+              {props.date}
+            </Text>
+            <ExtendedLink href={props.href} style={{ display: 'block' }}>
+              <Heading as="h3" variant="standard.20">
+                {props.title}
+              </Heading>
+            </ExtendedLink>
+          </Space>
+        </ContentWrapper>
+      </Space>
+      <ContentWrapper>
+        <ClampedText size="lg" color="textSecondary">
+          {props.ingress}
+        </ClampedText>
+      </ContentWrapper>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled(Space)({
   position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
 })
 
 const RoundedImage = styled(NextImage)({
   borderRadius: theme.radius.xl,
-  aspectRatio: '16 / 9',
+  aspectRatio: '3 / 2',
+  objectFit: 'cover',
 })
 const Image = (props: ImageProps) => <RoundedImage {...props} />
 
@@ -28,10 +63,7 @@ type ContentProps = {
 const Content = (props: ContentProps) => {
   return (
     <ContentWrapper>
-      <Space y={0.25}>
-        <Text size="sm" color="textSecondary" uppercase={true}>
-          {props.date}
-        </Text>
+      <Space y={0.75}>
         <div>
           <ExtendedLink href={props.href}>
             <Heading as="h3" variant="standard.20">

--- a/apps/store/src/features/blog/BlogArticleListBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleListBlock.tsx
@@ -30,15 +30,14 @@ export const BlogArticleListBlock = (props: Props) => {
       <GridLayout.Content width="1" align="center">
         <List>
           {filteredTeaserList.map((item) => (
-            <ArticleTeaser.Root key={item.id}>
+            <ArticleTeaser.Root
+              key={item.id}
+              href={item.href}
+              title={item.heading}
+              ingress={item.text}
+              date={formatter.dateFull(new Date(item.date))}
+            >
               <ArticleTeaser.Image {...item.image} alt={item.image.alt} />
-              <ArticleTeaser.Content
-                href={item.href}
-                title={item.heading}
-                date={formatter.dateFull(new Date(item.date))}
-              >
-                {item.text}
-              </ArticleTeaser.Content>
             </ArticleTeaser.Root>
           ))}
         </List>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

![Screenshot 2023-06-29 at 14.41.39.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/e225081c-feed-4306-8a83-d9d8f91f2bcb/Screenshot%202023-06-29%20at%2014.41.39.png)

- Align blog title and ingress to start on the same line

- Update aspect ratio for teaser images and fix content fit

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- More unified article teaser grid

- Images where being stretched

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
