### PR TITLE
fix(customer-first): make sure get's added into the document

### DIFF
--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -14,7 +14,7 @@ import { GlobalLinkStyles } from '@/components/RichText/RichText.styles'
 import { useApollo } from '@/services/apollo/client'
 import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
 import { BankIdContextProvider } from '@/services/bankId/BankIdContext'
-import { CustomerFirstScript } from '@/services/CustomerFirst'
+import { CustomerFirstLauncher } from '@/services/CustomerFirst'
 import { GTMAppScript } from '@/services/gtm'
 import { initDatadog } from '@/services/logger/client'
 import { PageTransitionProgressBar } from '@/services/nprogress/pageTransition'
@@ -107,7 +107,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
               </BankIdContextProvider>
             </TrackingProvider>
           </ShopSessionProvider>
-          <CustomerFirstScript />
+          <CustomerFirstLauncher />
         </JotaiProvider>
       </ApolloProvider>
     </>

--- a/apps/store/src/pages/_document.tsx
+++ b/apps/store/src/pages/_document.tsx
@@ -1,4 +1,5 @@
 import Document, { Head, Html, Main, NextScript } from 'next/document'
+import Script from 'next/script'
 import { theme } from 'ui'
 import { GTMBodyScript } from '@/services/gtm'
 import { contentFontClassName } from '@/utils/fonts'
@@ -8,6 +9,10 @@ import { UiLocale } from '@/utils/l10n/types'
 export default class MyDocument extends Document {
   lang() {
     return getLocaleOrFallback(this.props.locale as UiLocale).htmlLang
+  }
+
+  chatWidgetSrc() {
+    return getLocaleOrFallback(this.props.locale as UiLocale).chatWidgetSrc
   }
 
   render() {
@@ -29,6 +34,8 @@ export default class MyDocument extends Document {
           <GTMBodyScript />
           <Main />
           <NextScript />
+          {/* This needs to be loaded with 'beforeInteractive' strategy as it adds an iframe when window.load gets fired */}
+          <Script strategy="beforeInteractive" src={this.chatWidgetSrc()}></Script>
         </body>
       </Html>
     )

--- a/apps/store/src/services/CustomerFirst.tsx
+++ b/apps/store/src/services/CustomerFirst.tsx
@@ -1,13 +1,12 @@
 import { Global } from '@emotion/react'
 import { atom, useAtomValue, useSetAtom } from 'jotai'
-import Script from 'next/script'
 import { useCallback, useEffect } from 'react'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { useBreakpoint } from '@/utils/useBreakpoint/useBreakpoint'
 
 const OPEN_ATOM = atom(false)
 
-export const CustomerFirstScript = () => {
+export const CustomerFirstLauncher = () => {
   const isDesktop = useBreakpoint('lg')
   const open = useAtomValue(OPEN_ATOM)
   const { chatWidgetSrc } = useCurrentLocale()
@@ -15,12 +14,8 @@ export const CustomerFirstScript = () => {
   if (!chatWidgetSrc) return null
 
   const showLauncher = isDesktop || open
-  return (
-    <>
-      <Global styles={{ '#chat-iframe': { display: showLauncher ? 'initial' : 'none' } }} />
-      <Script strategy="afterInteractive" src={chatWidgetSrc} />
-    </>
-  )
+
+  return <Global styles={{ '#chat-iframe': { display: showLauncher ? 'initial' : 'none' } }} />
 }
 
 export const useCustomerFirst = () => {


### PR DESCRIPTION
This stack contains two possible solutions for the problem. Let's discuss on which one we want to move forward with.

## Describe your changes

* Make sure chat iframe get's added into the document by firing a `load` event for the `window` object.

## Justify why they are needed

I've noticed in [datadog](https://app.datadoghq.eu/rum/replay/sessions/b93e474b-8f91-4c57-a39b-ebcebd0d8ba8?highlightedEventId=AgAAAYn4MgH-4ckpEQAAAAAAAAAYAAAAAEFZbjRNZ2RVQUFDVmVwdFYtc19mYndBQgAAACQAAAAAMDE4OWY4MzUtNmNiYS00YjUzLThjN2QtMjFjMjVhZjhlYzQ3&seed=dca237d4-a3a3-420f-b374-6b8fc60b4768&ts=1692086174206&from=1692086174100) that some users were having problems to access the chat feature as nothing happened when chat button got clicked. 

<img width="663" alt="Screenshot 2023-08-15 at 11 51 42" src="https://github.com/HedvigInsurance/racoon/assets/19200662/4f853ab9-d7e1-40d0-83fc-25bee4bfb522">

The issue was that chat iframe was not getting added to the DOM at the moment users click on chat button, breaking the app:

<img width="668" alt="Screenshot 2023-08-15 at 11 41 13" src="https://github.com/HedvigInsurance/racoon/assets/19200662/946723af-396f-4344-95bc-b7d44587f986">

There are basically two ways to solve that:

1) Make sure chat iframe gets added to the DOM by firing a load event when the script gets loaded. This is more like an hack solution, so I'm not sure if it's enough.
2) Make sure chat script gets loaded before `window.load` get's fired by changing its load strategy to `beforeInteractive`. However [_next_ doesn't allow us](https://nextjs.org/docs/messages/no-before-interactive-script-outside-document) to use that strategy for loading scripts outside `_document` file, which mean we'd need to load chat script for all pages.

**This PR implements the solution 2)**