### PR TITLE
chore(eslint): enable prefer-optional-chain rule

### DIFF
--- a/apps/store/src/components/PriceCalculator/FetchInsurance.tsx
+++ b/apps/store/src/components/PriceCalculator/FetchInsurance.tsx
@@ -76,7 +76,7 @@ export const FetchInsurance = ({
       logger.info('Updated Insurely data collection ID', loggingContext)
 
       const updatedPriceIntent = priceIntentInsurelyUpdate.priceIntent
-      if (updatedPriceIntent && updatedPriceIntent.externalInsurer) {
+      if (updatedPriceIntent?.externalInsurer) {
         fetchInsuraceSuccess()
       } else {
         logger.warn('Failed to update Insurely data collection ID', loggingContext)

--- a/apps/store/src/components/ProductPage/PurchaseForm/useSelectedOffer.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/useSelectedOffer.ts
@@ -22,7 +22,7 @@ export const useSelectedOffer = () => {
         offer = action
       }
 
-      if (offer && offer.priceMatch) {
+      if (offer?.priceMatch) {
         datadogLogs.logger.info('Selected price matched offer', {
           offerId: offer.id,
           product: offer.variant.product.name,

--- a/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
+++ b/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
@@ -247,7 +247,7 @@ const useSignMigration = (
 
       if (!shopSession) return
 
-      if (!shopSession.customer || !shopSession.customer.ssn) {
+      if (!shopSession.customer?.ssn) {
         throw new Error('Must have customer data and ssn in it')
       }
 

--- a/apps/store/src/pages/checkout/index.tsx
+++ b/apps/store/src/pages/checkout/index.tsx
@@ -34,7 +34,7 @@ const NextCheckoutPage: NextPage<NextPageProps> = (props) => {
     [shopSession?.cart.entries],
   )
 
-  if (!shopSession || !shopSession.customer) return null
+  if (!shopSession?.customer) return null
 
   const { authenticationStatus } = shopSession.customer
 

--- a/packages/eslint-config-custom/eslint-config-custom.js
+++ b/packages/eslint-config-custom/eslint-config-custom.js
@@ -63,8 +63,6 @@ module.exports = {
         allowIndexSignaturePropertyAccess: true,
       },
     ],
-    '@typescript-eslint/no-unsafe-enum-comparison': 'off',
-    '@typescript-eslint/prefer-optional-chain': 'off',
     '@typescript-eslint/array-type': 'off',
     '@typescript-eslint/consistent-type-definitions': 'off',
     '@typescript-eslint/prefer-nullish-coalescing': 'off',


### PR DESCRIPTION
## Describe your changes

* Enable [_prefer-optional-chain_](https://typescript-eslint.io/rules/prefer-optional-chain) rule.

> `?.` optional chain expressions provide `undefined` if an object is `null` or `undefined`. Because the optional chain operator only chains when the property value is `null` or `undefined`, it is much safer than relying upon logical AND operator chaining `&&`; which chains on any truthy value. It is also often less code to use `?.` optional chaining than `&&` truthiness checks.
> 
> This rule reports on code where an && operator can be safely replaced with ?. optional chaining.

## Justify why they are needed

This is part of a series of PRs that includes new/updated rules added by typescript-eslint v6. The idea is to use those PRs so we discuss as a team if we want to enable a particular rule or not.
