### PR TITLE
GEN-1065 - refact(PageLink.apiAdyenCallback): return an URL object instead of a string

### DIFF
--- a/apps/store/src/services/adyen/useTokenizePaymentDetails.ts
+++ b/apps/store/src/services/adyen/useTokenizePaymentDetails.ts
@@ -19,7 +19,7 @@ export const useTokenizePaymentDetails = () => {
             browserInfo,
             paymentMethodDetails: JSON.stringify(paymentMethod),
             channel: TokenizationChannel.Web,
-            returnUrl: PageLink.apiAdyenCallback({ locale: routingLocale }),
+            returnUrl: PageLink.apiAdyenCallback({ locale: routingLocale }).href,
           },
         },
       })

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -130,8 +130,9 @@ export const PageLink = {
   paymentConnectLegacy: ({ locale }: Required<BaseParams>) => {
     return new URL(`/${locale}/payment/connect-legacy`, ORIGIN_URL)
   },
-  apiAdyenCallback: ({ locale }: Required<BaseParams>) =>
-    `${ORIGIN_URL}/api/adyen-callback/${locale}`,
+  apiAdyenCallback: ({ locale }: Required<BaseParams>) => {
+    return new URL(`api/adyen-callback/${locale}`, ORIGIN_URL)
+  },
   paymentConnectLegacySuccess: ({ locale }: Required<BaseParams>) =>
     `/${locale}/payment/connect-legacy/success`,
   paymentConnectLegacyError: ({ locale }: Required<BaseParams>) =>


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.apiAdyenCallback` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
