### PR TITLE
GEN-653 | Render link in sign disclaimer text

### DIFF
--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -199,11 +199,15 @@ const CheckoutPage = (props: CheckoutPageProps) => {
                         {t('SIGN_BUTTON', { count: cart.entries.length })}
                       </SignButton>
                       {userErrorMessage ? (
-                        <Text size="xs" color="textSecondary" align="center">
+                        <Text as="p" size="xs" color="textSecondary" align="center">
                           {userErrorMessage}
                         </Text>
                       ) : (
                         <TextWithLink
+                          as="p"
+                          size="xs"
+                          align="center"
+                          balance={true}
                           href={PageLink.privacyPolicy({ locale: routingLocale })}
                           target="_blank"
                         >

--- a/apps/store/src/components/ForeverPage/ForeverPage.tsx
+++ b/apps/store/src/components/ForeverPage/ForeverPage.tsx
@@ -66,7 +66,9 @@ export const ForeverPage = ({ code: initialCode }: Props) => {
       </GridLayout.Root>
       <GridLayout.Root>
         <GridLayout.Content width="1/3" align="center">
-          <TextWithLink href={PageLink.home()}>{t('FOREVER_PAGE_FOOTER_TEXT')}</TextWithLink>
+          <TextWithLink as="p" size="xs" align="center" balance={true} href={PageLink.home()}>
+            {t('FOREVER_PAGE_FOOTER_TEXT')}
+          </TextWithLink>
         </GridLayout.Content>
       </GridLayout.Root>
     </Layout>

--- a/apps/store/src/components/TextWithLink.tsx
+++ b/apps/store/src/components/TextWithLink.tsx
@@ -1,31 +1,29 @@
 import styled from '@emotion/styled'
 import Link from 'next/link'
+import { type ComponentProps } from 'react'
 import { Text } from 'ui'
 import { nestedLinkStyles } from './RichText/RichText.styles'
 
-type Props = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
-  href: string
-  children: string
-}
+type Props = ComponentProps<typeof Text> &
+  React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string
+    children: string
+  }
 
-export const TextWithLink = ({ children, ...linkProps }: Props) => {
+export const TextWithLink = ({ children, ...otherProps }: Props) => {
   const [beforeLink, rest] = children.split('[[', 2)
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (rest === undefined) {
-    return (
-      <Text size="xs" align="center" balance={true}>
-        {children}
-      </Text>
-    )
+    return <Text {...otherProps}>{children}</Text>
   }
 
   const [linkText, afterLink] = rest.split(']]', 2)
 
   return (
-    <StyledTextWithLink size="xs" align="center" balance={true}>
+    <StyledTextWithLink {...otherProps}>
       {beforeLink}
-      <Link {...linkProps}>{linkText}</Link>
+      <Link {...otherProps}>{linkText}</Link>
       {afterLink}
     </StyledTextWithLink>
   )

--- a/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
+++ b/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
 import { useRef } from 'react'
 import { FormEventHandler, ReactNode, useCallback, useEffect, useMemo } from 'react'
-import { Text, Space, Button, Heading, HedvigLogo, BankIdIcon, mq, theme } from 'ui'
+import { Space, Button, Heading, HedvigLogo, BankIdIcon, mq, theme } from 'ui'
 import { CartEntryItem } from '@/components/CartInventory/CartEntryItem/CartEntryItem'
 import { CartEntryList } from '@/components/CartInventory/CartEntryList'
 import { getCartEntry } from '@/components/CartInventory/CartInventory.helpers'
@@ -17,6 +17,7 @@ import {
 } from '@/components/CheckoutHeader/CheckoutHeader.helpers'
 import * as ComparisonTable from '@/components/ComparisonTable/ComparisonTable'
 import { ScrollPast } from '@/components/ProductPage/ScrollPast/ScrollPast'
+import { TextWithLink } from '@/components/TextWithLink'
 import {
   Money,
   ProductOfferFragment,
@@ -30,6 +31,8 @@ import { setupShopSessionServiceClientSide } from '@/services/shopSession/ShopSe
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { TrackingContextKey } from '@/services/Tracking/Tracking'
 import { useTracking } from '@/services/Tracking/useTracking'
+import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { PageLink } from '@/utils/PageLink'
 import { type ComparisonTableData } from '../manyPets.types'
 import { LatestAdoptionNote } from './LatestAdoptionNote'
 import { ManypetsLogo } from './ManypetsLogo'
@@ -60,6 +63,7 @@ export const ManyPetsMigrationPage = ({
   latestAdoptionDate,
   comparisonTableData,
 }: ManyPetsMigrationPageProps) => {
+  const { routingLocale } = useCurrentLocale()
   const { t } = useTranslation('checkout')
 
   const tracking = useTracking()
@@ -117,9 +121,16 @@ export const ManyPetsMigrationPage = ({
                   {signButtonContent}
                 </SignButton>
 
-                <Text as="p" size={{ _: 'xs', md: 'sm' }} align="center" color="textSecondary">
+                <TextWithLink
+                  as="p"
+                  size={{ _: 'xs', md: 'sm' }}
+                  align="center"
+                  color="textSecondary"
+                  href={PageLink.privacyPolicy({ locale: routingLocale })}
+                  target="_blank"
+                >
                   {t('SIGN_DISCLAIMER')}
-                </Text>
+                </TextWithLink>
               </Space>
             </form>
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-07-04 at 17.26.49.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/dcc01288-e7fc-47a3-ba81-74d26ab000d9/Screenshot%202023-07-04%20at%2017.26.49.png)


- Render link instead of placeholder in sign disclaimer text on MP migration page

- Allow consumer to pass text props to `TextWithLink` component

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We are rendering the placeholder instead of the link

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
