### PR TITLE
Blog: fetch all article teasers

### DIFF
--- a/apps/store/src/features/blog/ArticleTeaser/ArticleTeaser.tsx
+++ b/apps/store/src/features/blog/ArticleTeaser/ArticleTeaser.tsx
@@ -31,7 +31,7 @@ const Root = (props: Props) => {
                 {props.title}
               </Heading>
             </ExtendedLink>
-            <Text size="lg" color="textSecondary">
+            <Text as="p" size="lg" color="textSecondary">
               {props.ingress}
             </Text>
           </Space>

--- a/apps/store/src/features/blog/BlogArticleBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleBlock.tsx
@@ -14,10 +14,7 @@ type Props = SbBaseBlockProps<BlogArticleContentType['content']>
 
 export const BlogArticleBlock = (props: Props) => {
   const formatter = useFormatter()
-
-  const categories = props.blok.categories
-    .map((item) => (typeof item === 'string' ? null : convertToBlogArticleCategory(item)))
-    .filter(isBlogArticleCategory)
+  const categories = getCategories(props.blok.categories)
 
   return (
     <>
@@ -25,14 +22,15 @@ export const BlogArticleBlock = (props: Props) => {
         <GridLayout.Content width={{ base: '1', md: '5/6', lg: '2/3', xl: '1/2' }} align="center">
           <TopPadding />
           <Space y={0.5}>
-            <SpaceFlex space={0.25}>
-              {categories.map((item) => (
-                <Link key={item.id} href={item.href}>
-                  <Badge as="span">{item.name}</Badge>
-                </Link>
-              ))}
-              {categories.length === 0 && <Badge as="span">PLACEHOLDER</Badge>}
-            </SpaceFlex>
+            {categories.length > 0 && (
+              <SpaceFlex space={0.25}>
+                {categories.map((item) => (
+                  <Link key={item.id} href={item.href}>
+                    <Badge as="span">{item.name}</Badge>
+                  </Link>
+                ))}
+              </SpaceFlex>
+            )}
             <Space y={1.5}>
               <Heading as="h1" variant={{ _: 'serif.32', lg: 'serif.56' }}>
                 {props.blok.page_heading}
@@ -60,6 +58,12 @@ const TopPadding = styled.div({
 const UppercaseText = styled(Text)({
   textTransform: 'uppercase',
 })
+
+const getCategories = (categories: BlogArticleContentType['content']['categories']) => {
+  return categories
+    .map((item) => (typeof item === 'string' ? null : convertToBlogArticleCategory(item)))
+    .filter(isBlogArticleCategory)
+}
 
 const isBlogArticleCategory = (item: BlogArticleCategory | null): item is BlogArticleCategory => {
   return item !== null

--- a/apps/store/src/features/blog/BlogArticleListBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleListBlock.tsx
@@ -43,7 +43,7 @@ export const BlogArticleListBlock = (props: Props) => {
   return (
     <GridLayout.Root>
       <GridLayout.Content width={{ xxl: '5/6' }} align="center">
-        <Space y={4}>
+        <Space y={8}>
           <List>
             {visibleTeaserList.map((item, index) => (
               <ArticleTeaser.Root

--- a/apps/store/src/features/blog/fetchArticleTeasers.ts
+++ b/apps/store/src/features/blog/fetchArticleTeasers.ts
@@ -61,8 +61,14 @@ const fetchArticles = async (
     content_type: BLOG_ARTICLE_CONTENT_TYPE,
     starts_with: `${params.locale}/`,
     resolve_relations: `${BLOG_ARTICLE_CONTENT_TYPE}.categories`,
+    per_page: 100,
     ...(params.draft && { version: 'draft' }),
   })
+
+  if (response.total > response.perPage) {
+    // TODO: Implement pagination once we have more than 100 articles
+    throw new Error('Too many blog articles to fetch in one request')
+  }
 
   return response.data.stories as Array<BlogArticleContentType>
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fetch all article teasers instead of first 25

Render ingress as paragraph tag

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

I make the build fail if we have more than the max number of articles in one locale. This will be our trigger to implement pagination but if we never reach this limit we don't need to implement pagination.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
