### PR TITLE
LayoutWithMenu: prevent runtime error

### DIFF
--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -4,7 +4,7 @@ import { Fragment, type ReactElement } from 'react'
 import { FooterBlock } from '@/blocks/FooterBlock'
 import { HeaderBlock } from '@/blocks/HeaderBlock'
 import { ReusableBlockReference } from '@/blocks/ReusableBlockReference'
-import { PageStory, StoryblokPageProps } from '@/services/storyblok/storyblok'
+import { GlobalStory, PageStory, StoryblokPageProps } from '@/services/storyblok/storyblok'
 import { filterByBlockType, isProductStory } from '@/services/storyblok/Storyblok.helpers'
 import { useChangeLocale } from '@/utils/l10n/useChangeLocale'
 import { BreadcrumbList, BreadcrumbListItem } from './BreadcrumbList'
@@ -18,10 +18,11 @@ const Wrapper = styled.div({
 
 type LayoutWithMenuProps = {
   children: ReactElement<
-    Omit<StoryblokPageProps, 'story'> & {
+    Pick<StoryblokPageProps, 'trustpilot'> & {
       className: string
       [GLOBAL_PRODUCT_METADATA_PROP_NAME]: GlobalProductMetadata
       story: PageStory | undefined
+      globalStory: GlobalStory | undefined
       breadcrumbs?: Array<BreadcrumbListItem>
     }
   >
@@ -35,6 +36,9 @@ export const LayoutWithMenu = (props: LayoutWithMenuProps) => {
   useHydrateProductMetadata(props.children.props[GLOBAL_PRODUCT_METADATA_PROP_NAME])
 
   const handleLocaleChange = useChangeLocale(story)
+
+  // Happens for transitions from pages with layout to pages without layout
+  if (!globalStory) return null
 
   // Announcements are added as reusable blocks for Page and ProductPage content types
   const reusableBlock = filterByBlockType(


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Treat global story as nullable in layout with menu component

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We've noticed client-side runtime errors where we try to render the component with global story as undefined

- Not sure what a good loading state would be since this is some sort of race condition

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
