### PR TITLE
NO/DK: redirect all traffic from /new-member to shutdown info page

### DIFF
--- a/apps/store/next.config.js
+++ b/apps/store/next.config.js
@@ -98,13 +98,7 @@ module.exports = withBundleAnalyzer({
     const locales = ['no', 'no-en', 'dk', 'dk-en']
     const shutDownMarketsInfo = [
       ...locales.map((locale) => ({
-        source: `/${locale}/new-member`,
-        destination: `/${locale}/info`,
-        permanent: true,
-        locale: false,
-      })),
-      ...locales.map((locale) => ({
-        source: `/${locale}/new-member/offer/:slug*`,
+        source: `/${locale}/new-member/:path*`,
         destination: `/${locale}/info`,
         permanent: true,
         locale: false,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Redirect all NO/DK requests to `/new-member` to info page about shut down

- Requires merging: https://github.com/HedvigInsurance/back-office/pull/882

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We still need to support payment connect links but will only support directly using "old.hedvig.com" for that

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
