### PR TITLE
GEN-860 - chore: bump @apollo/client 3.7.17 - 3.8.1

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,7 @@
   "labels": ["needs approval/merge"],
   // Don't update nextjs until client-side navigation issue is solved
   // https://github.com/vercel/next.js/issues/53967
-  "ignoreDeps": ["next", "eslint-config-next", "@next/bundle-analyzer", "@apollo/client"],
+  "ignoreDeps": ["next", "eslint-config-next", "@next/bundle-analyzer"],
   "packageRules": [
     {
       "matchDepTypes": ["dependencies"],

--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@adyen/adyen-web": "3.23.0",
-    "@apollo/client": "3.7.17",
+    "@apollo/client": "3.8.1",
     "@apollo/experimental-nextjs-app-support": "0.4.1",
     "@datadog/browser-logs": "4.46.0",
     "@datadog/browser-rum": "4.46.0",

--- a/apps/store/src/services/bankId/useBankIdCheckoutSign.ts
+++ b/apps/store/src/services/bankId/useBankIdCheckoutSign.ts
@@ -86,6 +86,9 @@ export const useBankIdCheckoutSignApi = ({ dispatch }: Options) => {
           fetchSigning({
             variables: { shopSessionSigningId },
             pollInterval: 1000,
+            // Make sure 'onCompleted' gets called during the whole pooling process
+            // https://github.com/apollographql/apollo-client/pull/10229
+            notifyOnNetworkStatusChange: true,
             async onCompleted(data) {
               if (subscriber.closed) return
               const { status, completion } = data.shopSessionSigning

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,17 +41,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:3.7.17":
-  version: 3.7.17
-  resolution: "@apollo/client@npm:3.7.17"
+"@apollo/client@npm:3.8.1":
+  version: 3.8.1
+  resolution: "@apollo/client@npm:3.8.1"
   dependencies:
     "@graphql-typed-document-node/core": ^3.1.1
-    "@wry/context": ^0.7.0
-    "@wry/equality": ^0.5.0
-    "@wry/trie": ^0.4.0
+    "@wry/context": ^0.7.3
+    "@wry/equality": ^0.5.6
+    "@wry/trie": ^0.4.3
     graphql-tag: ^2.12.6
     hoist-non-react-statics: ^3.3.2
-    optimism: ^0.16.2
+    optimism: ^0.17.5
     prop-types: ^15.7.2
     response-iterator: ^0.2.6
     symbol-observable: ^4.0.0
@@ -73,7 +73,7 @@ __metadata:
       optional: true
     subscriptions-transport-ws:
       optional: true
-  checksum: d25e955f3c409885185405ca5876cb74538becafa202257a27483c07d7faa9ce83b34d4cab4b7fd9ad217f80d768e651881292c406dbbca221c91013917890d7
+  checksum: 3a1748359a7c0f339764e7764dc6c7426be1d522eda963416d3a693733edbce8408cb8f78f9c98b036d34621af663e3dd3446703dfd29037c78a77eacd3c70bb
   languageName: node
   linkType: hard
 
@@ -10762,7 +10762,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wry/equality@npm:^0.5.0":
+"@wry/context@npm:^0.7.3":
+  version: 0.7.3
+  resolution: "@wry/context@npm:0.7.3"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 91c1e9eee9046c48ff857d60dcbb59f22246ce0f9bb2d9b190e0555227e7ba3f86024032cc057f3f5141d3bee93fc6b2a15ce2c79fa512569d3432eb8e1af02b
+  languageName: node
+  linkType: hard
+
+"@wry/equality@npm:^0.5.6":
   version: 0.5.6
   resolution: "@wry/equality@npm:0.5.6"
   dependencies:
@@ -10771,16 +10780,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wry/trie@npm:^0.3.0":
-  version: 0.3.2
-  resolution: "@wry/trie@npm:0.3.2"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 151d06b519e1ff1c3acf6ee6846161b1d7d50bbecd4c48e5cd1b05f9e37c30602aff02e88f20105f6e6c54ae4123f9c4eb7715044d7fd927d4ba4ec3e755cd36
-  languageName: node
-  linkType: hard
-
-"@wry/trie@npm:^0.4.0":
+"@wry/trie@npm:^0.4.3":
   version: 0.4.3
   resolution: "@wry/trie@npm:0.4.3"
   dependencies:
@@ -20501,13 +20501,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"optimism@npm:^0.16.2":
-  version: 0.16.2
-  resolution: "optimism@npm:0.16.2"
+"optimism@npm:^0.17.5":
+  version: 0.17.5
+  resolution: "optimism@npm:0.17.5"
   dependencies:
     "@wry/context": ^0.7.0
-    "@wry/trie": ^0.3.0
-  checksum: a98ed9a0b8ee2b031010222099b60860d52860bf8182889f2695a7cf2185f21aca59020f78e2b47c0ae7697843caa576798d792967314ff59f6aa7c5d9de7f3a
+    "@wry/trie": ^0.4.3
+    tslib: ^2.3.0
+  checksum: 5990217d989e9857dc523a64cb6e5a9205eae68c7acac78f7dde8fbe50045d0f11ca8068cdbb51b1eae15510d96ad593a99cf98c6f86c41d1b6f90e54956ff11
   languageName: node
   linkType: hard
 
@@ -23373,7 +23374,7 @@ __metadata:
   resolution: "store@workspace:apps/store"
   dependencies:
     "@adyen/adyen-web": 3.23.0
-    "@apollo/client": 3.7.17
+    "@apollo/client": 3.8.1
     "@apollo/experimental-nextjs-app-support": 0.4.1
     "@babel/core": 7.22.10
     "@babel/preset-env": 7.22.10


### PR DESCRIPTION
## Describe your changes

* Bump `@apollo/client`: `3.17.1` --> `3.8.1`
* Update  apollo's `useQuery` instances in our code that relies on `onCompleted` callback.

I've went through the code looking for usages of `useQuery`'s `onCompleted` and proper updated them.

There's some occurrences where I think we don't need to do anything:

```
apps/store/src/components/InitiateCarCancellationPage/InitiateCarCancellationPage.tsx:
  34:     onCompleted(data) {
apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx:
  73:     onCompleted() {

```

## Justify why they are needed

### Some context

More details can be found [here](https://github.com/apollographql/apollo-client/pull/10229) but in summary `@apollo/client@3.8.1` changes the circumstances when `useQuery`'s `onCompleted` callback gets executed. Before:

> writes to the cache (it doesn't matter how the cache update occurs: directly via cache.writeQuery, via a separate useMutation call, etc.) trigger the onCompleted callback passed to useQuery.

Now `onCompleted` execution is directly related with query's `result` loading states: if the loading state doesn't change, `onCompleted` won't re-fire.

### Why does our code doesn't just works with `3.8.1`?

We've been "exploiting" that previous behaviour to write "side effect" code using apollo client's API instead of `useEffects` because, you know, nobody likes `useEffects`. This new version, which seems to be implementing the expect behaviour when it comes  about `onCompleted`,  then means to us that we'd need to stop looking at `onCompleted` as a escape hatch for `useEffects`. It also means it's not connected to apollo's cache in a global sense anymore meaning it only cares about the query that defines it. With that said `3.8.1` defines basically two use cases for `onCompleted`:

1) When you want to execute a callback with the data retrieved by a **particular query** after **its first successful data retrieval from the network**;
2) When you want to execute a callback with the data retrieved by a **particular query** after **every successful data retrieval from the network**

For option 1) one only needs to provide a `onCompleted` callback function. For option 2), `notifyOnNetworkStatusChange ` should also be set to `true`.