### PR TITLE
GEN-825 - styles(RemoveEntryDialog): make opening animation smoother

### DIFF
--- a/apps/store/src/components/CartInventory/RemoveEntryDialog.tsx
+++ b/apps/store/src/components/CartInventory/RemoveEntryDialog.tsx
@@ -1,6 +1,7 @@
+import { motion, type Transition } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
 import { FormEventHandler, ReactNode, useId } from 'react'
-import { Button, Text } from 'ui'
+import { Button, Text, theme } from 'ui'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
 import { CartFragmentFragment } from '@/services/apollo/generated'
 import { CartEntry } from './CartInventory.types'
@@ -30,7 +31,11 @@ export const RemoveEntryDialog = ({ children, title, ...mutationParams }: Props)
       <FullscreenDialog.Modal
         center={true}
         Footer={
-          <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={ANIMATE_TRANSITION}
+          >
             <Button form={formId} type="submit" loading={loading} disabled={loading}>
               {t('REMOVE_ENTRY_MODAL_CONFIRM_BUTTON')}
             </Button>
@@ -39,14 +44,32 @@ export const RemoveEntryDialog = ({ children, title, ...mutationParams }: Props)
                 {t('REMOVE_ENTRY_MODAL_CANCEL_BUTTON')}
               </Button>
             </FullscreenDialog.Close>
-          </>
+          </motion.div>
         }
       >
-        <form id={formId} onSubmit={handleSubmit} />
-        <Text size={{ _: 'md', lg: 'xl' }} align="center">
-          {t('REMOVE_ENTRY_MODAL_PROMPT', { name: title })}
-        </Text>
+        <motion.div
+          initial={{
+            opacity: 0,
+            y: '20%',
+          }}
+          animate={{
+            opacity: 1,
+            y: 0,
+          }}
+          transition={ANIMATE_TRANSITION}
+        >
+          <form id={formId} onSubmit={handleSubmit} />
+          <Text size={{ _: 'md', lg: 'xl' }} align="center">
+            {t('REMOVE_ENTRY_MODAL_PROMPT', { name: title })}
+          </Text>
+        </motion.div>
       </FullscreenDialog.Modal>
     </FullscreenDialog.Root>
   )
+}
+
+const ANIMATE_TRANSITION: Transition = {
+  duration: 0.6,
+  delay: 0.3,
+  ...theme.transitions.framer.easeInOutCubic,
 }


### PR DESCRIPTION
## Describe your changes

* Add same smoother opening animation for `RemoveEntryDialog` as we already have for `BankIdDialog` and `ChangeSsnWarningDialog`. With this addition we'll have 3 dialogs that share the same animation. I think it's time to try to abstract/share them which I'm gonna do in another PR. 

## Justify why they are needed

**Before**

 [before.mov](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/7c13f3c2-0d87-46c7-84d6-518b934b56a1/before.mov)

**After**

[after.mov](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/2f6fb664-d2e4-47b9-9c91-bf231867a7c8/after.mov)

