### PR TITLE
GEN-1182 / Replace ProductVariant.product with Offer.product in schema

### DIFF
--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -68,7 +68,7 @@ export const CartPage = () => {
                     <RemoveActionButton
                       shopSessionId={shopSession.id}
                       offer={item}
-                      title={item.variant.product.displayNameFull}
+                      title={item.product.displayNameFull}
                     />
                   </ProductItemContainer>
                 ))}

--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -130,7 +130,7 @@ const CheckoutPage = (props: CheckoutPageProps) => {
                       <RemoveActionButton
                         shopSessionId={shopSession.id}
                         offer={item}
-                        title={item.variant.product.displayNameFull}
+                        title={item.product.displayNameFull}
                         onCompleted={handleRemoveCartEntry}
                       />
                     </ProductItemContainer>

--- a/apps/store/src/components/ProductItem/EditActionButton.tsx
+++ b/apps/store/src/components/ProductItem/EditActionButton.tsx
@@ -23,7 +23,7 @@ export const EditActionButton = (props: Props) => {
       editProductOffer({
         shopSessionId: props.shopSessionId,
         offerId: props.offer.id,
-        productName: props.offer.variant.product.name,
+        productName: props.offer.product.name,
         data: props.offer.priceIntentData,
       })
     } catch (error) {

--- a/apps/store/src/components/ProductItem/ProductItemContainer.tsx
+++ b/apps/store/src/components/ProductItem/ProductItemContainer.tsx
@@ -7,7 +7,7 @@ import { useGetStartDateProps } from './useGetStartDateProps'
 
 type Offer = Pick<
   ProductOfferFragment,
-  'cost' | 'priceIntentData' | 'startDate' | 'displayItems' | 'deductible' | 'variant'
+  'cost' | 'priceIntentData' | 'startDate' | 'displayItems' | 'deductible' | 'variant' | 'product'
 >
 
 type Props = {
@@ -23,7 +23,7 @@ export const ProductItemContainer = (props: Props) => {
   const price = getOfferPrice(props.offer.cost)
 
   const startDateProps = getStartDateProps({
-    productName: props.offer.variant.product.name,
+    productName: props.offer.product.name,
     data: props.offer.priceIntentData,
     startDate: props.offer.startDate,
   })
@@ -51,8 +51,8 @@ export const ProductItemContainer = (props: Props) => {
 
   return (
     <ProductItem
-      title={props.offer.variant.product.displayNameFull}
-      pillowSrc={props.offer.variant.product.pillowImage.src}
+      title={props.offer.product.displayNameFull}
+      pillowSrc={props.offer.product.pillowImage.src}
       price={price}
       startDate={startDateProps}
       productDetails={productDetails}
@@ -64,9 +64,9 @@ export const ProductItemContainer = (props: Props) => {
   )
 }
 
-const getTierLevelDisplayName = (item: Pick<ProductOfferFragment, 'variant'>) => {
+const getTierLevelDisplayName = (item: Pick<ProductOfferFragment, 'variant' | 'product'>) => {
   // TODO: small hack, move logic to API
-  return item.variant.displayName !== item.variant.product.displayNameFull
+  return item.variant.displayName !== item.product.displayNameFull
     ? item.variant.displayName
     : undefined
 }

--- a/apps/store/src/components/ProductPage/PurchaseForm/useSelectedOffer.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/useSelectedOffer.ts
@@ -25,7 +25,7 @@ export const useSelectedOffer = () => {
       if (offer?.priceMatch) {
         datadogLogs.logger.info('Selected price matched offer', {
           offerId: offer.id,
-          product: offer.variant.product.name,
+          product: offer.product.name,
           productVariant: offer.variant.displayName,
           externalInsurer: offer.priceMatch.externalInsurer.displayName,
           priceReduction: offer.priceMatch.priceReduction.amount,

--- a/apps/store/src/components/QuickAdd/QuickAddCompleteContainer.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddCompleteContainer.tsx
@@ -70,7 +70,7 @@ const useProductSubtitle = (offer: OfferRecommendationFragment) => {
   // Should never happen
   datadogLogs.logger.error('Quick Add Complete | street address not found', {
     productOfferId: offer.id,
-    product: offer.variant.product.id,
+    product: offer.product.id,
   })
   return ''
 }

--- a/apps/store/src/features/carDealership/carDealershipFixtures.ts
+++ b/apps/store/src/features/carDealership/carDealershipFixtures.ts
@@ -6,16 +6,16 @@ const DEFAULT_OFFER = {
   variant: {
     displayName: 'Full insurance',
     typeOfContract: 'SE_CAR_FULL',
-    product: {
-      id: 'car-full',
-      displayNameFull: '',
-      displayNameShort: 'Car insurance',
-      name: 'Car Full',
-      pageLink: '',
-      pillowImage: { id: 'car-full-pillow', src: 'https://placekitten.com/200/300' },
-    },
     perils: [] as Array<Peril>,
     documents: [] as Array<any>,
+  },
+  product: {
+    id: 'car-full',
+    displayNameFull: '',
+    displayNameShort: 'Car insurance',
+    name: 'Car Full',
+    pageLink: '',
+    pillowImage: { id: 'car-full-pillow', src: 'https://placekitten.com/200/300' },
   },
   startDate: '2023-12-31',
   cost: {
@@ -71,15 +71,15 @@ export const CAR_TRIAL_DATA_QUERY = {
         variant: {
           displayName: 'Half insurance',
           typeOfContract: 'SE_CAR_HALF',
-          product: {
-            id: 'car-half',
-            name: 'Car Half',
-            displayNameFull: '',
-            pageLink: '',
-            pillowImage: { id: 'car-half-pillow', src: 'https://placekitten.com/200/300' },
-          },
           perils: [],
           documents: [],
+        },
+        product: {
+          id: 'car-half',
+          name: 'Car Half',
+          displayNameFull: '',
+          pageLink: '',
+          pillowImage: { id: 'car-half-pillow', src: 'https://placekitten.com/200/300' },
         },
         cost: {
           net: { amount: 479, currencyCode: CurrencyCode.Sek },
@@ -94,15 +94,15 @@ export const CAR_TRIAL_DATA_QUERY = {
         variant: {
           displayName: 'Traffic insurance',
           typeOfContract: 'SE_CAR_TRAFFIC',
-          product: {
-            id: 'car-traffic',
-            name: 'Car Traffic',
-            displayNameFull: '',
-            pageLink: '',
-            pillowImage: { id: 'car-traffic-pillow', src: 'https://placekitten.com/200/300' },
-          },
           perils: [],
           documents: [],
+        },
+        product: {
+          id: 'car-traffic',
+          name: 'Car Traffic',
+          displayNameFull: '',
+          pageLink: '',
+          pillowImage: { id: 'car-traffic-pillow', src: 'https://placekitten.com/200/300' },
         },
         cost: {
           net: { amount: 379, currencyCode: CurrencyCode.Sek },

--- a/apps/store/src/graphql/OfferRecommendationFragment.graphql
+++ b/apps/store/src/graphql/OfferRecommendationFragment.graphql
@@ -7,12 +7,12 @@ fragment OfferRecommendation on ProductOffer {
     displayTitle
     displayValue
   }
+  product {
+    id
+    displayNameFull
+  }
   variant {
     typeOfContract
-    product {
-      id
-      displayNameFull
-    }
   }
   cost {
     gross {

--- a/apps/store/src/graphql/ProductOfferFragment.graphql
+++ b/apps/store/src/graphql/ProductOfferFragment.graphql
@@ -1,19 +1,19 @@
 fragment ProductOffer on ProductOffer {
   id
+  product {
+    id
+    name
+    pageLink
+    displayNameFull
+    pillowImage {
+      id
+      alt
+      src
+    }
+  }
   variant {
     typeOfContract
     displayName
-    product {
-      id
-      name
-      pageLink
-      displayNameFull
-      pillowImage {
-        id
-        alt
-        src
-      }
-    }
     perils {
       ...Peril
     }

--- a/apps/store/src/services/Tracking/Tracking.ts
+++ b/apps/store/src/services/Tracking/Tracking.ts
@@ -21,12 +21,12 @@ type TrackingProductData = {
 
 type TrackingOffer = {
   cost: ProductOfferFragment['cost']
+  product: {
+    id: ProductOfferFragment['product']['id']
+    displayNameFull: ProductOfferFragment['product']['displayNameFull']
+  }
   variant: {
     typeOfContract: ProductOfferFragment['variant']['typeOfContract']
-    product: {
-      id: ProductOfferFragment['variant']['product']['id']
-      displayNameFull: ProductOfferFragment['variant']['product']['displayNameFull']
-    }
   }
   priceMatch?: ProductOfferFragment['priceMatch']
 }
@@ -144,7 +144,7 @@ export class Tracking {
         currency: offer.cost.gross.currencyCode as string,
 
         insurance_type: offer.variant.typeOfContract,
-        flow_type: offer.variant.product.name,
+        flow_type: offer.product.name,
         ...getLegacyEventFlags([offer.variant.typeOfContract]),
       },
       userData,
@@ -170,7 +170,7 @@ export class Tracking {
         currency: cart.cost.net.currencyCode as string,
 
         insurance_type: cart.entries[0].variant.typeOfContract,
-        flow_type: cart.entries[0].variant.product.name,
+        flow_type: cart.entries[0].product.name,
         memberId: memberId,
         ...getLegacyEventFlags(cart.entries.map((entry) => entry.variant.typeOfContract)),
       },
@@ -308,8 +308,8 @@ const offerToEcommerceEvent = ({
       currency: offer.cost.gross.currencyCode,
       items: [
         {
-          item_id: offer.variant.product.id,
-          item_name: offer.variant.product.displayNameFull,
+          item_id: offer.product.id,
+          item_name: offer.product.displayNameFull,
           price: offer.cost.gross.amount,
           item_variant: offer.variant.typeOfContract,
           ...(source && { item_list_id: source }),
@@ -339,8 +339,8 @@ const cartToEcommerceEvent = (
       value: cart.cost.net.amount,
       currency: cart.cost.net.currencyCode,
       items: cart.entries.map((entry) => ({
-        item_id: entry.variant.product.id,
-        item_name: entry.variant.product.displayNameFull,
+        item_id: entry.product.id,
+        item_name: entry.product.displayNameFull,
         price: entry.cost.gross.amount,
         variant: entry.variant.typeOfContract,
       })),


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Align product field with updated [schema](https://studio.apollographql.com/graph/Octopus-fxevz/variant/production/changelog/version/f3d56844-0602-4c25-9251-daf4a75a5d1a)

`product` is being removed from `ProductVariant` type and added to `ProductOffer` instead

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
`ProductVariant.product` is deprecated, get it through offer or intent instead.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
