### PR TITLE
GEN-664 - chore: update ComparisonTableStories

### DIFF
--- a/apps/store/src/components/ComparisonTable/ComparisonTable.stories.tsx
+++ b/apps/store/src/components/ComparisonTable/ComparisonTable.stories.tsx
@@ -1,12 +1,15 @@
-import { Meta } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 import * as ComparisonTable from './ComparisonTable'
 
+type Story = StoryObj<typeof ComparisonTable.Root>
+
 export default {
+  title: 'Components/Comparison Table',
   component: ComparisonTable.Root,
 } as Meta<typeof ComparisonTable.Root>
 
-export const Default = () => {
-  return (
+export const Default: Story = {
+  render: () => (
     <ComparisonTable.Root>
       <ComparisonTable.Head>
         <ComparisonTable.Header />
@@ -53,6 +56,5 @@ export const Default = () => {
         </ComparisonTable.Row>
       </ComparisonTable.Body>
     </ComparisonTable.Root>
-  )
+  ),
 }
-Default.args = {}

--- a/apps/store/src/components/ComparisonTable/DesktopComparisonTable.stories.tsx
+++ b/apps/store/src/components/ComparisonTable/DesktopComparisonTable.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { type Table, TableMarkers } from './ComparisonTable.types'
+import { DesktopComparisonTable } from './DesktopComparisonTable'
+
+const nbsp = '\u00A0'
+const table: Table = {
+  head: [TableMarkers.EmptyHeader, 'Basic', 'Standard', 'Premium'],
+  body: [
+    ['Attribute 1', `30${nbsp}000${nbsp}kr`, `60${nbsp}000${nbsp}kr`, `140${nbsp}000${nbsp}kr`],
+    ['Attribute 2', '[*]', '[*]', '[*]'],
+    ['Attribute 3', '[]', '[*]', '[*]'],
+    ['Attribute 4', '[]', '[*]', '[*]'],
+    ['Attribute 5', '[]', '[]', '[*]'],
+    ['Attribute 6', '[]', '[]', '[*]'],
+  ],
+}
+
+type Story = StoryObj<typeof DesktopComparisonTable>
+
+export default {
+  title: 'Components/Comparison Table/Desktop',
+  component: DesktopComparisonTable,
+} as Meta<typeof DesktopComparisonTable>
+
+export const Desktop: Story = {
+  render: () => <DesktopComparisonTable {...table} selectedColumn="Premium" />,
+}

--- a/apps/store/src/components/ComparisonTable/MobileComparisonTable.stories.tsx
+++ b/apps/store/src/components/ComparisonTable/MobileComparisonTable.stories.tsx
@@ -1,0 +1,34 @@
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+import type { Meta, StoryObj } from '@storybook/react'
+import { type Table, TableMarkers } from './ComparisonTable.types'
+import { MobileComparisonTable } from './MobileComparisonTable'
+
+const nbsp = '\u00A0'
+const table: Table = {
+  head: [TableMarkers.EmptyHeader, 'Basic', 'Standard', 'Premium'],
+  body: [
+    ['Attribute 1', `30${nbsp}000${nbsp}kr`, `60${nbsp}000${nbsp}kr`, `140${nbsp}000${nbsp}kr`],
+    ['Attribute 2', '[*]', '[*]', '[*]'],
+    ['Attribute 3', '[]', '[*]', '[*]'],
+    ['Attribute 4', '[]', '[*]', '[*]'],
+    ['Attribute 5', '[]', '[]', '[*]'],
+    ['Attribute 6', '[]', '[]', '[*]'],
+  ],
+}
+
+type Story = StoryObj<typeof MobileComparisonTable>
+
+export default {
+  title: 'Components/Comparison Table/Mobile',
+  component: MobileComparisonTable,
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'iphone12mini',
+    },
+  },
+} as Meta<typeof MobileComparisonTable>
+
+export const Mobile: Story = {
+  render: () => <MobileComparisonTable {...table} />,
+}


### PR DESCRIPTION
## Describe your changes

* Updates `ComparisonTable` stories so it uses new data structure for table representation.

https://github.com/HedvigInsurance/racoon/assets/19200662/d2e80dfd-b151-4787-bc94-303f2a0d7c25

## Justify why they are needed

We got a new [design](https://www.figma.com/file/qUhLjrKl98PAzHov9ilaDH/Hedvig-UI-Kit?type=design&node-id=3380-13894&mode=design&t=snZZXMBD7zxyZULO-4) for a _mobile_ version of the comparison table:
![image](https://github.com/HedvigInsurance/racoon/assets/19200662/64635b36-e5c3-4722-a289-2e708b4d5c9d)
