### PR TITLE
chore(eslint): document why we want to disable no-redundent-type-constituents-rule

### DIFF
--- a/apps/store/src/components/ComparisonTable/ComparisonTable.types.ts
+++ b/apps/store/src/components/ComparisonTable/ComparisonTable.types.ts
@@ -4,9 +4,9 @@ export const TableMarkers = {
   NotCovered: '[]',
 } as const
 
-type Row = Array<string | typeof TableMarkers.Covered | typeof TableMarkers.NotCovered>
+type Row = Array<string>
 
-export type Head = Array<string | typeof TableMarkers.EmptyHeader>
+export type Head = Array<string>
 
 export type Body = Array<Row>
 

--- a/apps/store/src/components/ComparisonTable/DesktopComparisonTable.tsx
+++ b/apps/store/src/components/ComparisonTable/DesktopComparisonTable.tsx
@@ -17,7 +17,7 @@ export const DesktopComparisonTable = ({ className, head, body, selectedColumn }
       <ComparisonTable.Head>
         <ComparisonTable.Row>
           {head.map((headerValue, index) => {
-            if (headerValue == TableMarkers.EmptyHeader)
+            if (headerValue === TableMarkers.EmptyHeader)
               return <ComparisonTable.Header key={`empty-header-${index}`} />
 
             return (

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -30,6 +30,7 @@ import { trackPageViews } from '@/services/Tracking/trackPageViews'
 import { contentFontClassName } from '@/utils/fonts'
 import { getCountryByLocale } from '@/utils/l10n/countryUtils'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
+import { UiLocale } from '@/utils/l10n/types'
 import { useDebugTranslationKeys } from '@/utils/l10n/useDebugTranslationKeys'
 import { useForceHtmlLangAttribute } from '@/utils/l10n/useForceHtmlLangAttribute'
 import { useAllowActiveStylesInSafari } from '@/utils/useAllowActiveStylesInSafari'
@@ -58,7 +59,7 @@ if (typeof window !== 'undefined') {
   initDatadog()
 
   Router.ready(() => {
-    const { routingLocale } = getLocaleOrFallback(Router.locale)
+    const { routingLocale } = getLocaleOrFallback(Router.locale as UiLocale)
     const { countryCode } = getCountryByLocale(routingLocale)
     tracking.reportAppInit({ countryCode })
 

--- a/apps/store/src/pages/_document.tsx
+++ b/apps/store/src/pages/_document.tsx
@@ -3,10 +3,11 @@ import { theme } from 'ui'
 import { GTMBodyScript } from '@/services/gtm'
 import { contentFontClassName } from '@/utils/fonts'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
+import { UiLocale } from '@/utils/l10n/types'
 
 export default class MyDocument extends Document {
   lang() {
-    return getLocaleOrFallback(this.props.locale).htmlLang
+    return getLocaleOrFallback(this.props.locale as UiLocale).htmlLang
   }
 
   render() {

--- a/apps/store/src/services/CustomerFirst.tsx
+++ b/apps/store/src/services/CustomerFirst.tsx
@@ -31,10 +31,10 @@ export const useCustomerFirst = () => {
     if (!chatWidgetSrc) return
 
     const iframeOrigin = new URL(chatWidgetSrc).origin
-    const handleMessage = ({ data, origin }: MessageEvent<MessageData | unknown>) => {
+    const handleMessage = ({ data, origin }: MessageEvent<unknown>) => {
       if (origin === iframeOrigin) {
-        if (data === 'showWidget') setOpen(true)
-        else if (data === 'hideWidget') setOpen(false)
+        if (data === MessageData.ShowWidget) setOpen(true)
+        else if (data === MessageData.HideWidget) setOpen(false)
       }
     }
     window.addEventListener('message', handleMessage)
@@ -49,4 +49,7 @@ export const useCustomerFirst = () => {
   return { show } as const
 }
 
-type MessageData = 'showWidget' | 'hideWidget'
+enum MessageData {
+  ShowWidget = 'showWidget',
+  HideWidget = 'hideWidget',
+}

--- a/apps/store/src/services/apollo/languageLink.ts
+++ b/apps/store/src/services/apollo/languageLink.ts
@@ -2,12 +2,12 @@ import { setContext } from '@apollo/client/link/context'
 import { i18n } from 'next-i18next'
 import { isBrowser } from '@/utils/env'
 import { getLocaleOrFallback, toIsoLocale } from '@/utils/l10n/localeUtils'
-import { type RoutingLocale } from '@/utils/l10n/types'
+import { type RoutingLocale, type UiLocale } from '@/utils/l10n/types'
 
 export const languageLink = setContext((_, { headers = {}, ...context }) => {
   if (!isBrowser()) return context
 
-  const locale = getLocaleOrFallback(i18n?.language).routingLocale
+  const locale = getLocaleOrFallback(i18n?.language as UiLocale).routingLocale
   return {
     headers: {
       ...headers,

--- a/apps/store/src/utils/l10n/localeUtils.ts
+++ b/apps/store/src/utils/l10n/localeUtils.ts
@@ -41,7 +41,7 @@ export const isRoutingLocale = (locale: unknown): locale is RoutingLocale => {
 }
 
 // Fallback is global, use country.defaultLocale for country-specific fallback
-export const getLocaleOrFallback = (locale: UiLocale | string | undefined): LocaleData => {
+export const getLocaleOrFallback = (locale?: UiLocale): LocaleData => {
   if (!isRoutingLocale(locale) && !isIsoLocale(locale)) {
     return locales[FALLBACK_LOCALE]
   }
@@ -50,7 +50,7 @@ export const getLocaleOrFallback = (locale: UiLocale | string | undefined): Loca
 
 export const getUrlLocale = (url: string): RoutingLocale => {
   const routingLocale = url.split('/')[0]
-  return getLocaleOrFallback(routingLocale).routingLocale
+  return getLocaleOrFallback(routingLocale as UiLocale).routingLocale
 }
 
 export const translateCountryName = (countryCode: CountryCode | CountryLabel, t: TFunction) => {

--- a/apps/store/src/utils/l10n/useCurrentCountry.ts
+++ b/apps/store/src/utils/l10n/useCurrentCountry.ts
@@ -2,8 +2,9 @@ import { useRouter } from 'next/router'
 import { CountryData } from '@/utils/l10n/countries'
 import { getCountryByLocale } from '@/utils/l10n/countryUtils'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
+import { type UiLocale } from './types'
 
 export const useCurrentCountry = (): CountryData => {
   const router = useRouter()
-  return getCountryByLocale(getLocaleOrFallback(router.locale).routingLocale)
+  return getCountryByLocale(getLocaleOrFallback(router.locale as UiLocale).routingLocale)
 }

--- a/apps/store/src/utils/l10n/useCurrentLocale.ts
+++ b/apps/store/src/utils/l10n/useCurrentLocale.ts
@@ -1,7 +1,8 @@
 import { useRouter } from 'next/router'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
+import { UiLocale } from '@/utils/l10n/types'
 
 export const useCurrentLocale = () => {
   const router = useRouter()
-  return getLocaleOrFallback(router.locale)
+  return getLocaleOrFallback(router.locale as UiLocale)
 }

--- a/packages/eslint-config-custom/eslint-config-custom.js
+++ b/packages/eslint-config-custom/eslint-config-custom.js
@@ -56,7 +56,7 @@ module.exports = {
     '@typescript-eslint/restrict-template-expressions': 'off', // Breaks with emotion styles referring to other components
     '@typescript-eslint/consistent-indexed-object-style': 'off',
 
-    // TODO: Typed lint rules that we might want to consider in the future
+    // Typed lint rules
     '@typescript-eslint/dot-notation': [
       'error',
       {
@@ -82,7 +82,6 @@ module.exports = {
       },
     ],
     '@typescript-eslint/non-nullable-type-assertion-style': 'off',
-    '@typescript-eslint/no-redundant-type-constituents': 'off',
 
     '@next/next/no-html-link-for-pages': 'off',
     'import/no-anonymous-default-export': 'off', // For Storybook stories
@@ -95,6 +94,13 @@ module.exports = {
       rules: {
         'testing-library/no-node-access': 'off',
         'testing-library/no-container': 'off',
+      },
+    },
+    // Graphql codegen generates types that breaks that rule
+    {
+      files: ['**/generated.ts'],
+      rules: {
+        '@typescript-eslint/no-redundant-type-constituents': 'off',
       },
     },
     // Allow requires in node js modules (assuming we don't have JS on frontend side)


### PR DESCRIPTION
## Describe your changes

Document why we want to disable typescript eslint [_no-redundant-type-constituents_](https://typescript-eslint.io/rules/no-redundant-type-constituents) rule

## Justify why they are needed

This is part of a series of PRs that includes new/updated rules added by typescript-eslint v6. The idea is to use those PRs so we discuss as a team if we want to enable a particular rule or not.
