### PR TITLE
Use car-specific price intent update mutation

### DIFF
--- a/apps/store/src/features/carDealership/ActionButtonsCar.tsx
+++ b/apps/store/src/features/carDealership/ActionButtonsCar.tsx
@@ -16,7 +16,6 @@ type Offer = Pick<ProductOfferFragment, 'id'> & {
 }
 
 type Props = {
-  shopSessionId: string
   priceIntent: Pick<PriceIntent, 'id' | 'data'> & { offers: Array<Offer> }
   offer: Offer
 
@@ -28,7 +27,6 @@ export const ActionButtonsCar = (props: Props) => {
   const [state, setState] = useState<State>('IDLE')
 
   const [editAndConfirm, loading] = useEditAndConfirm({
-    shopSessionId: props.shopSessionId,
     priceIntentId: props.priceIntent.id,
 
     onCompleted(priceIntent) {

--- a/apps/store/src/features/carDealership/PriceIntentDataUpdateCar.graphql
+++ b/apps/store/src/features/carDealership/PriceIntentDataUpdateCar.graphql
@@ -1,0 +1,10 @@
+mutation PriceIntentDataUpdateCar($priceIntentId: UUID!, $data: PricingFormData!) {
+  priceIntentDataUpdate(priceIntentId: $priceIntentId, data: $data) {
+    priceIntent {
+      ...PriceIntentFragment
+    }
+    userError {
+      message
+    }
+  }
+}

--- a/apps/store/src/features/carDealership/TrialExtensionBlock.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionBlock.tsx
@@ -13,7 +13,6 @@ const SIGN_AND_PAY_BUTTON = 'Signera och betala'
 const UNDO_REMOVE_BUTTON = 'Ångra borttagning'
 
 type Props = {
-  shopSessionId: string
   priceIntent: PriceIntent
 }
 
@@ -72,7 +71,6 @@ export const TrialExtensionBlock = (props: Props) => {
           <Space y={1}>
             <ProductItemContainer offer={selectedOffer} defaultExpanded={true}>
               <ActionButtonsCar
-                shopSessionId={props.shopSessionId}
                 priceIntent={props.priceIntent}
                 offer={selectedOffer}
                 onRemove={handleRemove}

--- a/apps/store/src/features/carDealership/useEditAndConfirm.tsx
+++ b/apps/store/src/features/carDealership/useEditAndConfirm.tsx
@@ -2,15 +2,13 @@ import { type ApolloError } from '@apollo/client'
 import { useTranslation } from 'next-i18next'
 import {
   usePriceIntentConfirmMutation,
-  usePriceIntentDataUpdateMutation,
+  usePriceIntentDataUpdateCarMutation,
 } from '@/services/apollo/generated'
 import { useAppErrorHandleContext } from '@/services/appErrors/AppErrorContext'
 import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 
 type EditAndConfirmParams = {
-  shopSessionId: string
   priceIntentId: string
-
   onCompleted: (priceIntent: PriceIntent) => void
 }
 
@@ -33,7 +31,7 @@ export const useEditAndConfirm = (params: EditAndConfirmParams) => {
     showError(new Error(t('UNKNOWN_ERROR_MESSAGE')))
   }
 
-  const [updateData, updateResult] = usePriceIntentDataUpdateMutation({
+  const [updateData, updateResult] = usePriceIntentDataUpdateCarMutation({
     onCompleted() {
       confirm()
     },
@@ -45,7 +43,6 @@ export const useEditAndConfirm = (params: EditAndConfirmParams) => {
       variables: {
         priceIntentId: params.priceIntentId,
         data,
-        customer: { shopSessionId: params.shopSessionId },
       },
       onError: handleError,
     })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Use a car dealership specific mutation to update price intent data

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- The one we use in price calculator also updates customer data so it needs shop session ID. We don't do that in this feature so passing shop session ID just becomes confusing.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
