### PR TITLE
chore(eslint): enable consistent-type-definitions rule

### DIFF
--- a/apps/store/src/@types/i18next.d.ts
+++ b/apps/store/src/@types/i18next.d.ts
@@ -13,6 +13,7 @@ import type checkout from '../../public/locales/en/checkout.json'
 import type common from '../../public/locales/en/common.json'
 import type purchaseForm from '../../public/locales/en/purchase-form.json'
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface I18nNamespaces {
   bankid: typeof bankid
   cart: typeof cart
@@ -22,6 +23,7 @@ interface I18nNamespaces {
 }
 
 declare module 'i18next' {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface CustomTypeOptions {
     defaultNS: 'common'
     resources: I18nNamespaces

--- a/apps/store/src/emotion.d.ts
+++ b/apps/store/src/emotion.d.ts
@@ -4,5 +4,6 @@ import { theme } from 'ui'
 declare module '@emotion/react' {
   type HedvigTheme = typeof theme
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   export interface Theme extends HedvigTheme {}
 }

--- a/apps/store/src/services/persister/Persister.types.ts
+++ b/apps/store/src/services/persister/Persister.types.ts
@@ -1,5 +1,6 @@
 import { OptionsType, TmpCookiesObj } from 'cookies-next/lib/types'
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface SimplePersister {
   save(value: string, key?: string, options?: OptionsType): void
 

--- a/packages/eslint-config-custom/eslint-config-custom.js
+++ b/packages/eslint-config-custom/eslint-config-custom.js
@@ -70,7 +70,7 @@ module.exports = {
         readonly: 'generic',
       },
     ],
-    '@typescript-eslint/consistent-type-definitions': 'off',
+    '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
     '@typescript-eslint/prefer-nullish-coalescing': 'off',
     '@typescript-eslint/non-nullable-type-assertion-style': 'off',
     '@typescript-eslint/no-redundant-type-constituents': 'off',

--- a/packages/ui/src/emotion.d.ts
+++ b/packages/ui/src/emotion.d.ts
@@ -4,5 +4,6 @@ import { theme } from './lib/theme/theme'
 declare module '@emotion/react' {
   type HedvigTheme = typeof theme
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   export interface Theme extends HedvigTheme {}
 }


### PR DESCRIPTION
## Describe your changes

* Enables typescript eslint [_consistent-type-definitions_](https://typescript-eslint.io/rules/consistent-type-definitions) rule

> TypeScript provides two common ways to define an object type: interface and type.
> The two are generally very similar, and can often be used interchangeably. Using the same type declaration style consistently helps with code readability.

Here I'm deciding upon using `type`. With that I had to update the code to disable some edge cases where we need to use `interface`. We could change it to enforce the usage of `interface`,  but that would cause a bigger change since we've been using `type` in our codebase for the majority of the cases.

## Justify why they are needed

This is part of a series of PRs that includes new/updated rules added by typescript-eslint v6. The idea is to use those PRs so we discuss as a team if we want to enable a particular rule or not.
