### PR TITLE
GEN-827 | Partner Init: pre-fill information from search params in price intent

### DIFF
--- a/apps/store/src/graphql/ProductData.graphql
+++ b/apps/store/src/graphql/ProductData.graphql
@@ -5,6 +5,7 @@ query ProductData($productName: String!) {
     displayNameFull
     displayNameShort
     tagline
+    pageLink
     pillowImage {
       id
       alt

--- a/apps/store/src/mocks/productData.ts
+++ b/apps/store/src/mocks/productData.ts
@@ -8,6 +8,7 @@ export const productData: ProductData = {
   displayNameFull: 'Homeowner Insurance',
   displayNameShort: 'Homeowner',
   tagline: 'For you, your stuff and your apartment',
+  pageLink: '/se/apartment-brf',
   pillowImage: {
     __typename: 'StoryblokImageAsset',
     id: '9003664',

--- a/apps/store/src/pages/api/partner/init.ts
+++ b/apps/store/src/pages/api/partner/init.ts
@@ -1,118 +1,52 @@
-import { ApolloClient } from '@apollo/client'
 import { NextApiHandler } from 'next'
+import { getProductData } from '@/components/ProductPage/ProductPage.helpers'
+import { OPEN_PRICE_CALCULATOR_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam'
 import { initializeApolloServerSide } from '@/services/apollo/client'
-import {
-  CountryCode,
-  PartnerWidgetInitDocument,
-  PartnerWidgetInitMutation,
-  PartnerWidgetInitMutationVariables,
-} from '@/services/apollo/generated'
-import { isIsoLocale, toRoutingLocale } from '@/utils/l10n/localeUtils'
-import { IsoLocale } from '@/utils/l10n/types'
+import { createPartnerShopSession } from '@/services/partner/createPartnerShopSession'
+import { parseSearchParams } from '@/services/partner/parseSearchParams'
+import { fetchPriceTemplate } from '@/services/PriceCalculator/PriceCalculator.helpers'
+import { priceIntentServiceInitServerSide } from '@/services/priceIntent/PriceIntentService'
+import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { ORIGIN_URL, PageLink } from '@/utils/PageLink'
-
-const DEFAULT_LOCALE: IsoLocale = 'sv-SE'
-
-enum SearchParam {
-  Locale = 'locale',
-  PartnerId = 'partnerId',
-  ExternalMemberId = 'externalMemberId',
-  ProductType = 'productType',
-  ExternalRequestId = 'requestId',
-}
 
 const handler: NextApiHandler = async (req, res) => {
   if (req.url === undefined) throw new Error(`Missing req.url`)
 
-  const { searchParams } = new URL(req.url, ORIGIN_URL)
-  const searchLocale = searchParams.get(SearchParam.Locale)
-  const externalMemberId = searchParams.get(SearchParam.ExternalMemberId)
-  const externalRequestId = searchParams.get(SearchParam.ExternalRequestId)
-  const productType = searchParams.get(SearchParam.ProductType)
-  const partnerId = searchParams.get(SearchParam.PartnerId)
-
-  const locale = isIsoLocale(searchLocale) ? searchLocale : DEFAULT_LOCALE
-  const routingLocale = toRoutingLocale(locale)
-
-  // TODO: Redirect to some error page
-  const fallbackRedirect = `${ORIGIN_URL}${PageLink.home({ locale: routingLocale })}`
-
-  if (!partnerId) {
-    console.warn(`Missing partnerId`)
-    res.redirect(fallbackRedirect)
-    return
-  }
-  console.info(`Partner Init | Partner ID = ${partnerId}`)
-
-  const apolloClient = await initializeApolloServerSide({ locale: routingLocale, req, res })
-  let data: Awaited<ReturnType<typeof initPartnerWidget>>
   try {
-    data = await initPartnerWidget(apolloClient, {
-      partnerId,
-      externalMemberId,
-      externalRequestId,
+    const { searchParams } = new URL(req.url, ORIGIN_URL)
+    const { locale, partnerWidgetInitVariables, productName, priceIntentData, customerData } =
+      parseSearchParams(searchParams)
+    console.info(`Partner Init | Partner ID = ${partnerWidgetInitVariables.partnerId}`)
+
+    const apolloClient = await initializeApolloServerSide({ locale, req, res })
+    const { id: shopSessionId, partnerName } = await createPartnerShopSession(
+      apolloClient,
+      partnerWidgetInitVariables,
+    )
+    setupShopSessionServiceServerSide({ apolloClient, req, res }).saveId(shopSessionId)
+    console.info(`Partner Init | Shop Session = ${shopSessionId}, Partner = ${partnerName}`)
+
+    const service = priceIntentServiceInitServerSide({ req, res, apolloClient })
+    const priceTemplate = fetchPriceTemplate(productName)
+    if (!priceTemplate) throw new Error(`Missing price template for ${productName}`)
+    const priceIntent = await service.create({ productName, priceTemplate, shopSessionId })
+    await service.update({
+      priceIntentId: priceIntent.id,
+      data: priceIntentData,
+      customer: { shopSessionId, ...customerData },
     })
+    console.info(`Partner Init | Price Intent = ${priceIntent.id}`)
+
+    const { pageLink } = await getProductData({ apolloClient, productName })
+    const nextUrl = new URL(pageLink, ORIGIN_URL)
+    nextUrl.searchParams.set(OPEN_PRICE_CALCULATOR_QUERY_PARAM, '1')
+    res.redirect(nextUrl.toString())
   } catch (error) {
-    console.warn(`Failed to initialize partner widget session: ${error}`)
+    console.error(`Failed to initialize partner widget session: ${error}`)
+    // TODO: Redirect to some error page
+    const fallbackRedirect = `${ORIGIN_URL}${PageLink.home({ locale: 'se' })}`
     res.redirect(fallbackRedirect)
-    return
   }
-
-  const shopSessionId = data.id
-  const partnerName = data.partnerName ?? undefined
-  console.info(`Partner Init | Shop Session = ${shopSessionId}, Partner = ${partnerName}`)
-
-  // TODO: prefill price intent
-
-  const pageLink = getProductPageLink(productType)
-  res.redirect(
-    PageLink.session({
-      shopSessionId,
-      locale: routingLocale,
-      next: pageLink,
-    }),
-  )
 }
 
 export default handler
-
-const initPartnerWidget = async (
-  apolloClient: ApolloClient<unknown>,
-  variables: Omit<PartnerWidgetInitMutationVariables['input'], 'countryCode'>,
-): Promise<PartnerWidgetInitMutation['partnerWidgetInit']> => {
-  const response = await apolloClient.mutate<
-    PartnerWidgetInitMutation,
-    PartnerWidgetInitMutationVariables
-  >({
-    mutation: PartnerWidgetInitDocument,
-    variables: {
-      input: {
-        countryCode: CountryCode.Se,
-        ...variables,
-      },
-    },
-  })
-
-  if (!response.data) {
-    const errors = response.errors?.map((error) => error.message).join('\n')
-    throw new Error(errors)
-  }
-
-  return response.data.partnerWidgetInit
-}
-
-// Temporary
-const getProductPageLink = (productType: string | null) => {
-  switch (productType) {
-    case 'SWEDISH_APARTMENT':
-      return `/se/forsakringar/hemforsakring/hyresratt`
-
-    case 'SWEDISH_HOUSE':
-      return `/se/forsakringar/hemforsakring/villaforsakring`
-    case 'SWEDISH_ACCIDENT':
-      return `/se/forsakringar/olycksfallsforsakring`
-
-    default:
-      return PageLink.store({ locale: 'se' })
-  }
-}

--- a/apps/store/src/services/partner/createPartnerShopSession.ts
+++ b/apps/store/src/services/partner/createPartnerShopSession.ts
@@ -1,0 +1,26 @@
+import { ApolloClient } from '@apollo/client'
+import {
+  PartnerWidgetInitDocument,
+  PartnerWidgetInitMutation,
+  PartnerWidgetInitMutationVariables,
+} from '@/services/apollo/generated'
+
+export const createPartnerShopSession = async (
+  apolloClient: ApolloClient<unknown>,
+  variables: PartnerWidgetInitMutationVariables['input'],
+): Promise<PartnerWidgetInitMutation['partnerWidgetInit']> => {
+  const response = await apolloClient.mutate<
+    PartnerWidgetInitMutation,
+    PartnerWidgetInitMutationVariables
+  >({
+    mutation: PartnerWidgetInitDocument,
+    variables: { input: variables },
+  })
+
+  if (!response.data) {
+    const errors = response.errors?.map((error) => error.message).join('\n')
+    throw new Error(errors)
+  }
+
+  return response.data.partnerWidgetInit
+}

--- a/apps/store/src/services/partner/parseSearchParams.ts
+++ b/apps/store/src/services/partner/parseSearchParams.ts
@@ -1,0 +1,120 @@
+import Personnummer from 'personnummer'
+import {
+  PartnerWidgetInitInput,
+  ShopSessionCustomerUpdateInput,
+  TypeOfContract,
+} from '@/services/apollo/generated'
+import { getCountryByLocale } from '@/utils/l10n/countryUtils'
+import { FALLBACK_LOCALE } from '@/utils/l10n/locales'
+import { isIsoLocale, toRoutingLocale } from '@/utils/l10n/localeUtils'
+import { RoutingLocale } from '@/utils/l10n/types'
+
+enum SearchParam {
+  // Needs to be added when doing the redirect
+  Locale = 'locale',
+
+  PartnerId = 'partnerId',
+  ExternalMemberId = 'externalMemberId',
+  ExternalRequestId = 'requestId',
+
+  ProductType = 'productType',
+  ApartmentSubType = 'subType',
+
+  // Is anyone using this?
+  Student = 'student',
+
+  Email = 'email',
+  Ssn = 'ssn',
+
+  // TODO: No longer used?
+  PhoneNumber = 'phoneNumber',
+  BirthDate = 'birthDate',
+  FirstName = 'firstName',
+  LastName = 'lastName',
+
+  StreetAddress = 'street',
+  ZipCode = 'zipCode',
+  City = 'city',
+  LivingSpace = 'livingSpace',
+  NumberCoInsured = 'coInsured',
+}
+
+type Data = {
+  locale: RoutingLocale
+  productName: string
+  partnerWidgetInitVariables: PartnerWidgetInitInput
+  customerData: Omit<ShopSessionCustomerUpdateInput, 'shopSessionId'>
+  priceIntentData: Record<string, unknown>
+}
+
+export const parseSearchParams = (searchParams: URLSearchParams): Data => {
+  const searchLocale = searchParams.get(SearchParam.Locale)
+  const locale = isIsoLocale(searchLocale) ? searchLocale : FALLBACK_LOCALE
+  const routingLocale = toRoutingLocale(locale)
+
+  const productType = searchParams.get(SearchParam.ProductType)
+  const apartmentSubType = searchParams.get(SearchParam.ApartmentSubType)
+  const productName = getProductName(productType, apartmentSubType)
+
+  const partnerId = searchParams.get(SearchParam.PartnerId)
+  if (partnerId === null) throw new Error(`Missing partnerId`)
+  const externalMemberId = searchParams.get(SearchParam.ExternalMemberId)
+  const externalRequestId = searchParams.get(SearchParam.ExternalRequestId)
+  const partnerWidgetInitVariables: Data['partnerWidgetInitVariables'] = {
+    countryCode: getCountryByLocale(routingLocale).countryCode,
+    partnerId,
+    ...(externalMemberId && { externalMemberId }),
+    ...(externalRequestId && { externalRequestId }),
+  }
+
+  const searchSsn = searchParams.get(SearchParam.Ssn)
+  let ssn: string | undefined = undefined
+  if (searchSsn && Personnummer.valid(searchSsn)) {
+    ssn = Personnummer.parse(searchSsn).format(true)
+  }
+  const email = searchParams.get(SearchParam.Email)
+  const customerData: Data['customerData'] = {
+    ssn,
+    ...(email && { email }),
+  }
+
+  const street = searchParams.get(SearchParam.StreetAddress)
+  const zipCode = searchParams.get(SearchParam.ZipCode)
+  const city = searchParams.get(SearchParam.City)
+  const searchLivingSpace = searchParams.get(SearchParam.LivingSpace)
+  const livingSpace = searchLivingSpace ? parseNumber(searchLivingSpace) : undefined
+  const searchNumberCoInsured = searchParams.get(SearchParam.NumberCoInsured)
+  const numberCoInsured = searchNumberCoInsured ? parseNumber(searchNumberCoInsured) : undefined
+
+  return {
+    locale: routingLocale,
+    productName,
+    partnerWidgetInitVariables,
+    customerData,
+    priceIntentData: {
+      ...(street && { street }),
+      ...(zipCode && { zipCode }),
+      ...(city && { city }),
+      ...(livingSpace && { livingSpace }),
+      ...(numberCoInsured && { numberCoInsured }),
+    },
+  }
+}
+
+const parseNumber = (value: string): number | undefined => {
+  const parsed = parseInt(value, 10)
+  return isNaN(parsed) ? undefined : parsed
+}
+
+const getProductName = (productType: string | null, subType: string | null) => {
+  switch (productType) {
+    case 'SWEDISH_APARTMENT':
+      return subType === 'BRF' ? TypeOfContract.SeApartmentBrf : TypeOfContract.SeApartmentRent
+    case 'SWEDISH_HOUSE':
+      return TypeOfContract.SeHouse
+    case 'SWEDISH_ACCIDENT':
+      return TypeOfContract.SeAccident
+    default:
+      return TypeOfContract.SeApartmentRent
+  }
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Pre-fill information passed as query params to the initial price intent

- Refactor API route to not make it too complicated

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Mimic how partner widget works

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
