### PR TITLE
GEN-664 - feat: added DesktopComparisonTable

### DIFF
--- a/apps/store/src/components/ComparisonTable/DesktopComparisonTable.tsx
+++ b/apps/store/src/components/ComparisonTable/DesktopComparisonTable.tsx
@@ -1,0 +1,50 @@
+import * as ComparisonTable from '@/components/ComparisonTable/ComparisonTable'
+import { getCellValue } from './ComparisonTable.helpers'
+import { type Head, type Body, TableMarkers } from './ComparisonTable.types'
+
+type Props = {
+  head: Head
+  body: Body
+  selectedColumn?: string
+  className?: string
+}
+
+export const DesktopComparisonTable = ({ className, head, body, selectedColumn }: Props) => {
+  const selectedColumnIndex = head.findIndex((headerValue) => headerValue === selectedColumn)
+
+  return (
+    <ComparisonTable.Root className={className}>
+      <ComparisonTable.Head>
+        <ComparisonTable.Row>
+          {head.map((headerValue, index) => {
+            if (headerValue == TableMarkers.EmptyHeader)
+              return <ComparisonTable.Header key={`empty-header-${index}`} />
+
+            return (
+              <ComparisonTable.Header key={headerValue} active={headerValue === selectedColumn}>
+                {headerValue}
+              </ComparisonTable.Header>
+            )
+          })}
+        </ComparisonTable.Row>
+      </ComparisonTable.Head>
+
+      <ComparisonTable.Body>
+        {body.map((row) => {
+          const [attribute, ...values] = row
+
+          return (
+            <ComparisonTable.Row key={attribute}>
+              <ComparisonTable.TitleDataCell>{attribute}</ComparisonTable.TitleDataCell>
+              {values.map((value, index) => (
+                <ComparisonTable.DataCell key={index} active={index + 1 === selectedColumnIndex}>
+                  {getCellValue(value)}
+                </ComparisonTable.DataCell>
+              ))}
+            </ComparisonTable.Row>
+          )
+        })}
+      </ComparisonTable.Body>
+    </ComparisonTable.Root>
+  )
+}


### PR DESCRIPTION
## Describe your changes

* Extracts _Desktop_ version of the Comparison Table into a component to be used on bigger viewports.

We got a new [design](https://www.figma.com/file/qUhLjrKl98PAzHov9ilaDH/Hedvig-UI-Kit?type=design&node-id=3380-13894&mode=design&t=snZZXMBD7zxyZULO-4) for a _mobile_ version of the comparison table:
![image](https://github.com/HedvigInsurance/racoon/assets/19200662/64635b36-e5c3-4722-a289-2e708b4d5c9d)
