### PR TITLE
Revert change and use canonical field instead

### DIFF
--- a/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
+++ b/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
@@ -8,17 +8,16 @@ import { StructuredDataOrganization } from './StructuredDataOrganization'
 
 type Props = {
   story: ISbStoryData<SEOData>
-  canonicalUrl?: string
 }
 
-export const HeadSeoInfo = ({ story, canonicalUrl = '' }: Props) => {
+export const HeadSeoInfo = ({ story }: Props) => {
   // AB testing
-  const { robots, seoTitle, seoMetaDescription, seoMetaOgImage } = story.content
+  const { canonicalUrl, robots, seoTitle, seoMetaDescription, seoMetaOgImage } = story.content
 
   return (
     <>
       <Head>
-        {canonicalUrl && <link rel="canonical" href={`${ORIGIN_URL}/${canonicalUrl}`} />}
+        {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
         <meta name="robots" content={robots} />
         {seoMetaDescription && (
           <>

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -49,7 +49,7 @@ const NextStoryblokPage = (props: NextContentPageProps) => {
 
   return (
     <BlogContext.Provider value={parseBlogContext(props)}>
-      <HeadSeoInfo story={abTestOriginStory || story} canonicalUrl={abTestOriginStory?.full_slug} />
+      <HeadSeoInfo story={abTestOriginStory || story} />
       <StoryblokComponent blok={story.content} />
     </BlogContext.Provider>
   )

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -162,6 +162,7 @@ export type SEOData = {
   seoMetaDescription?: string
   seoMetaOgImage?: StoryblokAsset
   abTestOrigin?: PageStory
+  canonicalUrl?: string
 }
 
 export type PageStory = ISbStoryData<


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Revert change we did for canonical tag. Use the manual field from Storyblok as Peter suggested from his thread. This should fix issue no.1  https://hedviginsurance.slack.com/archives/C02JPS466NS/p1689145200740139

Let's see if we should have canonical automatically matching the page and overwritten by the manual field.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Peter reported some SEO issues after the last change we did for A/B test page

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
