### PR TITLE
Redirect Car cancellation from WebOnboarding to Hedvig.com

### DIFF
--- a/apps/store/next.config.js
+++ b/apps/store/next.config.js
@@ -124,6 +124,13 @@ module.exports = withBundleAnalyzer({
               destination: '/api/campaign/:code?code=&next=/se/forsakringar',
               locale: false,
             },
+            {
+              source: '/se/new-member/initiate-car-cancellation',
+              has: [{ type: 'query', key: 'contractId' }],
+              destination: '/se/cancellation/car/initiate/:contractId',
+              permanent: true,
+              locale: false,
+            },
           ]
         : []
     return [...shutDownMarketsInfo, ...oldSiteCampaigns]


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add redirects for old car cancellation page to the new one

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- No one should be able to access the old page but we still see some traffic on it so let's make sure people end up on the new page

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
