### PR TITLE
GEN-833 | Display read only campaign code (can not be removed)

### DIFF
--- a/apps/store/src/components/CartInventory/CampaignSection.tsx
+++ b/apps/store/src/components/CartInventory/CampaignSection.tsx
@@ -57,7 +57,7 @@ export const CampaignSection = ({ shopSessionId, campaign }: Props) => {
           {t('CAMPAIGN_CODE_HEADING')}
         </Heading>
 
-        <Collapsible.Trigger asChild>
+        <Collapsible.Trigger asChild={true}>
           <Switch checked={open} />
         </Collapsible.Trigger>
       </SpaceBetween>
@@ -132,7 +132,8 @@ const ChipButton = styled.button({
   },
 
   ':disabled': {
-    opacity: 0.6,
+    opacity: 0.8,
+    cursor: 'not-allowed',
   },
 })
 

--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -9,6 +9,7 @@ import { CartEntryItem } from '@/components/CartInventory/CartEntryItem/CartEntr
 import { CartEntryList } from '@/components/CartInventory/CartEntryList'
 import { CartEntryOfferItem } from '@/components/CartInventory/CartEntryOfferItem'
 import { CostSummary } from '@/components/CartInventory/CostSummary'
+import { ReadOnlyCampaignSection } from '@/components/CartInventory/ReadOnlyCampaignSection'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { ProductRecommendationList } from '@/components/ProductRecommendationList/ProductRecommendationList'
 import { useProductRecommendations } from '@/components/ProductRecommendationList/useProductRecommendations'
@@ -71,12 +72,20 @@ export const CartPage = (props: CartPageProps) => {
             ))}
         </CartEntryList>
 
-        {shopSessionId && campaignsEnabled && (
-          <Space y={{ base: 1, sm: 1.5 }}>
-            <CampaignSection shopSessionId={shopSessionId} campaign={campaign} />
-            <HorizontalLine />
-          </Space>
-        )}
+        {campaignsEnabled
+          ? shopSessionId && (
+              <Space y={{ base: 1, sm: 1.5 }}>
+                <CampaignSection shopSessionId={shopSessionId} campaign={campaign} />
+                <HorizontalLine />
+              </Space>
+            )
+          : !!campaign && (
+              <Space y={{ base: 1, sm: 1.5 }}>
+                <ReadOnlyCampaignSection campaign={campaign} />
+                <HorizontalLine />
+              </Space>
+            )}
+
         {cost && <CostSummary {...cost} campaign={campaign} />}
 
         {showProductRecommendations && (

--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -11,6 +11,7 @@ import { CartEntryItem } from '@/components/CartInventory/CartEntryItem/CartEntr
 import { CartEntryList } from '@/components/CartInventory/CartEntryList'
 import { CartEntryOfferItem } from '@/components/CartInventory/CartEntryOfferItem'
 import { CostSummary } from '@/components/CartInventory/CostSummary'
+import { ReadOnlyCampaignSection } from '@/components/CartInventory/ReadOnlyCampaignSection'
 import { CheckoutStep } from '@/components/CheckoutHeader/Breadcrumbs'
 import { getCheckoutStepLink } from '@/components/CheckoutHeader/CheckoutHeader.helpers'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
@@ -132,7 +133,7 @@ const CheckoutPage = (props: CheckoutPageProps) => {
                     />
                   ))}
                 </CartEntryList>
-                {cart.campaigns.enabled && (
+                {cart.campaigns.enabled ? (
                   <>
                     <CampaignSection
                       shopSessionId={shopSessionId}
@@ -140,6 +141,13 @@ const CheckoutPage = (props: CheckoutPageProps) => {
                     />
                     <HorizontalLine />
                   </>
+                ) : (
+                  cart.campaigns.redeemed && (
+                    <>
+                      <ReadOnlyCampaignSection campaign={cart.campaigns.redeemed} />
+                      <HorizontalLine />
+                    </>
+                  )
                 )}
                 <CostSummary {...cart.cost} campaign={cart.campaigns.redeemed} />
                 <div />


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-08-07 at 13.46.03.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/39d5e841-04c5-4aeb-a057-b5f6f6bf3f23/Screenshot%202023-08-07%20at%2013.46.03.png)


- Add support for displaying a campaign code without giving user the option to remove it

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Useful for partner session where we have a pre-defined campaign code

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
