### PR TITLE
GEN-238 - refact(ConfirmationPage): migrate to ShopSessionOutcome query

### DIFF
--- a/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection.tsx
+++ b/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export const SwitchingAssistantSection = (props: Props) => {
   const { t } = useTranslation('checkout')
-  const switchingContracts = useSwitchingContracts({ shopSessionId: props.shopSessionId })
+  const switchingContracts = useSwitchingContracts({ shopSessionOutcomeId: props.shopSessionId })
 
   return (
     <Space y={{ base: 1.5, lg: 2 }}>

--- a/apps/store/src/components/ConfirmationPage/useSwitchingContracts.ts
+++ b/apps/store/src/components/ConfirmationPage/useSwitchingContracts.ts
@@ -18,11 +18,11 @@ export type BankSigneringContract = {
   approveByDate: string
 }
 
-type Params = { shopSessionId: string }
+type Params = { shopSessionOutcomeId: string }
 
-export const useSwitchingContracts = ({ shopSessionId }: Params) => {
+export const useSwitchingContracts = ({ shopSessionOutcomeId }: Params) => {
   const { data, refetch } = useShopSessionOutcomeQuery({
-    variables: { shopSessionId },
+    variables: { shopSessionOutcomeId },
     pollInterval: 10000,
   })
 
@@ -33,7 +33,7 @@ export const useSwitchingContracts = ({ shopSessionId }: Params) => {
   }, [refetch])
 
   return useMemo<Array<BankSigneringContract>>(() => {
-    const contracts = data?.shopSession.outcome?.createdContracts ?? []
+    const contracts = data?.shopSessionOutcome?.createdContracts ?? []
     const switchingContracts: Array<BankSigneringContract> = []
 
     contracts.forEach((contract) => {
@@ -42,7 +42,7 @@ export const useSwitchingContracts = ({ shopSessionId }: Params) => {
     })
 
     return switchingContracts
-  }, [data?.shopSession.outcome?.createdContracts])
+  }, [data?.shopSessionOutcome?.createdContracts])
 }
 
 export const convertToBankSigneringContract = (

--- a/apps/store/src/graphql/ShopSessionOutcome.graphql
+++ b/apps/store/src/graphql/ShopSessionOutcome.graphql
@@ -1,11 +1,5 @@
-query ShopSessionOutcome($shopSessionId: UUID!) {
-  shopSession(id: $shopSessionId) {
-    id
-    outcome {
-      id
-      createdContracts {
-        ...SwitchingContract
-      }
-    }
+query ShopSessionOutcome($shopSessionOutcomeId: UUID!) {
+  shopSessionOutcome(id: $shopSessionOutcomeId) {
+    ...ShopSessionOutcome
   }
 }

--- a/apps/store/src/graphql/ShopSessionOutcomeFragment.graphql
+++ b/apps/store/src/graphql/ShopSessionOutcomeFragment.graphql
@@ -1,0 +1,6 @@
+fragment ShopSessionOutcome on ShopSessionOutcome {
+  id
+  createdContracts {
+    ...SwitchingContract
+  }
+}

--- a/apps/store/src/graphql/ShopSessionOutcomeId.graphql
+++ b/apps/store/src/graphql/ShopSessionOutcomeId.graphql
@@ -1,0 +1,7 @@
+query ShopSessionOutcomeId($shopSessionId: UUID!) {
+  shopSession(id: $shopSessionId) {
+    outcome {
+      id
+    }
+  }
+}

--- a/apps/store/src/services/shopSession/ShopSessionService.ts
+++ b/apps/store/src/services/shopSession/ShopSessionService.ts
@@ -5,8 +5,12 @@ import {
   ShopSessionCreateMutationVariables,
   ShopSessionDocument,
   ShopSessionOutcomeDocument,
+  ShopSessionOutcomeFragment,
   ShopSessionOutcomeQuery,
   ShopSessionOutcomeQueryVariables,
+  ShopSessionOutcomeIdQuery,
+  ShopSessionOutcomeIdQueryVariables,
+  ShopSessionOutcomeIdDocument,
   ShopSessionQuery,
   ShopSessionQueryVariables,
 } from '@/services/apollo/generated'
@@ -99,16 +103,28 @@ export class ShopSessionService {
     return shopSession
   }
 
+  public async fetchOutcomeId(shopSessionId: string) {
+    const { data } = await this.apolloClient.query<
+      ShopSessionOutcomeIdQuery,
+      ShopSessionOutcomeIdQueryVariables
+    >({
+      query: ShopSessionOutcomeIdDocument,
+      variables: { shopSessionId },
+    })
+
+    return data.shopSession.outcome?.id ?? null
+  }
+
   public async fetchOutcome(
-    shopSessionId: string,
-  ): Promise<ShopSessionOutcomeQuery['shopSession']['outcome']> {
+    shopSessionOutcomeId: string,
+  ): Promise<ShopSessionOutcomeFragment | null> {
     const { data } = await this.apolloClient.query<
       ShopSessionOutcomeQuery,
       ShopSessionOutcomeQueryVariables
     >({
       query: ShopSessionOutcomeDocument,
-      variables: { shopSessionId },
+      variables: { shopSessionOutcomeId },
     })
-    return data.shopSession.outcome
+    return data.shopSessionOutcome ?? null
   }
 }


### PR DESCRIPTION
## Describe your changes

* Updates confirmation page so it relies on `ShopSessionOutcome`.

