### PR TITLE
GEN-1065 - refact(PageLink.customerService): return an URL object instead of a string

### DIFF
--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -145,9 +145,9 @@ export const PageLink = {
   apiRetargeting: ({ shopSessionId }: RetargetingRoute) => `/api/retargeting/${shopSessionId}`,
 } as const
 
-const CUSTOMER_SERVICE_URL: Partial<Record<RoutingLocale, string>> = {
-  se: '/se/hjalp/kundservice',
-  'se-en': '/se-en/help/customer-service',
+const CUSTOMER_SERVICE_URL: Partial<Record<RoutingLocale, URL>> = {
+  se: new URL('/se/hjalp/kundservice', ORIGIN_URL),
+  'se-en': new URL('/se-en/help/customer-service', ORIGIN_URL),
 }
 
 const DEDUCTIBLE_HELP_URL: Partial<Record<RoutingLocale, string>> = {


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.customerService` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
