### PR TITLE
GEN-918 - styles(TrustpilotBlock): update due design changes

### DIFF
--- a/apps/store/src/blocks/TrustpilotBlock.tsx
+++ b/apps/store/src/blocks/TrustpilotBlock.tsx
@@ -22,17 +22,17 @@ export const TrustpilotBlock = ({ blok }: Props) => {
     return null
   }
 
+  const isInternalLink = blok.link.linktype === 'story'
+
   return (
     <Wrapper {...storyblokEditable(blok)}>
-      <Link href={blok.link.url} target="_blank" rel="noopener">
-        <ScoreText as="span">
-          {t('TRUSTPILOT_SCORE', { score: data.score })}
-        </ScoreText>
-        <ReviewText as="span" color="textGreen" size={{_: 'md', md: 'xl'}}>
+      <ScoreText as="span">{t('TRUSTPILOT_SCORE', { score: data.score })}</ScoreText>
+      <Link href={blok.link.url} target={isInternalLink ? '_self' : '_blank'} rel="noopener">
+        <ReviewText as="span" color="textSecondaryOnGray">
           {t('TRUSTPILOT_REVIEWS_COUNT', {
             numberOfReviews: numberGrouping(data.totalReviews),
           })}
-          <TrustpilotLogo width="5.5em" />
+          <TrustpilotLogo width="7em" />
         </ReviewText>
       </Link>
     </Wrapper>
@@ -40,11 +40,27 @@ export const TrustpilotBlock = ({ blok }: Props) => {
 }
 
 const Wrapper = styled.div({
-  display: 'grid',
-  placeItems: 'center',
-  backgroundColor: theme.colors.signalGreenFill,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  aspectRatio: '4 / 5',
+  maxWidth: '100%',
+  background: `linear-gradient(
+    to bottom,
+    transparent 0%,
+    hsl(84, 96%, 90%) 30%,
+    hsl(84, 98%, 90%) 50%,
+    hsl(85, 100%, 90%) 70%,
+    transparent 100%
+  )`,
   paddingBlock: theme.space[10],
   paddingInline: theme.space.md,
+  fontSize: 'clamp(5.5rem, 20vw + 1.2rem, 13rem)',
+
+  [mq.lg]: {
+    aspectRatio: '16 / 9',
+  },
 })
 
 const Link = styled.a({
@@ -56,21 +72,18 @@ const Link = styled.a({
 })
 
 const ScoreText = styled(Text)({
-  lineHeight: '1.32',
-  fontSize: theme.fontSizes[11],
-  [mq.md]: {
-    // Font size this high is an edge case. That's why I'm not using Text's 'size' prop
-    fontSize: '12.5rem',
-  },
+  fontSize: '1em',
 })
 
 const ReviewText = styled(Text)({
   display: 'inline-flex',
-  alignItems: 'center',
+  alignItems: 'end',
   gap: theme.space.xxs,
+  fontSize: '0.16em',
 
   [mq.lg]: {
     gap: theme.space.xs,
+    fontSize: '0.12em',
   },
 })
 


### PR DESCRIPTION
## Describe your changes

* Updates `TrustpilotBlock` designs.

## Justify why they are needed

The idea is to create a component that looks like the image we have today but with real data from _Trustpilot_ API:

<img width="1792" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/65415ce8-26a9-40ee-9da3-15fc51a2233c">
 
 It doesn't look exactly alike because some things like gradients is difficult to accomplish only with CSS, but I think it looks good enough.
 
<img width="1791" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/f89c0434-414c-4fd5-b31c-ba0c18d30f19">


Can be tested [here](https://hedvig-dot-com-git-gen-918-stylestrustpilot-blok-727cd7-hedvig.vercel.app/se/forsakringar/hemforsakring/jamfor?_storyblok_version=&_storyblok_c=page&_storyblok_lang=default&_storyblok=357425347&_storyblok_rl=1692972742612&_storyblok_tk%5Btoken%5D=a8520f58d10badfecc105fab27c13a8eb7f3d884&_storyblok_tk%5Btimestamp%5D=1692972735&slug=se%2Fforsakringar%2Fhemforsakring%2Fjamfor&_storyblok_tk%5Bspace_id%5D=165473&_storyblok_release=0&draftMode=1)