### PR TITLE
GEN-1084 | Retargeting: redirect based on unique exposure

### DIFF
--- a/apps/store/src/features/retargeting/ShopSessionRetargeting.graphql
+++ b/apps/store/src/features/retargeting/ShopSessionRetargeting.graphql
@@ -14,6 +14,7 @@ query ShopSessionRetargeting($shopSessionId: UUID!) {
 
 fragment RetargetingPriceIntent on PriceIntent {
   id
+  data
   offers {
     ...RetargetingOffer
   }

--- a/apps/store/src/features/retargeting/getUserRedirect.test.ts
+++ b/apps/store/src/features/retargeting/getUserRedirect.test.ts
@@ -28,16 +28,8 @@ describe('getUserRedirect', () => {
           {
             id: '123',
             product: { name: 'test' },
-            offers: [
-              {
-                id: '123:offer1',
-                cost: {
-                  gross: {
-                    amount: 100,
-                  },
-                },
-              },
-            ],
+            data: { street: 'testgatan 1' },
+            offers: [FAKE_OFFER],
           },
         ],
       },
@@ -59,7 +51,14 @@ describe('getUserRedirect', () => {
         cart: {
           entries: [],
         },
-        priceIntents: [{ id: priceIntentId, product: { name: 'test' }, offers: [] }],
+        priceIntents: [
+          {
+            id: priceIntentId,
+            product: { name: 'test' },
+            data: { street: 'testgatan 1' },
+            offers: [FAKE_OFFER],
+          },
+        ],
       },
     }
 
@@ -71,73 +70,144 @@ describe('getUserRedirect', () => {
     expect(result.url.toString()).toContain(priceIntentId)
   })
 
-  describe('when multiple quotes are present but none are added into the cart', () => {
-    it('should return a modified cart redirect containing the ids of the cheapest offers for every product', () => {
-      // Arrange
-      const data: ShopSessionRetargetingQuery = {
-        shopSession: {
-          id: '123',
-          cart: {
-            entries: [],
+  it('should return product redirect for multiple price intents with the same exposure', () => {
+    // Arrange
+    const priceIntentId = '12345'
+    const data: ShopSessionRetargetingQuery = {
+      shopSession: {
+        id: '123',
+        cart: { entries: [] },
+        priceIntents: [
+          {
+            id: '123',
+            product: { name: 'SE_CAR' },
+            data: { registrationNumber: 'FRE123' },
+            offers: [FAKE_OFFER],
           },
-          priceIntents: [
-            {
-              id: '123',
-              product: { name: 'product1' },
-              offers: [
-                {
-                  id: '123:offer1',
-                  cost: {
-                    gross: {
-                      amount: 100,
-                    },
-                  },
-                },
-                {
-                  id: '123:offer2',
-                  cost: {
-                    gross: {
-                      amount: 200,
-                    },
-                  },
-                },
-              ],
-            },
-            {
-              id: '456',
-              product: { name: 'product2' },
-              offers: [
-                {
-                  id: '456:offer1',
-                  cost: {
-                    gross: {
-                      amount: 200,
-                    },
-                  },
-                },
-                {
-                  id: '456:offer2',
-                  cost: {
-                    gross: {
-                      amount: 150,
-                    },
-                  },
-                },
-              ],
-            },
-          ],
+          {
+            id: priceIntentId,
+            product: { name: 'SE_CAR' },
+            data: { registrationNumber: 'FRE123' },
+            offers: [FAKE_OFFER],
+          },
+        ],
+      },
+    }
+
+    // Act
+    const result = getUserRedirect(userParams, data)
+
+    // Assert
+    expect(result.type).toEqual(RedirectType.Product)
+    expect(result.url.toString()).toContain(priceIntentId)
+  })
+
+  it('should return modified cart if multiple price intents with different exposures are present', () => {
+    // Arrange
+    const data: ShopSessionRetargetingQuery = {
+      shopSession: {
+        id: '123',
+        cart: { entries: [] },
+        priceIntents: [
+          {
+            id: '123',
+            product: { name: 'SE_CAR' },
+            data: { registrationNumber: 'FRE123' },
+            offers: [FAKE_OFFER],
+          },
+          {
+            id: '456',
+            product: { name: 'SE_CAR' },
+            data: { registrationNumber: 'FRE456' },
+            offers: [FAKE_OFFER],
+          },
+        ],
+      },
+    }
+
+    // Act
+    const result = getUserRedirect(userParams, data)
+
+    // Assert
+    expect(result.type).toEqual(RedirectType.ModifiedCart)
+  })
+
+  it('should return modified cart with cheapest offers for every product', () => {
+    // Arrange
+    const data: ShopSessionRetargetingQuery = {
+      shopSession: {
+        id: '123',
+        cart: {
+          entries: [],
         },
-      }
+        priceIntents: [
+          {
+            id: '123',
+            product: { name: 'product1' },
+            data: { street: 'testgatan 1' },
+            offers: [
+              {
+                id: '123:offer1',
+                cost: {
+                  gross: {
+                    amount: 100,
+                  },
+                },
+              },
+              {
+                id: '123:offer2',
+                cost: {
+                  gross: {
+                    amount: 200,
+                  },
+                },
+              },
+            ],
+          },
+          {
+            id: '456',
+            product: { name: 'product2' },
+            data: { street: 'testgatan 1' },
+            offers: [
+              {
+                id: '456:offer1',
+                cost: {
+                  gross: {
+                    amount: 200,
+                  },
+                },
+              },
+              {
+                id: '456:offer2',
+                cost: {
+                  gross: {
+                    amount: 150,
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    }
 
-      // Act
-      const result = getUserRedirect(userParams, data) as Extract<
-        ReturnType<typeof getUserRedirect>,
-        { type: RedirectType.ModifiedCart }
-      >
+    // Act
+    const result = getUserRedirect(userParams, data) as Extract<
+      ReturnType<typeof getUserRedirect>,
+      { type: RedirectType.ModifiedCart }
+    >
 
-      // Assert
-      expect(result.type).toEqual(RedirectType.ModifiedCart)
-      expect(result.offers).toEqual(expect.arrayContaining(['123:offer1', '456:offer2']))
-    })
+    // Assert
+    expect(result.type).toEqual(RedirectType.ModifiedCart)
+    expect(result.offers).toEqual(expect.arrayContaining(['123:offer1', '456:offer2']))
   })
 })
+
+const FAKE_OFFER = {
+  id: '123:offer1',
+  cost: {
+    gross: {
+      amount: 100,
+    },
+  },
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Retargeting: redirect based on unique exposures

- If a user has multiple price intents for e.g. different cars we want to add all to cart and redirect to cart page

- Refactor logic in helper function and update tests

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- This works for now, but it makes more and more sense to move this logic to the backend

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
