### PR TITLE
Correctly pass Storyblok version when fetching story

### DIFF
--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -65,14 +65,15 @@ const NextProductPage = (props: ProductPageProps) => {
 }
 
 export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = async (context) => {
-  const { params, locale, draftMode } = context
+  const { params, locale, draftMode = false } = context
   if (!isRoutingLocale(locale)) return { notFound: true }
 
   const slug = (params?.slug ?? []).join('/')
 
   const apolloClient = initializeApollo({ locale })
 
-  console.time(`getStoryblokData | ${slug}`)
+  const timerName = `Get static props for ${locale}/${slug} ${draftMode ? '(draft)' : ''}`
+  console.time(timerName)
   const version = draftMode ? 'draft' : 'published'
   const [story, globalStory, translations, productMetadata, breadcrumbs] = await Promise.all([
     getStoryBySlug<PageStory | ProductStory>(slug, { version, locale }),
@@ -83,7 +84,7 @@ export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = a
   ]).catch((error) => {
     throw new Error(`Failed to fetch data for ${slug}: ${error.message}`, { cause: error })
   })
-  console.timeEnd(`getStoryblokData | ${slug}`)
+  console.timeEnd(timerName)
 
   const props = {
     ...translations,

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -332,7 +332,7 @@ export const getStoryBySlug = <StoryData extends ISbStoryData>(
   { version, locale }: StoryOptions,
 ): Promise<StoryData> => {
   const params: StoryblokFetchParams = {
-    version: version ?? USE_DRAFT_CONTENT ? 'draft' : 'published',
+    version: version ?? (USE_DRAFT_CONTENT ? 'draft' : 'published'),
     resolve_relations: `reusableBlockReference.reference,${BLOG_ARTICLE_CONTENT_TYPE}.categories,page.abTestOrigin`,
   }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Fix passing default Storyblok version when fetching story data

- Update logging when building CMS pages

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Fix issue in the build pipeline -- we incorrectly default to "draft" mode.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
