### PR TITLE
GEN-736 | Share link to cart from debug dialog

### DIFF
--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -17,6 +17,7 @@ import { useTracking } from '@/services/Tracking/useTracking'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { PageLink } from '@/utils/PageLink'
 import { CartPageProps } from './CartPageProps.types'
+import { PageDebugDialog } from './PageDebugDialog'
 
 export const CartPage = (props: CartPageProps) => {
   const { shopSessionId, entries, campaigns, campaignsEnabled, cost } = props
@@ -122,6 +123,8 @@ export const CartPage = (props: CartPageProps) => {
           <ProductRecommendationList recommendations={productRecommendations} />
         )}
       </Space>
+
+      <PageDebugDialog />
     </PageWrapper>
   )
 }

--- a/apps/store/src/components/CartPage/PageDebugDialog.tsx
+++ b/apps/store/src/components/CartPage/PageDebugDialog.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useMemo } from 'react'
+import { Space, Text } from 'ui'
+import { CopyToClipboard } from '@/components/DebugDialog/CopyToClipboard'
+import { DebugDialog } from '@/components/DebugDialog/DebugDialog'
+import { DebugShopSessionSection } from '@/components/DebugDialog/DebugShopSessionSection'
+import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { PageLink } from '@/utils/PageLink'
+
+export const PageDebugDialog = () => {
+  return (
+    <DebugDialog>
+      <Space y={1}>
+        <DebugShopSessionSection />
+        <LinkToCartSection />
+      </Space>
+    </DebugDialog>
+  )
+}
+
+const LinkToCartSection = () => {
+  const { shopSession } = useShopSession()
+  const { routingLocale } = useCurrentLocale()
+  const cartLink = useMemo(() => {
+    if (!shopSession) return null
+
+    return PageLink.session({
+      locale: routingLocale,
+      shopSessionId: shopSession.id,
+      next: PageLink.cart({ locale: routingLocale }),
+    })
+  }, [shopSession, routingLocale])
+
+  return (
+    <Space y={0.25}>
+      <Text as="p" size="sm">
+        Share link to cart
+      </Text>
+      <CopyToClipboard>{cartLink ?? ''}</CopyToClipboard>
+    </Space>
+  )
+}

