### PR TITLE
GEN-1168 | Build CarTrialExtensionBlock (draft)

### DIFF
--- a/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
+++ b/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
@@ -1,0 +1,119 @@
+import { storyblokEditable } from '@storyblok/react'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { CurrencyCode } from '@/services/apollo/generated'
+import { type SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { LoadingSkeleton } from './LoadingSkeleton'
+import { TrialExtensionForm } from './TrialExtensionForm'
+
+type Props = SbBaseBlockProps<{
+  requirePaymentConnection?: boolean
+}>
+
+export const CarTrialExtensionBlock = (props: Props) => {
+  const data = useCarTrialQuery()
+
+  if (!data) return <LoadingSkeleton {...storyblokEditable(props.blok)} />
+
+  return <TrialExtensionForm {...storyblokEditable(props.blok)} contract={data.trialContract} />
+}
+CarTrialExtensionBlock.blockName = 'carTrialExtension'
+
+const CAR_TRIAL_DATA_QUERY = {
+  id: '123',
+
+  trialContract: {
+    id: '1234',
+
+    premium: {
+      amount: 299,
+      currencyCode: CurrencyCode.Sek,
+    },
+
+    terminationDate: '2023-12-31',
+
+    exposure: {
+      displayNameFull: 'Volkswagen Polo · LPP 083',
+    },
+
+    variant: {
+      displayName: 'Full insurance',
+
+      displayItems: [
+        {
+          displayTitle: 'Address',
+          displayValue: 'Hedvigsgatan 11',
+        },
+      ],
+    },
+  },
+
+  priceIntent: {
+    id: '12345',
+    data: { mileage: 1500 },
+    offers: [
+      {
+        id: '123456',
+        variant: {
+          displayName: 'Full insurance',
+          typeOfContract: 'SE_CAR_FULL',
+        },
+      },
+      {
+        id: '1234567',
+        variant: {
+          displayName: 'Half insurance',
+          typeOfContract: 'SE_CAR_HALF',
+        },
+      },
+      {
+        id: '12345678',
+        variant: {
+          displayName: 'Traffic insurance',
+          typeOfContract: 'SE_CAR_TRAFFIC',
+        },
+      },
+    ],
+    defaultOffer: {
+      id: '123456',
+      cost: { net: { amount: 579, currencyCode: CurrencyCode.Sek } },
+      displayItems: [
+        {
+          displayTitle: 'Address',
+          displayValue: 'Hedvigsgatan 11',
+        },
+      ],
+      startDate: '2023-12-31',
+      variant: {
+        documents: [],
+
+        product: {
+          displayNameShort: 'Car insurance',
+        },
+      },
+    },
+  },
+} as const
+
+type CarTrialData = typeof CAR_TRIAL_DATA_QUERY
+
+const useCarTrialQuery = () => {
+  const router = useRouter()
+  const queryParam = router.query['id']
+  const id = typeof queryParam === 'string' ? queryParam : undefined
+
+  const [data, setData] = useState<CarTrialData>()
+
+  useEffect(() => {
+    // if (!id) return
+    if (!router.isReady) return
+
+    const handle = setTimeout(() => {
+      setData(CAR_TRIAL_DATA_QUERY)
+    }, 1000)
+
+    return () => clearTimeout(handle)
+  }, [router.isReady, id])
+
+  return data
+}

--- a/apps/store/src/features/carDealership/TrialExtensionForm.stories.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.stories.tsx
@@ -4,15 +4,13 @@ import { TrialExtensionForm } from './TrialExtensionForm'
 
 type Story = StoryObj<typeof TrialExtensionForm>
 
-const noop = () => {}
-
 const meta: Meta<typeof TrialExtensionForm> = {
   title: 'TrialExtensionForm',
   component: TrialExtensionForm,
 }
 
 export const WithoutExtension: Story = {
-  render: () => <TrialExtensionForm contract={FIXTURE_CONTRACT} onUndo={noop} />,
+  render: () => <TrialExtensionForm contract={FIXTURE_CONTRACT} />,
 }
 
 export default meta

--- a/apps/store/src/features/carDealership/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.tsx
@@ -4,15 +4,11 @@ import { Space, Button, RestartIcon } from 'ui'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { ProductItemContractContainerCar } from './ProductItemContractContainer'
 
-type Props = { onUndo: () => void } & Pick<
-  ComponentProps<typeof ProductItemContractContainerCar>,
-  'contract'
->
+type Props = Pick<ComponentProps<typeof ProductItemContractContainerCar>, 'contract'>
 
 export const TrialExtensionForm = (props: Props) => {
   const handleUndo = () => {
     datadogRum.addAction('Car dealership | Undo extension removal')
-    props.onUndo()
   }
 
   return (

--- a/apps/store/src/features/carDealership/carDealershipBlocks.ts
+++ b/apps/store/src/features/carDealership/carDealershipBlocks.ts
@@ -1,0 +1,3 @@
+import { CarTrialExtensionBlock } from './CarTrialExtensionBlock'
+
+export const carDealershipBlocks = [CarTrialExtensionBlock]

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -75,6 +75,7 @@ import { type ContentWidth, type ContentAlignment } from '@/components/GridLayou
 import { BLOG_ARTICLE_CONTENT_TYPE } from '@/features/blog/blog.constants'
 import { blogBlocks } from '@/features/blog/blogBlocks'
 // TODO: get rid of this import, services should avoid feature-imports
+import { carDealershipBlocks } from '@/features/carDealership/carDealershipBlocks'
 import { STORYBLOK_MANYPETS_FOLDER_SLUG } from '@/features/manyPets/manyPets.constants'
 import { manyPetsBlocks } from '@/features/manyPets/manyPetsBlocks'
 import { TrustpilotData } from '@/services/trustpilot/trustpilot.types'
@@ -305,6 +306,7 @@ export const initStoryblok = () => {
     InsurelyBlock,
     ...blogBlocks,
     ...manyPetsBlocks,
+    ...carDealershipBlocks,
   ]
   const blockAliases = { reusableBlock: PageBlock }
   const components = {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Build `CarTrialExtensionBlock` component

- Register new block in Storyblok

- Remove `onUndo` prop from `TrialExtensionForm`

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Based on new architecture for car dealership project

- `TrialExtensionForm` should handle removing and re-adding extension offer (no need for callback)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
