### PR TITLE
GEN-650 | Exclude product metadata stories from ISR

### DIFF
--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -367,14 +367,15 @@ export const getPageLinks = async (): Promise<PageLink[]> => {
   return pageLinks
 }
 
-const REUSABLE_BLOCK = 'reusable-blocks'
+const EXCLUDE_SLUGS = new Set([
+  'reusable-blocks',
+  'product-metadata',
+  STORYBLOK_MANYPETS_FOLDER_SLUG,
+])
 // TODO: Consider filtering by content-type on CMS side to exclude things like reusable-blocks
 export const getFilteredPageLinks = async () => {
   const allLinks = await getPageLinks()
-  return allLinks.filter(
-    ({ slugParts }) =>
-      slugParts[0] !== REUSABLE_BLOCK && slugParts[0] !== STORYBLOK_MANYPETS_FOLDER_SLUG,
-  )
+  return allLinks.filter(({ slugParts }) => EXCLUDE_SLUGS.has(slugParts[0]) === false)
 }
 
 export const getGlobalStory = (options: StoryOptions): Promise<GlobalStory> => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Exclude product metadata stories from CMS from being prerendered by ISR.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Saw some warnings about this in build logs.

These stories are not meant to be prerendered by ISR.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
