### PR TITLE
chore(TextWithLink): prevent warning by passing down to next/Link only known props

### DIFF
--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -108,7 +108,13 @@ const CheckoutPage = (props: CheckoutPageProps) => {
               <Heading as="h1" variant="standard.24" align="center">
                 {t('CHECKOUT_PAGE_HEADING')}
               </Heading>
-              <Heading as="h2" balance color="textSecondary" variant="standard.24" align="center">
+              <Heading
+                as="h2"
+                balance={true}
+                color="textSecondary"
+                variant="standard.24"
+                align="center"
+              >
                 {t('CHECKOUT_PAGE_SUBHEADING')}
               </Heading>
             </Headings>

--- a/apps/store/src/components/TextWithLink.tsx
+++ b/apps/store/src/components/TextWithLink.tsx
@@ -23,7 +23,9 @@ export const TextWithLink = ({ children, ...otherProps }: Props) => {
   return (
     <StyledTextWithLink {...otherProps}>
       {beforeLink}
-      <Link {...otherProps}>{linkText}</Link>
+      <Link href={otherProps.href} target={otherProps.target}>
+        {linkText}
+      </Link>
       {afterLink}
     </StyledTextWithLink>
   )


### PR DESCRIPTION
## Describe your changes

Prevent warning by passing down to next/Link only known props

## Justify why they are needed

We're currently getting this when loading _Checkout_ page.

<img width="779" alt="Screenshot 2023-07-27 at 14 11 43" src="https://github.com/HedvigInsurance/racoon/assets/19200662/68936529-6b32-403d-ae93-d1a5c17d7c26">

