### PR TITLE
chore: reset selected offer when a new price intent is created

### DIFF
--- a/apps/store/src/components/ProductPage/PriceIntentContext.tsx
+++ b/apps/store/src/components/ProductPage/PriceIntentContext.tsx
@@ -102,9 +102,10 @@ const usePriceIntentContextValue = () => {
   const createNewPriceIntent = useCallback(
     async (shopSession: ShopSession) => {
       priceIntentServiceInitClientSide(apolloClient).clear(priceTemplate.name, shopSession.id)
-      return updatePriceIntent(shopSession)
+      await updatePriceIntent(shopSession)
+      setSelectedOffer(null)
     },
-    [apolloClient, priceTemplate.name, updatePriceIntent],
+    [apolloClient, priceTemplate.name, updatePriceIntent, setSelectedOffer],
   )
 
   const router = useRouter()

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -47,8 +47,8 @@ type Props = {
 }
 
 export const OfferPresenter = (props: Props) => {
-  const { priceIntent, shopSession, scrollPastRef, onAddedToCart, onClickEdit } = props
-  const { selectedOffer } = props
+  const { priceIntent, shopSession, scrollPastRef, onAddedToCart, onClickEdit, selectedOffer } =
+    props
   const [, setSelectedOffer] = useSelectedOffer()
   const { t } = useTranslation('purchase-form')
   const formatter = useFormatter()


### PR DESCRIPTION
## Describe your changes

* Reset `selectedOffer` when a new price intent is created.

## Justify why they are needed

We're getting the following warning while adding products into the cart:

<img width="790" alt="Screenshot 2023-07-21 at 10 27 05" src="https://github.com/HedvigInsurance/racoon/assets/19200662/215b7ce2-4749-40be-9d98-0860cca151fa">

Removing those warnings will help clean our logs a little.