### PR TITLE
Blog: allow blogs to have 0 categories

### DIFF
--- a/apps/store/src/features/blog/BlogArticleBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleBlock.tsx
@@ -14,10 +14,7 @@ type Props = SbBaseBlockProps<BlogArticleContentType['content']>
 
 export const BlogArticleBlock = (props: Props) => {
   const formatter = useFormatter()
-
-  const categories = props.blok.categories
-    .map((item) => (typeof item === 'string' ? null : convertToBlogArticleCategory(item)))
-    .filter(isBlogArticleCategory)
+  const categories = getCategories(props.blok.categories)
 
   return (
     <>
@@ -25,14 +22,15 @@ export const BlogArticleBlock = (props: Props) => {
         <GridLayout.Content width={{ base: '1', md: '5/6', lg: '2/3', xl: '1/2' }} align="center">
           <TopPadding />
           <Space y={0.5}>
-            <SpaceFlex space={0.25}>
-              {categories.map((item) => (
-                <Link key={item.id} href={item.href}>
-                  <Badge as="span">{item.name}</Badge>
-                </Link>
-              ))}
-              {categories.length === 0 && <Badge as="span">PLACEHOLDER</Badge>}
-            </SpaceFlex>
+            {categories.length > 0 && (
+              <SpaceFlex space={0.25}>
+                {categories.map((item) => (
+                  <Link key={item.id} href={item.href}>
+                    <Badge as="span">{item.name}</Badge>
+                  </Link>
+                ))}
+              </SpaceFlex>
+            )}
             <Space y={1.5}>
               <Heading as="h1" variant={{ _: 'serif.32', lg: 'serif.56' }}>
                 {props.blok.page_heading}
@@ -60,6 +58,12 @@ const TopPadding = styled.div({
 const UppercaseText = styled(Text)({
   textTransform: 'uppercase',
 })
+
+const getCategories = (categories: BlogArticleContentType['content']['categories']) => {
+  return categories
+    .map((item) => (typeof item === 'string' ? null : convertToBlogArticleCategory(item)))
+    .filter(isBlogArticleCategory)
+}
 
 const isBlogArticleCategory = (item: BlogArticleCategory | null): item is BlogArticleCategory => {
   return item !== null

--- a/apps/store/src/features/blog/BlogArticleListBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleListBlock.tsx
@@ -43,7 +43,7 @@ export const BlogArticleListBlock = (props: Props) => {
   return (
     <GridLayout.Root>
       <GridLayout.Content width={{ xxl: '5/6' }} align="center">
-        <Space y={4}>
+        <Space y={8}>
           <List>
             {visibleTeaserList.map((item, index) => (
               <ArticleTeaser.Root


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

![Screenshot 2023-06-30 at 11.34.04.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/42eef06c-a16e-4239-9fc0-20f1ec4a4f10/Screenshot%202023-06-30%20at%2011.34.04.png)


Render article page with 0 categories correctly

Remove solution with showing PLACEHOLDER category while editing

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

It's okey to have articles without categories so no need to show PLACEHOLDER category

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
