### PR TITLE
Add helper to get props for pages that use LayoutWithMenu component

### DIFF
--- a/apps/store/src/components/LayoutWithMenu/getLayoutWithMenuProps.ts
+++ b/apps/store/src/components/LayoutWithMenu/getLayoutWithMenuProps.ts
@@ -1,0 +1,52 @@
+import { ApolloClient } from '@apollo/client'
+import { type GetStaticPropsContext, type GetServerSidePropsContext } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { initializeApollo, initializeApolloServerSide } from '@/services/apollo/client'
+import { getGlobalStory } from '@/services/storyblok/storyblok'
+import { GLOBAL_STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
+import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+import {
+  GLOBAL_PRODUCT_METADATA_PROP_NAME,
+  fetchGlobalProductMetadata,
+} from './fetchProductMetadata'
+
+export const getLayoutWithMenuProps = async (
+  context: GetServerSidePropsContext | GetStaticPropsContext,
+  defaultApolloClient?: ApolloClient<unknown>,
+) => {
+  if (!isRoutingLocale(context.locale)) {
+    console.warn(`Locale ${context.locale} is not supported`)
+    return null
+  }
+
+  let apolloClient = defaultApolloClient
+  if (!apolloClient) {
+    if (isGetServerSidePropsContext(context)) {
+      apolloClient = await initializeApolloServerSide({
+        req: context.req,
+        res: context.res,
+        locale: context.locale,
+      })
+    } else {
+      apolloClient = initializeApollo({ locale: context.locale })
+    }
+  }
+
+  const [globalStory, productMetadata, translations] = await Promise.all([
+    getGlobalStory({ version: context.draftMode ? 'draft' : 'published', locale: context.locale }),
+    fetchGlobalProductMetadata({ apolloClient }),
+    serverSideTranslations(context.locale),
+  ])
+
+  return {
+    [GLOBAL_STORY_PROP_NAME]: globalStory,
+    [GLOBAL_PRODUCT_METADATA_PROP_NAME]: productMetadata,
+    ...translations,
+  }
+}
+
+const isGetServerSidePropsContext = (
+  context: GetServerSidePropsContext | GetStaticPropsContext,
+): context is GetServerSidePropsContext => {
+  return 'req' in context && 'res' in context
+}

--- a/apps/store/src/pages/404.tsx
+++ b/apps/store/src/pages/404.tsx
@@ -1,18 +1,11 @@
 import { GetStaticProps, NextPageWithLayout } from 'next'
 import { useTranslation } from 'next-i18next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { Heading } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { ErrorPage } from '@/components/ErrorPage/ErrorPage'
-import {
-  fetchGlobalProductMetadata,
-  GLOBAL_PRODUCT_METADATA_PROP_NAME,
-} from '@/components/LayoutWithMenu/fetchProductMetadata'
+import { getLayoutWithMenuProps } from '@/components/LayoutWithMenu/getLayoutWithMenuProps'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
-import { initializeApollo } from '@/services/apollo/client'
-import { getGlobalStory } from '@/services/storyblok/storyblok'
-import { GLOBAL_STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { RoutingLocale } from '@/utils/l10n/types'
 import { PageLink } from '@/utils/PageLink'
@@ -43,21 +36,12 @@ export const getStaticProps: GetStaticProps = async (context) => {
   const rawLocale = context.locale ?? context.defaultLocale
   // TODO: Remove this when we have a global 404 page
   const locale: RoutingLocale = isRoutingLocale(rawLocale) ? rawLocale : 'se-en'
+  context.locale = locale
 
-  const apolloClient = initializeApollo({ locale })
-  const [globalStory, translations, productMetadata] = await Promise.all([
-    getGlobalStory({ locale }),
-    serverSideTranslations(locale),
-    fetchGlobalProductMetadata({ apolloClient }),
-  ])
+  const props = await getLayoutWithMenuProps(context)
+  if (props === null) return { notFound: true }
 
-  return {
-    props: {
-      ...translations,
-      [GLOBAL_STORY_PROP_NAME]: globalStory,
-      [GLOBAL_PRODUCT_METADATA_PROP_NAME]: productMetadata,
-    },
-  }
+  return { props }
 }
 
 NextPage.getLayout = (children) => <LayoutWithMenu overlayMenu={true}>{children}</LayoutWithMenu>

--- a/apps/store/src/pages/cart.tsx
+++ b/apps/store/src/pages/cart.tsx
@@ -1,6 +1,5 @@
 import type { GetStaticProps, NextPageWithLayout } from 'next'
 import { useTranslation } from 'next-i18next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Head from 'next/head'
 import { useMemo } from 'react'
 import {
@@ -10,16 +9,9 @@ import {
   getCartEntry,
 } from '@/components/CartInventory/CartInventory.helpers'
 import { CartPage } from '@/components/CartPage/CartPage'
-import {
-  fetchGlobalProductMetadata,
-  GLOBAL_PRODUCT_METADATA_PROP_NAME,
-} from '@/components/LayoutWithMenu/fetchProductMetadata'
+import { getLayoutWithMenuProps } from '@/components/LayoutWithMenu/getLayoutWithMenuProps'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
-import { initializeApollo } from '@/services/apollo/client'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
-import { getGlobalStory } from '@/services/storyblok/storyblok'
-import { GLOBAL_STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
-import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { useGetDiscountExplanation } from '@/utils/useDiscountExplanation'
 
 const NextCartPage: NextPageWithLayout = (props) => {
@@ -69,23 +61,12 @@ const NextCartPage: NextPageWithLayout = (props) => {
 NextCartPage.getLayout = (children) => <LayoutWithMenu>{children}</LayoutWithMenu>
 
 export const getStaticProps: GetStaticProps = async (context) => {
-  const { locale } = context
-  if (!isRoutingLocale(locale)) return { notFound: true }
-  const apolloClient = initializeApollo({ locale })
-  const [globalStory, translations, productMetadata] = await Promise.all([
-    getGlobalStory({ locale }),
-    serverSideTranslations(locale),
-    fetchGlobalProductMetadata({ apolloClient }),
-  ])
+  const props = await getLayoutWithMenuProps(context)
+  if (props === null) return { notFound: true }
 
-  const revalidate = process.env.VERCEL_ENV === 'preview' ? 1 : false
   return {
-    props: {
-      ...translations,
-      [GLOBAL_STORY_PROP_NAME]: globalStory,
-      [GLOBAL_PRODUCT_METADATA_PROP_NAME]: productMetadata,
-    },
-    revalidate,
+    props,
+    revalidate: process.env.VERCEL_ENV === 'preview' ? 1 : false,
   }
 }
 

--- a/apps/store/src/pages/forever/[code].tsx
+++ b/apps/store/src/pages/forever/[code].tsx
@@ -1,16 +1,8 @@
 import { GetServerSideProps, NextPageWithLayout } from 'next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Head from 'next/head'
 import { ForeverPage, type Props } from '@/components/ForeverPage/ForeverPage'
-import {
-  GLOBAL_PRODUCT_METADATA_PROP_NAME,
-  fetchGlobalProductMetadata,
-} from '@/components/LayoutWithMenu/fetchProductMetadata'
+import { getLayoutWithMenuProps } from '@/components/LayoutWithMenu/getLayoutWithMenuProps'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
-import { initializeApolloServerSide } from '@/services/apollo/client'
-import { getGlobalStory } from '@/services/storyblok/storyblok'
-import { GLOBAL_STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
-import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
 type Params = { code: string }
 
@@ -24,25 +16,15 @@ const NextPage: NextPageWithLayout<Props> = (props) => (
 )
 
 export const getServerSideProps: GetServerSideProps<Props, Params> = async (context) => {
-  const { locale, params, req, res } = context
-  if (!isRoutingLocale(locale)) return { notFound: true }
+  if (!context.params?.code) return { notFound: true }
 
-  const code = params?.code
-  if (!code) return { notFound: true }
-
-  const apolloClient = await initializeApolloServerSide({ locale, req, res })
-  const [globalStory, translations, productMetadata] = await Promise.all([
-    getGlobalStory({ locale }),
-    serverSideTranslations(locale),
-    fetchGlobalProductMetadata({ apolloClient }),
-  ])
+  const layoutWithMenuProps = await getLayoutWithMenuProps(context)
+  if (layoutWithMenuProps === null) return { notFound: true }
 
   return {
     props: {
-      ...translations,
-      [GLOBAL_STORY_PROP_NAME]: globalStory,
-      [GLOBAL_PRODUCT_METADATA_PROP_NAME]: productMetadata,
-      code,
+      ...layoutWithMenuProps,
+      code: context.params.code,
     },
   }
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Extract fetching logic required for any page that renders inside `LayoutWithMenu`

- Implement new helper function on relevant pages

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Avoid duplication and make it easier to use the layout component.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
