### PR TITLE
Update renovate config to use am/pm

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,9 @@
 {
+  // https://docs.renovatebot.com/
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
   // Restrict automerge to business hours so that we can react quickly if something goes wrong
-  "automergeSchedule": ["every weekday after 09:30 and before 15:30"],
+  "automergeSchedule": ["after 9:30 am and before 4:30 pm every weekday"],
   "labels": ["needs approval/merge"],
   // Don't update nextjs until client-side navigation issue is solved
   // https://github.com/vercel/next.js/issues/53967


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Update automerge schedule in renovate to use am/pm instead of 24h format

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Renovate doesn't seem to understand our current schedule

- This format is more inline with the examples in the [renovate docs](https://docs.renovatebot.com/configuration-options/#schedule)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
