### PR TITLE
GEN-1171 | CarDealership: derive selected offer based on tier level

### DIFF
--- a/apps/store/src/features/carDealership/TrialExtensionBlock.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionBlock.tsx
@@ -1,11 +1,11 @@
 import { datadogRum } from '@datadog/browser-rum'
 import { useTranslation } from 'next-i18next'
-import { type ComponentProps, useState } from 'react'
+import { useState } from 'react'
 import { BankIdIcon, Button, RestartIcon, Space, Text } from 'ui'
 import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
 import { ProductItemContractContainerCar } from '@/components/ProductItem/ProductItemContractContainer'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
-import { CurrencyCode, type ProductOfferFragment } from '@/services/apollo/generated'
+import { CurrencyCode } from '@/services/apollo/generated'
 import { type PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import { ActionButtonsCar } from './ActionButtonsCar'
 
@@ -16,26 +16,26 @@ type Props = {
   priceIntent: PriceIntent
 }
 
-type UpdateOfferFunction = ComponentProps<typeof ActionButtonsCar>['onUpdateOffer']
-
 export const TrialExtensionBlock = (props: Props) => {
   const { t } = useTranslation('checkout')
   const [isHidden, setIsHidden] = useState(false)
-  const [selectedOffer, setSelectedOffer] = useState<ProductOfferFragment>(() => {
+
+  const [tierLevel, setTierLevel] = useState(() => {
     // Use `PriceIntent.defaultOffer` when available
-    return props.priceIntent.offers[0]
+    return props.priceIntent.offers[0].variant.typeOfContract
   })
+  const selectedOffer =
+    props.priceIntent.offers.find((item) => item.variant.typeOfContract === tierLevel) ??
+    // Use `PriceIntent.defaultOffer` when available
+    props.priceIntent.offers[0]
 
-  const handleUpdateOffer: UpdateOfferFunction = (offer) => {
-    const newOffer = props.priceIntent.offers.find((item) => item.id === offer?.id)
-
-    if (newOffer) {
-      setSelectedOffer(newOffer)
-      return
+  const handleUpdate = (tierLevel: string) => {
+    const match = props.priceIntent.offers.find((item) => item.variant.typeOfContract === tierLevel)
+    if (!match) {
+      throw new Error(`Unable to find offer with tierLevel ${tierLevel}`)
     }
 
-    // Use `PriceIntent.defaultOffer` when available
-    setSelectedOffer(props.priceIntent.offers[0])
+    setTierLevel(tierLevel)
   }
 
   const handleRemove = () => {
@@ -74,7 +74,7 @@ export const TrialExtensionBlock = (props: Props) => {
                 priceIntent={props.priceIntent}
                 offer={selectedOffer}
                 onRemove={handleRemove}
-                onUpdateOffer={handleUpdateOffer}
+                onUpdate={handleUpdate}
               />
             </ProductItemContainer>
             {/* TODO: Add blue info card */}

--- a/apps/store/src/features/carDealership/useEditAndConfirm.tsx
+++ b/apps/store/src/features/carDealership/useEditAndConfirm.tsx
@@ -5,11 +5,10 @@ import {
   usePriceIntentDataUpdateCarMutation,
 } from '@/services/apollo/generated'
 import { useAppErrorHandleContext } from '@/services/appErrors/AppErrorContext'
-import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 
 type EditAndConfirmParams = {
   priceIntentId: string
-  onCompleted: (priceIntent: PriceIntent) => void
+  onCompleted: () => void
 }
 
 export const useEditAndConfirm = (params: EditAndConfirmParams) => {
@@ -18,17 +17,15 @@ export const useEditAndConfirm = (params: EditAndConfirmParams) => {
 
   const [confirm, confirmResult] = usePriceIntentConfirmMutation({
     variables: { priceIntentId: params.priceIntentId },
-    onCompleted(data) {
-      const priceIntent = data.priceIntentConfirm.priceIntent
-      if (priceIntent) {
-        params.onCompleted(priceIntent)
-      }
+    onCompleted() {
+      params.onCompleted()
     },
   })
 
   const handleError = (error: ApolloError) => {
     console.warn('EditAndConfirm error', error)
     showError(new Error(t('UNKNOWN_ERROR_MESSAGE')))
+    params.onCompleted()
   }
 
   const [updateData, updateResult] = usePriceIntentDataUpdateCarMutation({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Store selected tier level in React state and derive the selected offer based on that

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- The first iteration stored the offer itself in React state. However, then we need to update it every time we confirm the price intent which is error prone. This way we only update state when someone changes the tier level.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
