### PR TITLE
Revert "GEN-1078 - fix(customer-first): make sure get's added into the document"

### DIFF
--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -14,7 +14,7 @@ import { GlobalLinkStyles } from '@/components/RichText/RichText.styles'
 import { useApollo } from '@/services/apollo/client'
 import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
 import { BankIdContextProvider } from '@/services/bankId/BankIdContext'
-import { CustomerFirstLauncher } from '@/services/CustomerFirst'
+import { CustomerFirstScript } from '@/services/CustomerFirst'
 import { GTMAppScript } from '@/services/gtm'
 import { initDatadog } from '@/services/logger/client'
 import { PageTransitionProgressBar } from '@/services/nprogress/pageTransition'
@@ -107,7 +107,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
               </BankIdContextProvider>
             </TrackingProvider>
           </ShopSessionProvider>
-          <CustomerFirstLauncher />
+          <CustomerFirstScript />
         </JotaiProvider>
       </ApolloProvider>
     </>

--- a/apps/store/src/pages/_document.tsx
+++ b/apps/store/src/pages/_document.tsx
@@ -1,5 +1,4 @@
 import Document, { Head, Html, Main, NextScript } from 'next/document'
-import Script from 'next/script'
 import { theme } from 'ui'
 import { GTMBodyScript } from '@/services/gtm'
 import { contentFontClassName } from '@/utils/fonts'
@@ -9,10 +8,6 @@ import { UiLocale } from '@/utils/l10n/types'
 export default class MyDocument extends Document {
   lang() {
     return getLocaleOrFallback(this.props.locale as UiLocale).htmlLang
-  }
-
-  chatWidgetSrc() {
-    return getLocaleOrFallback(this.props.locale as UiLocale).chatWidgetSrc
   }
 
   render() {
@@ -34,8 +29,6 @@ export default class MyDocument extends Document {
           <GTMBodyScript />
           <Main />
           <NextScript />
-          {/* This needs to be loaded with 'beforeInteractive' strategy as it adds an iframe when window.load gets fired */}
-          <Script strategy="beforeInteractive" src={this.chatWidgetSrc()}></Script>
         </body>
       </Html>
     )

--- a/apps/store/src/services/CustomerFirst.tsx
+++ b/apps/store/src/services/CustomerFirst.tsx
@@ -1,12 +1,13 @@
 import { Global } from '@emotion/react'
 import { atom, useAtomValue, useSetAtom } from 'jotai'
+import Script from 'next/script'
 import { useCallback, useEffect } from 'react'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { useBreakpoint } from '@/utils/useBreakpoint/useBreakpoint'
 
 const OPEN_ATOM = atom(false)
 
-export const CustomerFirstLauncher = () => {
+export const CustomerFirstScript = () => {
   const isDesktop = useBreakpoint('lg')
   const open = useAtomValue(OPEN_ATOM)
   const { chatWidgetSrc } = useCurrentLocale()
@@ -14,8 +15,12 @@ export const CustomerFirstLauncher = () => {
   if (!chatWidgetSrc) return null
 
   const showLauncher = isDesktop || open
-
-  return <Global styles={{ '#chat-iframe': { display: showLauncher ? 'initial' : 'none' } }} />
+  return (
+    <>
+      <Global styles={{ '#chat-iframe': { display: showLauncher ? 'initial' : 'none' } }} />
+      <Script strategy="afterInteractive" src={chatWidgetSrc} />
+    </>
+  )
 }
 
 export const useCustomerFirst = () => {


### PR DESCRIPTION
## Describe your changes

This reverts a fix on customer1 load script strategy. The full reasoning behind it can be found in this slack [thread](https://hedviginsurance.slack.com/archives/C041SD67G82/p1693833006219719).

## Justify why they are needed

Loading it for all pages is drastically afeting SEO metrics. Let's revert it so customer1 script gets loaded on demand and talk with them aboout solving some issues we're having.

Related with #2973
