### PR TITLE
Add hide sound controls option

### DIFF
--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -19,6 +19,7 @@ export type VideoBlockProps = SbBaseBlockProps<
     | 'aspectRatioPortrait'
     | 'maxHeightLandscape'
     | 'maxHeightPortrait'
+    | 'hideSoundControl'
   >
 > & { className?: string }
 
@@ -43,6 +44,7 @@ export const VideoBlock = ({ className, blok, nested = false }: VideoBlockProps)
         maxHeightPortrait={blok.maxHeightPortrait}
         roundedCorners={!blok.fullBleed}
         showControls={blok.controls}
+        hideSoundControl={blok.hideSoundControl}
       />
     </ConditionalWrapper>
   )

--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -32,6 +32,7 @@ export type VideoProps = React.ComponentPropsWithoutRef<'video'> & {
   sources: VideoSource[]
   poster?: string
   showControls?: boolean
+  hideSoundControl?: boolean
 } & VideoSize
 
 const autoplaySettings = {
@@ -51,6 +52,7 @@ export const Video = ({
   onPlaying,
   onPause,
   showControls = true,
+  hideSoundControl = false,
   ...delegated
 }: VideoProps) => {
   const videoRef = useRef<HTMLVideoElement | null>(null)
@@ -60,7 +62,8 @@ export const Video = ({
   const playPauseButtonRef = useRef<HTMLButtonElement | null>(null)
 
   const [state, setState] = useState<State>(State.Paused)
-  const [muted, setMuted] = useState(true)
+  // Mute video if auto playing or hidden sound controls
+  const [muted, setMuted] = useState(delegated.autoPlay || hideSoundControl)
 
   useEffect(() => {
     // Lazy load videos that are autoplaying
@@ -216,21 +219,23 @@ export const Video = ({
                 {state === State.Paused ? 'Play' : 'Pause'}
               </span>
             </ControlButton>
-            <ControlButton
-              onClick={toggleSound}
-              variant="secondary"
-              size="small"
-              aria-labelledby={muteButtonId}
-            >
-              <SoundBars>
-                <span />
-                <span />
-                <span />
-              </SoundBars>
-              <span id={muteButtonId} hidden>
-                {muted ? 'Mute' : 'Unmute'}
-              </span>
-            </ControlButton>
+            {!hideSoundControl && (
+              <ControlButton
+                onClick={toggleSound}
+                variant="secondary"
+                size="small"
+                aria-labelledby={muteButtonId}
+              >
+                <SoundBars>
+                  <span />
+                  <span />
+                  <span />
+                </SoundBars>
+                <span id={muteButtonId} hidden>
+                  {muted ? 'Mute' : 'Unmute'}
+                </span>
+              </ControlButton>
+            )}
           </Controls>
         </VideoControls>
       )}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add setting to hide sound controls for videos without audio
- Set `muted` based on autoplaying or hidden sound controls Storyblok setting

### Before
<img width="1293" alt="Screenshot 2023-08-09 at 15 51 06" src="https://github.com/HedvigInsurance/racoon/assets/6661511/b71049ee-e043-47b1-8a5c-8847e71ca4b2">

### After
<img width="1281" alt="Screenshot 2023-08-09 at 15 50 33" src="https://github.com/HedvigInsurance/racoon/assets/6661511/6f958d4d-fc35-4bd5-ab57-e2101f82712a">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Currently we show sound control for some videos that doesn't have any audio track (like "Always with Hedvig"). And there might be use cases we want to disable mute/unmute.
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
