### PR TITLE
GEN-989 | Retargeting: redirect users with one product to PDP

### DIFF
--- a/apps/store/src/features/retargeting/useRedirectUser.ts
+++ b/apps/store/src/features/retargeting/useRedirectUser.ts
@@ -1,6 +1,9 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { useRouter } from 'next/router'
-import { useShopSessionQuery } from '@/services/apollo/generated'
+import {
+  type ShopSessionRetargetingQuery,
+  useShopSessionRetargetingQuery,
+} from '@/services/apollo/generated'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { PageLink } from '@/utils/PageLink'
 import { type RedirectUserParams } from './retargeting.types'
@@ -9,10 +12,10 @@ export const useRedirectUser = (params: RedirectUserParams) => {
   const { routingLocale } = useCurrentLocale()
   const router = useRouter()
 
-  useShopSessionQuery({
+  useShopSessionRetargetingQuery({
     variables: { shopSessionId: params.shopSessionId },
     onCompleted(data) {
-      if (data.shopSession.cart.entries.length > 0) {
+      if (hasAddedCartEntries(data)) {
         router.push(
           PageLink.session({
             shopSessionId: data.shopSession.id,
@@ -20,6 +23,19 @@ export const useRedirectUser = (params: RedirectUserParams) => {
             code: params.campaignCode,
           }),
         )
+        return
+      }
+
+      const priceIntentId = getSingleProduct(data)
+      if (priceIntentId) {
+        router.push(
+          PageLink.session({
+            shopSessionId: data.shopSession.id,
+            code: params.campaignCode,
+            priceIntentId,
+          }),
+        )
+        return
       }
     },
     onError(error) {
@@ -30,4 +46,18 @@ export const useRedirectUser = (params: RedirectUserParams) => {
       router.push(PageLink.store({ locale: routingLocale }))
     },
   })
+}
+
+const hasAddedCartEntries = (data: ShopSessionRetargetingQuery): boolean => {
+  return data.shopSession.cart.entries.length > 0
+}
+
+const getSingleProduct = (data: ShopSessionRetargetingQuery): string | null => {
+  const productNames = data.shopSession.priceIntents.map((priceIntent) => priceIntent.product.name)
+  const products = new Set(productNames)
+  if (products.size !== 1) return null
+
+  // Assume that the last price intent is the latest one
+  const priceIntent = data.shopSession.priceIntents[data.shopSession.priceIntents.length - 1]
+  return priceIntent.id
 }

--- a/apps/store/src/graphql/ShopSessionRetargeting.graphql
+++ b/apps/store/src/graphql/ShopSessionRetargeting.graphql
@@ -1,0 +1,16 @@
+query ShopSessionRetargeting($shopSessionId: UUID!) {
+  shopSession(id: $shopSessionId) {
+    id
+    cart {
+      entries {
+        id
+      }
+    }
+    priceIntents {
+      id
+      product {
+        name
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Retargeting: Redirect users with only one type of price intents to the relevant product details page

- Update to custom shop session query to cover all redirect cases

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We need to get a bit smarter about comparing price intents. E.g. two car price intents for different cars should not result in a redirect to the cart PDP. I want to solve that in a separate PR though.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
