### PR TITLE
Use videos from S3 bucket to save traffic usage on Storyblok

### DIFF
--- a/apps/store/next-csp.config.js
+++ b/apps/store/next-csp.config.js
@@ -93,6 +93,7 @@ const mediaSrc = [
   'https://dc.insurely.com',
   'https://vercel.live',
   'https://a.storyblok.com',
+  'https://s3.eu-central-1.amazonaws.com',
   "'self'",
 ]
 const connectSrc = [

--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -7,7 +7,9 @@ import { getOptimizedImageUrl } from '@/services/storyblok/Storyblok.helpers'
 
 export type VideoBlockProps = SbBaseBlockProps<
   {
+    // TODO: Remove video field once migrated to videoUrl
     video: StoryblokAsset
+    videoUrl?: string
     poster?: StoryblokAsset
     fullBleed?: boolean
     controls?: boolean
@@ -33,7 +35,7 @@ export const VideoBlock = ({ className, blok, nested = false }: VideoBlockProps)
       wrapWith={(children) => <Wrapper className={className}>{children}</Wrapper>}
     >
       <Video
-        sources={[{ url: blok.video.filename }]}
+        sources={[{ url: blok.videoUrl || blok.video.filename }]}
         poster={posterUrl}
         autoPlay={blok.autoPlay}
         aspectRatioLandscape={blok.aspectRatioLandscape}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add field for `videoUrl` to replace asset field
- Setup new S3 bucket for `hedvig-dot-com` content
- Add deprecation flag in Storyblok for video field

<img width="1725" alt="Screenshot 2023-07-04 at 15 31 43" src="https://github.com/HedvigInsurance/racoon/assets/6661511/c40e8ea4-45a7-4af5-8db8-c4cc730c9d7d">

To consider:
We currently only use one video format in sources, mp4. We should probably use webm as well. Should we add another field for that in Storyblok? In market-web we relied on the filename being the same and just added the file format to the path but that leaves for some errors if we wouldn't upload both formats in S3. 

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
We used around 3TB of traffic last month, most traffic is are due to videos stored in Storyblok. We currently pay $60 per 250GB for Storyblok traffic compared to $5.75 if we store it on S3.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
