### PR TITLE
GEN-1065 - refact(PageLink.apiRetargeting): return an URL object instead of a string

### DIFF
--- a/apps/store/src/features/retargeting/useApiRedirectEffect.ts
+++ b/apps/store/src/features/retargeting/useApiRedirectEffect.ts
@@ -43,7 +43,7 @@ export const getApiRedirect = (href: string, locale: RoutingLocale): Redirect =>
   }
 
   url.searchParams.delete(QueryParam.ShopSession)
-  url.pathname = PageLink.apiRetargeting({ shopSessionId })
+  url.pathname = PageLink.apiRetargeting({ shopSessionId }).pathname
   url.searchParams.set(QueryParam.Locale, locale)
   return { type: 'api', url }
 }

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -154,7 +154,9 @@ export const PageLink = {
     url.searchParams.set('shopSessionId', shopSessionId)
     return url
   },
-  apiRetargeting: ({ shopSessionId }: RetargetingRoute) => `/api/retargeting/${shopSessionId}`,
+  apiRetargeting: ({ shopSessionId }: RetargetingRoute) => {
+    return new URL(`/api/retargeting/${shopSessionId}`, ORIGIN_URL)
+  },
 } as const
 
 const CUSTOMER_SERVICE_URL: Partial<Record<RoutingLocale, URL>> = {


### PR DESCRIPTION
## Describe your changes

- Changes `PageLink.apiRetargeting` return type: `string` --> `URL`

## Justify why they are needed

This is an experiment where I intent to change return type of `PageLink` functions from `string` to `URL` object and see how it goes. The idea is to be able to easy change the URL returned by those utility functions in the caller - E.g: add a query parameter. We have a bunch of those functions and they are being used in several places so my idea is to tackle then one by one in a graphite stack.
