### PR TITLE
QuickAdd: make cost-prop optional

### DIFF
--- a/apps/store/src/components/QuickAdd/QuickAdd.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAdd.tsx
@@ -11,7 +11,7 @@ type Props = {
   subtitle: string
   pillow: ComponentProps<typeof Pillow>
   href: string
-  cost: ComponentProps<typeof Price>
+  cost?: ComponentProps<typeof Price>
   Body: ReactNode
   children: ReactNode
 }
@@ -40,11 +40,13 @@ export const QuickAdd = (props: Props) => {
         <Footer>
           <SpaceFlex space={0.5}>{props.children}</SpaceFlex>
 
-          <Price
-            {...props.cost}
-            color="textTranslucentPrimary"
-            secondaryColor="textTranslucentSecondary"
-          />
+          {props.cost && (
+            <Price
+              {...props.cost}
+              color="textTranslucentPrimary"
+              secondaryColor="textTranslucentSecondary"
+            />
+          )}
         </Footer>
       </Space>
     </Card>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- `QuickAdd`: make the cost-prop optional

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Required to support the incomplete quick add card where we might not have an offer yet

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
