### PR TITLE
GEN-973 | Fix displaying error messages in purchase form

### DIFF
--- a/apps/store/src/components/PriceCalculator/useHandleSubmitPriceCalculator.ts
+++ b/apps/store/src/components/PriceCalculator/useHandleSubmitPriceCalculator.ts
@@ -1,6 +1,8 @@
 import { datadogLogs } from '@datadog/browser-logs'
+import { useTranslation } from 'next-i18next'
 import { usePriceIntent } from '@/components/ProductPage/PriceIntentContext'
 import { usePriceIntentDataUpdateMutation } from '@/services/apollo/generated'
+import { useAppErrorHandleContext } from '@/services/appErrors/AppErrorContext'
 import { JSONData } from '@/services/PriceCalculator/PriceCalculator.types'
 import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
@@ -13,6 +15,8 @@ type Params = {
 export const useHandleSubmitPriceCalculator = ({ onSuccess }: Params) => {
   const { shopSession } = useShopSession()
   const [priceIntent] = usePriceIntent()
+  const { t } = useTranslation('purchase-form')
+  const { showError } = useAppErrorHandleContext()
   const [updateData, { loading }] = usePriceIntentDataUpdateMutation({
     // priceIntent.suggestedData may be updated based on customer.ssn
     refetchQueries: 'active',
@@ -30,6 +34,7 @@ export const useHandleSubmitPriceCalculator = ({ onSuccess }: Params) => {
         shopSessionId: shopSession?.id,
         priceIntentId: priceIntent?.id,
       })
+      showError(new Error(t('GENERAL_ERROR_DIALOG_PROMPT')))
     },
   })
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

![Screenshot 2023-08-28 at 17.04.34.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/04920237-9b9f-474a-967c-d1789862ca66/Screenshot%202023-08-28%20at%2017.04.34.png)

- Avoid displaying multiple error messages when confirming price intent

  - Separate error messages for user errors (UW filters) and system errors (e.g. network error)

- Display generic error dialog when an error occurs while updating price intent data (e.g. network error)

Co-author: @guilhermespopolin 

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We currently first display user error (UW filters) and then quickly switch to a generic error message

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
