### PR TITLE
GEN-823 - fix(PurchaseForm): handle error other than ApolloErrors by showing a general error message

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -304,6 +304,7 @@ type EditingStateProps = {
 
 const EditingState = (props: EditingStateProps) => {
   const { shopSession, priceIntent, onComplete } = props
+  const { t } = useTranslation('purchase-form')
   const tracking = useTracking()
 
   const [confirmPriceIntent, result] = usePriceIntentConfirmMutation({
@@ -331,6 +332,7 @@ const EditingState = (props: EditingStateProps) => {
         onComplete()
       } else {
         setIsLoadingPrice(false)
+        onComplete(t('GENERAL_ERROR_DIALOG_PROMPT'))
       }
     } catch (error) {
       // Error is already handled in onError callback


### PR DESCRIPTION
## Describe your changes

Make sure we display an error message informing that something went wrong while trying to get a price.

## Justify why they are needed

While using `msw` I could verify that in any case an error is raised we'll display an error dialog. However, in case we can't get a selected offer due malformed payload (thanks for the suggestions @alebedev) we'd just render `PurchaseForm` on it's _Idle_ state, which was exactly what was happening for the cases that originated the issue.