### PR TITLE
GEN-1085 | QuickAdd: use blue background

### DIFF
--- a/apps/store/src/components/QuickAdd/QuickAdd.stories.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAdd.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react'
 import { Button, Text } from 'ui'
+import { StartDate } from '@/components/ProductItem/StartDate'
 import { CurrencyCode } from '@/services/apollo/generated'
-import { StartDate } from '../ProductItem/StartDate'
 import { ProductDetail, QuickAdd } from './QuickAdd'
 
 const meta: Meta<typeof QuickAdd> = {
@@ -32,8 +32,10 @@ export const Default: Story = {
     ),
     children: (
       <>
-        <Button>Buy</Button>
-        <Button variant="ghost">Details</Button>
+        <Button size="medium">Buy</Button>
+        <Button size="medium" variant="ghost">
+          Details
+        </Button>
       </>
     ),
   },
@@ -55,8 +57,12 @@ export const Loading: Story = {
     ...Default.args,
     children: (
       <>
-        <Button loading={true}>Buy</Button>
-        <Button variant="ghost">Details</Button>
+        <Button size="medium" loading={true}>
+          Buy
+        </Button>
+        <Button size="medium" variant="ghost">
+          Details
+        </Button>
       </>
     ),
   },

--- a/apps/store/src/components/QuickAdd/QuickAdd.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAdd.tsx
@@ -52,9 +52,13 @@ export const QuickAdd = (props: Props) => {
 }
 
 const Card = styled.div({
-  backgroundColor: theme.colors.opaque1,
-  borderRadius: theme.radius.md,
   padding: theme.space.md,
+
+  borderRadius: theme.radius.md,
+  backgroundColor: theme.colors.blueFill1,
+  borderWidth: 1,
+  borderStyle: 'solid',
+  borderColor: theme.colors.borderTranslucent1,
 
   [mq.lg]: { padding: theme.space.lg },
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-09-07 at 10.04.45.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/20928bf8-c016-4e92-8f25-b17c289ce477/Screenshot%202023-09-07%20at%2010.04.45.png)


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Revert back to the existing color, better contrast from the actual cart items

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
