### PR TITLE
GEN-1065 - refact(PageLink.paymentConnectLegacySucess): return an URL object instead of a string

### DIFF
--- a/apps/store/src/pages/api/adyen-callback/[locale].ts
+++ b/apps/store/src/pages/api/adyen-callback/[locale].ts
@@ -20,7 +20,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     return
   }
 
-  res.redirect(302, PageLink.paymentConnectLegacySuccess({ locale: req.query.locale }))
+  res.redirect(302, PageLink.paymentConnectLegacySuccess({ locale: req.query.locale }).href)
 }
 
 export default handler

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -133,8 +133,9 @@ export const PageLink = {
   apiAdyenCallback: ({ locale }: Required<BaseParams>) => {
     return new URL(`api/adyen-callback/${locale}`, ORIGIN_URL)
   },
-  paymentConnectLegacySuccess: ({ locale }: Required<BaseParams>) =>
-    `/${locale}/payment/connect-legacy/success`,
+  paymentConnectLegacySuccess: ({ locale }: Required<BaseParams>) => {
+    return new URL(`/${locale}/payment/connect-legacy/success`, ORIGIN_URL)
+  },
   paymentConnectLegacyError: ({ locale }: Required<BaseParams>) =>
     `/${locale}/payment/connect-legacy/error`,
   apiAuthExchange: ({ authorizationCode, next }: AuthExchangeRoute) => {


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.paymentConnectLegacySucess` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
