### PR TITLE
GEN-668 / Show video cover when video has ended instead of the last frame

### DIFF
--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -134,6 +134,15 @@ export const Video = ({
   }, [wasPlaying, playVideo])
   useDialogEvent('close', handleDialogClose)
 
+  const handleVideoEnded: React.ReactEventHandler<HTMLVideoElement> = () => {
+    // Show the first frame of the video when it has ended
+    if (videoRef.current) {
+      videoRef.current.pause()
+      setState(State.Paused)
+      videoRef.current.currentTime = 0
+    }
+  }
+
   return (
     <VideoWrapper>
       {/*
@@ -156,6 +165,7 @@ export const Video = ({
         roundedCorners={roundedCorners}
         onPlaying={handlePlaying}
         onPause={handlePause}
+        onEnded={handleVideoEnded}
         {...autoplayAttributes}
         {...delegated}
       >


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
When videos has ended, re-load it to show the cover of the video.
This doesn't affect autoplaying videos that are looped and simply paused, when you use the controls.

### Before:

https://github.com/HedvigInsurance/racoon/assets/6661511/ca1851ec-e9a1-425e-beb1-9032f9e4a2ad

### After:

https://github.com/HedvigInsurance/racoon/assets/6661511/3b5bc908-7a8d-494a-ba3a-771a63942da5


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Non autoplaying videos stops on the last frame. A bit nicer to "rewind" and show the poster instead.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
