### PR TITLE
ShopBreakdown: implement product item container in retargeting block

### DIFF
--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -8,6 +8,7 @@ import { CartEntryList } from '@/components/CartInventory/CartEntryList'
 import { CartEntryOfferItem } from '@/components/CartInventory/CartEntryOfferItem'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { Skeleton } from '@/components/ProductItem/ProductItem'
+import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
 import { ProductRecommendationList } from '@/components/ProductRecommendationList/ProductRecommendationList'
 import { useProductRecommendations } from '@/components/ProductRecommendationList/useProductRecommendations'
 import { Divider, ShopBreakdown } from '@/components/ShopBreakdown/ShopBreakdown'
@@ -17,8 +18,9 @@ import { useTracking } from '@/services/Tracking/useTracking'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { PageLink } from '@/utils/PageLink'
 import { DiscountFieldContainer } from './DiscountFieldContainer'
+import { EditActionButton } from './EditActionButton'
 import { PageDebugDialog } from './PageDebugDialog'
-import { ProductItemContainer } from './ProductItemContainer'
+import { RemoveActionButton } from './RemoveActionButton'
 import { TotalAmountContainer } from './TotalAmountContainer'
 
 export const CartPage = () => {
@@ -58,7 +60,14 @@ export const CartPage = () => {
 
               <ShopBreakdown>
                 {shopSession.cart.entries.map((item) => (
-                  <ProductItemContainer key={item.id} shopSessionId={shopSession.id} offer={item} />
+                  <ProductItemContainer key={item.id} offer={item}>
+                    <EditActionButton shopSessionId={shopSession.id} offer={item} />
+                    <RemoveActionButton
+                      shopSessionId={shopSession.id}
+                      offerId={item.id}
+                      title={item.variant.product.displayNameFull}
+                    />
+                  </ProductItemContainer>
                 ))}
                 <DiscountFieldContainer shopSession={shopSession} />
                 <Divider />

--- a/apps/store/src/components/ProductItem/ProductItemContainer.tsx
+++ b/apps/store/src/components/ProductItem/ProductItemContainer.tsx
@@ -1,21 +1,17 @@
 import { useTranslation } from 'next-i18next'
-import { useMemo } from 'react'
-import { ProductItem } from '@/components/ProductItem/ProductItem'
+import { useMemo, type ReactNode } from 'react'
 import { type ProductOfferFragment } from '@/services/apollo/generated'
-import { EditActionButton } from './EditActionButton'
-import { RemoveActionButton } from './RemoveActionButton'
+import { ProductItem } from './ProductItem'
 import { useGetStartDateProps } from './useGetStartDateProps'
 
 type Props = {
-  shopSessionId: string
   offer: ProductOfferFragment
+  children: ReactNode
 }
 
 export const ProductItemContainer = (props: Props) => {
   const { t } = useTranslation('cart')
   const getStartDateProps = useGetStartDateProps()
-
-  const title = props.offer.variant.product.displayNameFull
 
   const hasDiscount = props.offer.cost.discount.amount > 0
   const price = {
@@ -53,19 +49,14 @@ export const ProductItemContainer = (props: Props) => {
 
   return (
     <ProductItem
-      title={title}
+      title={props.offer.variant.product.displayNameFull}
       pillowSrc={props.offer.variant.product.pillowImage.src}
       price={price}
       startDate={startDateProps}
       productDetails={productDetails}
       productDocuments={productDocuments}
     >
-      <EditActionButton shopSessionId={props.shopSessionId} offer={props.offer} />
-      <RemoveActionButton
-        shopSessionId={props.shopSessionId}
-        offerId={props.offer.id}
-        title={title}
-      />
+      {props.children}
     </ProductItem>
   )
 }

--- a/apps/store/src/components/ProductItem/useGetStartDateProps.ts
+++ b/apps/store/src/components/ProductItem/useGetStartDateProps.ts
@@ -1,7 +1,7 @@
 import { useTranslation } from 'next-i18next'
 import { type ComponentProps, useCallback } from 'react'
-import { ProductItem } from '@/components/ProductItem/ProductItem'
 import { useFormatter } from '@/utils/useFormatter'
+import { type ProductItem } from './ProductItem'
 
 type Params = {
   productName: string

--- a/apps/store/src/features/retargeting/MultiTierOffer.tsx
+++ b/apps/store/src/features/retargeting/MultiTierOffer.tsx
@@ -1,26 +1,21 @@
 import { useTranslation } from 'next-i18next'
-import { useMemo } from 'react'
-import { useProductItemProps } from '@/components/CartInventory/CartEntryItem/useProductItemProps'
-import { getCartEntry } from '@/components/CartInventory/CartInventory.helpers'
-import { ProductItem } from '@/components/ProductItem/ProductItem'
+import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
 import { type ProductOfferFragment } from '@/services/apollo/generated'
-import { ProductPageLink } from './ProductPageLink'
+import { ProductLinkActionButton } from './ProductPageLink'
 
 type Props = {
   product: ProductOfferFragment['variant']['product']
-  offers: Array<ProductOfferFragment>
   defaultOffer: ProductOfferFragment
 }
 
 export const MultiTierOffer = (props: Props) => {
   const { t } = useTranslation()
-  const cartEntry = useMemo(() => getCartEntry(props.defaultOffer), [props.defaultOffer])
 
   return (
-    <ProductItem {...useProductItemProps(cartEntry)}>
-      <ProductPageLink href={props.product.pageLink}>
+    <ProductItemContainer offer={props.defaultOffer}>
+      <ProductLinkActionButton href={props.product.pageLink}>
         {t('CRM_RETARGETING_CHOOSE_TIER')}
-      </ProductPageLink>
-    </ProductItem>
+      </ProductLinkActionButton>
+    </ProductItemContainer>
   )
 }

--- a/apps/store/src/features/retargeting/ProductPageLink.tsx
+++ b/apps/store/src/features/retargeting/ProductPageLink.tsx
@@ -6,7 +6,7 @@ type Props = {
   children: string
 }
 
-export const ProductPageLink = (props: Props) => {
+export const ProductLinkActionButton = (props: Props) => {
   return (
     <ButtonNextLink href={props.href} size="medium" variant="secondary-alt">
       <SpaceFlex space={0.5} align="center">

--- a/apps/store/src/features/retargeting/SingleTierOffer.tsx
+++ b/apps/store/src/features/retargeting/SingleTierOffer.tsx
@@ -1,14 +1,11 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { useMemo } from 'react'
-import { Button, theme } from 'ui'
-import { useProductItemProps } from '@/components/CartInventory/CartEntryItem/useProductItemProps'
-import { getCartEntry } from '@/components/CartInventory/CartInventory.helpers'
-import { ProductItem } from '@/components/ProductItem/ProductItem'
+import { ActionButton } from '@/components/ProductItem/ProductItem'
+import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
 import { useHandleSubmitAddToCart } from '@/components/ProductPage/PurchaseForm/useHandleSubmitAddToCart'
 import { type ProductOfferFragment } from '@/services/apollo/generated'
-import { ProductPageLink } from './ProductPageLink'
+import { ProductLinkActionButton } from './ProductPageLink'
 
 type Props = {
   shopSessionId: string
@@ -25,29 +22,19 @@ export const SingleTierOffer = (props: Props) => {
     },
   })
 
-  const cartEntry = useMemo(() => getCartEntry(props.offer), [props.offer])
-
   return (
-    <ProductItem {...useProductItemProps(cartEntry)}>
-      <ButtonGroup>
-        <ProductPageLink href={props.product.pageLink}>
-          {t('CART_ENTRY_EDIT_BUTTON')}
-        </ProductPageLink>
-        <Form onSubmit={getHandleSubmit(props.offer.id)}>
-          <Button type="submit" size="medium" variant="secondary-alt" loading={loading}>
-            {t('ADD_TO_CART_BUTTON_LABEL')}
-          </Button>
-        </Form>
-      </ButtonGroup>
-    </ProductItem>
+    <ProductItemContainer offer={props.offer}>
+      <ProductLinkActionButton href={props.product.pageLink}>
+        {t('CART_ENTRY_EDIT_BUTTON')}
+      </ProductLinkActionButton>
+      <Form onSubmit={getHandleSubmit(props.offer.id)}>
+        <ActionButton type="submit" loading={loading}>
+          {t('ADD_TO_CART_BUTTON_LABEL')}
+        </ActionButton>
+      </Form>
+    </ProductItemContainer>
   )
 }
-
-const ButtonGroup = styled.div({
-  display: 'grid',
-  gridTemplateColumns: 'repeat(2, 1fr)',
-  columnGap: theme.space.xs,
-})
 
 const Form = styled.form({
   display: 'grid',

--- a/apps/store/src/features/retargeting/useRetargetingOffers.ts
+++ b/apps/store/src/features/retargeting/useRetargetingOffers.ts
@@ -40,7 +40,6 @@ export const useRetargetingOffers = (): Array<Offer> | null => {
           type: 'multiple',
           product: item.offers[0].variant.product,
           defaultOffer: item.offers[0],
-          offers: item.offers,
         })
       }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Implement product item container in retargeting block

- Move product item container to product item folder to indicate that it is reusable

- Make container accept children instead of rendering predefined action buttons

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- I will continue implementing and seeing if this is the right abstractions

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
