### PR TITLE
GEN-1065 - refact(PageLink.apiAuthExchange): return an URL object instead of a string

### DIFF
--- a/apps/store/src/pages/payment/connect-legacy/start.tsx
+++ b/apps/store/src/pages/payment/connect-legacy/start.tsx
@@ -18,7 +18,7 @@ const Page = (props: Props) => {
   const authUrl = PageLink.apiAuthExchange({
     authorizationCode: props.authorizationCode,
     next: nextUrl,
-  })
+  }).href
 
   return (
     <Layout title={title}>

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -140,8 +140,13 @@ export const PageLink = {
     return new URL(`/${locale}/payment/connect-legacy/error`, ORIGIN_URL)
   },
   apiAuthExchange: ({ authorizationCode, next }: AuthExchangeRoute) => {
-    const nextQueryParam = next ? `?next=${next}` : ''
-    return `/api/auth/exchange/${authorizationCode}${nextQueryParam}`
+    const url = new URL(`/api/auth/exchange/${authorizationCode}`, ORIGIN_URL)
+
+    if (next) {
+      url.searchParams.set('next', next)
+    }
+
+    return url
   },
 
   retargeting: ({ locale, shopSessionId }: BaseParams & RetargetingRoute) => {


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.apiAuthExchange` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
