### PR TITLE
Refactor CartEntryItem helper components

### DIFF
--- a/apps/store/src/components/CartInventory/CartEntryItem/CartEntryItem.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem/CartEntryItem.tsx
@@ -5,7 +5,7 @@ import { Button, Dialog, Text, mq, theme } from 'ui'
 import { useEditProductOffer } from '@/components/CartPage/useEditProductOffer'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
-import { CartFragmentFragment } from '@/services/apollo/generated'
+import { type CartFragmentFragment } from '@/services/apollo/generated'
 import { CartEntry } from '../CartInventory.types'
 import { RemoveEntryDialog } from '../RemoveEntryDialog'
 import { CartEntryCollapsible } from './CartEntryCollapsible'
@@ -47,7 +47,11 @@ export const CartEntryItem = ({ defaultOpen = false, ...props }: Props) => {
           <div>
             <Text>{titleLabel}</Text>
 
-            <ShortSummary cartEntry={cartEntry} />
+            <ShortSummary
+              startDate={cartEntry.startDate}
+              productName={cartEntry.productName}
+              data={cartEntry.data}
+            />
           </div>
         </SpaceFlex>
       </Clickable>

--- a/apps/store/src/components/CartInventory/CartEntryItem/DetailsSheet.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem/DetailsSheet.tsx
@@ -1,13 +1,18 @@
 import styled from '@emotion/styled'
-import type { TFunction } from 'i18next'
+import { type TFunction } from 'i18next'
 import { useTranslation } from 'next-i18next'
 import { Heading, Text } from 'ui'
 import { Space, theme } from 'ui'
 import { useAutoFormat } from '@/utils/useFormatter'
-import { CartEntry } from '../CartInventory.types'
-import { DataTableRow, getDataTable } from '../DataTable/DataTable'
+import { type CartEntry } from '../CartInventory.types'
+import { type DataTableRow, getDataTable } from '../DataTable/DataTable'
 
-export const DetailsSheet = (props: CartEntry) => {
+type Props = Pick<
+  CartEntry,
+  'documents' | 'productName' | 'data' | 'tierLevelDisplayName' | 'deductibleDisplayName'
+>
+
+export const DetailsSheet = (props: Props) => {
   const { documents, productName, data } = props
   const { t } = useTranslation('cart')
   const dataTableRows = getDataTable(productName)

--- a/apps/store/src/components/CartInventory/CartEntryItem/ShortSummary.tsx
+++ b/apps/store/src/components/CartInventory/CartEntryItem/ShortSummary.tsx
@@ -2,23 +2,25 @@ import { useTranslation } from 'react-i18next'
 import { InfoIcon, Text, theme } from 'ui'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { useFormatter } from '@/utils/useFormatter'
-import { CartEntry } from '../CartInventory.types'
+import { type CartEntry } from '../CartInventory.types'
 import { Tooltip } from './Tooltip'
 
-export const ShortSummary = ({ cartEntry }: { cartEntry: CartEntry }) => {
+type Props = Pick<CartEntry, 'startDate' | 'productName' | 'data'>
+
+export const ShortSummary = (props: Props) => {
   const { t } = useTranslation('cart')
   const formatter = useFormatter()
 
   const content: Array<string> = []
 
-  const productBasedSummary = getProductBasedSummary(cartEntry)
+  const productBasedSummary = getProductBasedSummary(props.productName, props.data)
   if (productBasedSummary) {
     content.push(productBasedSummary)
   }
 
-  const labels = cartEntry.startDate
+  const labels = props.startDate
     ? {
-        text: t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(cartEntry.startDate) }),
+        text: t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(props.startDate) }),
         tooltip: t('CART_ITEM_TOOLTIP_SELF_SWITCH'),
       }
     : {
@@ -41,11 +43,11 @@ export const ShortSummary = ({ cartEntry }: { cartEntry: CartEntry }) => {
 }
 
 // TODO: retrieve this from API or some sort of central config.
-const getProductBasedSummary = (cartEntry: CartEntry) => {
-  switch (cartEntry.productName) {
+const getProductBasedSummary = (productName: string, data: Record<string, unknown>) => {
+  switch (productName) {
     case 'SE_PET_DOG':
     case 'SE_PET_CAT':
-      return cartEntry.data.name != null ? (cartEntry.data.name as string) : null
+      return data.name != null ? (data.name as string) : null
     default:
       return null
   }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Refactor CartEntryItem helpers to only accept props they actually use.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Make it possible to reuse them instead. Also avoid making them tightly coupled to the API.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
