### PR TITLE
Add CookieListBlock to display cookie list from OneTrust

### DIFF
--- a/apps/store/src/blocks/CookieListBlock.tsx
+++ b/apps/store/src/blocks/CookieListBlock.tsx
@@ -1,0 +1,13 @@
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+
+export const CookieListBlock = () => {
+  return (
+    <GridLayout.Root>
+      <GridLayout.Content width={{ base: '1', md: '2/3', xxl: '1/2' }} align={'center'}>
+        <div id="ot-sdk-cookie-policy"></div>
+      </GridLayout.Content>
+    </GridLayout.Root>
+  )
+}
+
+CookieListBlock.blockName = 'cookieList'

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -19,6 +19,7 @@ import { ComparisonTableBlock } from '@/blocks/ComparisonTableBlock'
 import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
 import { ContactSupportBlock } from '@/blocks/ContactSupportBlock'
 import { ContentBlock } from '@/blocks/ContentBlock'
+import { CookieListBlock } from '@/blocks/CookieListBlock'
 import { DownloadableContentItemBlock } from '@/blocks/DownloadableContentItemBlock'
 import { FooterBlock, FooterBlockProps, FooterLink, FooterSection } from '@/blocks/FooterBlock'
 import { GridBlock } from '@/blocks/GridBlock'
@@ -261,6 +262,7 @@ export const initStoryblok = () => {
     ImageTextBlock,
     InlineSpaceBlock,
     InsurableLimitsBlock,
+    CookieListBlock,
     MediaListBlock,
     ModalBlock,
     NavItemBlock,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add CookieListBlock to display cookie list from OneTrust

The OneTrust script fetches and outputs content in the div with the `id`. Styling is handled in OneTrust dashboard.

<img width="1213" alt="Screenshot 2023-08-21 at 14 09 12" src="https://github.com/HedvigInsurance/racoon/assets/6661511/b36dc6be-cdf4-4c56-839e-6ad46cd9a470">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Needed for GDPR compliance

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
