### PR TITLE
Manually manage Storyblok Cache Version

### DIFF
--- a/apps/store/scripts/publish-storyblok-cache-version.js
+++ b/apps/store/scripts/publish-storyblok-cache-version.js
@@ -1,0 +1,49 @@
+const StoryblokClient = require('storyblok-js-client')
+
+console.log('Publish Storyblok cache version in Edge config')
+
+const manageApiUrl = process.env.EDGE_CONFIG_MANAGE_API_URL
+if (!manageApiUrl) {
+  throw new Error('EDGE_CONFIG_MANAGE_API_URL not configured')
+}
+
+const manageApiToken = process.env.EDGE_CONFIG_MANAGE_API_TOKEN
+if (!manageApiToken) {
+  throw new Error('EDGE_CONFIG_MANAGE_API_TOKEN not configured')
+}
+
+const main = async () => {
+  const client = new StoryblokClient({
+    accessToken: process.env.NEXT_PUBLIC_STORYBLOK_ACCESS_TOKEN,
+  })
+
+  const { data } = await client.getStory('/se')
+  console.log(`Latest cache version: ${data.cv}`)
+
+  const response = await fetch(manageApiUrl, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${manageApiToken}`,
+      'Content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      items: [
+        {
+          operation: 'upsert',
+          key: 'storyblokCacheVersion',
+          value: data.cv,
+        },
+      ],
+    }),
+  })
+
+  if (response.ok) {
+    console.log('Cache version updated in Edge config')
+  } else {
+    console.error('Failed to update cache version in Edge config')
+    console.error(await response.text())
+    process.exit(1)
+  }
+}
+
+main()

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -71,7 +71,7 @@ export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = a
 
   const apolloClient = initializeApollo({ locale })
 
-  console.time('getStoryblokData')
+  console.time(`getStoryblokData | ${slug}`)
   const version = draftMode ? 'draft' : 'published'
   const [story, globalStory, translations, productMetadata, breadcrumbs] = await Promise.all([
     getStoryBySlug<PageStory | ProductStory>(slug, { version, locale }),
@@ -79,8 +79,10 @@ export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = a
     serverSideTranslations(locale),
     fetchGlobalProductMetadata({ apolloClient }),
     fetchBreadcrumbs(slug, { version, locale }),
-  ])
-  console.timeEnd('getStoryblokData')
+  ]).catch((error) => {
+    throw new Error(`Failed to fetch data for ${slug}: ${error.message}`, { cause: error })
+  })
+  console.timeEnd(`getStoryblokData | ${slug}`)
 
   const props = {
     ...translations,

--- a/apps/store/src/pages/api/revalidate.ts
+++ b/apps/store/src/pages/api/revalidate.ts
@@ -1,8 +1,8 @@
 import path from 'path'
-// import { get as getFromConfig } from '@vercel/edge-config'
+import { get as getFromConfig } from '@vercel/edge-config'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import StoryblokClient from 'storyblok-js-client'
-// import { publishStoryblokCacheVersion } from '@/services/storyblok/Storyblok.helpers'
+import { publishStoryblokCacheVersion } from '@/services/storyblok/Storyblok.helpers'
 
 type Payload = {
   action: 'published' | 'unpublished' | 'deleted'
@@ -28,16 +28,16 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   try {
     const { data } = await storyblokClient.getStory(`${story_id}`, {})
-    // const { cv } = data
-    // const storyblokCacheVersion = await getFromConfig('storyblokCacheVersion')
-    // if (storyblokCacheVersion !== cv) {
-    //   console.log(`Publishing new Storyblok cache version: ${cv}`)
-    //   try {
-    //     await publishStoryblokCacheVersion(cv)
-    //   } catch (error: unknown) {
-    //     console.error('Failed to publish Storyblok cache version', error)
-    //   }
-    // }
+    const { cv } = data
+    const storyblokCacheVersion = await getFromConfig('storyblokCacheVersion')
+    if (storyblokCacheVersion !== cv) {
+      console.log(`Publishing new Storyblok cache version: ${cv}`)
+      try {
+        await publishStoryblokCacheVersion(cv)
+      } catch (error: unknown) {
+        console.error('Failed to publish Storyblok cache version', error)
+      }
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const route = SLUG_TO_ROUTE_MAP[data.story.full_slug] ?? data.story.full_slug

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -42,13 +42,13 @@ export const fetchStory = async <StoryData extends ISbStoryData>(
   slug: string,
   params: StoryblokFetchParams,
 ): Promise<StoryData> => {
-  // let cv: number | undefined
-  // if (params.version === 'published') {
-  //   cv = await getStoryblokCacheVersion()
-  // }
+  let cv: number | undefined
+  if (params.version === 'published') {
+    cv = await getStoryblokCacheVersion()
+  }
   const response = await storyblokClient.getStory(slug, {
     ...params,
-    // cv,
+    cv,
     resolve_links: 'url',
   })
 

--- a/apps/store/vercel.json
+++ b/apps/store/vercel.json
@@ -1,6 +1,6 @@
 {
   "framework": "nextjs",
-  "buildCommand": "cd ../.. && yarn turbo run codegen --filter=store --force && yarn turbo run build --filter=store && ./apps/store/scripts/upload-sourcemaps-vercel.sh",
+  "buildCommand": "cd ../.. && yarn turbo run codegen --filter=store --force && node ./apps/store/scripts/publish-storyblok-cache-version.js && yarn turbo run build --filter=store && ./apps/store/scripts/upload-sourcemaps-vercel.sh",
   "ignoreCommand": "../../bin/vercel-ignore-step.sh",
   "installCommand": "cd ../.. && yarn install --immutable",
   "regions": ["arn1"],


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Manually manage Storyblok cache version by storing it in Edge Config

- Use only when fetching production content

- Improve logging timing of data fetching for CMS pages

- Improve logging failures when fetching data for CMS pages

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We are running into rate-limiting issues with Storyblok. To resolve it we need to fetch data from there CDN but this requires us to us the "cv" (cache version) option.

Usually, the Storyblok client takes care of this - but it doesn't work because of how Vercel runs each page build in a separate process.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
