### PR TITLE
GEN-1065 - refact(PageLink.paymentConnectLegacy): return an URL object instead of a string

### DIFF
--- a/apps/store/src/pages/payment/connect-legacy/start.tsx
+++ b/apps/store/src/pages/payment/connect-legacy/start.tsx
@@ -14,7 +14,7 @@ const Page = (props: Props) => {
   const { routingLocale: locale } = useCurrentLocale()
   const { title, startButton } = useAdyenTranslations()
 
-  const nextUrl = PageLink.paymentConnectLegacy({ locale })
+  const nextUrl = PageLink.paymentConnectLegacy({ locale }).pathname
   const authUrl = PageLink.apiAuthExchange({
     authorizationCode: props.authorizationCode,
     next: nextUrl,

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -127,7 +127,9 @@ export const PageLink = {
     return url
   },
 
-  paymentConnectLegacy: ({ locale }: Required<BaseParams>) => `/${locale}/payment/connect-legacy`,
+  paymentConnectLegacy: ({ locale }: Required<BaseParams>) => {
+    return new URL(`/${locale}/payment/connect-legacy`, ORIGIN_URL)
+  },
   apiAdyenCallback: ({ locale }: Required<BaseParams>) =>
     `${ORIGIN_URL}/api/adyen-callback/${locale}`,
   paymentConnectLegacySuccess: ({ locale }: Required<BaseParams>) =>


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.paymentConnectLegacy` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
