### PR TITLE
GEN-824 - refact: unify animations for FullScreenDialog

### DIFF
--- a/apps/store/src/blocks/ModalBlock.tsx
+++ b/apps/store/src/blocks/ModalBlock.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled'
 import { SbBlokData, StoryblokComponent, storyblokEditable } from '@storyblok/react'
-import { motion } from 'framer-motion'
 import { ComponentProps, useState } from 'react'
 import { Button, theme } from 'ui'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
@@ -26,15 +25,9 @@ export const ModalBlock = ({ blok }: ModalBlockProps) => {
         </FullscreenDialog.Trigger>
 
         <FullscreenDialog.Modal>
-          <AnimationWrapper
-            initial={{ opacity: 0, y: '2vh' }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3, ...theme.transitions.framer.easeInOutCubic }}
-          >
-            {blok.modalContent.map((nestedBlock) => (
-              <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} nested={true} />
-            ))}
-          </AnimationWrapper>
+          {blok.modalContent.map((nestedBlock) => (
+            <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} nested={true} />
+          ))}
         </FullscreenDialog.Modal>
       </FullscreenDialog.Root>
     </Wrapper>
@@ -48,8 +41,4 @@ const Wrapper = styled.div({
   justifyContent: 'center',
   paddingLeft: theme.space.md,
   paddingRight: theme.space.md,
-})
-
-const AnimationWrapper = styled(motion.div)({
-  width: '100%',
 })

--- a/apps/store/src/components/BankIdDialog.tsx
+++ b/apps/store/src/components/BankIdDialog.tsx
@@ -1,6 +1,5 @@
 import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
-import { motion, Transition } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
 import { ReactElement } from 'react'
 import { BankIdIcon, Button, CheckIcon, Text, theme, WarningTriangleIcon } from 'ui'
