### PR TITLE
Make sure we resolve path with query params to valid URL in ShopSession debugger

### DIFF
--- a/apps/store/src/pages/api/session/reset.ts
+++ b/apps/store/src/pages/api/session/reset.ts
@@ -9,11 +9,11 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   await resetSessionServerSide(req, res)
 
   const nextQueryParam = req.query['next']
-  const nextURL = new URL(ORIGIN_URL)
+  let nextURL = new URL(ORIGIN_URL)
   if (typeof nextQueryParam === 'string') {
-    nextURL.pathname = nextQueryParam
+    nextURL = new URL(nextQueryParam, nextURL)
   } else {
-    nextURL.pathname = PageLink.home()
+    nextURL = new URL(PageLink.home(), nextURL)
   }
 
   const destination = nextURL.toString()


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Make sure we construct `nextURL` with query params correctly. 
`se/forsakringar/hemforsakring/bostadsratt?openPriceCalculator=1` instead of `se/forsakringar/hemforsakring/bostadsratt%3FopenPriceCalculator=1`

Apparently you can't set pathname including query params, but you need to construct a new URL with the path and base URL.
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Annoying when reseting a session and you had the price calculator open it would cause a 404 due to misformatted query params in URL

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
