### PR TITLE
fix(CancellationForm): display it with the correct initial state when cancellation option equals BANKSIGNERING_INVALID_RENEWAL_DATE

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/CancellationForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/CancellationForm/CancellationForm.tsx
@@ -105,7 +105,7 @@ const BankSigneringCancellation = (props: BankSigneringCancellationProps) => {
   const formattedCompanyName = formatter.titleCase(props.companyName)
   const autoSwitchLabel = t('AUTO_SWITCH_START_DATE_LABEL', { company: formattedCompanyName })
 
-  if (props.requested && props.invalidRenewalDate) {
+  if (props.invalidRenewalDate) {
     return (
       <Space y={0.25}>
         <SmartDateInput date={date} onChange={props.onStartDateChange} />


### PR DESCRIPTION
## Describe your changes

- Update `CancellationForm` so it renders with the correct initial state for `BANKSIGNERING_INVALID_RENEWAL_DATE` cancellation option.

<img width="439" alt="Screenshot 2023-08-18 at 15 24 33" src="https://github.com/HedvigInsurance/racoon/assets/19200662/b47ff628-999b-4748-9c7f-be958d1f4c4e">

## Justify why they are needed

We've beeng displaying it with the incorrect intial state for `BANKSIGNERING_INVALID_RENEWAL_DATE` cancellation option as one could see the "Switch automatically" toggle for scenarios that we can't actually do it.
