### PR TITLE
GEN-1065 - refact(PageLink.store): return an URL object instead of a string

### DIFF
--- a/apps/store/src/components/ForeverPage/ForeverPage.tsx
+++ b/apps/store/src/components/ForeverPage/ForeverPage.tsx
@@ -38,7 +38,7 @@ export const ForeverPage = ({ code: initialCode }: Props) => {
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault()
-    router.prefetch(redirectUrl)
+    router.prefetch(redirectUrl.pathname)
     addCampaign(code)
   }
 

--- a/apps/store/src/features/retargeting/getUserRedirect.ts
+++ b/apps/store/src/features/retargeting/getUserRedirect.ts
@@ -3,7 +3,7 @@ import {
   RetargetingPriceIntentFragment,
   RetargetingOfferFragment,
 } from '@/services/apollo/generated'
-import { ORIGIN_URL, PageLink } from '@/utils/PageLink'
+import { PageLink } from '@/utils/PageLink'
 import { UserParams } from './retargeting.types'
 
 export enum RedirectType {
@@ -27,7 +27,7 @@ export const getUserRedirect = (
 ): Redirect => {
   const fallbackRedirect = {
     type: RedirectType.Fallback,
-    url: new URL(PageLink.store({ locale: userParams.locale }), ORIGIN_URL),
+    url: PageLink.store({ locale: userParams.locale }),
   } as const
 
   if (!data) return fallbackRedirect

--- a/apps/store/src/features/retargeting/useApiRedirectEffect.ts
+++ b/apps/store/src/features/retargeting/useApiRedirectEffect.ts
@@ -38,7 +38,7 @@ export const getApiRedirect = (href: string, locale: RoutingLocale): Redirect =>
   const shopSessionId = url.searchParams.get(QueryParam.ShopSession)
 
   if (!shopSessionId) {
-    url.pathname = PageLink.store({ locale })
+    url.pathname = PageLink.store({ locale }).pathname
     return { type: 'fallback', url }
   }
 

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -43,7 +43,7 @@ export const PageLink = {
     if (locale === 'se') {
       slug = 'forsakringar'
     }
-    return `${localePrefix(locale)}/${slug}`
+    return new URL(`${localePrefix(locale)}/${slug}`, ORIGIN_URL)
   },
   cart: ({ locale }: BaseParams = {}) => `${localePrefix(locale)}/cart`,
   checkout: ({ locale, expandCart = false }: CheckoutPage = {}) => {


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.store` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
