### PR TITLE
feat(ActionButton): update so they accept refs

### DIFF
--- a/apps/store/src/components/ProductItem/ProductItem.tsx
+++ b/apps/store/src/components/ProductItem/ProductItem.tsx
@@ -1,6 +1,6 @@
 import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
-import { type ComponentProps, useState, type ReactNode } from 'react'
+import { type ComponentProps, useState, forwardRef, type ReactNode } from 'react'
 import { Button, ButtonProps, Text, theme } from 'ui'
 import * as Collapsible from '@/components/Collapsible'
 import { Pillow } from '@/components/Pillow/Pillow'
@@ -54,9 +54,10 @@ export const ProductItem = (props: Props) => {
   )
 }
 
-export const ActionButton = (props: ButtonProps) => {
-  return <Button size="medium" variant="secondary-alt" {...props} />
-}
+export const ActionButton = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+  return <Button ref={ref} size="medium" variant="secondary-alt" {...props} />
+})
+ActionButton.displayName = 'ActionButton'
 
 const pulsingAnimation = keyframes({
   '0%': { opacity: 0.5 },


### PR DESCRIPTION
## Describe your changes

- Update `ActionButton`s so they can accept `refs`, solving the error bellow.

<img width="843" alt="Screenshot 2023-08-17 at 16 31 29" src="https://github.com/HedvigInsurance/racoon/assets/19200662/f63ddd50-d290-4a01-9b78-2beffd14070d">

## Justify why they are needed

Those buttons are being used as custom radix `Dialog` triggers, so they need to be able to accept `ref`s as radix uses them for focus management.

https://github.com/HedvigInsurance/racoon/assets/19200662/8b14a0c1-8a46-4fe0-85b4-de4fa7b45fe3
