### PR TITLE
hotfix(PurchaseForm): make sure we set a selectedOffer after confirming price intent

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -305,6 +305,7 @@ type EditingStateProps = {
 const EditingState = (props: EditingStateProps) => {
   const { shopSession, priceIntent, onComplete } = props
   const { t } = useTranslation('purchase-form')
+  const [, setSelectedOffer] = useSelectedOffer()
   const tracking = useTracking()
 
   const [confirmPriceIntent, result] = usePriceIntentConfirmMutation({
@@ -329,6 +330,8 @@ const EditingState = (props: EditingStateProps) => {
         tracking.setContext(TrackingContextKey.Customer, shopSession.customer)
         tracking.setPriceIntentContext(updatedPriceIntent)
         updatedPriceIntent.offers.forEach((offer) => tracking.reportOfferCreated(offer))
+        // TODO: set initially selectedOffer based on some logic; Ideally get it from the the API
+        setSelectedOffer(updatedPriceIntent.offers[0])
         onComplete()
       } else {
         setIsLoadingPrice(false)


### PR DESCRIPTION
Disclaimer: That was magically working before, even without these changes. Looking at the commit history, it seems there's nothing that could be causing the issue despite one update on jotai. However I've also tried to revert that change but the issue persisted. I think we can start with this just to make the app work again and I can continue looking at it to spot the real issue.

## Describe your changes

* Make sure we set a selectedOffer after confirming price intent

## Justify why they are needed

Raised [here](https://hedviginsurance.slack.com/archives/CPCUHMMJQ/p1692001712502579)