--- a/apps/store/src/components/DebugDialog/CopyToClipboard.tsx
+++ b/apps/store/src/components/DebugDialog/CopyToClipboard.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import styled from '@emotion/styled'
+import { useEffect, useState } from 'react'
+import { CheckIcon, Text, theme } from 'ui'
+import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
+
+export const CopyToClipboard = (props: { children: string }) => {
+  const [copied, setCopied] = useState(false)
+
+  const copy = () => {
+    navigator.clipboard.writeText(props.children)
+    setCopied(true)
+  }
+
+  useEffect(() => {
+    if (copied) {
+      const timeout = setTimeout(() => {
+        setCopied(false)
+      }, 5000)
+
+      return () => clearTimeout(timeout)
+    }
+  }, [copied])
+
+  return (
+    <CopyToClipboardWrapper>
+      <Elipsis as="p" size="sm">
+        {props.children}
+      </Elipsis>
+      <CopyToClipboardButton onClick={copy}>
+        {copied ? (
+          <SpaceFlex align="center" space={0.5}>
+            <CheckIcon size="1em" />
+            Copied
+          </SpaceFlex>
+        ) : (
+          'Copy'
+        )}
+      </CopyToClipboardButton>
+    </CopyToClipboardWrapper>
+  )
+}
+
+const CopyToClipboardWrapper = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: theme.space.lg,
+
+  backgroundColor: theme.colors.gray100,
+  padding: theme.space.xs,
+  borderRadius: theme.radius.xs,
+  border: `1px solid ${theme.colors.gray300}`,
+
+  '@media (hover: hover)': {
+    '&:hover': {
+      backgroundColor: theme.colors.gray200,
+    },
+  },
+})
+
+const Elipsis = styled(Text)({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
+const CopyToClipboardButton = styled.button({
+  cursor: 'pointer',
+  flexShrink: 0,
+})

--- a/apps/store/src/components/DebugDialog/DebugDialog.tsx
+++ b/apps/store/src/components/DebugDialog/DebugDialog.tsx
@@ -1,16 +1,18 @@
-import styled from '@emotion/styled'
-import { useEffect, useState } from 'react'
-import { CheckIcon, Dialog, Space, Text, theme } from 'ui'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
-import { SpaceFlex } from '../SpaceFlex/SpaceFlex'
+'use client'
 
-export const DebugDialog = () => {
+import { datadogRum } from '@datadog/browser-rum'
+import styled from '@emotion/styled'
+import { type ReactNode, useEffect, useState } from 'react'
+import { Dialog, mq, theme } from 'ui'
+
+export const DebugDialog = (props: { children: ReactNode }) => {
   const [isOpen, setOpen] = useState(false)
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       const ctrl = event.getModifierState('Control')
       if (ctrl && event.key === 'd') {
+        datadogRum.addAction('open debug-dialog')
         setOpen(true)
       }
     }
@@ -22,9 +24,7 @@ export const DebugDialog = () => {
   return (
     <Dialog.Root open={isOpen} onOpenChange={setOpen}>
       <DialogContent onClose={() => setOpen(false)}>
-        <DialogWindow>
-          <ShopSessionSection />
-        </DialogWindow>
+        <DialogWindow>{props.children}</DialogWindow>
       </DialogContent>
     </Dialog.Root>
   )
@@ -43,75 +43,8 @@ const DialogWindow = styled(Dialog.Window)({
   borderBottomLeftRadius: theme.radius.sm,
   maxWidth: `calc(100% - ${theme.space.xs} * 2)`,
   marginInline: 'auto',
-})
 
-const ShopSessionSection = () => {
-  const { shopSession } = useShopSession()
-
-  if (!shopSession) return null
-
-  return (
-    <Space y={0.25}>
-      <Text as="p" size="sm">
-        Shop Session
-      </Text>
-      <CopyToClipboard>{shopSession.id}</CopyToClipboard>
-    </Space>
-  )
-}
-
-const CopyToClipboard = (props: { children: string }) => {
-  const [copied, setCopied] = useState(false)
-
-  const copy = () => {
-    navigator.clipboard.writeText(props.children)
-    setCopied(true)
-  }
-
-  return (
-    <CopyToClipboardWrapper>
-      <Elipsis as="p" size="sm">
-        {props.children}
-      </Elipsis>
-      <CopyToClipboardButton onClick={copy}>
-        {copied ? (
-          <SpaceFlex align="center" space={0.5}>
-            <CheckIcon size="1em" />
-            Copied
-          </SpaceFlex>
-        ) : (
-          'Copy'
-        )}
-      </CopyToClipboardButton>
-    </CopyToClipboardWrapper>
-  )
-}
-
-const CopyToClipboardWrapper = styled.div({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: theme.space.lg,
-
-  backgroundColor: theme.colors.gray100,
-  padding: theme.space.xs,
-  borderRadius: theme.radius.xs,
-  border: `1px solid ${theme.colors.gray300}`,
-
-  '@media (hover: hover)': {
-    '&:hover': {
-      backgroundColor: theme.colors.gray200,
-    },
+  [mq.md]: {
+    maxWidth: '40rem',
   },
-})
-
-const Elipsis = styled(Text)({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-})
-
-const CopyToClipboardButton = styled.button({
-  cursor: 'pointer',
-  flexShrink: 0,
 })

--- a/apps/store/src/components/DebugDialog/DebugShopSessionSection.tsx
+++ b/apps/store/src/components/DebugDialog/DebugShopSessionSection.tsx
@@ -1,0 +1,18 @@
+import { Space, Text } from 'ui'
+import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { CopyToClipboard } from './CopyToClipboard'
+
+export const DebugShopSessionSection = () => {
+  const { shopSession } = useShopSession()
+
+  if (!shopSession) return null
+
+  return (
+    <Space y={0.25}>
+      <Text as="p" size="sm">
+        Shop Session
+      </Text>
+      <CopyToClipboard>{shopSession.id}</CopyToClipboard>
+    </Space>
+  )
+}

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -9,7 +9,6 @@ import { Provider as BalancerProvider } from 'react-wrap-balancer'
 import { globalStyles, theme } from 'ui'
 import { AppErrorDialog } from '@/components/AppErrorDialog'
 import { BankIdDialog } from '@/components/BankIdDialog'
-import { DebugDialog } from '@/components/DebugDialog/DebugDialog'
 import { GlobalBanner } from '@/components/GlobalBanner/GlobalBanner'
 import { GlobalLinkStyles } from '@/components/RichText/RichText.styles'
 import { useApollo } from '@/services/apollo/client'
@@ -101,7 +100,6 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
                 <BalancerProvider>
                   <AppErrorProvider>
                     <AppErrorDialog />
-                    <DebugDialog />
                     <GlobalBanner />
                     {getLayout(<Component {...pageProps} className={contentFontClassName} />)}
                   </AppErrorProvider>

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -16,6 +16,16 @@ type ForeverPage = BaseParams & { code: string }
 type CampaignAddRoute = { code: string; next?: string }
 type CheckoutPaymentTrustlyPage = BaseParams & { shopSessionId: string }
 
+type SessionLink = Required<BaseParams> & {
+  shopSessionId: string
+  // Relative URL to redirect to (default: home page)
+  next?: string
+  // Set a campaign code for the session
+  code?: string
+  // Resume the price intent and navigate to the related product page
+  priceIntentId?: string
+}
+
 // We need explicit locale when doing server-side redirects.  On client side NextJs adds it automatically
 const localePrefix = (locale?: RoutingLocale) => (locale ? `/${locale}` : '')
 
@@ -78,6 +88,22 @@ export const PageLink = {
   apiCampaign: ({ code, next }: CampaignAddRoute) => {
     const nextQueryParam = next ? `?next=${next}` : ''
     return `/api/campaign/${code}${nextQueryParam}`
+  },
+
+  session: (params: SessionLink) => {
+    const url = new URL(`/${params.locale}/session/${params.shopSessionId}`, ORIGIN_URL)
+
+    if (params.code) {
+      url.searchParams.set('code', params.code)
+    }
+
+    if (params.priceIntentId) {
+      url.searchParams.set('price_intent_id', params.priceIntentId)
+    } else if (params.next) {
+      url.searchParams.set('next', params.next)
+    }
+
+    return url.toString()
   },
 } as const
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-07-14 at 11.14.11.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/90c7c204-cb77-4cd0-b81b-7f39dea6964d/Screenshot%202023-07-14%20at%2011.14.11.png)


- Implement debug dialog on cart page

- Add section for sharing a link to the cart (and session)

- Remove global debug dialog instance in favor of page specific instances

- Refactor debug dialog to be more composable

- Add session link helper to `PageLink`

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We want to help inbound/outbound support teams to generate offers and share link to the cart

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
