### PR TITLE
Fix: use shop session outcome id to fetch switching contracts

### DIFF
--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -46,7 +46,7 @@ export const ConfirmationPage = (props: Props) => {
 
               {props.switching && (
                 <SwitchingAssistantSection
-                  shopSessionId={props.shopSessionId}
+                  shopSessionOutcomeId={props.shopSessionOutcomeId}
                   {...props.switching}
                 />
               )}

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
@@ -7,6 +7,7 @@ export type ConfirmationPageProps = Pick<StoryblokPageProps, 'globalStory'> & {
   currency: string
   cart: CartFragmentFragment
   shopSessionId: string
+  shopSessionOutcomeId: string
   switching?: {
     companyDisplayName: string
   }

--- a/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection.stories.tsx
+++ b/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection.stories.tsx
@@ -1,6 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
-import { ShopSessionOutcomeDocument } from '@/services/apollo/generated'
+import {
+  ContractExternalInsuranceCancellationStatus,
+  ShopSessionOutcomeDocument,
+  type ShopSessionOutcomeQuery,
+  type ShopSessionOutcomeQueryVariables,
+} from '@/services/apollo/generated'
 import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
 import { SwitchingAssistantSection } from './SwitchingAssistantSection'
 
@@ -27,7 +32,7 @@ const Template: Story = {
 export const Default: Story = {
   ...Template,
   args: {
-    shopSessionId: 'ecf94a27-9daa-460e-a272-48b60f2d74ec',
+    shopSessionOutcomeId: 'ecf94a27-9daa-460e-a272-48b60f2d74ec',
     companyDisplayName: 'ICA Försäkring',
   },
   parameters: {
@@ -37,45 +42,41 @@ export const Default: Story = {
           request: {
             query: ShopSessionOutcomeDocument,
             variables: {
-              shopSessionId: 'ecf94a27-9daa-460e-a272-48b60f2d74ec',
-            },
+              shopSessionOutcomeId: 'ecf94a27-9daa-460e-a272-48b60f2d74ec',
+            } satisfies ShopSessionOutcomeQueryVariables,
           },
           result: {
             data: {
-              shopSession: {
+              shopSessionOutcome: {
                 id: 'ecf94a27-9daa-460e-a272-48b60f2d74ec',
-                outcome: {
-                  id: 'd17845cb-16f3-4318-909e-e73888e1ef09',
-                  createdContracts: [
-                    {
-                      id: '11f48e7e-62de-4fdc-ac3b-6863a908c58f',
-                      variant: {
-                        displayName: 'Full coverage',
-                        __typename: 'ProductVariant',
-                      },
-                      externalInsuranceCancellation: {
-                        id: '9f015c25-b8bf-4da2-afab-077f2b2f28a1',
-                        status: 'NOT_INITIATED',
-                        externalInsurer: {
-                          id: 'ICA FÖRSÄKRING',
-                          displayName: 'ICA FÖRSÄKRING',
-                          __typename: 'ExternalInsurer',
-                        },
-                        bankSignering: {
-                          approveByDate: '2023-07-24',
-                          url: null,
-                          __typename: 'ContractBankSigneringCancellation',
-                        },
-                        __typename: 'ContractExternalInsuranceCancellation',
-                      },
-                      __typename: 'Contract',
+                createdContracts: [
+                  {
+                    id: '11f48e7e-62de-4fdc-ac3b-6863a908c58f',
+                    variant: {
+                      displayName: 'Full coverage',
+                      __typename: 'ProductVariant',
                     },
-                  ],
-                  __typename: 'ShopSessionOutcome',
-                },
-                __typename: 'ShopSession',
+                    externalInsuranceCancellation: {
+                      id: '9f015c25-b8bf-4da2-afab-077f2b2f28a1',
+                      status: ContractExternalInsuranceCancellationStatus.NotInitiated,
+                      externalInsurer: {
+                        id: 'ICA FÖRSÄKRING',
+                        displayName: 'ICA FÖRSÄKRING',
+                        __typename: 'ExternalInsurer',
+                      },
+                      bankSignering: {
+                        approveByDate: '2023-07-24',
+                        url: null,
+                        __typename: 'ContractBankSigneringCancellation',
+                      },
+                      __typename: 'ContractExternalInsuranceCancellation',
+                    },
+                    __typename: 'Contract',
+                  },
+                ],
+                __typename: 'ShopSessionOutcome',
               },
-            },
+            } satisfies ShopSessionOutcomeQuery,
           },
         },
       ],
@@ -95,45 +96,41 @@ export const Completed: Story = {
           request: {
             query: ShopSessionOutcomeDocument,
             variables: {
-              shopSessionId: 'ecf94a27-9daa-460e-a272-48b60f2d74ec',
-            },
+              shopSessionOutcomeId: 'ecf94a27-9daa-460e-a272-48b60f2d74ec',
+            } satisfies ShopSessionOutcomeQueryVariables,
           },
           result: {
             data: {
-              shopSession: {
+              shopSessionOutcome: {
                 id: 'ecf94a27-9daa-460e-a272-48b60f2d74ec',
-                outcome: {
-                  id: 'd17845cb-16f3-4318-909e-e73888e1ef09',
-                  createdContracts: [
-                    {
-                      id: '11f48e7e-62de-4fdc-ac3b-6863a908c58f',
-                      variant: {
-                        displayName: 'Full coverage',
-                        __typename: 'ProductVariant',
-                      },
-                      externalInsuranceCancellation: {
-                        id: '9f015c25-b8bf-4da2-afab-077f2b2f28a1',
-                        status: 'COMPLETED',
-                        externalInsurer: {
-                          id: 'ICA FÖRSÄKRING',
-                          displayName: 'ICA FÖRSÄKRING',
-                          __typename: 'ExternalInsurer',
-                        },
-                        bankSignering: {
-                          approveByDate: '2023-07-24',
-                          url: null,
-                          __typename: 'ContractBankSigneringCancellation',
-                        },
-                        __typename: 'ContractExternalInsuranceCancellation',
-                      },
-                      __typename: 'Contract',
+                createdContracts: [
+                  {
+                    id: '11f48e7e-62de-4fdc-ac3b-6863a908c58f',
+                    variant: {
+                      displayName: 'Full coverage',
+                      __typename: 'ProductVariant',
                     },
-                  ],
-                  __typename: 'ShopSessionOutcome',
-                },
-                __typename: 'ShopSession',
+                    externalInsuranceCancellation: {
+                      id: '9f015c25-b8bf-4da2-afab-077f2b2f28a1',
+                      status: ContractExternalInsuranceCancellationStatus.Completed,
+                      externalInsurer: {
+                        id: 'ICA FÖRSÄKRING',
+                        displayName: 'ICA FÖRSÄKRING',
+                        __typename: 'ExternalInsurer',
+                      },
+                      bankSignering: {
+                        approveByDate: '2023-07-24',
+                        url: null,
+                        __typename: 'ContractBankSigneringCancellation',
+                      },
+                      __typename: 'ContractExternalInsuranceCancellation',
+                    },
+                    __typename: 'Contract',
+                  },
+                ],
+                __typename: 'ShopSessionOutcome',
               },
-            },
+            } satisfies ShopSessionOutcomeQuery,
           },
         },
       ],

--- a/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection.tsx
+++ b/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection.tsx
@@ -4,13 +4,15 @@ import { CardSkeleton, ContractCard } from '../ContractCard'
 import { useSwitchingContracts } from '../useSwitchingContracts'
 
 type Props = {
-  shopSessionId: string
+  shopSessionOutcomeId: string
   companyDisplayName: string
 }
 
 export const SwitchingAssistantSection = (props: Props) => {
   const { t } = useTranslation('checkout')
-  const switchingContracts = useSwitchingContracts({ shopSessionOutcomeId: props.shopSessionId })
+  const switchingContracts = useSwitchingContracts({
+    shopSessionOutcomeId: props.shopSessionOutcomeId,
+  })
 
   return (
     <Space y={{ base: 1.5, lg: 2 }}>

--- a/apps/store/src/pages/confirmation/[shopSessionId].tsx
+++ b/apps/store/src/pages/confirmation/[shopSessionId].tsx
@@ -64,6 +64,7 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
       currency: shopSession.currencyCode,
       story,
       memberPartnerData,
+      shopSessionOutcomeId,
       ...getSwitching(outcome),
     },
   })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Use shop session outcome ID to fetch switching contracts

- Add types to storybook story

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Before we passed shop session ID which just seems like a bug

- Still I can't test it myself

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
