### PR TITLE
GEN-1065 - refact(PageLink.session): return an URL instead of a string

### DIFF
--- a/apps/store/src/components/CartPage/PageDebugDialog.tsx
+++ b/apps/store/src/components/CartPage/PageDebugDialog.tsx
@@ -31,7 +31,7 @@ const LinkToCartSection = () => {
       locale: routingLocale,
       shopSessionId: shopSession.id,
       next: PageLink.cart({ locale: routingLocale }),
-    })
+    }).toString()
   }, [shopSession, routingLocale])
 
   return <CopyToClipboard label="Copy link to cart">{cartLink ?? ''}</CopyToClipboard>

--- a/apps/store/src/components/ProductPage/PageDebugDialog.tsx
+++ b/apps/store/src/components/ProductPage/PageDebugDialog.tsx
@@ -33,7 +33,7 @@ const LinkToOfferSection = () => {
       locale: routingLocale,
       shopSessionId: shopSession.id,
       priceIntentId: priceIntent.id,
-    })
+    }).toString()
   }, [routingLocale, shopSession, priceIntent])
 
   return <CopyToClipboard label="Share link to offer">{link ?? ''}</CopyToClipboard>

--- a/apps/store/src/features/retargeting/getUserRedirect.test.ts
+++ b/apps/store/src/features/retargeting/getUserRedirect.test.ts
@@ -68,7 +68,7 @@ describe('getUserRedirect', () => {
 
     // Assert
     expect(result.type).toEqual(RedirectType.Product)
-    expect(result.url).toContain(priceIntentId)
+    expect(result.url.toString()).toContain(priceIntentId)
   })
 
   describe('when multiple quotes are present but none are added into the cart', () => {

--- a/apps/store/src/features/retargeting/getUserRedirect.ts
+++ b/apps/store/src/features/retargeting/getUserRedirect.ts
@@ -14,10 +14,10 @@ export enum RedirectType {
 }
 
 type Redirect =
-  | { type: Exclude<RedirectType, RedirectType.ModifiedCart>; url: string }
+  | { type: Exclude<RedirectType, RedirectType.ModifiedCart>; url: URL }
   | {
       type: RedirectType.ModifiedCart
-      url: string
+      url: URL
       offers: Array<string>
     }
 
@@ -27,7 +27,7 @@ export const getUserRedirect = (
 ): Redirect => {
   const fallbackRedirect = {
     type: RedirectType.Fallback,
-    url: new URL(PageLink.store({ locale: userParams.locale }), ORIGIN_URL).toString(),
+    url: new URL(PageLink.store({ locale: userParams.locale }), ORIGIN_URL),
   } as const
 
   if (!data) return fallbackRedirect

--- a/apps/store/src/pages/api/retargeting/[shopSessionId].ts
+++ b/apps/store/src/pages/api/retargeting/[shopSessionId].ts
@@ -23,17 +23,16 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const apolloClient = await initializeApolloServerSide({ req, res, locale: userParams.locale })
   const data = await fetchRetargetingData(apolloClient, userParams.shopSessionId)
   const redirect = getUserRedirect(userParams, data)
-  const nextURL = new URL(redirect.url)
 
   // TODO: handle the case we failed to add offers
   if (redirect.type === RedirectType.ModifiedCart) {
     await addOffersToCart(apolloClient, userParams.shopSessionId, redirect.offers)
-    nextURL.searchParams.set(CartPageQueryParam.ExpandCart, '1')
+    redirect.url.searchParams.set(CartPageQueryParam.ExpandCart, '1')
   }
 
   console.info(`Retargeting | Redirecting user to ${redirect.type}`)
-  console.debug(`Retargeting | Redirect URL: ${nextURL.toString()}`)
-  res.redirect(nextURL.toString())
+  console.debug(`Retargeting | Redirect URL: ${redirect.url.toString()}`)
+  res.redirect(redirect.url.toString())
 }
 
 export default handler

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -109,7 +109,7 @@ export const PageLink = {
       url.searchParams.set('next', params.next)
     }
 
-    return url.toString()
+    return url
   },
 
   paymentConnectLegacy: ({ locale }: Required<BaseParams>) => `/${locale}/payment/connect-legacy`,


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.session` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
