### PR TITLE
GEN-1065 - refact(PageLink.privacyPolicy): return an URL object instead of a string

### DIFF
--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -203,7 +203,7 @@ const CheckoutPage = (props: CheckoutPageProps) => {
                           size="xs"
                           align="center"
                           balance={true}
-                          href={PageLink.privacyPolicy({ locale: routingLocale })}
+                          href={PageLink.privacyPolicy({ locale: routingLocale }).href}
                           target="_blank"
                         >
                           {t('SIGN_DISCLAIMER')}

--- a/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
+++ b/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
@@ -120,7 +120,7 @@ export const ManyPetsMigrationPage = ({
                   size={{ _: 'xs', md: 'sm' }}
                   align="center"
                   color="textSecondary"
-                  href={PageLink.privacyPolicy({ locale: routingLocale })}
+                  href={PageLink.privacyPolicy({ locale: routingLocale }).href}
                   target="_blank"
                 >
                   {t('SIGN_DISCLAIMER')}

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -93,7 +93,7 @@ export const PageLink = {
     const url = PRIVACY_POLICY_URL[locale]
     if (!url) {
       datadogLogs.logger.error('Missing privacy policy link for locale', { locale })
-      return PageLink.home({ locale }).toString()
+      return PageLink.home({ locale })
     }
     return url
   },
@@ -155,7 +155,7 @@ const DEDUCTIBLE_HELP_URL: Partial<Record<RoutingLocale, URL>> = {
   'se-en': new URL('/se-en/insurances/pet-insurance/deductible', ORIGIN_URL),
 }
 
-const PRIVACY_POLICY_URL: Partial<Record<RoutingLocale, string>> = {
-  se: '/se/hedvig/personuppgifter',
-  'se-en': '/se-en/hedvig/privacy-policy',
+const PRIVACY_POLICY_URL: Partial<Record<RoutingLocale, URL>> = {
+  se: new URL('/se/hedvig/personuppgifter', ORIGIN_URL),
+  'se-en': new URL('/se-en/hedvig/privacy-policy', ORIGIN_URL),
 }


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.privacyPolicy` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
