### PR TITLE
Rennovate: ignore adyen SDK

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,7 @@
   "labels": ["needs approval/merge"],
   // Don't update nextjs until client-side navigation issue is solved
   // https://github.com/vercel/next.js/issues/53967
-  "ignoreDeps": ["next", "eslint-config-next", "@next/bundle-analyzer"],
+  "ignoreDeps": ["next", "eslint-config-next", "@next/bundle-analyzer", "@adyen/adyen-web"],
   "packageRules": [
     {
       "matchDepTypes": ["dependencies"],


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Ignore updates to Adyen SDK in Rennovate

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We are not able to upgrade to the latest version of Adyen SDK

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