@@ -34,7 +33,6 @@ export const BankIdDialog = () => {
 
   let content: ReactElement | null = null
   let footer: ReactElement | null = null
-  let animationState = currentOperation?.state
 
   const { ssn } = currentOperation ?? {}
   if (currentOperation !== null && ssn) {
@@ -88,7 +86,6 @@ export const BankIdDialog = () => {
             {t('DIALOG_BUTTON_CANCEL', { ns: 'common' })}
           </Button>
         )
-        animationState = BankIdState.Pending
         break
       }
       case BankIdState.Success: {
@@ -132,26 +129,8 @@ export const BankIdDialog = () => {
 
   return (
     <FullscreenDialog.Root open={isOpen} onOpenChange={handleOpenChange}>
-      <FullscreenDialog.Modal
-        Footer={
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={ANIMATE_TRANSITION}
-          >
-            {footer}
-          </motion.div>
-        }
-        center={true}
-      >
-        <motion.div
-          key={animationState}
-          initial={{ opacity: 0, y: 40 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={ANIMATE_TRANSITION}
-        >
-          {content}
-        </motion.div>
+      <FullscreenDialog.Modal Footer={footer} center={true}>
+        {content}
       </FullscreenDialog.Modal>
     </FullscreenDialog.Root>
   )
@@ -170,9 +149,3 @@ const pulseAnimation = keyframes({
   '100%': { opacity: 0.2 },
 })
 const Pulsating = styled.div({ animation: `${pulseAnimation} 2s ease-in-out infinite` })
-
-const ANIMATE_TRANSITION: Transition = {
-  duration: 0.6,
-  delay: 0.3,
-  ...theme.transitions.framer.easeInOutCubic,
-}

--- a/apps/store/src/components/CartInventory/RemoveEntryDialog.tsx
+++ b/apps/store/src/components/CartInventory/RemoveEntryDialog.tsx
@@ -1,7 +1,6 @@
-import { motion, type Transition } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
 import { FormEventHandler, ReactNode, useId } from 'react'
-import { Button, Text, theme } from 'ui'
+import { Button, Text } from 'ui'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
 import { CartFragmentFragment } from '@/services/apollo/generated'
 import { CartEntry } from './CartInventory.types'
@@ -31,11 +30,7 @@ export const RemoveEntryDialog = ({ children, title, ...mutationParams }: Props)
       <FullscreenDialog.Modal
         center={true}
         Footer={
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={ANIMATE_TRANSITION}
-          >
+          <>
             <Button form={formId} type="submit" loading={loading} disabled={loading}>
               {t('REMOVE_ENTRY_MODAL_CONFIRM_BUTTON')}
             </Button>
@@ -44,32 +39,14 @@ export const RemoveEntryDialog = ({ children, title, ...mutationParams }: Props)
                 {t('REMOVE_ENTRY_MODAL_CANCEL_BUTTON')}
               </Button>
             </FullscreenDialog.Close>
-          </motion.div>
+          </>
         }
       >
-        <motion.div
-          initial={{
-            opacity: 0,
-            y: '20%',
-          }}
-          animate={{
-            opacity: 1,
-            y: 0,
-          }}
-          transition={ANIMATE_TRANSITION}
-        >
-          <form id={formId} onSubmit={handleSubmit} />
-          <Text size={{ _: 'md', lg: 'xl' }} align="center">
-            {t('REMOVE_ENTRY_MODAL_PROMPT', { name: title })}
-          </Text>
-        </motion.div>
+        <form id={formId} onSubmit={handleSubmit} />
+        <Text size={{ _: 'md', lg: 'xl' }} align="center">
+          {t('REMOVE_ENTRY_MODAL_PROMPT', { name: title })}
+        </Text>
       </FullscreenDialog.Modal>
     </FullscreenDialog.Root>
   )
-}
-
-const ANIMATE_TRANSITION: Transition = {
-  duration: 0.6,
-  delay: 0.3,
-  ...theme.transitions.framer.easeInOutCubic,
 }

--- a/apps/store/src/components/ChangeSsnWarningDialog/ChangeSsnWarningDialog.tsx
+++ b/apps/store/src/components/ChangeSsnWarningDialog/ChangeSsnWarningDialog.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled'
-import { motion, type Transition } from 'framer-motion'
 import { useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button, Text, WarningTriangleIcon, theme } from 'ui'
@@ -36,39 +35,23 @@ export const ChangeSsnWarningDialog = ({ open, onAccept, onDecline }: Props) => 
       <FullscreenDialog.Modal
         center={true}
         Footer={
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={ANIMATE_TRANSITION}
-          >
+          <>
             <Button loading={loading} onClick={handleAccept}>
               {t('CHANGE_SSN_BUTTON')}
             </Button>
             <Button variant="ghost" onClick={onDecline}>
               {t('DIALOG_BUTTON_CANCEL', { ns: 'common' })}
             </Button>
-          </motion.div>
+          </>
         }
       >
-        <motion.div
-          initial={{
-            opacity: 0,
-            y: '20%',
-          }}
-          animate={{
-            opacity: 1,
-            y: 0,
-          }}
-          transition={ANIMATE_TRANSITION}
-        >
-          <IconWithText>
-            <WarningTriangleIcon size="1em" color={theme.colors.amber600} />
-            <Text align="center">{t('CHANGE_SSN_TITLE')}</Text>
-          </IconWithText>
-          <Text color="textSecondary" align="center">
-            {t('CHANGE_SSN_DESCRIPTION')}
-          </Text>
-        </motion.div>
+        <IconWithText>
+          <WarningTriangleIcon size="1em" color={theme.colors.amber600} />
+          <Text align="center">{t('CHANGE_SSN_TITLE')}</Text>
+        </IconWithText>
+        <Text color="textSecondary" align="center">
+          {t('CHANGE_SSN_DESCRIPTION')}
+        </Text>
       </FullscreenDialog.Modal>
     </FullscreenDialog.Root>
   )
@@ -80,9 +63,3 @@ const IconWithText = styled(Text)({
   justifyContent: 'center',
   alignItems: 'center',
 })
-
-const ANIMATE_TRANSITION: Transition = {
-  duration: 0.6,
-  delay: 0.3,
-  ...theme.transitions.framer.easeInOutCubic,
-}

--- a/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
+++ b/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
@@ -1,4 +1,6 @@
 import styled from '@emotion/styled'
+import { motion, type Transition } from 'framer-motion'
+import { type ReactNode } from 'react'
 import { CrossIcon, Dialog, mq, theme } from 'ui'
 
 type Props = {
@@ -16,15 +18,25 @@ export const Modal = ({ children, Footer, center = false }: Props) => {
         </CloseButton>
       </Header>
       {center ? (
-        <CenteredMain>{children}</CenteredMain>
+        <CenteredMain>
+          <AnimateContentWrapper>{children}</AnimateContentWrapper>
+        </CenteredMain>
       ) : (
         <Main>
           <ClearHeader />
-          {children}
+          <AnimateContentWrapper>{children}</AnimateContentWrapper>
           <ClearFooter />
         </Main>
       )}
-      {Footer && <FooterWrapper>{Footer}</FooterWrapper>}
+      {Footer && (
+        <FooterWrapper
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={ANIMATE_TRANSITION}
+        >
+          {Footer}
+        </FooterWrapper>
+      )}
     </Content>
   )
 }
@@ -80,7 +92,7 @@ const ClearFooter = styled.div({
   },
 })
 
-const FooterWrapper = styled.footer({
+const FooterWrapper = styled(motion.footer)({
   position: 'fixed',
   bottom: 0,
   left: 0,
@@ -98,6 +110,30 @@ const FooterWrapper = styled.footer({
   },
 })
 
+const AnimateContentWrapper = ({ children }: { children: ReactNode }) => {
+  return (
+    <motion.div
+      initial={{
+        opacity: 0,
+        y: '2vh',
+      }}
+      animate={{
+        opacity: 1,
+        y: 0,
+      }}
+      transition={ANIMATE_TRANSITION}
+    >
+      {children}
+    </motion.div>
+  )
+}
+
 export const Root = Dialog.Root
 export const Close = Dialog.Close
 export const Trigger = Dialog.Trigger
+
+const ANIMATE_TRANSITION: Transition = {
+  duration: 0.6,
+  delay: 0.3,
+  ...theme.transitions.framer.easeInOutCubic,
+}

--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -1,6 +1,5 @@
 import { UrlObject } from 'url'
 import styled from '@emotion/styled'
-import { motion } from 'framer-motion'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
@@ -127,16 +126,7 @@ const CategoryCTA = ({ link }: Pick<ProductCardProps, 'link'>) => {
       </FullscreenDialog.Trigger>
 
       <FullscreenDialog.Modal>
-        <AnimationWrapper
-          initial={{ opacity: 0, y: '2vh' }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.3, ...theme.transitions.framer.easeInOutCubic }}
-        >
-          <StyledSelectInsuranceGrid
-            products={productsByCategory}
-            heading={t('SELECT_INSURANCE')}
-          />
-        </AnimationWrapper>
+        <StyledSelectInsuranceGrid products={productsByCategory} heading={t('SELECT_INSURANCE')} />
       </FullscreenDialog.Modal>
     </FullscreenDialog.Root>
   )
@@ -206,10 +196,6 @@ const MainLink = styled(Link)({
   [`&:focus-visible ~ ${CallToAction} #read-more-btn`]: {
     boxShadow: theme.shadow.focus,
   },
-})
-
-const AnimationWrapper = styled(motion.div)({
-  width: '100%',
 })
 
 const StyledSelectInsuranceGrid = styled(SelectInsuranceGrid)({


### PR DESCRIPTION
## Describe your changes

* Unify opening animations for FullScreenDialog

Following is a list of components that relies on `FullScreenDialog`:

- `ModalBlock`
- `AppErrorDialog`
- `BankIdDialog`
- `RemoveEntryDialog`
- `EditEntryDialog`
- `ChangeSsnWarningDialog`
- `CheckoutPage`
- `ErrorDialog`
- `ProductCard`
- `ComparisonTableModal`
- `PurchaseForm`

From that list the following are the components that have some opening animations defined:

- `ModalBlock`
- `BankIdDialog`
- `RemoveEntryDialog`
- `ChangeSsnWarningDialog`
- `ProductCard`
- `ComparisonTableModal`

This ticket PR about unifying the opening animations for `FullScreenDialog` so they have a consistent UI. As a side effect, the components that were not defining an opening animation will now have one, providing a smoother experience. Take `EditEntryDialog` as an example:

**Before**

[Screen Recording 2023-08-02 at 16.27.47.mov](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/1deb694b-4f49-47d2-b3d5-b9bd9195ecc8/Screen%20Recording%202023-08-02%20at%2016.27.47.mov)

Dialog’s content is being shown even before overlay finishes animate and become full visible.

**After**

[Screen Recording 2023-08-02 at 16.29.39.mov](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/bef5566b-00ec-4ea4-a9a6-895f79b7242b/Screen%20Recording%202023-08-02%20at%2016.29.39.mov)

Now it waits for the overlay as we already do for other components like ChangeSsnWarningDialog

## Justify why they are needed

Maintenance day task.
