### PR TITLE
Add grid decorator to Storybook

### DIFF
--- a/apps/store/.storybook/decorators.tsx
+++ b/apps/store/.storybook/decorators.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { type Decorator } from '@storybook/react'
+import { Global } from '@emotion/react'
+import { ThemeProvider } from 'ui'
+import { storybookFontStyles } from 'ui/src/lib/storybookFontStyles'
+import { GridLayout } from '../src/components/GridLayout/GridLayout'
+
+export const themeDecorator: Decorator = (Story) => (
+  <>
+    <Global styles={storybookFontStyles} />
+    <ThemeProvider>
+      <Story />
+    </ThemeProvider>
+  </>
+)
+
+/**
+ * Decorator for defining grid layout as a parameter in a story.
+ * Example:
+ * parameters: {
+ *   grid: '1/2' or { base: '1', md: '5/6', lg: '2/3', xl: '1/2' },
+ * },
+ */
+export const gridDecorator: Decorator = (Story, options) => {
+  const width = options.parameters.grid
+  if (!width) return <Story />
+  return (
+    <GridLayout.Root style={{ paddingInline: 0 }}>
+      <GridLayout.Content width={width} align="center">
+        <Story />
+      </GridLayout.Content>
+    </GridLayout.Root>
+  )
+}

--- a/apps/store/.storybook/preview.tsx
+++ b/apps/store/.storybook/preview.tsx
@@ -1,11 +1,8 @@
-import { ThemeProvider } from 'ui'
-import { storybookFontStyles } from 'ui/src/lib/storybookFontStyles'
-import { Global } from '@emotion/react'
 import { RouterContext } from 'next/dist/shared/lib/router-context'
 import { MockedProvider } from '@apollo/client/testing'
 import './i18next'
-import React from 'react'
-import { type Decorator } from '@storybook/react'
+import { Preview } from '@storybook/react'
+import { gridDecorator, themeDecorator } from './decorators'
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -25,13 +22,8 @@ export const parameters = {
   },
 }
 
-export const decorators: Array<Decorator> = [
-  (Story) => (
-    <>
-      <Global styles={storybookFontStyles} />
-      <ThemeProvider>
-        <Story />
-      </ThemeProvider>
-    </>
-  ),
-]
+const preview: Preview = {
+  decorators: [themeDecorator, gridDecorator],
+}
+
+export default preview

--- a/apps/store/src/components/Accordion/Accordion.stories.tsx
+++ b/apps/store/src/components/Accordion/Accordion.stories.tsx
@@ -50,6 +50,9 @@ const ACCORDION_ITEMS = [
 
 export default {
   component: Accordion.Root,
+  parameters: {
+    grid: '1/2',
+  },
 } as Meta<typeof Accordion.Root>
 
 const Template: StoryFn<typeof Accordion.Root> = () => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Move decorators to separate file
- Add new gridDecorator

I thought it would be neat to better match Figma and Storybook stories in terms of layout. For example, showing Accordions as full screen is a bit misguiding since we will always restrict the width when implemented in the app. The only option we have today is the `layout` parameter that has `centered` or  `fullscreen`. I've added the GridLayout in some story templates but that feels like too much boilerplate when writing stories.

Instead we can have it as a global decorator that you enable by setting a `grid` parameter in the stories you want to use it.
```js
parameters: {
  grid: '1/2' or { base: '1', md: '5/6', lg: '2/3', xl: '1/2' },
}, 
```

### Before
<img width="1728" alt="Screenshot 2023-08-11 at 15 14 11" src="https://github.com/HedvigInsurance/racoon/assets/6661511/64842453-1063-49c9-a4c3-cd094641559a">

### After
<img width="1725" alt="Screenshot 2023-08-11 at 15 42 18" src="https://github.com/HedvigInsurance/racoon/assets/6661511/9362291d-f18f-4293-8d12-ec7e04a10554">


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Make story layouts match Figma/implementation

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
