### PR TITLE
GEN-1065 - refact(PageLink.apiCampaign): return an URl object instead of a string

### DIFF
--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -12,7 +12,6 @@ type BaseParams = { locale?: RoutingLocale }
 
 type ConfirmationPage = BaseParams & { shopSessionId: string }
 type CheckoutPage = BaseParams & { expandCart?: boolean }
-type CampaignAddRoute = { code: string; next?: string }
 type CheckoutPaymentTrustlyPage = BaseParams & { shopSessionId: string }
 type AuthExchangeRoute = { authorizationCode: string; next?: string }
 type RetargetingRoute = { shopSessionId: string }
@@ -109,10 +108,6 @@ export const PageLink = {
   },
   apiSessionCreate: (ssn: string) => {
     return new URL(`/api/session/create/?ssn=${ssn}`, ORIGIN_URL)
-  },
-  apiCampaign: ({ code, next }: CampaignAddRoute) => {
-    const nextQueryParam = next ? `?next=${next}` : ''
-    return `/api/campaign/${code}${nextQueryParam}`
   },
 
   session: (params: SessionLink) => {


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.apiCampaign` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
