### PR TITLE
GEN-1065 - refact(PageLink.paymentFailure): return an URL object instead of a string

### DIFF
--- a/apps/store/src/services/trustly/TrustlyIframe.tsx
+++ b/apps/store/src/services/trustly/TrustlyIframe.tsx
@@ -35,7 +35,7 @@ export const TrustlyIframe = ({ url, onSuccess, onFail }: Props) => {
       const url = event.currentTarget.contentWindow?.location.href
       if (url === PageLink.paymentSuccess({ locale: routingLocale }).href) {
         onSuccess()
-      } else if (url === PageLink.paymentFailure({ locale: routingLocale })) {
+      } else if (url === PageLink.paymentFailure({ locale: routingLocale }).href) {
         onFail()
       }
     } catch (error) {

--- a/apps/store/src/services/trustly/createTrustlyUrl.ts
+++ b/apps/store/src/services/trustly/createTrustlyUrl.ts
@@ -17,7 +17,7 @@ export const createTrustlyUrl = async ({ apolloClient, locale }: Params): Promis
     mutation: TrustlyInitDocument,
     variables: {
       successUrl: PageLink.paymentSuccess({ locale }).href,
-      failureUrl: PageLink.paymentFailure({ locale }),
+      failureUrl: PageLink.paymentFailure({ locale }).href,
     },
   })
 

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -68,7 +68,9 @@ export const PageLink = {
   paymentSuccess: ({ locale }: Required<BaseParams>) => {
     return new URL(`${locale}/payment-success`, ORIGIN_URL)
   },
-  paymentFailure: ({ locale }: Required<BaseParams>) => `${ORIGIN_URL}/${locale}/payment-failure`,
+  paymentFailure: ({ locale }: Required<BaseParams>) => {
+    return new URL(`${locale}/payment-failure`, ORIGIN_URL)
+  },
   paymentConnect: ({ locale }: BaseParams = {}) => `${localePrefix(locale)}/payment/connect`,
 
   forever: ({ locale, code }: ForeverPage) => `${localePrefix(locale)}/forever/${code}`,


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.paymentFailure` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
