### PR TITLE
Add field for specifying AB test origin story in Storyblok

### DIFF
--- a/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
+++ b/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
@@ -6,14 +6,19 @@ import { isRoutingLocale, toIsoLocale } from '@/utils/l10n/localeUtils'
 import { ORIGIN_URL } from '@/utils/PageLink'
 import { StructuredDataOrganization } from './StructuredDataOrganization'
 
-export const HeadSeoInfo = ({ story }: { story: ISbStoryData<SEOData> }) => {
+type Props = {
+  story: ISbStoryData<SEOData>
+  canonicalUrl?: string
+}
+
+export const HeadSeoInfo = ({ story, canonicalUrl = '' }: Props) => {
   // AB testing
-  const { canonicalUrl, robots, seoTitle, seoMetaDescription, seoMetaOgImage } = story.content
+  const { robots, seoTitle, seoMetaDescription, seoMetaOgImage } = story.content
 
   return (
     <>
       <Head>
-        {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+        {canonicalUrl && <link rel="canonical" href={`${ORIGIN_URL}/${canonicalUrl}`} />}
         <meta name="robots" content={robots} />
         {seoMetaDescription && (
           <>

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -41,10 +41,11 @@ const NextPage: NextPageWithLayout<PageProps> = (props) => {
 const NextStoryblokPage = (props: NextContentPageProps) => {
   const story = useStoryblokState(props.story)
   if (!story) return null
+  const abTestOriginStory = story.content.abTestOrigin
 
   return (
     <BlogContext.Provider value={parseBlogContext(props)}>
-      <HeadSeoInfo story={story} />
+      <HeadSeoInfo story={abTestOriginStory || story} canonicalUrl={abTestOriginStory?.full_slug} />
       <StoryblokComponent blok={story.content} />
     </BlogContext.Provider>
   )

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -158,7 +158,7 @@ export type SEOData = {
   seoTitle?: string
   seoMetaDescription?: string
   seoMetaOgImage?: StoryblokAsset
-  canonicalUrl?: string
+  abTestOrigin?: PageStory
 }
 
 export type PageStory = ISbStoryData<
@@ -333,7 +333,7 @@ export const getStoryBySlug = <StoryData extends ISbStoryData>(
 ): Promise<StoryData> => {
   const params: StoryblokFetchParams = {
     version: version ?? USE_DRAFT_CONTENT ? 'draft' : 'published',
-    resolve_relations: `reusableBlockReference.reference,${BLOG_ARTICLE_CONTENT_TYPE}.categories`,
+    resolve_relations: `reusableBlockReference.reference,${BLOG_ARTICLE_CONTENT_TYPE}.categories,page.abTestOrigin`,
   }
 
   return fetchStory<StoryData>(getStoryblokApi(), `${locale}/${slug}`, params)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add field in Page config to specify A/B test origin Story
- Use `abTestOriginStory` in `HeadSeoInfo` and pass canonical url
- Remove `canonicalUrl` field in Page config and use slug from `abTestOriginStory`

<img width="1725" alt="Screenshot 2023-07-03 at 17 20 58" src="https://github.com/HedvigInsurance/racoon/assets/6661511/3ee550d2-8df4-456d-acf8-0cb3919da55a">

<img width="1436" alt="Screenshot 2023-07-03 at 17 02 06" src="https://github.com/HedvigInsurance/racoon/assets/6661511/ce2cea8d-41b5-4154-9859-1a1025852a01">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
To avoid that Google index the A/B test variants as a new page, we should use the meta data from the origin page and add a canonical tag

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
