### PR TITLE
fix(customer-first): make sure chat iframe get's added into the document

### DIFF
--- a/apps/store/src/services/CustomerFirst.tsx
+++ b/apps/store/src/services/CustomerFirst.tsx
@@ -18,7 +18,17 @@ export const CustomerFirstScript = () => {
   return (
     <>
       <Global styles={{ '#chat-iframe': { display: showLauncher ? 'initial' : 'none' } }} />
-      <Script strategy="afterInteractive" src={chatWidgetSrc} />
+      <Script
+        strategy="afterInteractive"
+        src={chatWidgetSrc}
+        onLoad={() => {
+          // C1 attaches chat iframe in a window.load event handler. Since we can't load the script
+          // with 'beforeInteractive' strategy outside _document, we dispatch a load event to
+          // window object after this gets loaded.
+          const loadEvent = new Event('load')
+          window.dispatchEvent(loadEvent)
+        }}
+      />
     </>
   )
 }


### PR DESCRIPTION
This stack contains two possible solutions for the problem. Let's discuss on which one we want to move forward with.

## Describe your changes

* Make sure chat iframe get's added into the document by firing a `load` event for the `window` object.

## Justify why they are needed

I've noticed in [datadog](https://app.datadoghq.eu/rum/replay/sessions/b93e474b-8f91-4c57-a39b-ebcebd0d8ba8?highlightedEventId=AgAAAYn4MgH-4ckpEQAAAAAAAAAYAAAAAEFZbjRNZ2RVQUFDVmVwdFYtc19mYndBQgAAACQAAAAAMDE4OWY4MzUtNmNiYS00YjUzLThjN2QtMjFjMjVhZjhlYzQ3&seed=dca237d4-a3a3-420f-b374-6b8fc60b4768&ts=1692086174206&from=1692086174100) that some users were having problems to access the chat feature as nothing happened when chat button got clicked. 

<img width="663" alt="Screenshot 2023-08-15 at 11 51 42" src="https://github.com/HedvigInsurance/racoon/assets/19200662/4f853ab9-d7e1-40d0-83fc-25bee4bfb522">

The issue was that chat iframe was not getting added to the DOM at the moment users click on chat button, breaking the app:

<img width="668" alt="Screenshot 2023-08-15 at 11 41 13" src="https://github.com/HedvigInsurance/racoon/assets/19200662/946723af-396f-4344-95bc-b7d44587f986">

There are basically two ways to solve that:

1) Make sure chat iframe gets added to the DOM by firing a load event when the script gets loaded. This is more like an hack solution, so I'm not sure if it's enough.
2) Make sure chat script gets loaded before `window.load` get's fired by changing its load strategy to `beforeInteractive`. However [_next_ doesn't allow us](https://nextjs.org/docs/messages/no-before-interactive-script-outside-document) to use that strategy for loading scripts outside `_document` file, which means we'd need to load chat script for all pages.

**This PR implements the solution 1)**