### PR TITLE
GEN-995 | Don't forward shop session query param

### DIFF
--- a/apps/store/src/pages/session/[shopSessionId].tsx
+++ b/apps/store/src/pages/session/[shopSessionId].tsx
@@ -44,6 +44,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
 
   const nextURL = new URL(req.url || '', ORIGIN_URL)
   nextURL.pathname = PageLink.home({ locale })
+  nextURL.searchParams.delete('shopSessionId')
 
   const priceIntentId = query['price_intent_id']
   if (typeof priceIntentId === 'string') {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Avoid forwarding "shopSessionId" query param to the next URL from session resume route

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- I think it gets added to the URL by Next.js even if it's not a query param

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
