### PR TITLE
ProductItem: don't expect two action buttons

### DIFF
--- a/apps/store/src/components/ProductItem/ProductItem.tsx
+++ b/apps/store/src/components/ProductItem/ProductItem.tsx
@@ -138,7 +138,7 @@ const StyledProductDetails = styled(ProductDetails)({
 
 const Footer = styled.div({
   display: 'grid',
-  gridTemplateColumns: 'repeat(2, 1fr)',
+  gridAutoFlow: 'column',
   columnGap: theme.space.xs,
   paddingBottom: theme.space.md,
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Avoid expecting exactly two children (action buttons) in `ProductItem`

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We have a need for a single child that handles its own layout (car dealership)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
