### PR TITLE
GEN-756 | Debugger: add hidden page debugger

### DIFF
--- a/apps/store/README.md
+++ b/apps/store/README.md
@@ -138,3 +138,7 @@ We use a few custom headers when communicating with the API. These are:
 - `Hedvig-ShopSessionID`: The ID of the current shop session, used for debugging purposes.
 - `Hedvig-Language`: Java Locale code (e.g. `ca-ES`), used for API localisation including error messages.
 - `Authorization`: Bearer token for the currently authenticated user.
+
+## Page Debug Menu
+
+To show the page debug menu, press `Ctrl + d`. The menu will show the current shop session ID and other helpful information based on the page your are viewing.

--- a/apps/store/src/components/DebugDialog/DebugDialog.tsx
+++ b/apps/store/src/components/DebugDialog/DebugDialog.tsx
@@ -1,0 +1,117 @@
+import styled from '@emotion/styled'
+import { useEffect, useState } from 'react'
+import { CheckIcon, Dialog, Space, Text, theme } from 'ui'
+import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { SpaceFlex } from '../SpaceFlex/SpaceFlex'
+
+export const DebugDialog = () => {
+  const [isOpen, setOpen] = useState(false)
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const ctrl = event.getModifierState('Control')
+      if (ctrl && event.key === 'd') {
+        setOpen(true)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [])
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={setOpen}>
+      <DialogContent onClose={() => setOpen(false)}>
+        <DialogWindow>
+          <ShopSessionSection />
+        </DialogWindow>
+      </DialogContent>
+    </Dialog.Root>
+  )
+}
+
+const DialogContent = styled(Dialog.Content)({
+  maxWidth: '100%',
+  display: 'flex',
+  alignItems: 'center',
+})
+
+const DialogWindow = styled(Dialog.Window)({
+  padding: theme.space.lg,
+  paddingTop: theme.space.md,
+  borderBottomRightRadius: theme.radius.sm,
+  borderBottomLeftRadius: theme.radius.sm,
+  maxWidth: `calc(100% - ${theme.space.xs} * 2)`,
+  marginInline: 'auto',
+})
+
+const ShopSessionSection = () => {
+  const { shopSession } = useShopSession()
+
+  if (!shopSession) return null
+
+  return (
+    <Space y={0.25}>
+      <Text as="p" size="sm">
+        Shop Session
+      </Text>
+      <CopyToClipboard>{shopSession.id}</CopyToClipboard>
+    </Space>
+  )
+}
+
+const CopyToClipboard = (props: { children: string }) => {
+  const [copied, setCopied] = useState(false)
+
+  const copy = () => {
+    navigator.clipboard.writeText(props.children)
+    setCopied(true)
+  }
+
+  return (
+    <CopyToClipboardWrapper>
+      <Elipsis as="p" size="sm">
+        {props.children}
+      </Elipsis>
+      <CopyToClipboardButton onClick={copy}>
+        {copied ? (
+          <SpaceFlex align="center" space={0.5}>
+            <CheckIcon size="1em" />
+            Copied
+          </SpaceFlex>
+        ) : (
+          'Copy'
+        )}
+      </CopyToClipboardButton>
+    </CopyToClipboardWrapper>
+  )
+}
+
+const CopyToClipboardWrapper = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: theme.space.lg,
+
+  backgroundColor: theme.colors.gray100,
+  padding: theme.space.xs,
+  borderRadius: theme.radius.xs,
+  border: `1px solid ${theme.colors.gray300}`,
+
+  '@media (hover: hover)': {
+    '&:hover': {
+      backgroundColor: theme.colors.gray200,
+    },
+  },
+})
+
+const Elipsis = styled(Text)({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
+const CopyToClipboardButton = styled.button({
+  cursor: 'pointer',
+  flexShrink: 0,
+})

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import { Provider as BalancerProvider } from 'react-wrap-balancer'
 import { globalStyles, theme } from 'ui'
 import { AppErrorDialog } from '@/components/AppErrorDialog'
 import { BankIdDialog } from '@/components/BankIdDialog'
+import { DebugDialog } from '@/components/DebugDialog/DebugDialog'
 import { GlobalBanner } from '@/components/GlobalBanner/GlobalBanner'
 import { GlobalLinkStyles } from '@/components/RichText/RichText.styles'
 import { useApollo } from '@/services/apollo/client'
@@ -100,6 +101,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
                 <BalancerProvider>
                   <AppErrorProvider>
                     <AppErrorDialog />
+                    <DebugDialog />
                     <GlobalBanner />
                     {getLayout(<Component {...pageProps} className={contentFontClassName} />)}
                   </AppErrorProvider>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-07-13 at 11.21.03.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/fca475cc-70d0-4e99-b7dc-56a99d372bba/Screenshot%202023-07-13%20at%2011.21.03.png)


- Add hidden debug menu that you can access by pressing `?` on your keyboard

- Show ShopSession ID with option to copy to clipboard

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Allow us to present debug information for internal use

- We can expose things like shop session information or links

- I think we want to make this page specific so we can display information
  that is relevant to the page you are on

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
