### PR TITLE
Cart Resume: show skeleton UI in draft mode

### DIFF
--- a/apps/store/src/features/retargeting/RetargetingBlock.tsx
+++ b/apps/store/src/features/retargeting/RetargetingBlock.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { motion, AnimatePresence } from 'framer-motion'
+import { useRouter } from 'next/router'
+import { useMemo } from 'react'
 import { mq, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { MENU_BAR_HEIGHT_DESKTOP, MENU_BAR_HEIGHT_MOBILE } from '@/components/Header/HeaderStyles'
@@ -19,6 +21,9 @@ type Props = SbBaseBlockProps<{
 export const RetargetingBlock = (props: Props) => {
   const offers = useRetargetingOffers()
 
+  const isInStoryblokEditor = useIsInStoryblokEditor()
+  const showEmptyState = offers === null || (isInStoryblokEditor && offers.length === 0)
+
   return (
     <GridLayout.Root {...storyblokEditable(props.blok)}>
       <GridLayoutContent
@@ -26,8 +31,8 @@ export const RetargetingBlock = (props: Props) => {
         align={props.blok.layout?.alignment ?? 'center'}
       >
         <List>
-          {offers === null ? (
-            Array.from({ length: 3 }).map((_, index) => <Skeleton key={index} />)
+          {showEmptyState ? (
+            <EmptyState />
           ) : (
             <AnimatePresence mode="popLayout">
               {offers.map((item) => (
@@ -65,3 +70,18 @@ const List = styled.ul({
   flexDirection: 'column',
   gap: theme.space.md,
 })
+
+const EmptyState = () => {
+  return (
+    <>
+      {Array.from({ length: 3 }).map((_, index) => (
+        <Skeleton key={index} />
+      ))}
+    </>
+  )
+}
+
+const useIsInStoryblokEditor = () => {
+  const router = useRouter()
+  return useMemo(() => router.query['draftMode'] === '1', [router.query])
+}

--- a/apps/store/src/pages/api/draft.ts
+++ b/apps/store/src/pages/api/draft.ts
@@ -37,6 +37,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const url = new URL(req.url ?? '', ORIGIN_URL)
   url.searchParams.delete('secret')
 
+  url.searchParams.set('draftMode', '1')
   const targetUrl = `/${story.full_slug}`
   console.debug(`Previewing ${targetUrl}`)
   res.redirect(`${targetUrl}?${url.searchParams.toString()}`)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

![Screenshot 2023-08-22 at 11.56.17.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/36793d54-2fe6-414f-939f-871297699f40/Screenshot%202023-08-22%20at%2011.56.17.png)

- Show skeleton UI on cart resume page while in draft more (in Storyblok editor)

- Add query param after navigating from draft mode API route

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- To make it easier to preview how the page will look like for editors

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
