### PR TITLE
GEN-1065 - refact(PageLink.paymentSucess): return an URL object instead of a string

### DIFF
--- a/apps/store/src/services/trustly/TrustlyIframe.tsx
+++ b/apps/store/src/services/trustly/TrustlyIframe.tsx
@@ -33,7 +33,7 @@ export const TrustlyIframe = ({ url, onSuccess, onFail }: Props) => {
   const handleLoad: ReactEventHandler<HTMLIFrameElement> = (event) => {
     try {
       const url = event.currentTarget.contentWindow?.location.href
-      if (url === PageLink.paymentSuccess({ locale: routingLocale })) {
+      if (url === PageLink.paymentSuccess({ locale: routingLocale }).href) {
         onSuccess()
       } else if (url === PageLink.paymentFailure({ locale: routingLocale })) {
         onFail()

--- a/apps/store/src/services/trustly/createTrustlyUrl.ts
+++ b/apps/store/src/services/trustly/createTrustlyUrl.ts
@@ -16,7 +16,7 @@ export const createTrustlyUrl = async ({ apolloClient, locale }: Params): Promis
   const response = await apolloClient.mutate<TrustlyInitMutation, TrustlyInitMutationVariables>({
     mutation: TrustlyInitDocument,
     variables: {
-      successUrl: PageLink.paymentSuccess({ locale }),
+      successUrl: PageLink.paymentSuccess({ locale }).href,
       failureUrl: PageLink.paymentFailure({ locale }),
     },
   })

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -65,7 +65,9 @@ export const PageLink = {
     const pathname = `${localePrefix(locale)}/confirmation/${shopSessionId}`
     return new URL(pathname, ORIGIN_URL)
   },
-  paymentSuccess: ({ locale }: Required<BaseParams>) => `${ORIGIN_URL}/${locale}/payment-success`,
+  paymentSuccess: ({ locale }: Required<BaseParams>) => {
+    return new URL(`${locale}/payment-success`, ORIGIN_URL)
+  },
   paymentFailure: ({ locale }: Required<BaseParams>) => `${ORIGIN_URL}/${locale}/payment-failure`,
   paymentConnect: ({ locale }: BaseParams = {}) => `${localePrefix(locale)}/payment/connect`,
 


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.paymentSucess` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
