### PR TITLE
GEN-1065 - refact(PageLink.apiSessionReset): return an URL object instead of a string

### DIFF
--- a/apps/store/src/components/DebugDialog/DebugShopSessionSection.tsx
+++ b/apps/store/src/components/DebugDialog/DebugShopSessionSection.tsx
@@ -19,7 +19,7 @@ export const DebugShopSessionSection = () => {
     <Space y={0.25}>
       <CopyToClipboard label="Shop Session">{shopSession.id}</CopyToClipboard>
 
-      <Button variant="secondary" href={PageLink.apiSessionReset({ next: nextUrl })}>
+      <Button variant="secondary" href={PageLink.apiSessionReset({ next: nextUrl }).href}>
         Reset Shop Session
       </Button>
 

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -99,8 +99,13 @@ export const PageLink = {
   },
 
   apiSessionReset: ({ next }: { next?: string } = {}) => {
-    const nextQueryParam = next ? `?next=${next}` : ''
-    return `/api/session/reset${nextQueryParam}`
+    const url = new URL('/api/session/reset', ORIGIN_URL)
+
+    if (next) {
+      url.searchParams.set('next', next)
+    }
+
+    return url
   },
   apiSessionCreate: (ssn: string) => `/api/session/create/?ssn=${ssn}`,
   apiCampaign: ({ code, next }: CampaignAddRoute) => {


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.apiSessionReset` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
