### PR TITLE
GEN-910 - feat(pet-insurance): added min/max constraints for 'birthDate' input

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -45,6 +45,7 @@
     "apollo-link-timeout": "4.0.0",
     "clone-deep": "4.0.1",
     "cookies-next": "2.1.2",
+    "date-fns": "2.30.0",
     "downshift": "8.1.0",
     "framer-motion": "10.16.0",
     "graphql": "16.8.0",

--- a/apps/store/src/services/PriceCalculator/data/SE_PET_CAT.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_PET_CAT.ts
@@ -1,9 +1,14 @@
+import { subWeeks, subYears } from 'date-fns'
+import { formatInputDateValue } from '@/utils/date'
 import { setI18nNamespace, tKey } from '@/utils/i18n'
 import { LAYOUT, ssnSeSection } from '../formFragments'
 import { yourAddressSectionWithlivingSpace } from '../formFragments'
 import { Template } from '../PriceCalculator.types'
 
 setI18nNamespace('purchase-form')
+
+const MIN = formatInputDateValue(subYears(new Date(), 20)) // at maximum 20 years old
+const MAX = formatInputDateValue(subWeeks(new Date(), 12)) // at mininum 12 weeks old
 
 export const SE_PET_CAT: Template = {
   name: 'SE_PET_CAT',
@@ -57,6 +62,8 @@ export const SE_PET_CAT: Template = {
             type: 'date',
             name: 'birthDate',
             label: { key: tKey('FIELD_BIRTH_DATE_PET_LABEL') },
+            min: MIN,
+            max: MAX,
             required: true,
           },
           layout: LAYOUT.FULL_WIDTH,

--- a/apps/store/src/services/PriceCalculator/data/SE_PET_DOG.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_PET_DOG.ts
@@ -1,12 +1,17 @@
+import { subWeeks, subYears } from 'date-fns'
 import {
   LAYOUT,
   ssnSeSection,
   yourAddressSectionWithlivingSpace,
 } from '@/services/PriceCalculator/formFragments'
+import { formatInputDateValue } from '@/utils/date'
 import { setI18nNamespace, tKey } from '@/utils/i18n'
 import { Template } from '../PriceCalculator.types'
 
 setI18nNamespace('purchase-form')
+
+const MIN = formatInputDateValue(subYears(new Date(), 20)) // at maximum 20 years old
+const MAX = formatInputDateValue(subWeeks(new Date(), 8)) // at mininum 8 weeks old
 
 export const SE_PET_DOG: Template = {
   name: 'SE_PET_DOG',
@@ -54,6 +59,8 @@ export const SE_PET_DOG: Template = {
             type: 'date',
             name: 'birthDate',
             label: { key: tKey('FIELD_BIRTH_DATE_PET_LABEL') },
+            min: MIN,
+            max: MAX,
             required: true,
           },
           layout: LAYOUT.FULL_WIDTH,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3797,6 +3797,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.21.0":
+  version: 7.22.10
+  resolution: "@babel/runtime@npm:7.22.10"
+  dependencies:
+    regenerator-runtime: ^0.14.0
+  checksum: 524d41517e68953dbc73a4f3616b8475e5813f64e28ba89ff5fca2c044d535c2ea1a3f310df1e5bb06162e1f0b401b5c4af73fe6e2519ca2450d9d8c44cf268d
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/runtime@npm:7.22.5"
@@ -13480,6 +13489,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns@npm:2.30.0":
+  version: 2.30.0
+  resolution: "date-fns@npm:2.30.0"
+  dependencies:
+    "@babel/runtime": ^7.21.0
+  checksum: f7be01523282e9bb06c0cd2693d34f245247a29098527d4420628966a2d9aad154bd0e90a6b1cf66d37adcb769cd108cf8a7bd49d76db0fb119af5cdd13644f4
+  languageName: node
+  linkType: hard
+
 "de-indent@npm:^1.0.2":
   version: 1.0.2
   resolution: "de-indent@npm:1.0.2"
@@ -22078,6 +22096,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerator-runtime@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "regenerator-runtime@npm:0.14.0"
+  checksum: 1c977ad82a82a4412e4f639d65d22be376d3ebdd30da2c003eeafdaaacd03fc00c2320f18120007ee700900979284fc78a9f00da7fb593f6e6eeebc673fba9a3
+  languageName: node
+  linkType: hard
+
 "regenerator-transform@npm:^0.15.1":
   version: 0.15.1
   resolution: "regenerator-transform@npm:0.15.1"
@@ -23405,6 +23430,7 @@ __metadata:
     babel-loader: 9.1.3
     clone-deep: 4.0.1
     cookies-next: 2.1.2
+    date-fns: 2.30.0
     downshift: 8.1.0
     eslint: 8.47.0
     eslint-config-custom: "workspace:"


### PR DESCRIPTION
## Describe your changes

- Added min/max constraints for 'birthDate' input field for Cat and Dog insurance. They follow their respective underwriter guidelines for [cat](https://github.com/HedvigInsurance/underwriter/blob/master/src/main/kotlin/com/hedvig/underwriter/service/guidelines/SwedishCatGuidelines.kt#L18-L24) and [dog](https://github.com/HedvigInsurance/underwriter/blob/master/src/main/kotlin/com/hedvig/underwriter/service/guidelines/SwedishDogGuidelines.kt#L19-L25) insurances.

## Justify why they are needed

[Ticket](https://www.notion.so/hedviginsurance/Price-calculator-missing-validation-for-date-picker-field-birth-date-pet-insurance-b91a57daa5994d938e1e05b2fd901b55?pvs=4)
