### PR TITLE
GEN-670 - fix: change ssn warning dialog glitch

### DIFF
--- a/apps/store/src/components/ChangeSsnWarningDialog/ChangeSsnWarningDialog.tsx
+++ b/apps/store/src/components/ChangeSsnWarningDialog/ChangeSsnWarningDialog.tsx
@@ -24,11 +24,7 @@ export const ChangeSsnWarningDialog = ({ open, onAccept, onDecline }: Props) => 
     await resetShopSession()
 
     if (onAccept) {
-      if (onAccept instanceof Promise) {
-        await onAccept()
-      } else {
-        onAccept()
-      }
+      await onAccept()
     }
 
     setLoading(false)

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorAccordion.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorAccordion.tsx
@@ -1,7 +1,11 @@
-import { ReactNode } from 'react'
+import { datadogRum } from '@datadog/browser-rum'
+import { useRouter } from 'next/router'
+import { type ReactNode, useCallback, useState } from 'react'
 import { SsnSeSection } from '@/components/PriceCalculator/SsnSeSection'
+import { OPEN_PRICE_CALCULATOR_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam'
 import { Form, FormSection } from '@/services/PriceCalculator/PriceCalculator.types'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
+import { ChangeSsnWarningDialog } from '../ChangeSsnWarningDialog/ChangeSsnWarningDialog'
 import * as Accordion from './Accordion'
 import { PriceCalculatorAccordionSection } from './PriceCalculatorAccordionSection'
 import { useTranslateFieldLabel } from './useTranslateFieldLabel'
@@ -14,51 +18,94 @@ type Props = {
   onActiveSectionChange: (sectionId: string) => void
 }
 
-export const PriceCalculatorAccordion = (props: Props) => {
-  const { form, children, activeSectionId, onActiveSectionChange } = props
+export const PriceCalculatorAccordion = ({
+  form,
+  children,
+  activeSectionId,
+  onActiveSectionChange,
+  shopSession,
+}: Props) => {
+  const router = useRouter()
   const translateLabel = useTranslateFieldLabel()
+  const [showChangeSsnDialog, setShowChangeSsnDialog] = useState(false)
 
-  const handleSsnSectionCompleted = () => {
+  const handleActiveSectionChange = useCallback(
+    (sectionId: string) => {
+      if (sectionId === SsnSeSection.sectionId && shopSession.customer?.ssn) {
+        setShowChangeSsnDialog(true)
+      } else {
+        onActiveSectionChange(sectionId)
+      }
+    },
+    [onActiveSectionChange, shopSession.customer?.ssn],
+  )
+
+  const handleSsnSectionCompleted = useCallback(() => {
     const nextSectionIndex =
       form.sections.findIndex((section) => section.id === SsnSeSection.sectionId) + 1
     if (!form.sections[nextSectionIndex]) {
       throw new Error(`Failed to find section after ${SsnSeSection.sectionId}`)
     }
     onActiveSectionChange(form.sections[nextSectionIndex].id)
-  }
+  }, [form.sections, onActiveSectionChange])
+
+  const handleAcceptChangeSsn = useCallback(async () => {
+    datadogRum.addAction('Cleared shopSession to change SSN in price calculator', {
+      shopSessionId: shopSession.id,
+    })
+
+    const url = new URL(window.location.href)
+    if (!url.searchParams.has(OPEN_PRICE_CALCULATOR_QUERY_PARAM)) {
+      url.searchParams.append(OPEN_PRICE_CALCULATOR_QUERY_PARAM, '1')
+    }
+
+    await router.replace(url)
+    setShowChangeSsnDialog(false)
+  }, [shopSession, router])
+
+  const handleDeclineChangeSsn = useCallback(() => {
+    setShowChangeSsnDialog(false)
+  }, [])
 
   return (
-    <Accordion.Root
-      type="single"
-      value={activeSectionId}
-      onValueChange={onActiveSectionChange}
-      collapsible={true}
-    >
-      {form.sections.map((section, index) => {
-        let content
-        if (section.id === SsnSeSection.sectionId) {
-          content = (
-            <SsnSeSection shopSession={props.shopSession} onCompleted={handleSsnSectionCompleted} />
-          )
-        } else {
-          content = children(section, index)
-        }
+    <>
+      <Accordion.Root
+        type="single"
+        value={activeSectionId}
+        onValueChange={handleActiveSectionChange}
+        collapsible={true}
+      >
+        {form.sections.map((section, index) => {
+          let content
+          if (section.id === SsnSeSection.sectionId) {
+            content = (
+              <SsnSeSection shopSession={shopSession} onCompleted={handleSsnSectionCompleted} />
+            )
+          } else {
+            content = children(section, index)
+          }
 
-        return (
-          <PriceCalculatorAccordionSection
-            key={section.id}
-            active={section.id === activeSectionId}
-            valid={section.state === 'valid'}
-            title={translateLabel(section.title)}
-            value={section.id}
-            previewFieldName={section.preview?.fieldName}
-            previewLabel={section.preview?.label}
-            items={section.items}
-          >
-            {content}
-          </PriceCalculatorAccordionSection>
-        )
-      })}
-    </Accordion.Root>
+          return (
+            <PriceCalculatorAccordionSection
+              key={section.id}
+              active={section.id === activeSectionId}
+              valid={section.state === 'valid'}
+              title={translateLabel(section.title)}
+              value={section.id}
+              previewFieldName={section.preview?.fieldName}
+              previewLabel={section.preview?.label}
+              items={section.items}
+            >
+              {content}
+            </PriceCalculatorAccordionSection>
+          )
+        })}
+      </Accordion.Root>
+      <ChangeSsnWarningDialog
+        open={showChangeSsnDialog}
+        onAccept={handleAcceptChangeSsn}
+        onDecline={handleDeclineChangeSsn}
+      />
+    </>
   )
 }

--- a/apps/store/src/components/PriceCalculator/SsnSeSection.tsx
+++ b/apps/store/src/components/PriceCalculator/SsnSeSection.tsx
@@ -1,11 +1,8 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { useTranslation } from 'next-i18next'
-import { useRouter } from 'next/router'
-import { FormEventHandler, useCallback } from 'react'
+import { type FormEventHandler } from 'react'
 import { Button, Space } from 'ui'
-import { ChangeSsnWarningDialog } from '@/components/ChangeSsnWarningDialog/ChangeSsnWarningDialog'
 import { PersonalNumberField } from '@/components/PersonalNumberField/PersonalNumberField'
-import { OPEN_PRICE_CALCULATOR_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam'
 import {
   ShopSessionAuthenticationStatus,
   useShopSessionCustomerUpdateMutation,
@@ -16,33 +13,9 @@ import { useErrorMessage } from '@/utils/useErrorMessage'
 
 const SsnFieldName = 'ssn'
 
-type Props = {
-  shopSession: ShopSession
-  onCompleted: () => void
-}
+type Props = { shopSession: ShopSession; onCompleted: () => void }
 
-// States
-// - Empty or auth required => Sign in offered
-// - Member authenticated => Warning to reset session in order to edit
 export const SsnSeSection = ({ shopSession, onCompleted }: Props) => {
-  const router = useRouter()
-
-  const handleChangeSsn = useCallback(async () => {
-    datadogLogs.logger.info('Cleared shopSession to change SSN in price calculator')
-
-    const url = new URL(window.location.href)
-    url.searchParams.append(OPEN_PRICE_CALCULATOR_QUERY_PARAM, '1')
-    await router.replace(url)
-  }, [router])
-
-  if (shopSession.customer?.ssn) {
-    return <ChangeSsnWarningDialog open={true} onAccept={handleChangeSsn} onDecline={onCompleted} />
-  } else {
-    return <SsnInputSection shopSession={shopSession} onCompleted={onCompleted} />
-  }
-}
-
-const SsnInputSection = ({ shopSession, onCompleted }: Props) => {
   const { t } = useTranslation('purchase-form')
   const { showLoginPrompt } = useBankIdContext()
   const [updateCustomer, result] = useShopSessionCustomerUpdateMutation({
@@ -74,24 +47,24 @@ const SsnInputSection = ({ shopSession, onCompleted }: Props) => {
   }
 
   const errorMessage = useErrorMessage(result.error)
+
   return (
-    <>
-      <form onSubmit={handleSubmit}>
-        <Space y={errorMessage ? 1 : 0.25}>
-          <PersonalNumberField
-            label={t('FIELD_SSN_SE_LABEL')}
-            name={SsnFieldName}
-            defaultValue={shopSession.customer?.ssn ?? ''}
-            required={true}
-            warning={!!errorMessage}
-            message={errorMessage}
-          />
-          <Button type="submit" loading={result.loading}>
-            {t('SUBMIT_LABEL_PROCEED')}
-          </Button>
-        </Space>
-      </form>
-    </>
+    <form onSubmit={handleSubmit}>
+      <Space y={errorMessage ? 1 : 0.25}>
+        <PersonalNumberField
+          label={t('FIELD_SSN_SE_LABEL')}
+          name={SsnFieldName}
+          defaultValue={shopSession.customer?.ssn ?? ''}
+          required={true}
+          warning={!!errorMessage}
+          message={errorMessage}
+        />
+        <Button type="submit" loading={result.loading}>
+          {t('SUBMIT_LABEL_PROCEED')}
+        </Button>
+      </Space>
+    </form>
   )
 }
+
 SsnSeSection.sectionId = 'ssn-se'


### PR DESCRIPTION
## Describe your changes

* Updates condition for the appearance of `ChangeSsnWarningDialog`

## Justify why they are needed

As it can be seen in the video below, the _glitch_ happens because `ChangeSsnWarningDialog` get's shown for a brief moment when we load information for an _authenticated user_. In those situations we need to display BankId Dialog but `ChangeSsnWarningDialog` also get's show because:

*  `ChangeSsnWarningDialog` appearance is based on the [presence of `shopsSession.customer?.ssn`](https://github.com/HedvigInsurance/racoon/blob/main/apps/store/src/components/PriceCalculator/SsnSeSection.tsx#L38).
* In that scenario the active section is still _ssn_; It will be the next one only when Bankid Dialog get's resolved, which makes sense I think. That also means `SsnSeSection` will be re-rendered but this time `shopsSession.customer` will be present - causing the appearance of `ChangeSsnWarningDialog`.;

I think what we want in this case is a more imperative solution where we get to decide when to show`ChangeSsnWarningDialog` - when "Edit" button get's clicked and we already have a loaded customer. 
 
https://github.com/HedvigInsurance/racoon/assets/19200662/276850c6-c6b6-40e4-8fcf-0f44dd09bfee

