### PR TITLE
GEN-1141 | Add `ActionButtonCar` component

### DIFF
--- a/apps/store/src/features/carDealership/ActionButtonsCar.tsx
+++ b/apps/store/src/features/carDealership/ActionButtonsCar.tsx
@@ -1,0 +1,91 @@
+import { datadogRum } from '@datadog/browser-rum'
+import styled from '@emotion/styled'
+import { useState } from 'react'
+import { theme } from 'ui'
+import { type ProductOfferFragment } from '@/services/apollo/generated'
+import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
+import { ActionButton } from '../../components/ProductItem/ProductItem'
+import { ActionStateEdit } from './ActionStateEdit'
+import { useEditAndConfirm } from './useEditAndConfirm'
+
+type State = 'IDLE' | 'EDITING'
+
+type Offer = Pick<ProductOfferFragment, 'id'> & {
+  variant: Pick<ProductOfferFragment['variant'], 'typeOfContract' | 'displayName'>
+}
+
+type Props = {
+  shopSessionId: string
+  priceIntent: Pick<PriceIntent, 'id' | 'data'> & { offers: Array<Offer> }
+  offer: Offer
+
+  onUpdateOffer: (offer: Offer | null) => void
+  onRemove: () => void
+}
+
+export const ActionButtonsCar = (props: Props) => {
+  const [state, setState] = useState<State>('IDLE')
+
+  const [editAndConfirm, loading] = useEditAndConfirm({
+    shopSessionId: props.shopSessionId,
+    priceIntentId: props.priceIntent.id,
+
+    onCompleted(priceIntent) {
+      const newOffer = priceIntent.offers.find(
+        (offer) => offer.variant.typeOfContract === props.offer.variant.typeOfContract,
+      )
+      props.onUpdateOffer(newOffer ?? null)
+      setState('IDLE')
+    },
+  })
+
+  const handleClickEdit = () => {
+    datadogRum.addAction('Offer Car Edit')
+    setState('EDITING')
+  }
+
+  const handleClickRemove = () => {
+    datadogRum.addAction('Offer Car Remove')
+    props.onRemove()
+  }
+
+  if (state === 'EDITING') {
+    const handleCancel = () => setState('IDLE')
+
+    const handleSave = (option: string, data: Record<string, unknown>) => {
+      const newOffer = props.priceIntent.offers.find((offer) => offer.id === option)
+      if (newOffer && newOffer.id !== props.offer.id) {
+        props.onUpdateOffer(newOffer)
+      }
+      editAndConfirm(data)
+    }
+
+    const options = props.priceIntent.offers.map((offer) => ({
+      name: offer.variant.displayName,
+      value: offer.id,
+    }))
+
+    return (
+      <ActionStateEdit
+        options={options}
+        onSave={handleSave}
+        onCancel={handleCancel}
+        loading={loading}
+        data={props.priceIntent.data}
+      />
+    )
+  }
+
+  return (
+    <ButtonWrapper>
+      <ActionButton onClick={handleClickEdit}>Edit</ActionButton>
+      <ActionButton onClick={handleClickRemove}>Remove</ActionButton>
+    </ButtonWrapper>
+  )
+}
+
+const ButtonWrapper = styled.div({
+  display: 'grid',
+  gridAutoFlow: 'column',
+  gap: theme.space.xs,
+})

