### PR TITLE
GEN-637 - feat: make Trustpilot data available globally

### DIFF
--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -33,6 +33,7 @@ export const LayoutWithMenu = (props: LayoutWithMenuProps) => {
   const { story, globalStory, className, breadcrumbs } = props.children.props
 
   useHydrateProductMetadata(props.children.props[GLOBAL_PRODUCT_METADATA_PROP_NAME])
+
   const handleLocaleChange = useChangeLocale(story)
 
   // Announcements are added as reusable blocks for Page and ProductPage content types

--- a/apps/store/src/components/ProductPage/ProductPage.types.ts
+++ b/apps/store/src/components/ProductPage/ProductPage.types.ts
@@ -1,6 +1,7 @@
 import { ProductDataQuery } from '@/services/apollo/generated'
 import { Template } from '@/services/PriceCalculator/PriceCalculator.types'
 import { ProductStory, StoryblokPageProps } from '@/services/storyblok/storyblok'
+import { type TrustpilotData } from '@/services/trustpilot/trustpilot.types'
 
 export type ProductData = Exclude<ProductDataQuery['product'], null | undefined>
 
@@ -13,4 +14,5 @@ export type ProductPageProps = StoryblokPageProps & {
   priceTemplate: Template
   productData: ProductData
   initialSelectedVariant?: ProductDataVariant
+  trustpilot: TrustpilotData | null
 }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -72,6 +72,7 @@ import { blogBlocks } from '@/features/blog/blogBlocks'
 // TODO: get rid of this import, services should avoid feature-imports
 import { STORYBLOK_MANYPETS_FOLDER_SLUG } from '@/features/manyPets/manyPets.constants'
 import { manyPetsBlocks } from '@/features/manyPets/manyPetsBlocks'
+import { TrustpilotData } from '@/services/trustpilot/trustpilot.types'
 import { isBrowser } from '@/utils/env'
 import { Features } from '@/utils/Features'
 import { getLocaleOrFallback, isRoutingLocale } from '@/utils/l10n/localeUtils'
@@ -98,6 +99,7 @@ export type StoryblokQueryParams = {
 export type StoryblokPageProps = {
   [STORY_PROP_NAME]: PageStory
   [GLOBAL_STORY_PROP_NAME]: GlobalStory
+  trustpilot: TrustpilotData | null
 }
 
 export type StoryblokVersion = 'draft' | 'published'


### PR DESCRIPTION
## Describe your changes

* Fetch _Trustpilot_ data for Storyblok pages and make it available globally.

How the whole thing works:

1. Real data is stored in store's [_Edge Config_ storage](https://vercel.com/hedvig/hedvig-dot-com/stores/edge-config/ecfg_viia3ntdquafelygrc3g6lfs3d2a/items#item=trustpilot);
2. This PR will set a cron job that's going to update it every Monday at 8:00 (just picked that number. Gonna double check if that's enough) - check `apps/store/vercel.json` and `apps/store/src/pages/api/cron/trustpilot.ts` files
3. There's a new service - `apps/store/src/services/trustpilot/trustpilot.tsx` - which is responsible to provide a way to retrieve that data from the storage. It also gonna store it in a Jotai's atom so it can be available in the whole app. We then fetch that data and proper hydrate the atom in the `apps/store/src/pages/[[...slug]].tsx` and `apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx` files respectively.
4. `TrustpilotBlock` then reads that data from the atom and proper display it.

<img width="974" alt="Screenshot 2023-07-06 at 17 41 54" src="https://github.com/HedvigInsurance/racoon/assets/19200662/50d291c1-cbac-491b-b7ac-de9cc9c54d14">

## Justify why they are needed

Requested by design/editors

Can be tested [here](https://hedvig-dot-com-git-gen-637-feattrustpilot-blocksplit2-hedvig.vercel.app/se/test-home?__vercel_draft=1)