### PR TITLE
GEN-1065 - refact(PageLink.cart): return an URL object instead of a string

### DIFF
--- a/apps/store/src/app/shop-session-debugger/CreateSessionForm.tsx
+++ b/apps/store/src/app/shop-session-debugger/CreateSessionForm.tsx
@@ -27,7 +27,7 @@ export const CreateSessionForm = () => {
     }
 
     window.localStorage.setItem(HEDVIG_DEBUGGER_SSN, ssn)
-    window.location.href = PageLink.cart({ locale: 'se-en' })
+    window.location.href = PageLink.cart({ locale: 'se-en' }).href
   }
 
   return (

--- a/apps/store/src/components/CartPage/PageDebugDialog.tsx
+++ b/apps/store/src/components/CartPage/PageDebugDialog.tsx
@@ -30,7 +30,7 @@ const LinkToCartSection = () => {
     return PageLink.session({
       locale: routingLocale,
       shopSessionId: shopSession.id,
-      next: PageLink.cart({ locale: routingLocale }),
+      next: PageLink.cart({ locale: routingLocale }).pathname,
     }).toString()
   }, [shopSession, routingLocale])
 

--- a/apps/store/src/features/retargeting/getUserRedirect.ts
+++ b/apps/store/src/features/retargeting/getUserRedirect.ts
@@ -38,7 +38,7 @@ export const getUserRedirect = (
       url: PageLink.session({
         locale: userParams.locale,
         shopSessionId: data.shopSession.id,
-        next: PageLink.cart({ locale: userParams.locale }),
+        next: PageLink.cart({ locale: userParams.locale }).pathname,
         code: userParams.campaignCode,
       }),
     }
@@ -64,7 +64,7 @@ export const getUserRedirect = (
       url: PageLink.session({
         locale: userParams.locale,
         shopSessionId: data.shopSession.id,
-        next: PageLink.cart({ locale: userParams.locale }),
+        next: PageLink.cart({ locale: userParams.locale }).pathname,
         code: userParams.campaignCode,
       }),
       offers,

--- a/apps/store/src/pages/api/session/create.ts
+++ b/apps/store/src/pages/api/session/create.ts
@@ -18,7 +18,7 @@ import {
 } from '@/services/priceIntent/PriceIntentService'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { RoutingLocale } from '@/utils/l10n/types'
-import { ORIGIN_URL, PageLink } from '@/utils/PageLink'
+import { PageLink } from '@/utils/PageLink'
 
 const TEST_SSN = '199808302393'
 const productNames = ['SE_APARTMENT_RENT', 'SE_ACCIDENT'] as const
@@ -65,9 +65,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     throw new Error('Unable to create ShopSession with products', { cause: error })
   }
 
-  const nextURL = new URL(ORIGIN_URL)
-  nextURL.pathname = PageLink.cart({ locale: DEFAULT_LOCALE })
-  const destination = nextURL.toString()
+  const destination = PageLink.cart({ locale: DEFAULT_LOCALE }).href
   console.log(`Re-directing to destination: ${destination}`)
   return res.redirect(destination)
 }

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -45,7 +45,9 @@ export const PageLink = {
     }
     return new URL(`${localePrefix(locale)}/${slug}`, ORIGIN_URL)
   },
-  cart: ({ locale }: BaseParams = {}) => `${localePrefix(locale)}/cart`,
+  cart: ({ locale }: BaseParams = {}) => {
+    return new URL(`${localePrefix(locale)}/cart`, ORIGIN_URL)
+  },
   checkout: ({ locale, expandCart = false }: CheckoutPage = {}) => {
     const expandCartQueryParam = expandCart ? `?${QueryParam.ExpandCart}=1` : ''
     return `${localePrefix(locale)}/checkout${expandCartQueryParam}`


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.cart` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
