### PR TITLE
🚨 Always use robots field from the source story in A/B test cases

### DIFF
--- a/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
+++ b/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
@@ -8,17 +8,19 @@ import { StructuredDataOrganization } from './StructuredDataOrganization'
 
 type Props = {
   story: ISbStoryData<SEOData>
+  robots?: 'index' | 'noindex'
 }
 
-export const HeadSeoInfo = ({ story }: Props) => {
-  // AB testing
-  const { canonicalUrl, robots, seoTitle, seoMetaDescription, seoMetaOgImage } = story.content
+export const HeadSeoInfo = ({ story, robots }: Props) => {
+  const { canonicalUrl, seoTitle, seoMetaDescription, seoMetaOgImage } = story.content
+  // Make it possible to override robots value for A/B test cases
+  const robotsContent = robots ?? story.content.robots
 
   return (
     <>
       <Head>
         {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
-        <meta name="robots" content={robots} />
+        <meta name="robots" content={robotsContent} />
         {seoMetaDescription && (
           <>
             <meta name="description" content={seoMetaDescription} />

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -46,10 +46,12 @@ const NextStoryblokPage = (props: NextContentPageProps) => {
   const story = useStoryblokState(props.story)
   if (!story) return null
   const abTestOriginStory = story.content.abTestOrigin
+  // Always use robots value from the source page in A/B test cases
+  const robots = story.content.robots
 
   return (
     <BlogContext.Provider value={parseBlogContext(props)}>
-      <HeadSeoInfo story={abTestOriginStory || story} />
+      <HeadSeoInfo story={abTestOriginStory || story} robots={robots} />
       <StoryblokComponent blok={story.content} />
     </BlogContext.Provider>
   )
@@ -59,7 +61,6 @@ const NextProductPage = (props: ProductPageProps) => {
   const { story: initialStory, ...pageProps } = props
   const story = useStoryblokState(initialStory)
   if (!story) return null
-
   return (
     <>
       <HeadSeoInfo story={story} />


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Use robots field from Storyblok for the source page in every case to make sure A/B test pages get noindex. 
This should fix issue no.3  https://hedviginsurance.slack.com/archives/C02JPS466NS/p1689145200740139

<img width="1321" alt="Screenshot 2023-07-12 at 10 13 10" src="https://github.com/HedvigInsurance/racoon/assets/6661511/7ceb26b6-5cf4-47b3-8201-02c68fe04c18">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Peter reported some SEO issues after the last change we did for A/B test page

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
