### PR TITLE
GEN-637 - feat: added a service to retrieve Trustpilot data

### DIFF
--- a/apps/store/.env.local.example
+++ b/apps/store/.env.local.example
@@ -48,6 +48,10 @@ EDGE_CONFIG=
 EDGE_CONFIG_MANAGE_API_URL=https://api.vercel.com/v1/edge-config/:configId/items?teamId=:teamId
 EDGE_CONFIG_MANAGE_API_TOKEN=:token
 
+# Trustpilot
+TRUSTPILOT_HEDVIG_BUSINESS_UNIT_ID=
+TRUSTPILOT_API_KEY=
+
 FALLBACK_ORIGIN_URL=https://www.dev.hedvigit.com
 
 NEXT_PUBLIC_EXPERIMENT_ID=<experiment-id>

--- a/apps/store/src/services/trustpilot/trustpilot.tsx
+++ b/apps/store/src/services/trustpilot/trustpilot.tsx
@@ -1,0 +1,59 @@
+import { atom, useAtomValue } from 'jotai'
+import { useHydrateAtoms } from 'jotai/utils'
+import { type TrustpilotData } from './trustpilot.types'
+
+type JSONResponse = {
+  score: {
+    trustScore: number
+  }
+  numberOfReviews: {
+    total: number
+  }
+}
+
+const trustpilotAtom = atom<TrustpilotData | null>(null)
+
+export const useTrustpilotData = () => {
+  return useAtomValue(trustpilotAtom)
+}
+
+export const useHydrateTrustpilotData = (data: TrustpilotData | null) => {
+  useHydrateAtoms([[trustpilotAtom, data] as const])
+}
+
+export const fetchTrustpilotData = async () => {
+  try {
+    const hedvigBusinessUnitId = process.env.TRUSTPILOT_HEDVIG_BUSINESS_UNIT_ID
+    if (!hedvigBusinessUnitId) {
+      throw new Error('TRUSTPILOT_HEDVIG_BUSINESS_UNIT_ID is not configured')
+    }
+
+    const trustpilotApiKey = process.env.TRUSTPILOT_API_KEY
+    if (!trustpilotApiKey) {
+      throw new Error('`TRUSTPILOT_API_KEY` is not configured')
+    }
+
+    const response = await fetch(
+      `https://api.trustpilot.com/v1/business-units/${hedvigBusinessUnitId}`,
+      {
+        headers: {
+          apiKey: trustpilotApiKey,
+        },
+      },
+    )
+
+    if (!response.ok) {
+      throw new Error(`Failed to retrieve Trustpilot information: ${response.statusText}`)
+    }
+
+    const { score, numberOfReviews }: JSONResponse = await response.json()
+
+    return {
+      score: score.trustScore,
+      totalReviews: numberOfReviews.total,
+    }
+  } catch (error) {
+    console.error(error)
+    return null
+  }
+}

--- a/apps/store/src/services/trustpilot/trustpilot.types.ts
+++ b/apps/store/src/services/trustpilot/trustpilot.types.ts
@@ -1,0 +1,4 @@
+export type TrustpilotData = {
+  score: number
+  totalReviews: number
+}


### PR DESCRIPTION
## Describe your changes

* Adds a `TrustpilotBlock` that displays _Trustpilot_ data.


How the whole thing works:

1. Real data is stored in store's [_Edge Config_ storage](https://vercel.com/hedvig/hedvig-dot-com/stores/edge-config/ecfg_viia3ntdquafelygrc3g6lfs3d2a/items#item=trustpilot);
2. This PR will set a cron job that's going to update it every Monday at 8:00 (just picked that number. Gonna double check if that's enough) - check `apps/store/vercel.json` and `apps/store/src/pages/api/cron/trustpilot.ts` files
3. There's a new service - `apps/store/src/services/trustpilot/trustpilot.tsx` - which is responsible to provide a way to retrieve that data from the storage. It also gonna store it in a Jotai's atom so it can be available in the whole app. We then fetch that data and proper hydrate the atom in the `apps/store/src/pages/[[...slug]].tsx` and `apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx` files respectively.
4. `TrustpilotBlock` then reads that data from the atom and proper display it.

<img width="974" alt="Screenshot 2023-07-06 at 17 41 54" src="https://github.com/HedvigInsurance/racoon/assets/19200662/50d291c1-cbac-491b-b7ac-de9cc9c54d14">

## Justify why they are needed

Requested by design/editors

Can be tested [here](https://hedvig-dot-com-git-gen-637-feattrustpilot-blocksplit2-hedvig.vercel.app/se/test-home?__vercel_draft=1)