### PR TITLE
GEN-666 | CartItem: make the whole card clickable to expand

### DIFF
--- a/apps/store/src/components/CartInventory/CartEntryItem/CartEntryCollapsible.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem/CartEntryCollapsible.tsx
@@ -2,22 +2,26 @@ import styled from '@emotion/styled'
 import * as Collapsible from '@radix-ui/react-collapsible'
 import { motion } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
-import React, { ReactNode, useState } from 'react'
+import React, { ReactNode } from 'react'
 import { ChevronIcon, Text, theme } from 'ui'
 import { ProductOfferFragment } from '@/services/apollo/generated'
 import { useFormatter } from '@/utils/useFormatter'
 
-type Props = { defaultOpen: boolean; cost: ProductOfferFragment['cost']; children: ReactNode }
+type Props = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  cost: ProductOfferFragment['cost']
+  children: ReactNode
+}
 
-export const CartEntryCollapsible = ({ defaultOpen, cost, children }: Props) => {
-  const [open, setOpen] = useState(defaultOpen)
+export const CartEntryCollapsible = ({ open, onOpenChange, cost, children }: Props) => {
   const { t } = useTranslation('cart')
   const formatter = useFormatter()
 
   const hasDiscountApplied = cost.discount.amount > 0
 
   return (
-    <Collapsible.Root open={open} onOpenChange={setOpen}>
+    <Collapsible.Root open={open} onOpenChange={onOpenChange}>
       <DetailsHeader>
         <Trigger>
           {t('VIEW_ENTRY_DETAILS_BUTTON')}
@@ -69,12 +73,11 @@ const PriceFlex = styled.div({
   gap: theme.space.xs,
 })
 
-const Trigger = styled(Collapsible.Trigger)({
+const Trigger = styled.div({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
   gap: theme.space.xs,
-  cursor: 'pointer',
   fontSize: theme.fontSizes.md,
 
   svg: {
@@ -86,7 +89,9 @@ const Trigger = styled(Collapsible.Trigger)({
   },
 })
 
-const DetailsHeader = styled.div({
+const DetailsHeader = styled(Collapsible.Trigger)({
   display: 'flex',
   justifyContent: 'space-between',
+  cursor: 'pointer',
+  width: '100%',
 })

--- a/apps/store/src/components/CartInventory/CartEntryItem/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem/CartEntryItem.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { Button, Dialog, Space, Text, mq, theme } from 'ui'
+import { useState } from 'react'
+import { Button, Dialog, Text, mq, theme } from 'ui'
 import { useEditProductOffer } from '@/components/CartPage/useEditProductOffer'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
@@ -23,6 +24,7 @@ export const CartEntryItem = ({ defaultOpen = false, ...props }: Props) => {
   const { shopSessionId, readOnly, onRemove, ...cartEntry } = props
   const { title: titleLabel, cost, pillow } = cartEntry
   const { t } = useTranslation('cart')
+  const [expanded, setExpanded] = useState(defaultOpen)
 
   const [editProductOffer, editState] = useEditProductOffer()
   const handleConfirmEdit = () => {
@@ -36,20 +38,22 @@ export const CartEntryItem = ({ defaultOpen = false, ...props }: Props) => {
 
   return (
     <Layout.Main>
-      <SpaceFlex space={0.75}>
-        <Layout.Pillow>
-          <Pillow size="small" {...pillow} />
-        </Layout.Pillow>
+      <Clickable onClick={() => setExpanded((prev) => !prev)}>
+        <SpaceFlex space={0.75}>
+          <Layout.Pillow>
+            <Pillow size="small" {...pillow} />
+          </Layout.Pillow>
 
-        <div>
-          <Text>{titleLabel}</Text>
-          <ShortSummary cartEntry={cartEntry} />
-        </div>
-      </SpaceFlex>
+          <div>
+            <Text>{titleLabel}</Text>
+            <ShortSummary cartEntry={cartEntry} />
+          </div>
+        </SpaceFlex>
+      </Clickable>
 
-      <Space y={1}>
+      <Layout.Bottom>
         <Layout.Details>
-          <CartEntryCollapsible defaultOpen={defaultOpen} cost={cost}>
+          <CartEntryCollapsible open={expanded} onOpenChange={setExpanded} cost={cost}>
             <DetailsSheet {...cartEntry} />
           </CartEntryCollapsible>
         </Layout.Details>
@@ -59,36 +63,54 @@ export const CartEntryItem = ({ defaultOpen = false, ...props }: Props) => {
             <EditEntryButton onConfirm={handleConfirmEdit} loading={editState === 'loading'} />
 
             <RemoveEntryDialog shopSessionId={shopSessionId} onCompleted={onRemove} {...cartEntry}>
-              <Dialog.Trigger asChild>
-                <Button variant="secondary-alt" size="small">
+              <Dialog.Trigger asChild={true}>
+                <Button variant="secondary-alt" size="medium">
                   {t('REMOVE_ENTRY_BUTTON')}
                 </Button>
               </Dialog.Trigger>
             </RemoveEntryDialog>
           </ActionsRow>
         )}
-      </Space>
+      </Layout.Bottom>
     </Layout.Main>
   )
 }
 
 const Main = styled.li({
-  padding: theme.space.md,
   borderRadius: theme.radius.sm,
   backgroundColor: theme.colors.opaque1,
+})
+
+const Clickable = styled.div({
+  cursor: 'pointer',
+
+  '@media (hover: hover)': {
+    [`${Main}:has(> &:hover)`]: {
+      backgroundColor: theme.colors.grayTranslucent200,
+    },
+  },
+
+  padding: theme.space.md,
+  [mq.md]: { padding: theme.space.lg },
+})
+
+const Bottom = styled.div({
+  paddingInline: theme.space.md,
+  paddingBottom: theme.space.md,
 
   display: 'flex',
   flexDirection: 'column',
   gap: theme.space.md,
 
   [mq.md]: {
-    padding: theme.space.lg,
-    gap: theme.space.lg,
+    paddingInline: theme.space.lg,
+    paddingBottom: theme.space.lg,
   },
 })
 
 const Layout = {
   Main,
+  Bottom,
   Pillow: styled.div({ flexShrink: 0 }),
   Details: styled.div({
     paddingTop: theme.space.md,
@@ -97,9 +119,7 @@ const Layout = {
 } as const
 
 const ActionsRow = styled.div({
-  display: 'flex',
+  display: 'grid',
   gap: theme.space.sm,
-  '> *': {
-    width: '50%',
-  },
+  gridTemplateColumns: '1fr 1fr',
 })

--- a/apps/store/src/components/CartInventory/CartEntryItem/EditEntryButton.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem/EditEntryButton.tsx
@@ -15,7 +15,7 @@ export const EditEntryButton = ({ onConfirm, loading }: Props) => {
   return (
     <FullscreenDialog.Root>
       <FullscreenDialog.Trigger asChild={true}>
-        <Button variant="secondary-alt" size="small">
+        <Button variant="secondary-alt" size="medium">
           {t('CART_ENTRY_EDIT_BUTTON')}
         </Button>
       </FullscreenDialog.Trigger>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

https://github.com/HedvigInsurance/racoon/assets/1220232/9eeeabb5-8deb-4a30-a1c6-8ef8ea16be24

- Make the "whole" Cart Item card clickable to exapand and collapse the details

- Add hover state to the Cart Item card

- Make the action buttons medium size

- Make the full collapsible "header" clickable

😈

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

I decided to only make the top part of the card clickable instead of litteraly the whole card. This is to avoid overlapping with the action buttons. Click events propagate so if the whole card is clickable, it will be triggered even if the user clicks on the action buttons e.g.

Instead of trying to work around this, I decided to only make the top part clickable.

I used the `:has` parent selector to only apply the hover state when hovering over the top part of the card. This has surprisingly good browser support already at 87%.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
