### PR TITLE
Setup Apollo Client in App Router

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "@adyen/adyen-web": "3.23.0",
-    "@apollo/client": "3.7.17",
+    "@apollo/client": "rc",
+    "@apollo/experimental-nextjs-app-support": "0.4.1",
     "@datadog/browser-logs": "4.46.0",
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",

--- a/apps/store/src/app/layout.tsx
+++ b/apps/store/src/app/layout.tsx
@@ -2,18 +2,22 @@
 // next.config.js - { compiler: { emotion: true } }
 /** @jsxImportSource react */
 
+import { type PropsWithChildren } from 'react'
 import { NextAppDirEmotionCacheProvider } from 'tss-react/next/appDir'
+import { ApolloWrapper } from '@/services/apollo/app-router/ApolloWrapper'
 import { contentFontClassName } from '@/utils/fonts'
 
-const Layout = ({ children }: { children: JSX.Element }) => {
+const Layout = ({ children }: PropsWithChildren) => {
   return (
     <html lang="en">
       {/* head-tag needed, even if empty: https://docs.tss-react.dev/ssr/next.js */}
       <head></head>
       <body className={contentFontClassName}>
-        <NextAppDirEmotionCacheProvider options={{ key: 'css' }}>
-          {children}
-        </NextAppDirEmotionCacheProvider>
+        <ApolloWrapper>
+          <NextAppDirEmotionCacheProvider options={{ key: 'css' }}>
+            {children}
+          </NextAppDirEmotionCacheProvider>
+        </ApolloWrapper>
       </body>
     </html>
   )

--- a/apps/store/src/services/apollo/app-router/ApolloWrapper.tsx
+++ b/apps/store/src/services/apollo/app-router/ApolloWrapper.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { ApolloLink } from '@apollo/client'
+import {
+  ApolloNextAppProvider,
+  NextSSRInMemoryCache,
+  NextSSRApolloClient,
+} from '@apollo/experimental-nextjs-app-support/ssr'
+import { type PropsWithChildren } from 'react'
+import { createHeadersLink } from '../createHeadersLink'
+import { errorLink } from '../errorLink'
+import { httpLink } from '../httpLink'
+import { languageLink } from '../languageLink'
+import { userErrorLink } from '../userErrorLink'
+
+const makeClient = () => {
+  const headersLink = createHeadersLink()
+
+  return new NextSSRApolloClient({
+    name: 'Web:Racoon:Store',
+    cache: new NextSSRInMemoryCache(),
+
+    link: ApolloLink.from([
+      // Has to be the first to process output last
+      // We re-raise userError results as errors, we don't want errorLink to see those
+      userErrorLink,
+      errorLink,
+      headersLink,
+      languageLink,
+      httpLink,
+    ]),
+
+    ssrMode: typeof window === 'undefined',
+    connectToDevTools: process.env.NODE_ENV === 'development',
+  })
+}
+
+export const ApolloWrapper = ({ children }: PropsWithChildren) => {
+  return <ApolloNextAppProvider makeClient={makeClient}>{children}</ApolloNextAppProvider>
+}

--- a/apps/store/src/services/apollo/app-router/client.ts
+++ b/apps/store/src/services/apollo/app-router/client.ts
@@ -1,0 +1,23 @@
+import { ApolloClient, ApolloLink, InMemoryCache } from '@apollo/client'
+import { registerApolloClient } from '@apollo/experimental-nextjs-app-support/rsc'
+import { errorLink } from '../errorLink'
+import { httpLink } from '../httpLink'
+import { userErrorLink } from '../userErrorLink'
+import { headersLink } from './headersLink'
+
+export const { getClient } = registerApolloClient(() => {
+  return new ApolloClient({
+    name: 'Web:Racoon:Store',
+
+    link: ApolloLink.from([
+      // Has to be the first to process output last
+      // We re-raise userError results as errors, we don't want errorLink to see those
+      userErrorLink,
+      errorLink,
+      headersLink,
+      httpLink,
+    ]),
+
+    cache: new InMemoryCache(),
+  })
+})

--- a/apps/store/src/services/apollo/app-router/headersLink.ts
+++ b/apps/store/src/services/apollo/app-router/headersLink.ts
@@ -1,0 +1,66 @@
+import { setContext } from '@apollo/client/link/context'
+import jwtDecode, { type JwtPayload } from 'jwt-decode'
+import { headers } from 'next/headers'
+import {
+  getAccessToken,
+  getRefreshToken,
+  resetAuthTokens,
+  saveAuthTokens,
+} from '@/services/authApi/app-router/persist'
+import { refreshAccessToken } from '@/services/authApi/oauth'
+import { getShopSessionId } from '@/services/shopSession/app-router/ShopSession.utils'
+import { getUrlLocale, toIsoLocale } from '@/utils/l10n/localeUtils'
+import { type RoutingLocale } from '@/utils/l10n/types'
+
+export const headersLink = setContext(async (_, prevContext) => {
+  return {
+    ...prevContext,
+    headers: {
+      ...prevContext.headers,
+
+      ...(await performTokenRefreshIfNeeded()),
+      ...getHedvigLanguageHeader(),
+      ...getShopSessionHeader(),
+    },
+  }
+})
+
+const getHedvigLanguageHeader = (): Record<string, string> => {
+  const headerList = headers()
+  const url = headerList.get('x-invoke-path')
+
+  let locale: RoutingLocale = 'se'
+  if (url) {
+    locale = getUrlLocale(url)
+  }
+
+  return { 'Hedvig-Language': toIsoLocale(locale) }
+}
+
+const getShopSessionHeader = (): Record<string, string> | undefined => {
+  const shopSessionId = getShopSessionId()
+  return shopSessionId ? { 'Hedvig-ShopSessionID': shopSessionId } : undefined
+}
+
+const performTokenRefreshIfNeeded = async (): Promise<Record<string, string> | undefined> => {
+  const currentAccessToken = getAccessToken()
+  if (!currentAccessToken) return
+
+  const { exp: expiryInSeconds } = jwtDecode<JwtPayload>(currentAccessToken)
+  const hasExpired = expiryInSeconds && Date.now() >= expiryInSeconds * 1000
+  if (!hasExpired) return { authorization: `Bearer ${currentAccessToken}` }
+
+  const currentRefreshToken = getRefreshToken()
+
+  if (!currentRefreshToken) {
+    console.warn('Token refresh: no refresh token found')
+    resetAuthTokens()
+    return
+  }
+
+  const { accessToken, refreshToken } = await refreshAccessToken(currentRefreshToken)
+
+  saveAuthTokens({ accessToken, refreshToken })
+
+  return { Authorization: `Bearer ${accessToken}` }
+}

--- a/apps/store/src/services/apollo/client.ts
+++ b/apps/store/src/services/apollo/client.ts
@@ -1,94 +1,37 @@
-import {
-  ApolloClient,
-  ApolloError,
-  ApolloLink,
-  createHttpLink,
-  from,
-  InMemoryCache,
-  NormalizedCacheObject,
-} from '@apollo/client'
-import { setContext } from '@apollo/client/link/context'
-import { ErrorResponse, onError } from '@apollo/client/link/error'
+import { ApolloClient, ApolloLink, InMemoryCache, type NormalizedCacheObject } from '@apollo/client'
 import { mergeDeep } from '@apollo/client/utilities'
-import ApolloLinkTimeout from 'apollo-link-timeout'
-import { GetServerSidePropsContext } from 'next'
-import { i18n } from 'next-i18next'
-import { AppInitialProps } from 'next/app'
+import { type GetServerSidePropsContext } from 'next'
+import { type AppInitialProps } from 'next/app'
 import { useMemo } from 'react'
 import { getAuthHeaders } from '@/services/authApi/persist'
 import { isBrowser } from '@/utils/env'
-import { getLocaleOrFallback, toIsoLocale } from '@/utils/l10n/localeUtils'
-import { RoutingLocale } from '@/utils/l10n/types'
+import { toIsoLocale } from '@/utils/l10n/localeUtils'
+import { type RoutingLocale } from '@/utils/l10n/types'
 import { getShopSessionHeader, performTokenRefreshIfNeeded } from './apollo.helpers'
+import { createHeadersLink } from './createHeadersLink'
+import { errorLink } from './errorLink'
+import { httpLink } from './httpLink'
+import { languageLink } from './languageLink'
+import { userErrorLink } from './userErrorLink'
 
 const APOLLO_STATE_PROP_NAME = '__APOLLO_STATE__'
 
 let apolloClient: ApolloClient<NormalizedCacheObject>
 
-const errorLink = onError((error: ErrorResponse) => {
-  if (error.graphQLErrors)
-    error.graphQLErrors.forEach(({ message, locations, path }) =>
-      console.log(`[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`),
-    )
-  if (error.networkError) console.log(`[Network error]: ${error.networkError}`)
-})
-
-const userErrorLink = new ApolloLink((operation, forward) => {
-  return forward(operation).map((fetchResult) => {
-    for (const result of Object.values(fetchResult.data ?? {})) {
-      const { userError } = result ?? {}
-      if (userError) {
-        throw new ApolloError({
-          errorMessage: userError.message,
-          extraInfo: { userError },
-        })
-      }
-    }
-    return fetchResult
-  })
-})
-
-const languageLink = setContext((_, { headers = {}, ...context }) => {
-  if (!isBrowser()) return context
-
-  const locale = getLocaleOrFallback(i18n?.language).routingLocale
-  return {
-    headers: {
-      ...headers,
-      ...getHedvigLanguageHeader(locale),
-    },
-    ...context,
-  }
-})
-
-const TIMEOUT_50_SECONDS = 50 * 1000
-const timeoutLink = new ApolloLinkTimeout(TIMEOUT_50_SECONDS)
-const httpLink = createHttpLink({ uri: process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT })
-const timeoutHttpLink = timeoutLink.concat(httpLink)
-
 const createApolloClient = (defaultHeaders?: Record<string, string>) => {
-  const headersLink = setContext(async (_, prevContext) => {
-    const headers = { ...defaultHeaders }
-    if (isBrowser()) {
-      Object.assign(headers, {
-        ...(await performTokenRefreshIfNeeded()),
-        ...getShopSessionHeader(),
-      })
-    }
-    return { headers, ...prevContext }
-  })
+  const headersLink = createHeadersLink(defaultHeaders)
 
   return new ApolloClient({
     name: 'Web:Racoon:Store',
     ssrMode: typeof window === 'undefined',
-    link: from([
+    link: ApolloLink.from([
       // Has to be the first to process output last
       // We re-raise userError results as errors, we don't want errorLink to see those
       userErrorLink,
       errorLink,
       headersLink,
       languageLink,
-      timeoutHttpLink,
+      httpLink,
     ]),
     cache: new InMemoryCache(),
     connectToDevTools: process.env.NODE_ENV === 'development',

--- a/apps/store/src/services/apollo/createHeadersLink.ts
+++ b/apps/store/src/services/apollo/createHeadersLink.ts
@@ -1,0 +1,17 @@
+import { type ApolloLink } from '@apollo/client'
+import { setContext } from '@apollo/client/link/context'
+import { isBrowser } from '@/utils/env'
+import { getShopSessionHeader, performTokenRefreshIfNeeded } from './apollo.helpers'
+
+export const createHeadersLink = (defaultHeaders?: Record<string, string>): ApolloLink => {
+  return setContext(async (_, prevContext) => {
+    const headers = { ...defaultHeaders }
+    if (isBrowser()) {
+      Object.assign(headers, {
+        ...(await performTokenRefreshIfNeeded()),
+        ...getShopSessionHeader(),
+      })
+    }
+    return { headers, ...prevContext }
+  })
+}

--- a/apps/store/src/services/apollo/errorLink.ts
+++ b/apps/store/src/services/apollo/errorLink.ts
@@ -1,0 +1,9 @@
+import { type ErrorResponse, onError } from '@apollo/client/link/error'
+
+export const errorLink = onError((error: ErrorResponse) => {
+  if (error.graphQLErrors)
+    error.graphQLErrors.forEach(({ message, locations, path }) =>
+      console.log(`[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`),
+    )
+  if (error.networkError) console.log(`[Network error]: ${error.networkError}`)
+})

--- a/apps/store/src/services/apollo/httpLink.ts
+++ b/apps/store/src/services/apollo/httpLink.ts
@@ -1,0 +1,8 @@
+import { createHttpLink } from '@apollo/client'
+import ApolloLinkTimeout from 'apollo-link-timeout'
+
+const TIMEOUT_50_SECONDS = 50 * 1000
+const timeoutLink = new ApolloLinkTimeout(TIMEOUT_50_SECONDS)
+const baseHttpLink = createHttpLink({ uri: process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT })
+
+export const httpLink = timeoutLink.concat(baseHttpLink)

--- a/apps/store/src/services/apollo/languageLink.ts
+++ b/apps/store/src/services/apollo/languageLink.ts
@@ -1,0 +1,22 @@
+import { setContext } from '@apollo/client/link/context'
+import { i18n } from 'next-i18next'
+import { isBrowser } from '@/utils/env'
+import { getLocaleOrFallback, toIsoLocale } from '@/utils/l10n/localeUtils'
+import { type RoutingLocale } from '@/utils/l10n/types'
+
+export const languageLink = setContext((_, { headers = {}, ...context }) => {
+  if (!isBrowser()) return context
+
+  const locale = getLocaleOrFallback(i18n?.language).routingLocale
+  return {
+    headers: {
+      ...headers,
+      ...getHedvigLanguageHeader(locale),
+    },
+    ...context,
+  }
+})
+
+const getHedvigLanguageHeader = (locale: RoutingLocale) => ({
+  'hedvig-language': toIsoLocale(locale),
+})

--- a/apps/store/src/services/apollo/userErrorLink.ts
+++ b/apps/store/src/services/apollo/userErrorLink.ts
@@ -1,0 +1,16 @@
+import { ApolloError, ApolloLink } from '@apollo/client'
+
+export const userErrorLink = new ApolloLink((operation, forward) => {
+  return forward(operation).map((fetchResult) => {
+    for (const result of Object.values(fetchResult.data ?? {})) {
+      const { userError } = result ?? {}
+      if (userError) {
+        throw new ApolloError({
+          errorMessage: userError.message,
+          extraInfo: { userError },
+        })
+      }
+    }
+    return fetchResult
+  })
+})

--- a/apps/store/src/services/authApi/app-router/persist.ts
+++ b/apps/store/src/services/authApi/app-router/persist.ts
@@ -1,0 +1,64 @@
+import { type OptionsType } from 'cookies-next/lib/types'
+import { cookies } from 'next/headers'
+import { type CookieParams } from '@/utils/types'
+
+const COOKIE_KEY = '_hvsession'
+const REFRESH_TOKEN_COOKIE_KEY = '_hvrefresh'
+const ACCESS_TOKEN_SESSION_FIELD = 'token'
+const MAX_AGE = 60 * 60 * 24 // 24 hours
+
+const OPTIONS: OptionsType = {
+  maxAge: MAX_AGE,
+  path: '/',
+  ...(process.env.NODE_ENV === 'production' && {
+    secure: true,
+  }),
+}
+
+type SaveAuthTokensParams = CookieParams & {
+  accessToken: string
+  refreshToken: string
+}
+
+export const saveAuthTokens = (params: SaveAuthTokensParams) => {
+  const { accessToken, refreshToken, ...cookieParams } = params
+  const cookieStore = cookies()
+
+  cookieStore.set(COOKIE_KEY, serialize(accessToken), { ...cookieParams, ...OPTIONS })
+  cookieStore.set(REFRESH_TOKEN_COOKIE_KEY, refreshToken, { ...cookieParams, ...OPTIONS })
+}
+
+export const resetAuthTokens = () => {
+  const cookieStore = cookies()
+  cookieStore.delete(COOKIE_KEY)
+  cookieStore.delete(REFRESH_TOKEN_COOKIE_KEY)
+}
+
+export const getRefreshToken = (): string | undefined => {
+  return cookies().get(REFRESH_TOKEN_COOKIE_KEY)?.value
+}
+
+export const getAccessToken = (): string | undefined => {
+  const cookieValue = cookies().get(COOKIE_KEY)?.value
+  return cookieValue ? deserialize(cookieValue) : undefined
+}
+
+export const getAuthHeaders = (): Record<string, string> => {
+  const accessToken = getAccessToken()
+  return accessToken ? { Authorization: `Bearer ${accessToken}` } : {}
+}
+
+const serialize = (accessToken: string) => {
+  return JSON.stringify({ [ACCESS_TOKEN_SESSION_FIELD]: accessToken })
+}
+
+const deserialize = (value: string) => {
+  try {
+    const data = JSON.parse(value)
+    const accessToken = data[ACCESS_TOKEN_SESSION_FIELD]
+    return typeof accessToken === 'string' ? accessToken : undefined
+  } catch (error) {
+    console.warn('Unable to deserialize session')
+    return undefined
+  }
+}

--- a/apps/store/src/services/shopSession/app-router/ShopSession.utils.ts
+++ b/apps/store/src/services/shopSession/app-router/ShopSession.utils.ts
@@ -1,0 +1,7 @@
+import { cookies } from 'next/headers'
+import { COOKIE_KEY_SHOP_SESSION } from '../ShopSession.constants'
+
+export const getShopSessionId = () => {
+  const cookieStore = cookies()
+  return cookieStore.get(COOKIE_KEY_SHOP_SESSION)?.value
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,6 +77,56 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@apollo/client@npm:rc":
+  version: 3.8.0-rc.1
+  resolution: "@apollo/client@npm:3.8.0-rc.1"
+  dependencies:
+    "@graphql-typed-document-node/core": ^3.1.1
+    "@wry/context": ^0.7.3
+    "@wry/equality": ^0.5.6
+    "@wry/trie": ^0.4.3
+    graphql-tag: ^2.12.6
+    hoist-non-react-statics: ^3.3.2
+    optimism: ^0.17.5
+    prop-types: ^15.7.2
+    response-iterator: ^0.2.6
+    symbol-observable: ^4.0.0
+    ts-invariant: ^0.10.3
+    tslib: ^2.3.0
+    zen-observable-ts: ^1.2.5
+  peerDependencies:
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+    graphql-ws: ^5.5.5
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    subscriptions-transport-ws: ^0.9.0 || ^0.11.0
+  peerDependenciesMeta:
+    graphql-ws:
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+    subscriptions-transport-ws:
+      optional: true
+  checksum: dd13e21c76acae50bd0de02546b8426191d6830057c67c902ee505aac62205749efa4bdfb599102f25791ed53a917fdd2d8a5844ea7ce515a5d8c42fa6f02d4e
+  languageName: node
+  linkType: hard
+
+"@apollo/experimental-nextjs-app-support@npm:0.4.1":
+  version: 0.4.1
+  resolution: "@apollo/experimental-nextjs-app-support@npm:0.4.1"
+  dependencies:
+    superjson: ^1.12.2
+    ts-invariant: ^0.10.3
+  peerDependencies:
+    "@apollo/client": ">=3.8.0-rc || ^3.8.0"
+    next: ^13.4.1
+    react: ^18
+  checksum: bff8e4e4a476a61d916a78c62c63e723f54d842c6710382736e22725592b4e5827c8137f69ba7deb403a243e82f45af904ab53ffff01fc1b854430e102d2c733
+  languageName: node
+  linkType: hard
+
 "@ardatan/relay-compiler@npm:12.0.0":
   version: 12.0.0
   resolution: "@ardatan/relay-compiler@npm:12.0.0"
@@ -10290,12 +10340,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wry/context@npm:^0.7.3":
+  version: 0.7.3
+  resolution: "@wry/context@npm:0.7.3"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 91c1e9eee9046c48ff857d60dcbb59f22246ce0f9bb2d9b190e0555227e7ba3f86024032cc057f3f5141d3bee93fc6b2a15ce2c79fa512569d3432eb8e1af02b
+  languageName: node
+  linkType: hard
+
 "@wry/equality@npm:^0.5.0":
   version: 0.5.2
   resolution: "@wry/equality@npm:0.5.2"
   dependencies:
     tslib: ^2.3.0
   checksum: 19a01043a0583663924ed9f4ea109818b9b4cb540877ca75ea49545689f54c6bfc69e725a8b3b129a2ac15ea368fd40bbb94c22e7a5e4ec370f7c4697e64b8b1
+  languageName: node
+  linkType: hard
+
+"@wry/equality@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "@wry/equality@npm:0.5.6"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 9addf8891bdff5e23eecff03641846e7a56c1de3c9362c25e69c0b2ee3303e74b22e9a0376920283cd9d3bdd1bada12df54be5eaa29c2d801d33d94992672e14
   languageName: node
   linkType: hard
 
@@ -10308,7 +10376,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wry/trie@npm:^0.4.0":
+"@wry/trie@npm:^0.4.0, @wry/trie@npm:^0.4.3":
   version: 0.4.3
   resolution: "@wry/trie@npm:0.4.3"
   dependencies:
@@ -12587,6 +12655,15 @@ __metadata:
     "@types/node": ^16.10.2
     cookie: ^0.4.0
   checksum: 5c7bf4edf946f8955014417fa609a0426476a6cce7d5f4ae0e7d8309d997e55fd3e41b63dcbbb15d44f6db099f4cdada7144d3c40968deb19efb7f918f8ed7e4
+  languageName: node
+  linkType: hard
+
+"copy-anything@npm:^3.0.2":
+  version: 3.0.5
+  resolution: "copy-anything@npm:3.0.5"
+  dependencies:
+    is-what: ^4.1.8
+  checksum: d39f6601c16b7cbd81cdb1c1f40f2bf0f2ca0297601cf7bfbb4ef1d85374a6a89c559502329f5bada36604464df17623e111fe19a9bb0c3f6b1c92fe2cbe972f
   languageName: node
   linkType: hard
 
@@ -16991,6 +17068,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-what@npm:^4.1.8":
+  version: 4.1.15
+  resolution: "is-what@npm:4.1.15"
+  checksum: fe27f6cd4af41be59a60caf46ec09e3071bcc69b9b12a7c871c90f54360edb6d0bc7240cb944a251fb0afa3d35635d1cecea9e70709876b368a8285128d70a89
+  languageName: node
+  linkType: hard
+
 "is-windows@npm:^1.0.1":
   version: 1.0.2
   resolution: "is-windows@npm:1.0.2"
@@ -19800,6 +19884,17 @@ __metadata:
     "@wry/context": ^0.7.0
     "@wry/trie": ^0.3.0
   checksum: a98ed9a0b8ee2b031010222099b60860d52860bf8182889f2695a7cf2185f21aca59020f78e2b47c0ae7697843caa576798d792967314ff59f6aa7c5d9de7f3a
+  languageName: node
+  linkType: hard
+
+"optimism@npm:^0.17.5":
+  version: 0.17.5
+  resolution: "optimism@npm:0.17.5"
+  dependencies:
+    "@wry/context": ^0.7.0
+    "@wry/trie": ^0.4.3
+    tslib: ^2.3.0
+  checksum: 5990217d989e9857dc523a64cb6e5a9205eae68c7acac78f7dde8fbe50045d0f11ca8068cdbb51b1eae15510d96ad593a99cf98c6f86c41d1b6f90e54956ff11
   languageName: node
   linkType: hard
 
@@ -22663,7 +22758,8 @@ __metadata:
   resolution: "store@workspace:apps/store"
   dependencies:
     "@adyen/adyen-web": 3.23.0
-    "@apollo/client": 3.7.17
+    "@apollo/client": rc
+    "@apollo/experimental-nextjs-app-support": 0.4.1
     "@babel/core": 7.22.9
     "@babel/preset-env": 7.22.9
     "@babel/preset-react": 7.22.5
@@ -23099,6 +23195,15 @@ __metadata:
   peerDependencies:
     graphql: ^15.7.2 || ^16.0.0
   checksum: cc2e98d5c9d89c44d2e15eca188781c6ebae13d1661c42a99cee9d2897aebe2a22bc118eefff83244a79c88ee4ea24d46973ebf26ae7cb47ac1857fb8ee2c947
+  languageName: node
+  linkType: hard
+
+"superjson@npm:^1.12.2":
+  version: 1.13.1
+  resolution: "superjson@npm:1.13.1"
+  dependencies:
+    copy-anything: ^3.0.2
+  checksum: 9c8c664a924ce097250112428805ccc8b500018b31a91042e953d955108b8481c156005d836b413940c9fa5f124a3195f55f3a518fe76510a254a59f9151a204
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Setup Apollo Client in the App Router to work with RSC and streaming SSR

- Refactor Apollo Client helpers to be more reusable and easier to understand

- Duplicate some utils to make use of new headers/cookies helper functions from Next.js

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- So we can start fetching data in the App Router from the API. It will look something like this:

    ```jsx
    const ServerComponent = async () => {
      const { data } = await getClient().query({ query: QueryDocument })
      return <div>{data}</div>
    }
    ```

- Original article explaining the setup: https://www.apollographql.com/blog/announcement/frontend/using-apollo-client-with-next-js-13-releasing-an-official-library-to-support-the-app-router/

- More up-to-date info: https://github.com/apollographql/apollo-client-nextjs/tree/main/package

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