--- a/apps/store/src/features/carDealership/ActionStateEdit.tsx
+++ b/apps/store/src/features/carDealership/ActionStateEdit.tsx
@@ -1,0 +1,100 @@
+import { datadogRum } from '@datadog/browser-rum'
+import styled from '@emotion/styled'
+import { theme } from 'ui'
+import { InputSelect } from '@/components/InputSelect/InputSelect'
+import { CarMileageField } from '@/components/PriceCalculator/CarMileageField'
+import { ActionButton } from '../../components/ProductItem/ProductItem'
+
+const MILEAGE_DATA_KEY = 'mileage'
+const OFFER_KEY = 'offer'
+
+type EditingStateProps = {
+  data: Record<string, unknown>
+  onSave: (option: string, data: Record<string, unknown>) => void
+  loading: boolean
+
+  options: Array<{ name: string; value: string }>
+
+  onCancel: () => void
+}
+
+export const ActionStateEdit = (props: EditingStateProps) => {
+  const handleChangeTierLevel = () => {
+    datadogRum.addAction('Offer Car Tier Level Change')
+  }
+
+  const handleClickCancel = () => {
+    datadogRum.addAction('Offer Car Cancel')
+    props.onCancel()
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    datadogRum.addAction('Offer Car Save')
+
+    const formData = new FormData(event.currentTarget)
+    const data = {
+      [MILEAGE_DATA_KEY]: formData.get(MILEAGE_DATA_KEY),
+    }
+
+    const option = formData.get(OFFER_KEY)
+    if (typeof option !== 'string') {
+      throw new Error('Missing offer')
+    }
+
+    props.onSave(option, data)
+  }
+
+  const mileageField = {
+    type: 'car-mileage',
+    name: MILEAGE_DATA_KEY,
+    label: { key: 'FIELD_MILEAGE_LABEL' },
+    required: true,
+    defaultValue: '1000',
+  } as const
+
+  const mileage = props.data[MILEAGE_DATA_KEY]
+  const defaultValue = typeof mileage === 'string' ? mileage : undefined
+
+  return (
+    <FormWrapper onSubmit={handleSubmit}>
+      <InputWrapper>
+        <InputSelect
+          name={OFFER_KEY}
+          onChange={handleChangeTierLevel}
+          defaultValue={defaultValue}
+          options={props.options}
+          backgroundColor="backgroundStandard"
+        />
+        <CarMileageField field={mileageField} backgroundColor="backgroundStandard" />
+      </InputWrapper>
+
+      <ButtonWrapper>
+        <ActionButton type="submit" variant="primary-alt" loading={props.loading}>
+          Save
+        </ActionButton>
+        <ActionButton type="button" onClick={handleClickCancel}>
+          Cancel
+        </ActionButton>
+      </ButtonWrapper>
+    </FormWrapper>
+  )
+}
+
+const FormWrapper = styled.form({
+  display: 'grid',
+  gridAutoFlow: 'row',
+  gap: theme.space.sm,
+})
+
+const InputWrapper = styled.div({
+  display: 'grid',
+  gridAutoFlow: 'row',
+  gap: theme.space.xxs,
+})
+
+const ButtonWrapper = styled.div({
+  display: 'grid',
+  gridAutoFlow: 'column',
+  gap: theme.space.xs,
+})

--- a/apps/store/src/features/carDealership/useEditAndConfirm.tsx
+++ b/apps/store/src/features/carDealership/useEditAndConfirm.tsx
@@ -1,0 +1,57 @@
+import { type ApolloError } from '@apollo/client'
+import { useTranslation } from 'next-i18next'
+import {
+  usePriceIntentConfirmMutation,
+  usePriceIntentDataUpdateMutation,
+} from '@/services/apollo/generated'
+import { useAppErrorHandleContext } from '@/services/appErrors/AppErrorContext'
+import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
+
+type EditAndConfirmParams = {
+  shopSessionId: string
+  priceIntentId: string
+
+  onCompleted: (priceIntent: PriceIntent) => void
+}
+
+export const useEditAndConfirm = (params: EditAndConfirmParams) => {
+  const { t } = useTranslation('common')
+  const { showError } = useAppErrorHandleContext()
+
+  const [confirm, confirmResult] = usePriceIntentConfirmMutation({
+    variables: { priceIntentId: params.priceIntentId },
+    onCompleted(data) {
+      const priceIntent = data.priceIntentConfirm.priceIntent
+      if (priceIntent) {
+        params.onCompleted(priceIntent)
+      }
+    },
+  })
+
+  const handleError = (error: ApolloError) => {
+    console.warn('EditAndConfirm error', error)
+    showError(new Error(t('UNKNOWN_ERROR_MESSAGE')))
+  }
+
+  const [updateData, updateResult] = usePriceIntentDataUpdateMutation({
+    onCompleted() {
+      confirm()
+    },
+    onError: handleError,
+  })
+
+  const editAndConfirm = (data: Record<string, unknown>) => {
+    updateData({
+      variables: {
+        priceIntentId: params.priceIntentId,
+        data,
+        customer: { shopSessionId: params.shopSessionId },
+      },
+      onError: handleError,
+    })
+  }
+
+  const loading = updateResult.loading || confirmResult.loading
+
+  return [editAndConfirm, loading] as const
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add `ActionButtonCar` component that handles editing car price intent inline

- Start new "carDealership" feature module to group files

Usage:

```
<ActionButtonsCar
  shopSessionId="123"
  priceIntent={{
    id: '123',
    data: {},
    offers: [
      {
        id: '1234',
        variant: { typeOfContract: 'test', displayName: 'Full insurance' },
      },
      {
        id: '1235',
        variant: { typeOfContract: 'test1', displayName: 'Half insurance' },
      },
      {
        id: '1236',
        variant: { typeOfContract: 'test2', displayName: 'Traffic insurance' },
      },
    ],
  }}
  offer={{ id: '1234', variant: { typeOfContract: 'test', displayName: 'Full insurance' } }}
  onRemove={() => {}}
  onUpdateOffer={() => {}}
/>
```
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Support car dealership features

- I left some translations hard coded for now since the UI is still pending

- I will add tests once we are happy with adding the full set of features

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
