### PR TITLE
GEN-670 - styles(ChangeSsnWarningDialog): smooth transition

### DIFF
--- a/apps/store/src/components/BankIdDialog.tsx
+++ b/apps/store/src/components/BankIdDialog.tsx
@@ -1,6 +1,6 @@
 import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
-import { AnimatePresence, motion, Target, TargetAndTransition, Transition } from 'framer-motion'
+import { motion, Transition } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
 import { ReactElement } from 'react'
 import { BankIdIcon, Button, CheckIcon, Text, theme, WarningTriangleIcon } from 'ui'
@@ -132,18 +132,26 @@ export const BankIdDialog = () => {
 
   return (
     <FullscreenDialog.Root open={isOpen} onOpenChange={handleOpenChange}>
-      <FullscreenDialog.Modal Footer={footer} center={true}>
-        <AnimatePresence>
+      <FullscreenDialog.Modal
+        Footer={
           <motion.div
-            key={animationState}
-            initial={ANIMATE_INITIAL}
-            animate={ANIMATE_ANIMATE}
-            exit={ANIMATE_EXIT}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
             transition={ANIMATE_TRANSITION}
           >
-            {content}
+            {footer}
           </motion.div>
-        </AnimatePresence>
+        }
+        center={true}
+      >
+        <motion.div
+          key={animationState}
+          initial={{ opacity: 0, y: 40 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={ANIMATE_TRANSITION}
+        >
+          {content}
+        </motion.div>
       </FullscreenDialog.Modal>
     </FullscreenDialog.Root>
   )
@@ -163,11 +171,8 @@ const pulseAnimation = keyframes({
 })
 const Pulsating = styled.div({ animation: `${pulseAnimation} 2s ease-in-out infinite` })
 
-const ANIMATE_TRANSITION: Transition = { duration: 0.6, ...theme.transitions.framer.easeInOutCubic }
-const ANIMATE_INITIAL: Target = { opacity: 0, y: 40 }
-const ANIMATE_ANIMATE: TargetAndTransition = {
-  opacity: 1,
-  y: 0,
-  transition: { delay: 0.3, ...ANIMATE_TRANSITION },
+const ANIMATE_TRANSITION: Transition = {
+  duration: 0.6,
+  delay: 0.3,
+  ...theme.transitions.framer.easeInOutCubic,
 }
-const ANIMATE_EXIT: TargetAndTransition = { opacity: 0, y: -40 }

--- a/apps/store/src/components/ChangeSsnWarningDialog/ChangeSsnWarningDialog.tsx
+++ b/apps/store/src/components/ChangeSsnWarningDialog/ChangeSsnWarningDialog.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { motion, type Transition } from 'framer-motion'
 import { useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button, Text, WarningTriangleIcon, theme } from 'ui'
@@ -35,23 +36,39 @@ export const ChangeSsnWarningDialog = ({ open, onAccept, onDecline }: Props) => 
       <FullscreenDialog.Modal
         center={true}
         Footer={
-          <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={ANIMATE_TRANSITION}
+          >
             <Button loading={loading} onClick={handleAccept}>
               {t('CHANGE_SSN_BUTTON')}
             </Button>
             <Button variant="ghost" onClick={onDecline}>
               {t('DIALOG_BUTTON_CANCEL', { ns: 'common' })}
             </Button>
-          </>
+          </motion.div>
         }
       >
-        <IconWithText>
-          <WarningTriangleIcon size="1em" color={theme.colors.amber600} />
-          <Text align="center">{t('CHANGE_SSN_TITLE')}</Text>
-        </IconWithText>
-        <Text color="textSecondary" align="center">
-          {t('CHANGE_SSN_DESCRIPTION')}
-        </Text>
+        <motion.div
+          initial={{
+            opacity: 0,
+            y: '20%',
+          }}
+          animate={{
+            opacity: 1,
+            y: 0,
+          }}
+          transition={ANIMATE_TRANSITION}
+        >
+          <IconWithText>
+            <WarningTriangleIcon size="1em" color={theme.colors.amber600} />
+            <Text align="center">{t('CHANGE_SSN_TITLE')}</Text>
+          </IconWithText>
+          <Text color="textSecondary" align="center">
+            {t('CHANGE_SSN_DESCRIPTION')}
+          </Text>
+        </motion.div>
       </FullscreenDialog.Modal>
     </FullscreenDialog.Root>
   )
@@ -63,3 +80,9 @@ const IconWithText = styled(Text)({
   justifyContent: 'center',
   alignItems: 'center',
 })
+
+const ANIMATE_TRANSITION: Transition = {
+  duration: 0.6,
+  delay: 0.3,
+  ...theme.transitions.framer.easeInOutCubic,
+}

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -25,7 +25,7 @@ const StyledOverlay = styled(DialogPrimitive.Overlay, {
   position: 'fixed',
   inset: 0,
   '@media (prefers-reduced-motion: no-preference)': {
-    animation: `${overlayShow} 150ms cubic-bezier(0.16, 1, 0.3, 1) forwards`,
+    animation: `${overlayShow} 500ms cubic-bezier(0.16, 1, 0.3, 1) forwards`,
   },
 
   ...(frosted && {


### PR DESCRIPTION
Disclaimer: William is not here to validate. I guess it's personal preference then 🤷🏻 

## Describe your changes

* Updates Dialog overlay transition by making it slower. It was too fast before. 
* Add transition for `ChangeSsnWarningDialog`
* Update `BankIdDialog` transition so they match and refactored a little. `AnimationPresence` animations doesn't in that case so I guess we can simplify it?! Let me know what you think.

https://github.com/HedvigInsurance/racoon/assets/19200662/cf252b4e-3696-4c7b-95ab-a8cb84a8c950

https://github.com/HedvigInsurance/racoon/assets/19200662/3c29adce-3ec1-49db-ba9f-81ff0777c940

## Justify why they are needed

It was requested by design that we make `ChangeSsnWarningDialog` by applying a smoother transition to it.