### PR TITLE
GEN-1144 - feat: added remove contract modal

### DIFF
--- a/apps/store/public/locales/en/cart.json
+++ b/apps/store/public/locales/en/cart.json
@@ -58,6 +58,8 @@
   "QUICK_ADD_HOUSEHOLD_SIZE_one": "Covers {{count}} person",
   "QUICK_ADD_HOUSEHOLD_SIZE_other": "Covers {{count}} people",
   "RECOMMENDATIONS_HEADING": "Discover more insurances",
+  "REMOVE_CONTRACT_MODAL_PROMPT_SUBTITLE": "We would like to remind you to take out another insurance in good time before your trial insurance with Hedvig has expired. Otherwise, you risk the car becoming uninsured.",
+  "REMOVE_CONTRACT_MODAL_PROMPT_TITLE": "Are you sure you want to remove the insurance?",
   "REMOVE_ENTRY_BUTTON": "Remove",
   "REMOVE_ENTRY_MODAL_CANCEL_BUTTON": "Cancel",
   "REMOVE_ENTRY_MODAL_CONFIRM_BUTTON": "Yes, remove",

--- a/apps/store/public/locales/sv-se/cart.json
+++ b/apps/store/public/locales/sv-se/cart.json
@@ -58,6 +58,8 @@
   "QUICK_ADD_HOUSEHOLD_SIZE_one": "Täcker {{count}} person",
   "QUICK_ADD_HOUSEHOLD_SIZE_other": "Täcker {{count}} personer",
   "RECOMMENDATIONS_HEADING": "Upptäck fler försäkringar",
+  "REMOVE_CONTRACT_MODAL_PROMPT_SUBTITLE": "Vill vi påminna om att teckna en annan försäkring i god tid innan din prova-på-försäkring hos Hedvig har löpt ut. Annars riskerar du att bilen blir oförsäkrad.",
+  "REMOVE_CONTRACT_MODAL_PROMPT_TITLE": "Är du säker på att du vill ta bort försäkringen?",
   "REMOVE_ENTRY_BUTTON": "Ta bort",
   "REMOVE_ENTRY_MODAL_CANCEL_BUTTON": "Avbryt",
   "REMOVE_ENTRY_MODAL_CONFIRM_BUTTON": "Ja, ta bort",

--- a/apps/store/src/components/ProductItem/CartDealershipRemoveButton.tsx
+++ b/apps/store/src/components/ProductItem/CartDealershipRemoveButton.tsx
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled'
+import { useTranslation } from 'react-i18next'
+import { Button, Text } from 'ui'
+import * as FullScreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
+import { ActionButton } from './ProductItem'
+
+type Props = {
+  onRemoveContract: () => void
+}
+
+export const CartDealershipRemoveButton = (props: Props) => {
+  const { t } = useTranslation('cart')
+
+  const handleRemoveContract = () => {
+    props.onRemoveContract()
+  }
+
+  return (
+    <FullScreenDialog.Root>
+      <FullScreenDialog.Trigger asChild={true}>
+        <ActionButton>{t('REMOVE_ENTRY_BUTTON')}</ActionButton>
+      </FullScreenDialog.Trigger>
+
+      <FullScreenDialog.Modal
+        center={true}
+        Footer={
+          <>
+            <Button onClick={handleRemoveContract}>{t('REMOVE_ENTRY_MODAL_CONFIRM_BUTTON')}</Button>
+            <FullScreenDialog.Close asChild={true}>
+              <Button type="button" variant="ghost">
+                {t('REMOVE_ENTRY_MODAL_CANCEL_BUTTON')}
+              </Button>
+            </FullScreenDialog.Close>
+          </>
+        }
+      >
+        <TextWrapper>
+          <Text size={{ _: 'md', lg: 'xl' }} align="center">
+            {t('REMOVE_CONTRACT_MODAL_PROMPT_TITLE')}
+          </Text>
+          <Text size={{ _: 'md', lg: 'xl' }} color="textSecondary" align="center" balance={true}>
+            {t('REMOVE_CONTRACT_MODAL_PROMPT_SUBTITLE')}
+          </Text>
+        </TextWrapper>
+      </FullScreenDialog.Modal>
+    </FullScreenDialog.Root>
+  )
+}
+
+const TextWrapper = styled.div({
+  maxWidth: '38rem',
+  marginInline: 'auto',
+})


### PR DESCRIPTION
## Describe your changes

- Adds `RemoveContractActionButton` that users will click on in case they want to remove the extension car offer.

<img width="1198" alt="Screenshot 2023-09-19 at 09 59 32" src="https://github.com/HedvigInsurance/racoon/assets/19200662/22daad68-0331-42cd-8362-f839c22270c1">


## Justify why they are needed

Required for _Car Dealership_ feature
