### PR TITLE
GEN-1065 - refact(PageLink.forever): return an URL object instead of a string

### DIFF
--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -12,7 +12,6 @@ type BaseParams = { locale?: RoutingLocale }
 
 type ConfirmationPage = BaseParams & { shopSessionId: string }
 type CheckoutPage = BaseParams & { expandCart?: boolean }
-type ForeverPage = BaseParams & { code: string }
 type CampaignAddRoute = { code: string; next?: string }
 type CheckoutPaymentTrustlyPage = BaseParams & { shopSessionId: string }
 type AuthExchangeRoute = { authorizationCode: string; next?: string }
@@ -71,8 +70,6 @@ export const PageLink = {
   paymentFailure: ({ locale }: Required<BaseParams>) => {
     return new URL(`${locale}/payment-failure`, ORIGIN_URL)
   },
-
-  forever: ({ locale, code }: ForeverPage) => `${localePrefix(locale)}/forever/${code}`,
 
   customerService: ({ locale }: Required<BaseParams>) => {
     const url = CUSTOMER_SERVICE_URL[locale]


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.forever` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
