### PR TITLE
TextField: avoid tabbing to delete button

### DIFF
--- a/apps/store/src/components/TextField/TextField.tsx
+++ b/apps/store/src/components/TextField/TextField.tsx
@@ -105,8 +105,7 @@ export const TextField = (props: Props) => {
                 type="button"
                 onClick={handleClickDelete}
                 aria-hidden={true}
-                // TODO: Get this lokalised
-                aria-label="Clear field"
+                tabIndex={-1}
               >
                 <CrossIconSmall />
               </DeleteButton>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Exclude delete button when tabbing through the form

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- It's annoying to tab twice to get to the next field

- Possibly you end up deleting the field text by accident

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
