### PR TITLE
fix(CostSummary): define applied discount based on cost field

### DIFF
--- a/apps/store/src/components/CartInventory/CartInventory.helpers.tsx
+++ b/apps/store/src/components/CartInventory/CartInventory.helpers.tsx
@@ -46,7 +46,7 @@ export const getTotal = (shopSession: ShopSession) => {
 }
 
 export const getCrossOut = (shopSession: ShopSession) => {
-  const hasDiscount = shopSession.cart.redeemedCampaigns.length !== 0
+  const hasDiscount = shopSession.cart.cost.discount.amount > 0
 
   if (!hasDiscount) return undefined
   return shopSession.cart.cost.gross

--- a/apps/store/src/components/CartInventory/CartInventory.tsx
+++ b/apps/store/src/components/CartInventory/CartInventory.tsx
@@ -89,7 +89,7 @@ const getCartTotal = (cart: CartFragmentFragment) => {
 }
 
 const getCartCrossOut = (cart: CartFragmentFragment) => {
-  const hasDiscount = cart.redeemedCampaigns.length !== 0
+  const hasDiscount = cart.cost.discount.amount > 0
 
   if (!hasDiscount) return undefined
   switch (cart.redeemedCampaigns[0].discount.type) {


### PR DESCRIPTION
## Describe your changes

Update helper functions used to provide data to `CostSummary` so they rely on `cost` field while identifying if there's some discount being applied to your purchase.

**Before**

<img width="668" alt="after" src="https://github.com/HedvigInsurance/racoon/assets/19200662/36cc5562-7e12-4a73-bdb0-8f7db2d22652">

**After**

<img width="542" alt="before" src="https://github.com/HedvigInsurance/racoon/assets/19200662/426cd612-a405-47df-8e0f-fd5ac11908ee">

## Justify why they are needed

So the Cost summary doesn't look so confusing since it might be some cases where the product you have added into the cart is not covered by the campaign code you've added.

Also going to update the [contingency plan](https://github.com/HedvigInsurance/racoon/pull/2691) by removing these changes after this get's merged.
