### PR TITLE
GEN-1065 - refact(PageLink.apiSessionCreate): return an URL object instead of a string

### DIFF
--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -107,7 +107,9 @@ export const PageLink = {
 
     return url
   },
-  apiSessionCreate: (ssn: string) => `/api/session/create/?ssn=${ssn}`,
+  apiSessionCreate: (ssn: string) => {
+    return new URL(`/api/session/create/?ssn=${ssn}`, ORIGIN_URL)
+  },
   apiCampaign: ({ code, next }: CampaignAddRoute) => {
     const nextQueryParam = next ? `?next=${next}` : ''
     return `/api/campaign/${code}${nextQueryParam}`


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.apiSessionCreate` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
