### PR TITLE
chore(eslint): enable prefer-nullish-coalescing rule

### DIFF
--- a/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
+++ b/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
@@ -66,7 +66,7 @@ export const ExtraBuildingsField = ({
     const data = Object.fromEntries(formData.entries())
 
     await onSubmit({
-      [field.name]: [...(field.value || []), convertExtraBuilding(data)],
+      [field.name]: [...(field.value ?? []), convertExtraBuilding(data)],
     })
     setIsOpen(false)
   }
@@ -75,7 +75,7 @@ export const ExtraBuildingsField = ({
     const identifier = JSON.stringify(extraBuilding)
 
     await onSubmit({
-      [field.name]: (field.value || []).filter((item) => {
+      [field.name]: (field.value ?? []).filter((item) => {
         const itemIdentifier = JSON.stringify(item)
         return itemIdentifier !== identifier
       }),

--- a/apps/store/src/components/PriceCalculator/StepperInput/StepperInput.tsx
+++ b/apps/store/src/components/PriceCalculator/StepperInput/StepperInput.tsx
@@ -22,7 +22,7 @@ type Props = {
  */
 export const StepperInput = (props: Props) => {
   const { max, min = 0, value, defaultValue, label, optionLabel, ...inputProps } = props
-  const [internalValue, setInternalValue] = useState(value || defaultValue || min)
+  const [internalValue, setInternalValue] = useState(value ?? defaultValue ?? min)
   const { highlight, animationProps } = useHighlightAnimation<HTMLDivElement>()
 
   const increment: MouseEventHandler = (event) => {

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -47,7 +47,7 @@ const NextStoryblokPage = (props: NextContentPageProps) => {
 
   return (
     <BlogContext.Provider value={parseBlogContext(props)}>
-      <HeadSeoInfo story={abTestOriginStory || story} robots={robots} />
+      <HeadSeoInfo story={abTestOriginStory ?? story} robots={robots} />
       <StoryblokComponent blok={story.content} />
       <DefaultDebugDialog />
     </BlogContext.Provider>

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -76,7 +76,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
   usePublishPartnerInitEvent()
 
   const apolloClient = useApollo(pageProps)
-  const getLayout = Component.getLayout || ((page) => page)
+  const getLayout = Component.getLayout ?? ((page) => page)
 
   return (
     <>

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -43,7 +43,9 @@ export const fetchStory = async <StoryData extends ISbStoryData>(
 ): Promise<StoryData> => {
   let cv: number | undefined
   if (params.version === 'published') {
-    cv = (STORYBLOK_CACHE_VERSION && parseInt(STORYBLOK_CACHE_VERSION)) || undefined
+    const cacheVersion = STORYBLOK_CACHE_VERSION ? parseInt(STORYBLOK_CACHE_VERSION) : NaN
+    const isCacheVersionValid = !isNaN(cacheVersion)
+    cv = isCacheVersionValid ? cacheVersion : undefined
   }
   const response = await storyblokClient.getStory(slug, {
     ...params,

--- a/apps/store/src/utils/l10n/countryUtils.ts
+++ b/apps/store/src/utils/l10n/countryUtils.ts
@@ -25,7 +25,7 @@ export const getCountryLocale = (country: CountryLabel, language: Language): Iso
     throw new Error(`Failed to find country id=${country}`)
   }
   return (
-    countryData.locales.find((locale) => locales[locale].language === language) ||
+    countryData.locales.find((locale) => locales[locale].language === language) ??
     countryData.defaultLocale
   )
 }

--- a/packages/eslint-config-custom/eslint-config-custom.js
+++ b/packages/eslint-config-custom/eslint-config-custom.js
@@ -71,7 +71,16 @@ module.exports = {
       },
     ],
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
-    '@typescript-eslint/prefer-nullish-coalescing': 'off',
+    '@typescript-eslint/prefer-nullish-coalescing': [
+      'error',
+      {
+        ignoreConditionalTests: true,
+        ignorePrimitives: {
+          string: true,
+          boolean: true,
+        },
+      },
+    ],
     '@typescript-eslint/non-nullable-type-assertion-style': 'off',
     '@typescript-eslint/no-redundant-type-constituents': 'off',
 

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -24,8 +24,8 @@ export const BadgeBase = styled(
   'div',
   elementConfig,
 )<BadgeBaseProps>(({ color, size, ...props }) => {
-  color = color || 'blueFill1'
-  size = size || 'sm'
+  color = color ?? 'blueFill1'
+  size = size ?? 'sm'
   return {
     display: 'inline-block',
     color: theme.colors.dark,

--- a/packages/ui/src/components/Heading/Heading.tsx
+++ b/packages/ui/src/components/Heading/Heading.tsx
@@ -31,6 +31,7 @@ const HeadingBase = styled(
   elementConfig,
 )<HeadingBaseProps>(({ color, variant, align, ...props }) => {
   // GOTCHA: We may get empty string from Storyblok, this should be handled safely
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   variant = variant || 'standard.32'
   return {
     color: color ? getColor(color) : 'currentColor',


### PR DESCRIPTION
## Describe your changes

* Enable typescript eslint [_prefer-nullish-coalescing_](https://typescript-eslint.io/rules/prefer-nullish-coalescing) rule.

> The `??` nullish coalescing runtime operator allows providing a default value when dealing with `null` or `undefined`. Because the nullish coalescing operator only coalesces when the original value is `null` or `undefined`, it is much safer than relying upon logical OR operator chaining `||`, which coalesces on any falsy value.

I've configure it to ignore conditional cases and `string` and `boolean` primitives.

## Justify why they are needed

This is part of a series of PRs that includes new/updated rules added by typescript-eslint v6. The idea is to use those PRs so we discuss as a team if we want to enable a particular rule or not.
