### PR TITLE
refact(PriceIntentContext): log 'BankSignering Offered' when confirming the price intent

### DIFF
--- a/apps/store/src/components/ProductPage/PriceIntentContext.tsx
+++ b/apps/store/src/components/ProductPage/PriceIntentContext.tsx
@@ -1,6 +1,5 @@
 import { useApolloClient } from '@apollo/client'
 import { datadogLogs } from '@datadog/browser-logs'
-import { datadogRum } from '@datadog/browser-rum'
 import { useRouter } from 'next/router'
 import {
   createContext,
@@ -12,7 +11,6 @@ import {
 } from 'react'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import {
-  ExternalInsuranceCancellationOption,
   PriceIntentFragmentFragment,
   PriceIntentQueryResult,
   ProductOfferFragment,
@@ -113,19 +111,6 @@ const usePriceIntentContextValue = () => {
       }),
     [onReady, priceIntentId, updatePriceIntent],
   )
-
-  // TODO: maybe associate this with some piece of code that is directly related with getting offers like when
-  // confirming price intent.
-  useEffect(() => {
-    if (!priceIntent) return
-
-    const hasBankSigneringOffer = priceIntent.offers.some(
-      (item) => item.cancellation.option === ExternalInsuranceCancellationOption.Banksignering,
-    )
-    if (hasBankSigneringOffer) {
-      datadogRum.addAction('BankSignering Offered')
-    }
-  }, [priceIntent])
 
   useEffect(() => {
     setSelectedOffer((prev) => {

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -1,4 +1,5 @@
 import { datadogLogs } from '@datadog/browser-logs'
+import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
 import { motion, Variants } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
@@ -329,6 +330,12 @@ const EditingState = (props: EditingStateProps) => {
         tracking.setContext(TrackingContextKey.Customer, shopSession.customer)
         tracking.setPriceIntentContext(updatedPriceIntent)
         updatedPriceIntent.offers.forEach((offer) => tracking.reportOfferCreated(offer))
+        const hasBankSigneringOffer = updatedPriceIntent.offers.some(
+          (item) => item.cancellation.option === ExternalInsuranceCancellationOption.Banksignering,
+        )
+        if (hasBankSigneringOffer) {
+          datadogRum.addAction('BankSignering Offered')
+        }
         onComplete()
       } else {
         setIsLoadingPrice(false)


### PR DESCRIPTION
## Describe your changes

* Refact `PriceIntentContext` by moving _log BankSignering Offered_ code as a side effect of having successfully completed a price intent instead of run it every time `priceIntent` changes in our app.

## Justify why they are needed

I think this represents more when we want to log those.