### PR TITLE
GEN-1115 - feat: hide chat based on CMS config

### DIFF
--- a/apps/store/index.d.ts
+++ b/apps/store/index.d.ts
@@ -14,6 +14,7 @@ declare module 'next' {
 
 type GlobalAppProps = SSRConfig & {
   [SHOP_SESSION_PROP_NAME]?: string
+  hideChat?: boolean
 }
 
 declare module 'next/app' {

--- a/apps/store/src/components/ProductPage/ProductPage.types.ts
+++ b/apps/store/src/components/ProductPage/ProductPage.types.ts
@@ -15,4 +15,5 @@ export type ProductPageProps = StoryblokPageProps & {
   productData: ProductData
   initialSelectedVariant?: ProductDataVariant
   trustpilot: TrustpilotData | null
+  hideChat?: boolean
 }

--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -109,6 +109,7 @@ export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = a
     [STORY_PROP_NAME]: story,
     breadcrumbs,
     trustpilot,
+    hideChat: story.content.hideChat ?? false,
   }
 
   if (isProductStory(story)) {

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -107,7 +107,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
               </BankIdContextProvider>
             </TrackingProvider>
           </ShopSessionProvider>
-          <CustomerFirstScript />
+          <CustomerFirstScript hideChat={pageProps.hideChat} />
         </JotaiProvider>
       </ApolloProvider>
     </>

--- a/apps/store/src/services/CustomerFirst.tsx
+++ b/apps/store/src/services/CustomerFirst.tsx
@@ -1,5 +1,5 @@
 import { Global } from '@emotion/react'
-import { atom, useAtomValue, useSetAtom } from 'jotai'
+import { atom, useAtom } from 'jotai'
 import Script from 'next/script'
 import { useCallback, useEffect } from 'react'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
@@ -7,14 +7,18 @@ import { useBreakpoint } from '@/utils/useBreakpoint/useBreakpoint'
 
 const OPEN_ATOM = atom(false)
 
-export const CustomerFirstScript = () => {
+type Props = {
+  hideChat?: boolean
+}
+
+export const CustomerFirstScript = ({ hideChat = false }: Props) => {
   const isDesktop = useBreakpoint('lg')
-  const open = useAtomValue(OPEN_ATOM)
   const { chatWidgetSrc } = useCurrentLocale()
+  const { open } = useCustomerFirst()
 
   if (!chatWidgetSrc) return null
 
-  const showLauncher = isDesktop || open
+  const showLauncher = hideChat ? open : isDesktop || open
   return (
     <>
       <Global styles={{ '#chat-iframe': { display: showLauncher ? 'initial' : 'none' } }} />
@@ -24,7 +28,7 @@ export const CustomerFirstScript = () => {
 }
 
 export const useCustomerFirst = () => {
-  const setOpen = useSetAtom(OPEN_ATOM)
+  const [open, setOpen] = useAtom(OPEN_ATOM)
   const { chatWidgetSrc } = useCurrentLocale()
 
   useEffect(() => {
@@ -46,7 +50,7 @@ export const useCustomerFirst = () => {
     window.customerFirstAPI?.openWidget()
   }, [setOpen])
 
-  return { show } as const
+  return { open, show } as const
 }
 
 enum MessageData {

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -105,6 +105,7 @@ export type StoryblokPageProps = {
   [STORY_PROP_NAME]: PageStory
   [GLOBAL_STORY_PROP_NAME]: GlobalStory
   trustpilot: TrustpilotData | null
+  hideChat?: boolean
 }
 
 export type StoryblokVersion = 'draft' | 'published'
@@ -179,6 +180,7 @@ export type PageStory = ISbStoryData<
     overlayMenu?: boolean
     hideFooter?: boolean
     hideBreadcrumbs?: boolean
+    hideChat?: boolean
   } & SEOData
 >
 
@@ -193,6 +195,7 @@ export type ProductStory = ISbStoryData<
     announcement?: ExpectedBlockType<ReusableBlockReferenceProps>
     body: Array<SbBlokData>
     globalStory: GlobalStory
+    hideChat?: boolean
   } & SEOData
 >
 


### PR DESCRIPTION
## Describe your changes

* Hide _customer1_ chat based on a CMS page config (`hideChat`)

The following is how it works:
* If user navigates to a "hide chat" page **and** chat is closed then we hide it. Otherwise it get's displayed.
Observe that doesn't cover the whole thing though because users can start a chat on a "show chat" page, send some messages and minimize it (in other words, close it) while they await for a response. In the meantime they can navigate to a "hide chat page" and then we'd be hiding the whole thing. Peter knows about this and he thinks it's a good enough solution for now.

https://github.com/HedvigInsurance/racoon/assets/19200662/4fb251c0-4ac7-4050-aef0-c9bf0c8683d8

## Justify why they are needed

Desired by Peter.
