### PR TITLE
ShopBreakdown: simplify `useAddToCart` hook

### DIFF
--- a/apps/store/src/components/ShopBreakdown/QuickAdd.stories.tsx
+++ b/apps/store/src/components/ShopBreakdown/QuickAdd.stories.tsx
@@ -5,6 +5,10 @@ import { QuickAdd } from './QuickAdd'
 const meta: Meta<typeof QuickAdd> = {
   title: 'Components / Shop Breakdown / Quick Add',
   component: QuickAdd,
+  argTypes: {
+    onAdd: { action: 'onAdd' },
+    onDismiss: { action: 'onDismiss' },
+  },
 }
 
 export default meta

--- a/apps/store/src/components/ShopBreakdown/QuickAdd.tsx
+++ b/apps/store/src/components/ShopBreakdown/QuickAdd.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { FormEventHandler, type ComponentProps } from 'react'
+import { type ComponentProps } from 'react'
 import { Button, Space, Text, mq, theme } from 'ui'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { Price } from '@/components/Price'
@@ -11,7 +11,7 @@ type Props = {
   subtitle: string
   pillow: ComponentProps<typeof Pillow>
   cost: ComponentProps<typeof Price>
-  onSubmitAdd: FormEventHandler<HTMLFormElement>
+  onAdd: () => void
   loading: boolean
   onDismiss: () => void
 }
@@ -37,16 +37,14 @@ export const QuickAdd = (props: Props) => {
           {t('ACCIDENT_OFFER_DESCRIPTION')}
         </Text>
         <Footer>
-          <form onSubmit={props.onSubmitAdd}>
-            <SpaceFlex space={0.5}>
-              <Button type="submit" size="medium" loading={props.loading}>
-                {t('QUICK_ADD_BUTTON')}
-              </Button>
-              <Button type="button" size="medium" variant="ghost" onClick={props.onDismiss}>
-                {t('QUICK_ADD_DISMISS')}
-              </Button>
-            </SpaceFlex>
-          </form>
+          <SpaceFlex space={0.5}>
+            <Button size="medium" onClick={props.onAdd} loading={props.loading}>
+              {t('QUICK_ADD_BUTTON')}
+            </Button>
+            <Button size="medium" variant="ghost" onClick={props.onDismiss}>
+              {t('QUICK_ADD_DISMISS')}
+            </Button>
+          </SpaceFlex>
 
           <Price
             {...props.cost}

--- a/apps/store/src/components/ShopBreakdown/QuickAddAccidentContainer.tsx
+++ b/apps/store/src/components/ShopBreakdown/QuickAddAccidentContainer.tsx
@@ -2,12 +2,12 @@ import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
 import { atom, useAtom } from 'jotai'
 import { useTranslation } from 'next-i18next'
-import { useHandleSubmitAddToCart } from '@/components/ProductPage/PurchaseForm/useHandleSubmitAddToCart'
 import {
   OfferRecommendationFragment,
   ProductRecommendationFragment,
 } from '@/services/apollo/generated'
 import { useTracking } from '@/services/Tracking/useTracking'
+import { useAddToCart } from '@/utils/useAddToCart'
 import { QuickAdd } from './QuickAdd'
 
 type Props = {
@@ -20,7 +20,7 @@ export const QuickAddAccidentContainer = (props: Props) => {
   const [show, setShow] = useShowQuickAddOffer()
   const { t } = useTranslation('cart')
 
-  const [getHandleSubmitAddToCart, loading] = useHandleSubmitAddToCart({
+  const [addToCart, loading] = useAddToCart({
     shopSessionId: props.shopSessionId,
     onSuccess() {
       datadogLogs.logger.info('Added quick offer to cart', {
@@ -31,14 +31,13 @@ export const QuickAddAccidentContainer = (props: Props) => {
   })
 
   const tracking = useTracking()
-  const handleSubmitAddToCart = getHandleSubmitAddToCart(props.offer.id)
-  const handleAdd: typeof handleSubmitAddToCart = (event) => {
+  const handleAdd = () => {
     datadogRum.addAction('Quick add to cart', {
       priceIntentId: props.offer.id,
       product: props.product.id,
     })
     tracking.reportAddToCart(props.offer, 'recommendations')
-    return handleSubmitAddToCart(event)
+    addToCart(props.offer.id)
   }
 
   if (!show) return null
@@ -63,7 +62,7 @@ export const QuickAddAccidentContainer = (props: Props) => {
       subtitle={subtitle}
       pillow={props.product.pillowImage}
       cost={cost}
-      onSubmitAdd={handleAdd}
+      onAdd={handleAdd}
       loading={loading}
       onDismiss={handleDismiss}
     />

--- a/apps/store/src/features/retargeting/SingleTierOffer.tsx
+++ b/apps/store/src/features/retargeting/SingleTierOffer.tsx
@@ -1,10 +1,9 @@
 import { datadogLogs } from '@datadog/browser-logs'
-import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { ActionButton } from '@/components/ProductItem/ProductItem'
 import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
-import { useHandleSubmitAddToCart } from '@/components/ProductPage/PurchaseForm/useHandleSubmitAddToCart'
 import { type ProductOfferFragment } from '@/services/apollo/generated'
+import { useAddToCart } from '@/utils/useAddToCart'
 import { ProductLinkActionButton } from './ProductPageLink'
 
 type Props = {
@@ -16,7 +15,7 @@ type Props = {
 
 export const SingleTierOffer = (props: Props) => {
   const { t } = useTranslation('cart')
-  const [getHandleSubmit, loading] = useHandleSubmitAddToCart({
+  const [addToCart, loading] = useAddToCart({
     shopSessionId: props.shopSessionId,
     onSuccess: (productOfferId) => {
       datadogLogs.logger.info('CRM Retarget | Add to cart success')
@@ -29,16 +28,9 @@ export const SingleTierOffer = (props: Props) => {
       <ProductLinkActionButton href={props.product.pageLink}>
         {t('CART_ENTRY_EDIT_BUTTON')}
       </ProductLinkActionButton>
-      <Form onSubmit={getHandleSubmit(props.offer.id)}>
-        <ActionButton type="submit" loading={loading}>
-          {t('ADD_TO_CART_BUTTON_LABEL')}
-        </ActionButton>
-      </Form>
+      <ActionButton onClick={() => addToCart(props.offer.id)} loading={loading}>
+        {t('ADD_TO_CART_BUTTON_LABEL')}
+      </ActionButton>
     </ProductItemContainer>
   )
 }
-
-const Form = styled.form({
-  display: 'grid',
-  justifyContent: 'stretch',
-})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Refactor `useAddToCart` hook to just return a regular callback function

- Only handle `nextUrl` in `OfferPresenter`

- Remove form in `QuickAdd` component

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- The `useAddToCart` hook assumed that we used a form to add to cart but we don't always need to. This change makes it more flexible.

- I also move it to the utility folder to signal that it's used in multiple places.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
