### PR TITLE
GEN-1155 - fix(ButtonBlock): enable anchor links

### DIFF
--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -59,9 +59,9 @@ export const fetchStory = async <StoryData extends ISbStoryData>(
 
 const MISSING_LINKS = new Set()
 export const getLinkFieldURL = (link: LinkField, linkText?: string) => {
-  if (link.story) return makeAbsolute(link.story.url)
+  if (link.story) return makeAbsolute(appendAnchor(link.story.url, link.anchor))
 
-  if (link.linktype === 'url') return makeAbsolute(link.url)
+  if (link.linktype === 'url') return makeAbsolute(appendAnchor(link.url, link.anchor))
 
   // Warn about CMS links without target. This could be either reference to something not yet created or misconfiguration
   if (!MISSING_LINKS.has(link.id)) {
@@ -69,7 +69,7 @@ export const getLinkFieldURL = (link: LinkField, linkText?: string) => {
     console.log('Did not see story field in link, returning empty URL.', linkText, link)
   }
 
-  return makeAbsolute(link.cached_url)
+  return makeAbsolute(appendAnchor(link.cached_url, link.anchor))
 }
 
 const makeAbsolute = (url: string) => {
@@ -78,6 +78,8 @@ const makeAbsolute = (url: string) => {
   }
   return '/' + url
 }
+
+const appendAnchor = (url: string, anchor?: string) => (anchor ? `${url}#${anchor}` : url)
 
 export const isProductStory = (story: ISbStoryData): story is ProductStory => {
   return story.content.component === 'product'

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -132,6 +132,7 @@ export type LinkField = {
   linktype: 'multilink' | 'story' | 'url'
   target?: string
   rel?: string
+  anchor?: string
   cached_url: string
   title?: string
   story?: {


### PR DESCRIPTION
## Describe your changes

Enable anchor links for `ButtonBlock`.

## Justify why they are needed

Requested by Peter

**Before**

![Untitled](https://github.com/HedvigInsurance/racoon/assets/19200662/e9ecec6d-d2b3-441f-a522-b6557c3cda20)

**After**

<img width="1181" alt="Screenshot 2023-09-18 at 10 04 26" src="https://github.com/HedvigInsurance/racoon/assets/19200662/019f18a9-7280-4688-9945-46d4ceb55f82">
