### PR TITLE
GEN-990 | Create new CRM Retargeting Page

### DIFF
--- a/apps/store/src/features/retargeting/RetargetingPage.tsx
+++ b/apps/store/src/features/retargeting/RetargetingPage.tsx
@@ -1,0 +1,57 @@
+import { keyframes } from '@emotion/react'
+import styled from '@emotion/styled'
+import { type ComponentProps } from 'react'
+import { theme } from 'ui'
+import { Pillow } from '@/components/Pillow/Pillow'
+
+type Props = {
+  pillows: Array<
+    ComponentProps<typeof Pillow> & {
+      id: string
+    }
+  >
+}
+
+export const RetargetingPage = (props: Props) => {
+  return (
+    <Wrapper>
+      <Grid>
+        {props.pillows.map((item, index) => (
+          <PillowWrapper key={item.id} index={index}>
+            <Pillow {...item} />
+          </PillowWrapper>
+        ))}
+      </Grid>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div({
+  height: '100dvh',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+})
+
+const Grid = styled.div({
+  display: 'grid',
+  gridAutoFlow: 'column',
+  gap: theme.space.xs,
+})
+
+const spin = keyframes({
+  '0%': { opacity: '0.25' },
+  '50%': {
+    opacity: '1',
+    transform: 'scale(1.05)',
+  },
+  '100%': { opacity: 0.25 },
+})
+
+const PillowWrapper = styled.div<{ index: number }>(({ index }) => {
+  const delay = index * 150
+  return {
+    animation: `${spin} 1000ms both infinite`,
+    animationDelay: `${delay}ms`,
+  }
+})

--- a/apps/store/src/pages/session/resume.tsx
+++ b/apps/store/src/pages/session/resume.tsx
@@ -1,0 +1,32 @@
+import { type GetStaticProps } from 'next'
+import Head from 'next/head'
+import { type ComponentProps } from 'react'
+import { fetchGlobalProductMetadata } from '@/components/LayoutWithMenu/fetchProductMetadata'
+import { RetargetingPage } from '@/features/retargeting/RetargetingPage'
+import { initializeApollo } from '@/services/apollo/client'
+import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+
+type Props = ComponentProps<typeof RetargetingPage>
+
+const Page = (props: Props) => {
+  return (
+    <>
+      <Head>
+        <title>Hedvig</title>
+        <meta name="robots" content="noindex,follow" />
+      </Head>
+      <RetargetingPage {...props} />
+    </>
+  )
+}
+
+export default Page
+
+export const getStaticProps: GetStaticProps<Props> = async (context) => {
+  if (!isRoutingLocale(context.locale)) return { notFound: true }
+  const apolloClient = initializeApollo({ locale: context.locale })
+  const productMetadata = await fetchGlobalProductMetadata({ apolloClient })
+  const pillows = productMetadata.map((item) => item.pillowImage).slice(0, 6)
+
+  return { props: { pillows } }
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-08-29 at 13.02.29.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/584ffcbd-1c72-4ad0-ba9b-7c8ddaf0d8d4/Screenshot%202023-08-29%20at%2013.02.29.png)


- Create new landing page for CRM Retargeting feature

- Display loading spinner while we determine where to send the user

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- The page will communicate with the API and determine where to redirect the user

- The shop session ID will be passed as a query param to make the page static

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
