### PR TITLE
Fix bug: showing auto switch when option is NONE

### DIFF
--- a/apps/store/src/components/CartInventory/CartInventory.helpers.tsx
+++ b/apps/store/src/components/CartInventory/CartInventory.helpers.tsx
@@ -53,9 +53,11 @@ export const getCrossOut = (shopSession: ShopSession) => {
 }
 
 export const getCartEntry = (item: ShopSession['cart']['entries'][number]): CartEntry => {
-  const invalidRenewalDate =
-    item.cancellation.option === ExternalInsuranceCancellationOption.BanksigneringInvalidRenewalDate
-  const hasCancellation = item.cancellation.requested && !invalidRenewalDate
+  const isInvalidOption = [
+    ExternalInsuranceCancellationOption.BanksigneringInvalidRenewalDate,
+    ExternalInsuranceCancellationOption.None,
+  ].includes(item.cancellation.option)
+  const hasCancellation = !isInvalidOption && item.cancellation.requested
 
   return {
     offerId: item.id,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

![Screenshot 2023-07-18 at 17.32.12.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/4656b676-930e-4d0a-ab10-0d9ee2365fc1/Screenshot%202023-07-18%20at%2017.32.12.png)

Don't show "automatic switch" message when cancellation option is "NONE"

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

But discovered by Sonny

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
