### PR TITLE
BlogArticle: fix editor crashing

### DIFF
--- a/apps/store/src/features/blog/BlogArticleBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleBlock.tsx
@@ -8,13 +8,16 @@ import { type SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { useFormatter } from '@/utils/useFormatter'
 import { BLOG_ARTICLE_CONTENT_TYPE } from './blog.constants'
 import { convertToBlogArticleCategory } from './blog.helpers'
-import { type BlogArticleContentType } from './blog.types'
+import { BlogArticleCategory, type BlogArticleContentType } from './blog.types'
 
 type Props = SbBaseBlockProps<BlogArticleContentType['content']>
 
 export const BlogArticleBlock = (props: Props) => {
-  const categories = props.blok.categories.map(convertToBlogArticleCategory)
   const formatter = useFormatter()
+
+  const categories = props.blok.categories
+    .map((item) => (typeof item === 'string' ? null : convertToBlogArticleCategory(item)))
+    .filter(isBlogArticleCategory)
 
   return (
     <>
@@ -28,6 +31,7 @@ export const BlogArticleBlock = (props: Props) => {
                   <Badge as="span">{item.name}</Badge>
                 </Link>
               ))}
+              {categories.length === 0 && <Badge as="span">PLACEHOLDER</Badge>}
             </SpaceFlex>
             <Space y={1.5}>
               <Heading as="h1" variant={{ _: 'serif.32', lg: 'serif.56' }}>
@@ -56,3 +60,7 @@ const TopPadding = styled.div({
 const UppercaseText = styled(Text)({
   textTransform: 'uppercase',
 })
+
+const isBlogArticleCategory = (item: BlogArticleCategory | null): item is BlogArticleCategory => {
+  return item !== null
+}

--- a/apps/store/src/features/blog/blog.types.ts
+++ b/apps/store/src/features/blog/blog.types.ts
@@ -7,7 +7,8 @@ export type BlogArticleContentType = ISbStoryData<
     footer: Array<SbBlokData>
     body: Array<SbBlokData>
     content: ISbRichtext
-    categories: Array<ISbStoryData>
+    // While editing, categories are just UUIDs
+    categories: Array<ISbStoryData> | Array<string>
     teaser_text: string
     page_heading: string
     teaser_image: StoryblokAsset


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-06-29 at 16.47.22.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/07c7cfc9-02ad-4ee9-97e0-aa9104680388/Screenshot%202023-06-29%20at%2016.47.22.png)


Prevent Storyblok editor from crashing when editing blog articles

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

React crashes when editing since categories are returned as a list of UUIDs instead of being resolved as Story objects.

I show a placeholder when this happens.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
