### PR TITLE
Add OneTrust cookie list styling

### DIFF
--- a/apps/store/src/blocks/CookieListBlock.tsx
+++ b/apps/store/src/blocks/CookieListBlock.tsx
@@ -1,13 +1,105 @@
+import styled from '@emotion/styled'
+import { mq, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 
 export const CookieListBlock = () => {
   return (
     <GridLayout.Root>
       <GridLayout.Content width={{ base: '1', md: '2/3', xxl: '1/2' }} align={'center'}>
-        <div id="ot-sdk-cookie-policy"></div>
+        <OneTrustCookieInfo id="ot-sdk-cookie-policy"></OneTrustCookieInfo>
       </GridLayout.Content>
     </GridLayout.Root>
   )
 }
+
+/**
+ * OneTrust CSS overides for Cookie List
+ * Styling is written in string litteral to make it easy
+ * to migrate between OneTrust and the component
+ */
+
+const OneTrustCookieInfo = styled.div`
+  * {
+    font-weight: 400 !important;
+    -webkit-font-smoothing: antialiased !important;
+    -moz-osx-font-smoothing: grayscale !important;
+  }
+
+  #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-description,
+  #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-cookie-policy-group-desc {
+    font-size: ${theme.fontSizes.md};
+  }
+
+  #ot-sdk-cookie-policy .ot-sdk-container,
+  #ot-sdk-cookie-policy-v2 {
+    padding: 0 !important;
+  }
+
+  #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-table-header,
+  #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td {
+    font-size: ${theme.space.md};
+  }
+
+  #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table th,
+  #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table td {
+    border-color: ${theme.colors.borderTranslucent2};
+  }
+
+  #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h3,
+  #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h4 {
+    font-weight: 400;
+    line-height: 1.26;
+  }
+
+  .ot-cookies-td:before {
+    color: ${theme.colors.textPrimary};
+  }
+
+  #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h3,
+  #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h4 {
+    margin-top: ${theme.space.xxl};
+    margin-bottom: ${theme.space.xs};
+    font-size: ${theme.fontSizes.md};
+  }
+
+  #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy a,
+  #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy a:hover {
+    background-color: transparent;
+  }
+
+  #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-cookie-policy-group {
+    margin-bottom: ${theme.space.xs};
+  }
+
+  ${mq.md} {
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h3,
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h4 {
+      font-size: ${theme.fontSizes.xl};
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-description,
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-cookie-policy-group-desc {
+      font-size: ${theme.fontSizes.xl};
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table {
+      font-size: ${theme.fontSizes.md};
+    }
+  }
+  ${mq.lg} {
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-table-header,
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td {
+      font-size: ${theme.fontSizes.md};
+    }
+  }
+
+  /* OneTrust breakpoint override */
+  @media only screen and (max-width: 530px) {
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td:before {
+      font-weight: 400;
+      color: ${theme.colors.textPrimary};
+    }
+  }
+`
 
 CookieListBlock.blockName = 'cookieList'


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add OneTrust cookie list styling. Makes it easier to change to override it in the component than having it in OneTrust dashboard, so I migrated it over from there. I kept it in string format to make migration back and forth easier ( and it's a pain to write class name styling with object syntax 😆)


https://github.com/HedvigInsurance/racoon/assets/6661511/f82251a1-5fb9-4ddc-af6c-46762ad52bb9


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
