### PR TITLE
fix(GlobalBanner): make sure it only renders client side avoiding hydration errors

### DIFF
--- a/apps/store/src/components/GlobalBanner/GlobalBanner.tsx
+++ b/apps/store/src/components/GlobalBanner/GlobalBanner.tsx
@@ -3,7 +3,7 @@ import { Banner } from '@/components/Banner/Banner'
 import { useDebugShopSession } from '@/utils/useDebugShopSession'
 import { useGlobalBanner } from './useGlobalBanner'
 
-export const GlobalBanner = () => {
+const GlobalBanner = () => {
   const { banner, dismissBanner } = useGlobalBanner()
 
   useDebugShopSession()
@@ -26,3 +26,5 @@ const Ellipsis = styled.span({
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
 })
+
+export default GlobalBanner

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -3,13 +3,13 @@ import { Global } from '@emotion/react'
 import { Provider as JotaiProvider } from 'jotai'
 import { appWithTranslation } from 'next-i18next'
 import type { AppPropsWithLayout } from 'next/app'
+import dynamic from 'next/dynamic'
 import Head from 'next/head'
 import Router from 'next/router'
 import { Provider as BalancerProvider } from 'react-wrap-balancer'
 import { globalStyles, theme } from 'ui'
 import { AppErrorDialog } from '@/components/AppErrorDialog'
 import { BankIdDialog } from '@/components/BankIdDialog'
-import { GlobalBanner } from '@/components/GlobalBanner/GlobalBanner'
 import { GlobalLinkStyles } from '@/components/RichText/RichText.styles'
 import { useApollo } from '@/services/apollo/client'
 import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
@@ -33,6 +33,10 @@ import { useDebugTranslationKeys } from '@/utils/l10n/useDebugTranslationKeys'
 import { useForceHtmlLangAttribute } from '@/utils/l10n/useForceHtmlLangAttribute'
 import { useAllowActiveStylesInSafari } from '@/utils/useAllowActiveStylesInSafari'
 import { useReloadOnCountryChange } from '@/utils/useReloadOnCountryChange'
+
+const DynamicGlobalBanner = dynamic(() => import('@/components/GlobalBanner/GlobalBanner'), {
+  ssr: false,
+})
 
 // Enable API mocking
 if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
@@ -92,7 +96,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
                 <BalancerProvider>
                   <AppErrorProvider>
                     <AppErrorDialog />
-                    <GlobalBanner />
+                    <DynamicGlobalBanner />
                     {getLayout(<Component {...pageProps} className={contentFontClassName} />)}
                   </AppErrorProvider>
                 </BalancerProvider>


### PR DESCRIPTION
## Describe your changes

* Make sure `GlobalBanner` only gets rendered client side as it depends on storage based atom. By doing so we can avoid hydration errors.

## Justify why they are needed

We've been getting [hydration error logs](https://app.datadoghq.eu/rum/error-tracking?query=%40application.id%3Ad86e86d8-8d9a-4b00-a2cb-10b8d7671fa2&from_ts=1691154363205&to_ts=1691157963205&live=true) for a while now. I could track them down to a particular [deployment in prod](https://github.com/HedvigInsurance/racoon/commit/481cf34aaf7ef5b049e29a6201f574e08b6c0448) where I've changed `GlobalBanner` atom state to leverage `sessionStorage`. That was causing the hydration errors. Here I'm using the [Jotai's suggested solution](https://jotai.org/docs/utilities/storage#server-side-rendering) to fix the issue.