### PR TITLE
ShopBreakdown: add presentational `QuickAdd` component

### DIFF
--- a/apps/store/src/components/Price.tsx
+++ b/apps/store/src/components/Price.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { ComponentProps } from 'react'
 import { Text, theme } from 'ui'
 import { CurrencyCode } from '@/services/apollo/generated'
 import { useFormatter } from '@/utils/useFormatter'
@@ -7,22 +8,29 @@ type Props = {
   currencyCode: CurrencyCode
   amount: number
   reducedAmount?: number
+
+  color?: ComponentProps<typeof Text>['color']
+  secondaryColor?: ComponentProps<typeof Text>['color']
 }
 
-export const Price = (props: Props) => {
+export const Price = ({
+  color = 'textPrimary',
+  secondaryColor = 'textSecondary',
+  ...props
+}: Props) => {
   const formatter = useFormatter()
 
   return (
     <Wrapper>
       {props.reducedAmount !== undefined && (
-        <Text as="p" size="md" strikethrough={true} color="textSecondary">
+        <Text as="p" size="md" strikethrough={true} color={secondaryColor}>
           {formatter.monthlyPrice({
             amount: props.amount,
             currencyCode: props.currencyCode,
           })}
         </Text>
       )}
-      <Text as="p" size="md">
+      <Text as="p" size="md" color={color}>
         {formatter.monthlyPrice({
           currencyCode: props.currencyCode,
           amount: props.reducedAmount ?? props.amount,

--- a/apps/store/src/components/ShopBreakdown/QuickAdd.stories.tsx
+++ b/apps/store/src/components/ShopBreakdown/QuickAdd.stories.tsx
@@ -1,0 +1,43 @@
+import { type Meta, type StoryObj } from '@storybook/react'
+import { CurrencyCode } from '@/services/apollo/generated'
+import { QuickAdd } from './QuickAdd'
+
+const meta: Meta<typeof QuickAdd> = {
+  title: 'Components / Shop Breakdown / Quick Add',
+  component: QuickAdd,
+}
+
+export default meta
+type Story = StoryObj<typeof QuickAdd>
+
+export const Default: Story = {
+  args: {
+    title: 'Accident insurance',
+    subtitle: 'Covers 2 people',
+    pillow: {
+      src: 'https://a.storyblok.com/f/165473/832x832/a61cfbf4ae/hedvig-pillows-cat.png',
+    },
+    cost: {
+      currencyCode: CurrencyCode.Sek,
+      amount: 99,
+    },
+  },
+}
+
+export const WithDiscount: Story = {
+  args: {
+    ...Default.args,
+    cost: {
+      currencyCode: CurrencyCode.Sek,
+      amount: 99,
+      reducedAmount: 49,
+    },
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    ...Default.args,
+    loading: true,
+  },
+}

--- a/apps/store/src/components/ShopBreakdown/QuickAdd.tsx
+++ b/apps/store/src/components/ShopBreakdown/QuickAdd.tsx
@@ -1,0 +1,91 @@
+import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
+import { type ComponentProps } from 'react'
+import { Button, Space, Text, mq, theme } from 'ui'
+import { Pillow } from '@/components/Pillow/Pillow'
+import { Price } from '@/components/Price'
+import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
+
+type Props = {
+  title: string
+  subtitle: string
+  pillow: ComponentProps<typeof Pillow>
+  cost: ComponentProps<typeof Price>
+  onAdd: () => void
+  loading: boolean
+  onDismiss: () => void
+}
+
+export const QuickAdd = (props: Props) => {
+  const { t } = useTranslation('cart')
+
+  return (
+    <Card>
+      <Space y={1}>
+        <Header>
+          <SpaceFlex space={1} align="center">
+            <Pillow size="small" {...props.pillow} />
+            <div>
+              <Text color="textTranslucentPrimary">{props.title}</Text>
+              <Text color="textTranslucentSecondary">{props.subtitle}</Text>
+            </div>
+          </SpaceFlex>
+        </Header>
+        <Divider />
+        <Text color="textTranslucentSecondary">
+          {/* TODO: move this text to the api so it can be used with other offer types */}
+          {t('ACCIDENT_OFFER_DESCRIPTION')}
+        </Text>
+        <Footer>
+          <SpaceFlex space={0.5}>
+            <Button size="medium" onClick={props.onAdd} loading={props.loading}>
+              {t('QUICK_ADD_BUTTON')}
+            </Button>
+            <Button size="medium" variant="ghost" onClick={props.onDismiss}>
+              {t('QUICK_ADD_DISMISS')}
+            </Button>
+          </SpaceFlex>
+
+          <Price
+            {...props.cost}
+            color="textTranslucentPrimary"
+            secondaryColor="textTranslucentSecondary"
+          />
+        </Footer>
+      </Space>
+    </Card>
+  )
+}
+
+const Card = styled.div({
+  backgroundColor: theme.colors.blueFill1,
+  borderRadius: theme.radius.md,
+  padding: theme.space.md,
+  borderWidth: 1,
+  borderStyle: 'solid',
+  borderColor: theme.colors.borderTranslucent1,
+
+  [mq.lg]: { padding: theme.space.lg },
+})
+
+const Header = styled.div({
+  paddingBottom: theme.space.xs,
+})
+
+const Divider = styled.div({
+  height: 1,
+  backgroundColor: theme.colors.borderTranslucent1,
+})
+
+const Footer = styled.div({
+  paddingTop: theme.space.xs,
+  display: 'grid',
+  gridTemplateRows: 'auto auto',
+  gap: theme.space.md,
+
+  [mq.sm]: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-08-25 at 11.28.49.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/f1daf795-a6c7-4ab7-9a81-0168176f7646/Screenshot%202023-08-25%20at%2011.28.49.png)


- Add presentational component for `QuickAdd` (from Figma)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Will replace existing `CartEntryOfferItem`

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
