### PR TITLE
GEN-792 | Switch from `Cart.redeemedCampaigns` -> `Cart.redeemedCampaign`

### DIFF
--- a/apps/store/src/components/CartInventory/CartInventory.helpers.tsx
+++ b/apps/store/src/components/CartInventory/CartInventory.helpers.tsx
@@ -33,11 +33,8 @@ export const useGetDiscountDurationExplanation = () => {
 }
 
 export const getTotal = (shopSession: ShopSession) => {
-  const hasDiscount = shopSession.cart.redeemedCampaigns.length !== 0
-
-  if (!hasDiscount) return shopSession.cart.cost.net
-  // Only expecting one discount right now. Going forward we'd need to make this work for multi discounts.
-  switch (shopSession.cart.redeemedCampaigns[0].discount.type) {
+  if (!shopSession.cart.redeemedCampaign) return shopSession.cart.cost.net
+  switch (shopSession.cart.redeemedCampaign.discount.type) {
     case CampaignDiscountType.FreeMonths:
       return shopSession.cart.cost.discount
     default:

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -102,7 +102,7 @@ export const OfferPresenter = (props: Props) => {
 
   const discountTooltipProps = useDiscountTooltipProps(
     selectedOffer,
-    shopSession.cart.redeemedCampaigns,
+    shopSession.cart.redeemedCampaign ?? undefined,
   )
 
   const displayPrice = formatter.monthlyPrice(selectedOffer.cost.net)
@@ -282,7 +282,7 @@ type GetCancellationOptionParams = {
 
 const useDiscountTooltipProps = (
   selectedOffer: ProductOfferFragment,
-  redeemedCampaigns?: Array<RedeemedCampaign>,
+  campaign?: RedeemedCampaign,
 ) => {
   const { t } = useTranslation(['purchase-form', 'cart'])
   const formatter = useFormatter()
@@ -311,11 +311,10 @@ const useDiscountTooltipProps = (
       } as const
     }
 
-    const redeemedCampaign = redeemedCampaigns?.[0]
-    if (redeemedCampaign && selectedOffer.cost.discount.amount > 0) {
+    if (campaign && selectedOffer.cost.discount.amount > 0) {
       return {
         children: getDiscountExplanation({
-          ...redeemedCampaign.discount,
+          ...campaign.discount,
           amount: selectedOffer.cost.discount,
         }),
         subtitle: t('DISCOUNT_PRICE_AFTER_EXPIRATION', {
@@ -325,7 +324,7 @@ const useDiscountTooltipProps = (
         color: 'green',
       } as const
     }
-  }, [t, formatter, getDiscountExplanation, selectedOffer, redeemedCampaigns])
+  }, [t, formatter, getDiscountExplanation, selectedOffer, campaign])
 
   return tooltipProps
 }

--- a/apps/store/src/graphql/CartFragment.graphql
+++ b/apps/store/src/graphql/CartFragment.graphql
@@ -15,7 +15,7 @@ fragment CartFragment on Cart {
       currencyCode
     }
   }
-  redeemedCampaigns {
+  redeemedCampaign {
     id
     code
     discount {

--- a/apps/store/src/pages/cart/index.tsx
+++ b/apps/store/src/pages/cart/index.tsx
@@ -24,15 +24,21 @@ const NextCartPage: NextPageWithLayout = (props) => {
     () => shopSession?.cart.entries.map(getCartEntry),
     [shopSession?.cart.entries],
   )
-  const campaigns = shopSession?.cart.redeemedCampaigns.map((item) => ({
-    id: item.id,
-    code: item.code,
-    discountExplanation: getDiscountExplanation(item.discount),
-    discountDurationExplanation: getDiscountDurationExplanation(
-      shopSession.cart.redeemedCampaigns[0].discount,
-      shopSession.cart.cost.gross,
-    ),
-  }))
+
+  const campaign = shopSession?.cart.redeemedCampaign
+  const campaigns = campaign
+    ? [
+        {
+          id: campaign.id,
+          code: campaign.code,
+          discountExplanation: getDiscountExplanation(campaign.discount),
+          discountDurationExplanation: getDiscountDurationExplanation(
+            campaign.discount,
+            shopSession.cart.cost.gross,
+          ),
+        },
+      ]
+    : []
 
   const cost = shopSession
     ? {

--- a/apps/store/src/pages/checkout/index.tsx
+++ b/apps/store/src/pages/checkout/index.tsx
@@ -40,6 +40,7 @@ const NextCheckoutPage: NextPage<NextPageProps> = (props) => {
 
   const { authenticationStatus } = shopSession.customer
 
+  const campaign = shopSession.cart.redeemedCampaign
   const cart = {
     id: shopSession.cart.id,
     cost: {
@@ -49,15 +50,19 @@ const NextCheckoutPage: NextPage<NextPageProps> = (props) => {
     entries,
     campaigns: {
       enabled: shopSession.cart.campaignsEnabled,
-      list: shopSession.cart.redeemedCampaigns.map((item) => ({
-        id: item.id,
-        code: item.code,
-        discountExplanation: getDiscountExplanation(item.discount),
-        discountDurationExplanation: getDiscountDurationExplanation(
-          shopSession.cart.redeemedCampaigns[0].discount,
-          shopSession.cart.cost.gross,
-        ),
-      })),
+      list: campaign
+        ? [
+            {
+              id: campaign.id,
+              code: campaign.code,
+              discountExplanation: getDiscountExplanation(campaign.discount),
+              discountDurationExplanation: getDiscountDurationExplanation(
+                campaign.discount,
+                shopSession.cart.cost.gross,
+              ),
+            },
+          ]
+        : [],
     },
   } satisfies CheckoutPageProps['cart']
 

--- a/apps/store/src/services/Tracking/Tracking.ts
+++ b/apps/store/src/services/Tracking/Tracking.ts
@@ -187,7 +187,7 @@ export class Tracking {
     const event = TrackingEvent.Adtraction
     const customer = context.customer as ShopSession['customer']
     // We currently only support 1 campaign code
-    const campaignCode = cart.redeemedCampaigns[0]?.code
+    const campaignCode = cart.redeemedCampaign?.code
     const email = customer?.email
     const productCategories = getAdtractionProductCategories(cart)
     const eventData = {

--- a/apps/store/src/utils/useDiscountBanner.ts
+++ b/apps/store/src/utils/useDiscountBanner.ts
@@ -8,11 +8,10 @@ export const useDiscountBanner = () => {
   const { shopSession } = useShopSession()
   const { banner, addBanner } = useGlobalBanner()
 
-  const hasDiscount = !!shopSession?.cart.redeemedCampaigns.length
-
+  const campaign = shopSession?.cart.redeemedCampaign
   useEffect(() => {
-    if (hasDiscount && banner === null) {
+    if (campaign && banner === null) {
       addBanner(t('GLOBAL_BANNER_CAMPAIGN'), 'campaign')
     }
-  }, [hasDiscount, banner, addBanner, t])
+  }, [campaign, banner, addBanner, t])
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Switch from using `Cart.redeemedCampaigns` field (deprecated) to `Cart.redeemedCampaign` (new field)

- Update related parsing logic

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We parse this field in a lot of places, I think I will refactor it in a future PR

- I decided to keep some of the old logic related to lists of campaigns, but I think we should remove it in a future PR

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
