### PR TITLE
GEN-975 - fix(TextBlock): proper render rich text content

### DIFF
--- a/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
+++ b/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
@@ -1,5 +1,6 @@
 import { ISbRichtext, storyblokEditable } from '@storyblok/react'
 import Link from 'next/link'
+import { useMemo, type ReactNode } from 'react'
 import { render, RenderOptions, MARK_LINK } from 'storyblok-rich-text-react-renderer'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { RichText } from '@/components/RichText/RichText'
@@ -12,7 +13,23 @@ export type RichTextBlockProps = SbBaseBlockProps<{
   largeText?: boolean
 }>
 
-const richTextRenderOptions: RenderOptions = {
+export const RichTextBlock = ({ blok }: RichTextBlockProps) => {
+  const content = useMemo(() => renderRichText(blok.content), [blok.content])
+
+  return (
+    <GridLayout.Root {...storyblokEditable(blok)}>
+      <GridLayout.Content
+        width={blok.layout?.widths ?? { base: '1', md: '2/3', xl: '1/2' }}
+        align={blok.layout?.alignment ?? 'center'}
+      >
+        <RichText largeText={blok.largeText}>{content}</RichText>
+      </GridLayout.Content>
+    </GridLayout.Root>
+  )
+}
+RichTextBlock.blockName = 'richText'
+
+const RENDER_OPTIONS: RenderOptions = {
   blokResolvers: {
     image: (props) => <ImageBlock blok={props as ImageBlockProps['blok']} nested={true} />,
   },
@@ -55,18 +72,7 @@ const isExternalLink = (href?: string) => href?.match(/^(https?:)?\/\//)
 
 const appendAnchor = (href: string, anchor?: string) => (anchor ? `${href}#${anchor}` : href)
 
-export const RichTextBlock = ({ blok }: RichTextBlockProps) => {
-  return (
-    <GridLayout.Root {...storyblokEditable(blok)}>
-      <GridLayout.Content
-        width={blok.layout?.widths ?? { base: '1', md: '2/3', xl: '1/2' }}
-        align={blok.layout?.alignment ?? 'center'}
-      >
-        <RichText largeText={blok.largeText}>
-          {render(blok.content, richTextRenderOptions)}
-        </RichText>
-      </GridLayout.Content>
-    </GridLayout.Root>
-  )
-}
-RichTextBlock.blockName = 'richText'
+export const renderRichText = (
+  content: ISbRichtext,
+  renderOptions: RenderOptions = RENDER_OPTIONS,
+) => render(content, renderOptions) as ReactNode

--- a/apps/store/src/blocks/TextBlock.tsx
+++ b/apps/store/src/blocks/TextBlock.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled'
-import { ISbRichtext, renderRichText, storyblokEditable } from '@storyblok/react'
+import { ISbRichtext, storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
-import { UIColors, Text, FontSizes, Space } from 'ui'
-import { nestedLinkStyles } from '@/components/RichText/RichText.styles'
+import { Text, getColor, UIColors, FontSizes } from 'ui'
+import { RichText } from '@/components/RichText/RichText'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { renderRichText } from './RichTextBlock/RichTextBlock'
 
 type TextColor = keyof Pick<UIColors, 'textPrimary' | 'textSecondary' | 'textTertiary'>
 
@@ -17,13 +18,13 @@ export type TextBlockProps = SbBaseBlockProps<{
 }>
 
 export const TextBlock = ({ blok }: TextBlockProps) => {
-  const contentHtml = useMemo(() => renderRichText(blok.body), [blok.body])
+  const content = useMemo(() => renderRichText(blok.body), [blok.body])
   const fontSizes = {
     _: blok.fontSize ?? 'md',
     ...(blok.fontSizeDesktop && { md: blok.fontSizeDesktop }),
   }
   return (
-    <StyledText
+    <Text
       {...storyblokEditable(blok)}
       as="div"
       align={blok.textAlignment}
@@ -31,11 +32,32 @@ export const TextBlock = ({ blok }: TextBlockProps) => {
       color={blok.color ?? 'textPrimary'}
       size={fontSizes}
     >
-      <Space y={1} dangerouslySetInnerHTML={{ __html: contentHtml }}></Space>
-    </StyledText>
+      <StyledRichText color={blok.color ?? 'textSecondary'}>{content}</StyledRichText>
+    </Text>
   )
 }
 
-const StyledText = styled(Text)(nestedLinkStyles)
+const StyledRichText = styled(RichText)<{ color: TextColor }>(({ color }) => ({
+  fontSize: 'inherit',
+
+  p: {
+    color: 'inherit',
+    fontSize: 'inherit',
+  },
+  'h2, h3, h4': {
+    color: 'inherit',
+    fontSize: 'inherit',
+  },
+  'ul li': {
+    '&::before': {
+      backgroundColor: getColor(color),
+    },
+  },
+  'ol li': {
+    '::marker': {
+      color: 'inherit',
+    },
+  },
+}))
 
 TextBlock.blockName = 'text'

--- a/apps/store/src/components/RichText/RichText.tsx
+++ b/apps/store/src/components/RichText/RichText.tsx
@@ -1,15 +1,11 @@
 import styled from '@emotion/styled'
-import { ReactNode } from 'react'
+import { type PropsWithChildren } from 'react'
 import { richTextStyles } from '@/components/RichText/RichText.styles'
 
-type RichTextProps = {
-  children: ReactNode
-  contentHTML?: string
-  largeText?: boolean
-}
+type RichTextProps = PropsWithChildren<{ largeText?: boolean }>
 
-export const RichText = ({ largeText, children }: RichTextProps) => {
-  return <Content data-large-text={largeText}>{children}</Content>
+export const RichText = ({ largeText, ...rest }: RichTextProps) => {
+  return <Content data-large-text={largeText} {...rest} />
 }
 
 const Content = styled.div(richTextStyles)


### PR DESCRIPTION
## Describe your changes

- Fix text formatting for `TextBlock`'s rich text field - `body`

<img width="1080" alt="Screenshot 2023-09-20 at 10 07 13" src="https://github.com/HedvigInsurance/racoon/assets/19200662/4bf37fea-abc6-42b0-b918-c607920ea49c">

## Justify why they are needed

`TextBlock` was accepting a rich text field but none formatting was being applied. Now the same one we use for `RichTextBlock` is being applied for `TextBlock` as well.
