### PR TITLE
refact(PriceIntentContext): make sure 'synchronyze' code are place inside effects

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,7 @@
   "labels": ["needs approval/merge"],
   // Don't update nextjs until client-side navigation issue is solved
   // https://github.com/vercel/next.js/issues/53967
-  "ignoreDeps": ["next", "eslint-config-next", "@next/bundle-analyzer", "@apollo/client"],
+  "ignoreDeps": ["next", "eslint-config-next", "@next/bundle-analyzer"],
   "packageRules": [
     {
       "matchDepTypes": ["dependencies"],

--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@adyen/adyen-web": "3.23.0",
-    "@apollo/client": "3.7.17",
+    "@apollo/client": "3.8.1",
     "@apollo/experimental-nextjs-app-support": "0.4.1",
     "@datadog/browser-logs": "4.46.0",
     "@datadog/browser-rum": "4.46.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,17 +41,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:3.7.17":
-  version: 3.7.17
-  resolution: "@apollo/client@npm:3.7.17"
+"@apollo/client@npm:3.8.1":
+  version: 3.8.1
+  resolution: "@apollo/client@npm:3.8.1"
   dependencies:
     "@graphql-typed-document-node/core": ^3.1.1
-    "@wry/context": ^0.7.0
-    "@wry/equality": ^0.5.0
-    "@wry/trie": ^0.4.0
+    "@wry/context": ^0.7.3
+    "@wry/equality": ^0.5.6
+    "@wry/trie": ^0.4.3
     graphql-tag: ^2.12.6
     hoist-non-react-statics: ^3.3.2
-    optimism: ^0.16.2
+    optimism: ^0.17.5
     prop-types: ^15.7.2
     response-iterator: ^0.2.6
     symbol-observable: ^4.0.0
@@ -73,7 +73,7 @@ __metadata:
       optional: true
     subscriptions-transport-ws:
       optional: true
-  checksum: d25e955f3c409885185405ca5876cb74538becafa202257a27483c07d7faa9ce83b34d4cab4b7fd9ad217f80d768e651881292c406dbbca221c91013917890d7
+  checksum: 3a1748359a7c0f339764e7764dc6c7426be1d522eda963416d3a693733edbce8408cb8f78f9c98b036d34621af663e3dd3446703dfd29037c78a77eacd3c70bb
   languageName: node
   linkType: hard
 
@@ -10713,25 +10713,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wry/equality@npm:^0.5.0":
-  version: 0.5.2
-  resolution: "@wry/equality@npm:0.5.2"
+"@wry/context@npm:^0.7.3":
+  version: 0.7.3
+  resolution: "@wry/context@npm:0.7.3"
   dependencies:
     tslib: ^2.3.0
-  checksum: 19a01043a0583663924ed9f4ea109818b9b4cb540877ca75ea49545689f54c6bfc69e725a8b3b129a2ac15ea368fd40bbb94c22e7a5e4ec370f7c4697e64b8b1
+  checksum: 91c1e9eee9046c48ff857d60dcbb59f22246ce0f9bb2d9b190e0555227e7ba3f86024032cc057f3f5141d3bee93fc6b2a15ce2c79fa512569d3432eb8e1af02b
   languageName: node
   linkType: hard
 
-"@wry/trie@npm:^0.3.0":
-  version: 0.3.1
-  resolution: "@wry/trie@npm:0.3.1"
+"@wry/equality@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "@wry/equality@npm:0.5.6"
   dependencies:
     tslib: ^2.3.0
-  checksum: c3f6b200aefc64b5cd9976b7ed0dd22852eb826d835c5dccd3d03ef788d258af50ca64e8de654e5f812134afdb9d5890f334c8de2276d0dca1751785694654f9
+  checksum: 9addf8891bdff5e23eecff03641846e7a56c1de3c9362c25e69c0b2ee3303e74b22e9a0376920283cd9d3bdd1bada12df54be5eaa29c2d801d33d94992672e14
   languageName: node
   linkType: hard
 
-"@wry/trie@npm:^0.4.0":
+"@wry/trie@npm:^0.4.3":
   version: 0.4.3
   resolution: "@wry/trie@npm:0.4.3"
   dependencies:
@@ -20433,13 +20433,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"optimism@npm:^0.16.2":
-  version: 0.16.2
-  resolution: "optimism@npm:0.16.2"
+"optimism@npm:^0.17.5":
+  version: 0.17.5
+  resolution: "optimism@npm:0.17.5"
   dependencies:
     "@wry/context": ^0.7.0
-    "@wry/trie": ^0.3.0
-  checksum: a98ed9a0b8ee2b031010222099b60860d52860bf8182889f2695a7cf2185f21aca59020f78e2b47c0ae7697843caa576798d792967314ff59f6aa7c5d9de7f3a
+    "@wry/trie": ^0.4.3
+    tslib: ^2.3.0
+  checksum: 5990217d989e9857dc523a64cb6e5a9205eae68c7acac78f7dde8fbe50045d0f11ca8068cdbb51b1eae15510d96ad593a99cf98c6f86c41d1b6f90e54956ff11
   languageName: node
   linkType: hard
 
@@ -23304,7 +23305,7 @@ __metadata:
   resolution: "store@workspace:apps/store"
   dependencies:
     "@adyen/adyen-web": 3.23.0
-    "@apollo/client": 3.7.17
+    "@apollo/client": 3.8.1
     "@apollo/experimental-nextjs-app-support": 0.4.1
     "@babel/core": 7.22.10
     "@babel/preset-env": 7.22.10


### PR DESCRIPTION
## Describe your changes

* Updates `PriceIntentContext` by moving code that should be run whenever `priceIntent` changes from `useQuery`'s `onCompleted` callback to an `useEffect`
* Update `@apollo/client` version `3.7.17` --> `3.8.1`
* Remove `@apollo/client` from _renovate_'s ignore list

## Justify why they are needed

We had a [faulty update](https://github.com/HedvigInsurance/racoon/pull/2952)  of `@apollo/client` over the weekend which caused a bug in our app where one [couldn't get a price for any product](https://hedviginsurance.slack.com/archives/CPCUHMMJQ/p1692001712502579). The bug was caused by a [fix](https://github.com/apollographql/apollo-client/issues/11140) added by apollo team meaning `3.8.1` implements a more correct behaviour for `onCompleted` callback functions when compared to `3.7.17` - in other terms, our code was working before but it shouldn't have. Initially we've reverted the change but this PR is about proper fixing our code while using `3.8.1` version.