### PR TITLE
Fix: locale redirect matching stuff it shouldn't

### DIFF
--- a/apps/store/src/features/retargeting/useApiRedirectEffect.ts
+++ b/apps/store/src/features/retargeting/useApiRedirectEffect.ts
@@ -27,8 +27,9 @@ export const useApiRedirectEffect = () => {
       datadogRum.setGlobalContextProperty('isRetargeting', true)
     }
 
-    router.push(redirect.url)
-  }, [router, redirect])
+    // Avoid `router.push` since it triggers middleware for API routes
+    window.location.assign(redirect.url.toString())
+  }, [router, redirect, routingLocale])
 }
 
 type Redirect = { type: 'api' | 'fallback'; url: URL }

--- a/apps/store/src/middleware.ts
+++ b/apps/store/src/middleware.ts
@@ -8,9 +8,16 @@ import { toRoutingLocale } from '@/utils/l10n/localeUtils'
 
 export const config = {
   matcher: [
-    '/', // Failsafe, always match root
-    // Anything that can be a subject to redirect
-    '/((?!api|_next|favicon.ico|favicon-32x32|site.webmanifest).*)',
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     *
+     * OR paths that contain a period (.) from public-folder
+     */
+    '/((?!api|_next/static|_next/image|.*\\.).*)',
+    '/',
   ],
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Use browser API to navigate on to API route

- Update middleware matching to exclude paths that contain a dot/period (.)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Next.js router navigation triggers the middleware for some unknown reason

- We have an issue where we add locale to static files in the public folder. Excluding paths with a dot/period (.) will prevent this.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
