### PR TITLE
PaymentConnectLegacy: fix redirect to error page

### DIFF
--- a/apps/store/src/pages/payment/connect-legacy/index.tsx
+++ b/apps/store/src/pages/payment/connect-legacy/index.tsx
@@ -35,7 +35,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (context) => 
     return {
       redirect: {
         destination: PageLink.paymentConnectLegacyError({ locale: context.locale }).pathname,
-        permanent: false,
+        statusCode: 307,
       },
     }
   }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- PaymentConnectLegacy: redirect to error with explicit status code

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Next.js forwards the request method from the form submission which results in HTTP ERROR 405 (method not supported). This fixes that.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
