### PR TITLE
GEN-1075 | Explore: sticky go-to-checkout button on cart page

### DIFF
--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -21,6 +21,7 @@ import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { useTracking } from '@/services/Tracking/useTracking'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { PageLink } from '@/utils/PageLink'
+import { zIndexes } from '@/utils/zIndex'
 import { QueryParam } from './CartPage.constants'
 import { PageDebugDialog } from './PageDebugDialog'
 
@@ -81,12 +82,14 @@ export const CartPage = () => {
                 <QuickAddOfferContainer shopSessionId={shopSession.id} {...offerRecommendation} />
               )}
 
-              <ButtonNextLink
-                href={PageLink.checkout({ expandCart: true })}
-                onClick={handleClickCheckout}
-              >
-                {t('CHECKOUT_BUTTON')}
-              </ButtonNextLink>
+              <StickyFooter>
+                <ButtonNextLink
+                  href={PageLink.checkout({ expandCart: true })}
+                  onClick={handleClickCheckout}
+                >
+                  {t('CHECKOUT_BUTTON')}
+                </ButtonNextLink>
+              </StickyFooter>
             </Space>
           </GridLayout.Content>
         </GridLayout.Root>
@@ -125,6 +128,28 @@ const PageWrapper = styled.div({
 
   [mq.sm]: {
     paddingTop: theme.space.xxl,
+  },
+})
+
+const StickyFooter = styled.div({
+  position: 'fixed',
+  bottom: 0,
+  left: 0,
+  right: 0,
+  paddingBlock: theme.space.lg,
+  paddingInline: theme.space.xs,
+  backgroundColor: theme.colors.backgroundStandard,
+  boxShadow: 'rgba(0, 0, 0, 0.06) 0 -2px 12px',
+  zIndex: zIndexes.header,
+  borderTopWidth: 1,
+  borderTopStyle: 'solid',
+  borderTopColor: theme.colors.borderOpaque1,
+
+  [mq.lg]: {
+    position: 'static',
+    boxShadow: 'none',
+    padding: 0,
+    backgroundColor: 'transparent',
   },
 })
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes



![Screenshot 2023-09-04 at 11.20.13.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/04b1dff6-1a5f-4dd6-a250-d9bfdb362918/Screenshot%202023-09-04%20at%2011.20.13.png)

- Cart page: explore a sticky "go to checkout" button

- Keep the layout on desktop

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- I investigated putting the button in the header which I like but would require a lot more work since it needs to integrate with the header...

- I based the design on the cart from Nike.com

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
