### PR TITLE
GEN-1065 - refact(PageLink.paymentConnect): return an URL object instead of a string

### DIFF
--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -71,7 +71,6 @@ export const PageLink = {
   paymentFailure: ({ locale }: Required<BaseParams>) => {
     return new URL(`${locale}/payment-failure`, ORIGIN_URL)
   },
-  paymentConnect: ({ locale }: BaseParams = {}) => `${localePrefix(locale)}/payment/connect`,
 
   forever: ({ locale, code }: ForeverPage) => `${localePrefix(locale)}/forever/${code}`,
 


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.paymentConnect` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
