### PR TITLE
Bugfix / Make sure name fields in checkout are editable when name is missing

### DIFF
--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -17,7 +17,6 @@ import { getCheckoutStepLink } from '@/components/CheckoutHeader/CheckoutHeader.
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
 import { PersonalNumberField } from '@/components/PersonalNumberField/PersonalNumberField'
 import { useProductRecommendations } from '@/components/ProductRecommendationList/useProductRecommendations'
-import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { TextField } from '@/components/TextField/TextField'
 import { TextWithLink } from '@/components/TextWithLink'
 import {
@@ -178,7 +177,7 @@ const CheckoutPage = (props: CheckoutPageProps) => {
                       disabled
                     />
                     {shouldCollectName && (
-                      <SpaceFlex space={0.25}>
+                      <>
                         <TextField
                           type="text"
                           label={t('FORM_FIRST_NAME_LABEL')}
@@ -191,7 +190,7 @@ const CheckoutPage = (props: CheckoutPageProps) => {
                           name={FormElement.LastName}
                           required
                         />
-                      </SpaceFlex>
+                      </>
                     )}
                     {shouldCollectEmail && (
                       <TextField


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Fix [issue](https://hedviginsurance.slack.com/archives/CPCUHMMJQ/p1692087830953549) in checkout where name fields were none editable for customers with missing name.
Make sure name fields are displayed correctly. 

### Before
<img width="786" alt="Screenshot 2023-08-15 at 13 22 54" src="https://github.com/HedvigInsurance/racoon/assets/6661511/7cf64485-4398-4fe0-a92a-6b474f04ea6c">

### After
<img width="788" alt="Screenshot 2023-08-15 at 13 24 11" src="https://github.com/HedvigInsurance/racoon/assets/6661511/dbee8aee-4526-424c-9578-710b82a579c5">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
