### PR TITLE
GEN-1037 | Fix: redirect checkout->cart after removing last offer

### DIFF
--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -67,7 +67,7 @@ export const CartPage = () => {
                     <EditActionButton shopSessionId={shopSession.id} offer={item} />
                     <RemoveActionButton
                       shopSessionId={shopSession.id}
-                      offerId={item.id}
+                      offer={item}
                       title={item.variant.product.displayNameFull}
                     />
                   </ProductItemContainer>

--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -129,7 +129,7 @@ const CheckoutPage = (props: CheckoutPageProps) => {
                       <EditActionButton shopSessionId={shopSession.id} offer={item} />
                       <RemoveActionButton
                         shopSessionId={shopSession.id}
-                        offerId={item.id}
+                        offer={item}
                         title={item.variant.product.displayNameFull}
                         onCompleted={handleRemoveCartEntry}
                       />


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Checkout page: fix bug so user is redirected to cart if they remove all offers

- Refactor `RemoveActionButton` a little to clean up some mistakes

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- The user currently stays on the checkout page even if they remove all offers

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
