### PR TITLE
fix(Manypets): don't rely on ProductOffer type

### DIFF
--- a/apps/store/src/features/manyPets/manyPetsService.ts
+++ b/apps/store/src/features/manyPets/manyPetsService.ts
@@ -1,4 +1,4 @@
-import { ProductOffer } from '@/services/apollo/generated'
+import { ProductOfferFragment } from '@/services/apollo/generated'
 import { TableDataTemplate } from './data/SE_PET_INSURANCE_COMPARISON_TABLE'
 import {
   ComparisonTableTemplate,
@@ -9,7 +9,7 @@ import {
 
 const parseComparisonTableTemplate: (
   tableTemplate: ComparisonTableTemplate,
-  offer: ProductOffer,
+  offer: ProductOfferFragment,
 ) => ParsedComparisonTableTemplate = (tableTemplate, offer) => {
   return Object.entries(tableTemplate).reduce<ParsedComparisonTableTemplate>(
     (result, [attribute, valueOrValueGetter]) => {
@@ -25,7 +25,9 @@ const parseComparisonTableTemplate: (
   )
 }
 
-export const getComparisonTableData: (offer: ProductOffer) => ComparisonTableData = (offer) => {
+export const getComparisonTableData: (offer: ProductOfferFragment) => ComparisonTableData = (
+  offer,
+) => {
   const tierLevel: TierLevel = offer.priceIntentData.subType
   const comparisonTableTemplate = TableDataTemplate[tierLevel]
   const parsedComparisonTableTemplate = parseComparisonTableTemplate(comparisonTableTemplate, offer)

--- a/apps/store/src/pages/manypets/migration/[shopSessionId].tsx
+++ b/apps/store/src/pages/manypets/migration/[shopSessionId].tsx
@@ -17,7 +17,7 @@ import {
   ManyPetsMigrationOffersQuery,
   ManyPetsMigrationOffersQueryVariables,
   Money,
-  ProductOffer,
+  ProductOfferFragment,
   ShopSessionDocument,
   ShopSessionQuery,
   ShopSessionQueryVariables,
@@ -70,10 +70,10 @@ const NextManyPetsMigrationPage: NextPage<Props> = ({
   )
 }
 
-const isPetRelatedOffer = (offer: ProductOffer) =>
+const isPetRelatedOffer = (offer: ProductOfferFragment) =>
   offer.variant.typeOfContract.includes('SE_DOG') || offer.variant.typeOfContract.includes('SE_CAT')
 
-const sortByStartDate = (offerA: ProductOffer, offerB: ProductOffer) =>
+const sortByStartDate = (offerA: ProductOfferFragment, offerB: ProductOfferFragment) =>
   Date.parse(offerA.startDate) - Date.parse(offerB.startDate)
 
 export const getServerSideProps: GetServerSideProps<Props, Params> = async (context) => {
@@ -121,15 +121,15 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
     return { notFound: true }
   }
 
-  // It should be possible to get any other offers that are not pet related offers here, but we're
+  // It should not be possible to get any other offers that are not pet related offers here, but we're
   // filtering them just to be safe.
-  const offers = (data.petMigrationOffers as Array<ProductOffer>).filter(isPetRelatedOffer)
+  const offers = data.petMigrationOffers.filter(isPetRelatedOffer)
   // Since it shouldn't be possible to have offers with different tier levels, like SE_DOG_BASIC and SE_DOG_STANDARD,
   // any offer can be used to determine the tier level and therefore get the appropriate comparison table data.
   const baseOffer = offers[0]
   const totalCost: Money = {
-    amount: offers.reduce((sum, offer) => sum + offer.price.amount, 0),
-    currencyCode: baseOffer.price.currencyCode,
+    amount: offers.reduce((sum, offer) => sum + offer.cost.net.amount, 0),
+    currencyCode: baseOffer.cost.net.currencyCode,
   }
   const offersWithStartDate = offers.filter((offer) => offer.startDate !== undefined)
   const latestAdoptionDate = offersWithStartDate.sort(sortByStartDate)[0].startDate


### PR DESCRIPTION
## Describe your changes

* Get price data from `cost` field.

## Justify why they are needed

I've just released a some changes that removes usage of `ProductOffer.price` field. That breaks ManyPets migration which was still relying on it.