### PR TITLE
Add landing page before starting payment connect legacy flow

### DIFF
--- a/apps/store/src/pages/api/auth/exchange/[code].ts
+++ b/apps/store/src/pages/api/auth/exchange/[code].ts
@@ -18,7 +18,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   if (url === undefined) {
     console.error('Missing url: ', url)
-    return res.redirect(...fallbackRedirect)
+    res.redirect(...fallbackRedirect)
+    return
   }
 
   const nextUrl = new URL(url, ORIGIN_URL)
@@ -26,7 +27,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const nextQueryParam = nextUrl.searchParams.get(QueryParam.Next)
   if (!nextQueryParam) {
     console.error('Missing next query parameter: ', url)
-    return res.redirect(...fallbackRedirect)
+    res.redirect(...fallbackRedirect)
+    return
   }
   nextUrl.searchParams.delete(QueryParam.Next)
   nextUrl.pathname = nextQueryParam
@@ -49,7 +51,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   console.log(`Re-directing to destination: ${redirectUrl}`)
-  return res.redirect(redirectStatus, redirectUrl)
+  res.redirect(redirectStatus, redirectUrl)
 }
 
 export default handler

--- a/apps/store/src/pages/payment/connect-legacy/start.tsx
+++ b/apps/store/src/pages/payment/connect-legacy/start.tsx
@@ -1,0 +1,52 @@
+import { type GetServerSideProps } from 'next'
+import { Button } from 'ui'
+import { Layout } from '@/components/PaymentConnectPage/Layout'
+import { useAdyenTranslations } from '@/services/adyen/useAdyenTranslations'
+import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { PageLink } from '@/utils/PageLink'
+
+type Props = {
+  authorizationCode: string
+}
+
+const Page = (props: Props) => {
+  const { routingLocale: locale } = useCurrentLocale()
+  const { title, startButton } = useAdyenTranslations()
+
+  const nextUrl = PageLink.paymentConnectLegacy({ locale })
+  const authUrl = PageLink.apiAuthExchange({
+    authorizationCode: props.authorizationCode,
+    next: nextUrl,
+  })
+
+  return (
+    <Layout title={title}>
+      <form method="POST" action={authUrl}>
+        <Button type="submit">{startButton}</Button>
+      </form>
+    </Layout>
+  )
+}
+
+// eslint-disable-next-line @typescript-eslint/require-await -- required by Next.js
+export const getServerSideProps: GetServerSideProps<Props> = async (context) => {
+  if (!isRoutingLocale(context.locale)) {
+    throw new Error(`Payment Connect Legacy Start | Invalid locale: ${context.locale}`)
+  }
+
+  const { authorizationCode } = context.query
+
+  if (typeof authorizationCode !== 'string') {
+    return {
+      redirect: {
+        destination: PageLink.paymentConnectLegacyError({ locale: context.locale }),
+        permanent: false,
+      },
+    }
+  }
+
+  return { props: { authorizationCode } }
+}
+
+export default Page

--- a/apps/store/src/services/adyen/useAdyenTranslations.ts
+++ b/apps/store/src/services/adyen/useAdyenTranslations.ts
@@ -7,6 +7,7 @@ export const useAdyenTranslations = (): {
   success: string
   retry: string
   error: { heading: string; body: string }
+  startButton: string
 } => {
   const { locale } = useCurrentLocale()
 
@@ -22,6 +23,7 @@ export const useAdyenTranslations = (): {
           heading: 'Der opstod en uventet fejl',
           body: 'Prøv venligst igen eller kontakt os i chatten hvis problemet fortsætter.',
         },
+        startButton: 'Tryk her for at begynde',
       }
     case 'nb-NO':
       return {
@@ -34,6 +36,7 @@ export const useAdyenTranslations = (): {
           heading: 'Det oppstod en feil',
           body: 'Vennligst prøv igjen eller gå tilbake. Hvis feilen vedvarer, vennligst kontakt oss i chatten',
         },
+        startButton: 'Trykk her for å begynne',
       }
     default:
       return {
@@ -46,6 +49,7 @@ export const useAdyenTranslations = (): {
           heading: 'Something went wrong',
           body: 'We could not connect your credit card. Please try again.',
         },
+        startButton: 'Press here to begin',
       }
   }
 }

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -15,6 +15,7 @@ type CheckoutPage = BaseParams & { expandCart?: boolean }
 type ForeverPage = BaseParams & { code: string }
 type CampaignAddRoute = { code: string; next?: string }
 type CheckoutPaymentTrustlyPage = BaseParams & { shopSessionId: string }
+type AuthExchangeRoute = { authorizationCode: string; next?: string }
 
 type SessionLink = BaseParams & {
   shopSessionId: string
@@ -117,6 +118,10 @@ export const PageLink = {
     `/${locale}/payment/connect-legacy/success`,
   paymentConnectLegacyError: ({ locale }: Required<BaseParams>) =>
     `/${locale}/payment/connect-legacy/error`,
+  apiAuthExchange: ({ authorizationCode, next }: AuthExchangeRoute) => {
+    const nextQueryParam = next ? `?next=${next}` : ''
+    return `/api/auth/exchange/${authorizationCode}${nextQueryParam}`
+  },
 } as const
 
 const CUSTOMER_SERVICE_URL: Partial<Record<RoutingLocale, string>> = {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add landing page before the payment connect legacy flow

- Fix issue where we return from the API route function


![Screenshot 2023-07-25 at 14.59.14.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/1ba54fd7-e3b3-4e8e-9de7-3a5598431e29/Screenshot%202023-07-25%20at%2014.59.14.png)


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We want the user to be able to load the page without consuming the authorization code accidentally

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
