### PR TITLE
GEN-636 - fix(AccordionItemBlock): get proper content height with asChild prop

### DIFF
--- a/apps/store/src/blocks/AccordionItemBlock.tsx
+++ b/apps/store/src/blocks/AccordionItemBlock.tsx
@@ -21,7 +21,7 @@ export const AccordionItemBlock = ({ blok, openItem }: AccordionItemBlockProps) 
       <Accordion.HeaderWithTrigger>
         <Text size={{ _: 'md', md: 'lg' }}>{blok.title}</Text>
       </Accordion.HeaderWithTrigger>
-      <Accordion.Content open={openItem === value}>
+      <Accordion.Content open={openItem === value} asChild={true}>
         <ContentWrapper>
           <Content dangerouslySetInnerHTML={{ __html: contentHtml }} />
         </ContentWrapper>


### PR DESCRIPTION
## Describe your changes

* Fix an issue where accordions don't work as they should when they have lists as their content.

I've spent some time trying to understand why exactly the issue just happens with lists and/or why this solves it, but to be honest I actually didn't really understand it 😅 
I mean,  theirs docs mention about composing radix functionalities with custom components with `asChild` prop. So my honest guess is that without it radix can't proper get content's container height which results on the undesirable behaviour. That doesn't explain why it just happens with lists tho 🤷🏻 

https://github.com/HedvigInsurance/racoon/assets/19200662/05778057-e4a9-466e-93e3-36fd7a25f32b

## Justify why they are needed

https://github.com/HedvigInsurance/racoon/assets/19200662/477be385-12eb-41c6-9193-ddae052e9125