### PR TITLE
GEN-1081 - fix(c1): make it work with lazy load strategy

### DIFF
--- a/apps/store/index.d.ts
+++ b/apps/store/index.d.ts
@@ -47,6 +47,7 @@ declare global {
 
     // Customer First (C1)
     customerFirstAPI?: {
+      createWidget(): void
       openWidget(): void
       closeWidget(): void
     }

--- a/apps/store/src/services/CustomerFirst.tsx
+++ b/apps/store/src/services/CustomerFirst.tsx
@@ -22,7 +22,11 @@ export const CustomerFirstScript = ({ hideChat = false }: Props) => {
   return (
     <>
       <Global styles={{ '#chat-iframe': { display: showLauncher ? 'initial' : 'none' } }} />
-      <Script strategy="afterInteractive" src={chatWidgetSrc} />
+      <Script
+        strategy="afterInteractive"
+        src={chatWidgetSrc}
+        onLoad={() => window.customerFirstAPI?.createWidget()}
+      />
     </>
   )
 }


### PR DESCRIPTION
## Describe your changes

Make usage of `createWidget` API to append _customer1_ chat iframe into the DOM. With it we can better control when to load it, in contrast with the current setup where its loading process was being done on an _onload_ event handler they attach when _c1_ script get's parsed.

<img width="626" alt="Screenshot 2023-09-19 at 09 46 48" src="https://github.com/HedvigInsurance/racoon/assets/19200662/878fa8db-a9c6-4f70-b8ed-f679104a21eb">

**Disclaimers**

1. With this change we're appending the chat iframe into the DOM after _c1_ gets loaded with `next/Script` `onLoad` prop. That's because right now we just want fix the issue that originated this ticket where chat iframe might not get loaded with lazy loading approach. However we have different plans for the future where we'd condition chat iframe addition into the DOM as a result of a button click. (check [here](https://www.notion.so/hedviginsurance/Customer1-create-launch-button-desktop-114e9f7239dc4b38a45800006c6a822c?pvs=4)).
2. I could verify that even with the addition of `createWidget` on their API, their script still appends chat iframe into the DOM in a `onload` event handler (check image below). That's good because without it chat wouldn't be available in prod today, at least not before getting this merged. My idea however is to get this merged and then ask them to remove that.

<img width="838" alt="Screenshot 2023-09-19 at 10 25 31" src="https://github.com/HedvigInsurance/racoon/assets/19200662/6f7e7d10-8d68-4af9-a00d-cbe226a5ec0c">

## Justify why they are needed

So _c1_ works properly when lazy loading its script.
