### PR TITLE
GEN-1118 | Fix: padding inside accordion item

### DIFF
--- a/apps/store/src/components/Accordion/Accordion.tsx
+++ b/apps/store/src/components/Accordion/Accordion.tsx
@@ -20,7 +20,7 @@ export const Trigger = styled(AccordionPrimitives.Trigger)({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  gap: theme.space.xs,
+  gap: theme.space.md,
   paddingBlock: theme.space.sm,
   paddingInline: theme.space.md,
   fontSize: theme.fontSizes.md,
@@ -50,6 +50,8 @@ export const Item = styled(AccordionPrimitives.Item)({
   },
 })
 
+const OPEN_CLOSE_ICON_SIZE = '1rem'
+
 type HeaderWithTriggerProps = PropsWithChildren<unknown> & {
   icon?: ReactElement
 }
@@ -60,8 +62,8 @@ export const HeaderWithTrigger = ({ children }: HeaderWithTriggerProps) => {
       <Trigger>
         {children}
 
-        <OpenIcon size="1rem" />
-        <CloseIcon size="1rem" />
+        <OpenIcon size={OPEN_CLOSE_ICON_SIZE} />
+        <CloseIcon size={OPEN_CLOSE_ICON_SIZE} />
       </Trigger>
     </AccordionPrimitives.Header>
   )
@@ -84,7 +86,7 @@ type ContentProps = AccordionPrimitives.AccordionContentProps & { open: boolean 
 export const Content = forwardRef<HTMLDivElement, ContentProps>(
   ({ children, open, ...props }, forwardedRef) => {
     return (
-      <StyledContent {...props} ref={forwardedRef} forceMount>
+      <StyledContent {...props} ref={forwardedRef} forceMount={true}>
         <motion.div
           initial={open ? 'opened' : 'closed'}
           transition={{
@@ -117,6 +119,7 @@ const StyledContent = styled(AccordionPrimitives.Content)({
   paddingInline: theme.space.md,
 
   [mq.lg]: {
-    paddingInline: theme.space.lg,
+    paddingLeft: theme.space.lg,
+    paddingRight: `calc(${theme.space.lg} + ${OPEN_CLOSE_ICON_SIZE})`,
   },
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-09-13 at 17.38.20.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/e8719ce6-7d67-4526-b8ea-3c31445a4b89/Screenshot%202023-09-13%20at%2017.38.20.png)


- Tweak the padding inside accordion item so text doesn't get to close to the edge of the container

- Also make the body text align with the heading

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
