### PR TITLE
GEN-1065 - refact(PageLink.deductibleHelp): return an URL object instead of a string

### DIFF
--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -150,9 +150,9 @@ const CUSTOMER_SERVICE_URL: Partial<Record<RoutingLocale, URL>> = {
   'se-en': new URL('/se-en/help/customer-service', ORIGIN_URL),
 }
 
-const DEDUCTIBLE_HELP_URL: Partial<Record<RoutingLocale, string>> = {
-  se: '/se/forsakringar/djurforsakring/sjalvrisk',
-  'se-en': '/se-en/insurances/pet-insurance/deductible',
+const DEDUCTIBLE_HELP_URL: Partial<Record<RoutingLocale, URL>> = {
+  se: new URL('/se/forsakringar/djurforsakring/sjalvrisk', ORIGIN_URL),
+  'se-en': new URL('/se-en/insurances/pet-insurance/deductible', ORIGIN_URL),
 }
 
 const PRIVACY_POLICY_URL: Partial<Record<RoutingLocale, string>> = {


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.deductibleHelp` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
