### PR TITLE
GEN-1065 - refact(PageLink.confirmation): return an URL object instead of a string

### DIFF
--- a/apps/store/src/components/CheckoutHeader/CheckoutHeader.helpers.ts
+++ b/apps/store/src/components/CheckoutHeader/CheckoutHeader.helpers.ts
@@ -50,6 +50,6 @@ export const getCheckoutStepLink = ({ step, shopSessionId, locale }: GetCheckout
       return PageLink.checkoutPaymentTrustly({ locale, shopSessionId }).href
     case CheckoutStep.Confirmation:
     case CheckoutStep.Done:
-      return PageLink.confirmation({ locale, shopSessionId })
+      return PageLink.confirmation({ locale, shopSessionId }).href
   }
 }

--- a/apps/store/src/pages/checkout/[shopSessionId]/payment/[status].tsx
+++ b/apps/store/src/pages/checkout/[shopSessionId]/payment/[status].tsx
@@ -24,9 +24,12 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
   if (!status || !shopSessionId) return { notFound: true }
 
   const fallbackRedirect = {
-    redirect: { destination: PageLink.confirmation({ locale, shopSessionId }), permanent: false },
+    redirect: {
+      destination: PageLink.confirmation({ locale, shopSessionId }).pathname,
+      permanent: false,
+    },
   } as const
-
+  
   let shopSession: ShopSession, apolloClient: ApolloClient<unknown>
   try {
     apolloClient = await initializeApolloServerSide({ req, res, locale })

--- a/apps/store/src/pages/checkout/[shopSessionId]/payment/trustly.tsx
+++ b/apps/store/src/pages/checkout/[shopSessionId]/payment/trustly.tsx
@@ -23,7 +23,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async ({
   const { shopSessionId } = params
   if (!shopSessionId) return { notFound: true }
 
-  const nextUrl = PageLink.confirmation({ locale, shopSessionId })
+  const nextUrl = PageLink.confirmation({ locale, shopSessionId }).pathname
 
   try {
     const apolloClient = await initializeApolloServerSide({ req, res, locale })

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -61,9 +61,10 @@ export const PageLink = {
     const pathname = `${localePrefix(locale)}/checkout/${shopSessionId}/payment/trustly`
     return new URL(pathname, ORIGIN_URL)
   },
-  confirmation: ({ locale, shopSessionId }: ConfirmationPage) =>
-    `${localePrefix(locale)}/confirmation/${shopSessionId}`,
-
+  confirmation: ({ locale, shopSessionId }: ConfirmationPage) => {
+    const pathname = `${localePrefix(locale)}/confirmation/${shopSessionId}`
+    return new URL(pathname, ORIGIN_URL)
+  },
   paymentSuccess: ({ locale }: Required<BaseParams>) => `${ORIGIN_URL}/${locale}/payment-success`,
   paymentFailure: ({ locale }: Required<BaseParams>) => `${ORIGIN_URL}/${locale}/payment-failure`,
   paymentConnect: ({ locale }: BaseParams = {}) => `${localePrefix(locale)}/payment/connect`,


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.confirmation` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
