### PR TITLE
chore(eslint): enable no-unsafe-enum-comparison rule

### DIFF
--- a/apps/store/src/components/PriceCalculator/CurrentInsuranceField/InputCurrentInsurance.tsx
+++ b/apps/store/src/components/PriceCalculator/CurrentInsuranceField/InputCurrentInsurance.tsx
@@ -25,9 +25,11 @@ export const InputCurrentInsurance = (props: InputCurrentInsuranceProps) => {
   const [hasInsurance, setHasInsurance] = useState(!!company)
 
   const handleRadioValueChange = (newValue: string) => {
-    datadogRum.addAction('Select HasInsurance', { value: newValue })
-    if (newValue === RadioOption.NO) onCompanyChange(undefined)
-    setHasInsurance(newValue === RadioOption.YES)
+    const newValueEnum = newValue as RadioOption
+
+    datadogRum.addAction('Select HasInsurance', { value: newValueEnum })
+    if (newValueEnum === RadioOption.NO) onCompanyChange(undefined)
+    setHasInsurance(newValueEnum === RadioOption.YES)
   }
 
   const handleChangeExternalInsurer: ChangeEventHandler<HTMLSelectElement> = (event) => {

--- a/apps/store/src/services/slack/slack.types.ts
+++ b/apps/store/src/services/slack/slack.types.ts
@@ -1,5 +1,7 @@
+import { SlashCommand } from './slack.constants'
+
 export type SlashCommandRequest = {
-  command: string
+  command: SlashCommand
   response_url: string
   user_id: string
   user_name: string


### PR DESCRIPTION
## Describe your changes

* Enables [_no-unsafe-enum-comparison_](https://typescript-eslint.io/rules/no-unsafe-enum-comparison) rule

> The TypeScript compiler can be surprisingly lenient when working with enums. For example, it will allow you to compare enum values against numbers even though they might not have any type overlap
> 
> ```
> enum Fruit {
>   Apple,
>   Banana,
> }
> 
> declare let fruit: Fruit;
> 
> fruit === 999; // No error
> ```

## Justify why they are needed

This is part of a series of PRs that includes new/updated rules added by typescript-eslint v6. The idea is to use those PRs so we discuss as a team if we want to enable a particular rule or not.
