### PR TITLE
GEN-1189 - refact(CarTrialExtensionBlock): query real data from shopSession and priceItent

### DIFF
--- a/apps/store/src/features/carDealership/ActionButtonsCar.tsx
+++ b/apps/store/src/features/carDealership/ActionButtonsCar.tsx
@@ -5,7 +5,7 @@ import { theme } from 'ui'
 import { ActionButton } from '@/components/ProductItem/ProductItem'
 import { type ProductOfferFragment } from '@/services/apollo/generated'
 import { ActionStateEdit } from './ActionStateEdit'
-import { type CarTrialData } from './carDealershipFixtures'
+import { type TrialExtension } from './carDealershipFixtures'
 import { RemoveCarOfferActionButton } from './RemoveCarOfferActionButton'
 import { useEditAndConfirm } from './useEditAndConfirm'
 
@@ -21,9 +21,8 @@ type Offer = Pick<ProductOfferFragment, 'id'> & {
 }
 
 type Props = {
-  priceIntent: CarTrialData['priceIntent']
+  priceIntent: TrialExtension['priceIntent']
   offer: Offer
-
   onUpdate: (tierLevel: string) => void
   onRemove: () => void
 }

--- a/apps/store/src/features/carDealership/CarTrialExtension.graphql
+++ b/apps/store/src/features/carDealership/CarTrialExtension.graphql
@@ -1,0 +1,77 @@
+query CarTrialExtension($shopSessionId: UUID!) {
+  shopSession(id: $shopSessionId) {
+    id
+    customer {
+      ssn
+      authenticationStatus
+    }
+    cart {
+      id
+      entries {
+        id
+      }
+    }
+    priceIntents {
+      id
+      data
+      offers {
+        id
+        startDate
+        cost {
+          net {
+            amount
+            currencyCode
+          }
+          gross {
+            amount
+            currencyCode
+          }
+          discount {
+            amount
+            currencyCode
+          }
+        }
+        displayItems {
+          key
+          value
+          displayTitle
+          displayValue
+        }
+        priceIntentData
+        deductible {
+          displayName
+          tagline
+        }
+        product {
+          id
+          name
+          displayNameFull
+          pageLink
+          pillowImage {
+            id
+            src
+            alt
+          }
+        }
+        variant {
+          typeOfContract
+          displayName
+          perils {
+            ...Peril
+          }
+          documents {
+            type
+            displayName
+            url
+          }
+        }
+      }
+      defaultOffer {
+        id
+        variant {
+          typeOfContract
+        }
+      }
+    }
+  }
+}

--- a/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
+++ b/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
@@ -1,8 +1,8 @@
 import { storyblokEditable } from '@storyblok/react'
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
+import { useCarTrialExtensionQuery } from '@/services/apollo/generated'
 import { type SbBaseBlockProps } from '@/services/storyblok/storyblok'
-import { CAR_TRIAL_DATA_QUERY, CarTrialData } from './carDealershipFixtures'
+import { CAR_TRIAL_DATA_QUERY, type TrialExtension } from './carDealershipFixtures'
 import { LoadingSkeleton } from './LoadingSkeleton'
 import { TrialExtensionForm } from './TrialExtensionForm'
 
@@ -32,18 +32,20 @@ const useCarTrialQuery = () => {
   const queryParam = router.query['id']
   const id = typeof queryParam === 'string' ? queryParam : undefined
 
-  const [data, setData] = useState<CarTrialData>()
+  const { data: carTrialExtensionData } = useCarTrialExtensionQuery({
+    variables: id ? { shopSessionId: id } : undefined,
+    skip: !id,
+  })
 
-  useEffect(() => {
-    // if (!id) return
-    if (!router.isReady) return
+  if (carTrialExtensionData) {
+    const data: TrialExtension = {
+      ...CAR_TRIAL_DATA_QUERY,
+      shopSession: carTrialExtensionData.shopSession,
+      priceIntent: carTrialExtensionData.shopSession.priceIntents[0],
+    }
 
-    const handle = setTimeout(() => {
-      setData(CAR_TRIAL_DATA_QUERY)
-    }, 1000)
+    return data
+  }
 
-    return () => clearTimeout(handle)
-  }, [router.isReady, id])
-
-  return data
+  return null
 }

--- a/apps/store/src/features/carDealership/TrialExtensionForm.stories.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta<typeof TrialExtensionForm> = {
 export const WithPaymentConnected: Story = {
   args: {
     contract: CAR_TRIAL_DATA_QUERY.trialContract,
-    priceIntent: CAR_TRIAL_DATA_QUERY.priceIntent,
+    priceIntent: CAR_TRIAL_DATA_QUERY.shopSession.priceIntents[0]!,
     shopSession: CAR_TRIAL_DATA_QUERY.shopSession,
     requirePaymentConnection: false,
   },

--- a/apps/store/src/features/carDealership/carDealershipFixtures.ts
+++ b/apps/store/src/features/carDealership/carDealershipFixtures.ts
@@ -1,200 +1,81 @@
 // TODO: Remove this file as soon we start to get data from the API
 import { CurrencyCode, Peril, ShopSessionAuthenticationStatus } from '@/services/apollo/generated'
+import { CarTrialExtensionQuery } from '@/services/apollo/generated'
+
+export type TrialExtension = {
+  id: string
+  trialContract: typeof TRIAL_CONTRACT
+  shopSession: CarTrialExtensionQuery['shopSession']
+  priceIntent: CarTrialExtensionQuery['shopSession']['priceIntents'][number]
+}
+
+const TRIAL_CONTRACT = {
+  id: '1234',
+
+  premium: {
+    amount: 299,
+    currencyCode: CurrencyCode.Sek,
+  },
+
+  terminationDate: '2023-12-31',
+
+  exposure: {
+    displayNameFull: 'Volkswagen Polo · LPP 083',
+  },
+
+  variant: {
+    displayName: 'Full insurance',
+
+    displayItems: [
+      {
+        key: 'address',
+        value: 'Hedvigsgatan 11',
+        displayTitle: 'Address',
+        displayValue: 'Hedvigsgatan 11',
+      },
+    ],
+  },
+}
 
 const DEFAULT_OFFER = {
   id: '123456',
-  variant: {
-    displayName: 'Full insurance',
-    typeOfContract: 'SE_CAR_FULL',
-    perils: [] as Array<Peril>,
-    documents: [] as Array<any>,
-
-    // Deprecated
-    product: {
-      id: 'car-full',
-      displayNameFull: 'Car insurance',
-      displayNameShort: 'Car',
-      name: 'Car Full',
-      pageLink: '',
-      pillowImage: {
-        id: 'car-full-pillow',
-        src: 'https://a.storyblok.com/f/165473/832x832/1fe7a75de6/hedvig-pillows-car.png',
-      },
-    },
-  },
-  product: {
-    id: 'car-full',
-    displayNameFull: 'Car insurance',
-    displayNameShort: 'Car',
-    name: 'Car Full',
-    pageLink: '',
-    pillowImage: {
-      id: 'car-full-pillow',
-      src: 'https://a.storyblok.com/f/165473/832x832/1fe7a75de6/hedvig-pillows-car.png',
-    },
-  },
-  product: {
-    id: 'car-full',
-    displayNameFull: '',
-    displayNameShort: 'Car insurance',
-    name: 'Car Full',
-    pageLink: '',
-    pillowImage: { id: 'car-full-pillow', src: 'https://placekitten.com/200/300' },
-  },
   startDate: '2023-12-31',
   cost: {
     net: { amount: 579, currencyCode: CurrencyCode.Sek },
     gross: { amount: 579, currencyCode: CurrencyCode.Sek },
     discount: { amount: 0, currencyCode: CurrencyCode.Sek },
   },
-  priceIntentData: {},
   displayItems: [
     {
+      key: 'address',
+      value: 'Hedvigsgatan 11',
       displayTitle: 'Address',
       displayValue: 'Hedvigsgatan 11',
     },
-  ] as Array<any>,
-} as const
+  ],
+  priceIntentData: {},
+  product: {
+    id: 'car-full',
+    name: 'Car Full',
+    displayNameFull: 'Car insurance',
+    pageLink: '',
+    pillowImage: {
+      id: 'car-full-pillow',
+      src: 'https://a.storyblok.com/f/165473/832x832/1fe7a75de6/hedvig-pillows-car.png',
+    },
+  },
+  variant: {
+    typeOfContract: 'SE_CAR_FULL',
+    displayName: 'Full insurance',
+    perils: [] as Array<Peril>,
+    documents: [] as Array<any>,
+  },
+}
 
 export const CAR_TRIAL_DATA_QUERY = {
   id: '123',
 
-  trialContract: {
-    id: '1234',
-
-    premium: {
-      amount: 299,
-      currencyCode: CurrencyCode.Sek,
-    },
-
-    terminationDate: '2023-12-31',
-
-    exposure: {
-      displayNameFull: 'Volkswagen Polo · LPP 083',
-    },
-
-    currentAgreement: {
-      displayName: 'Full insurance',
-
-      displayItems: [
-        {
-          displayTitle: 'Address',
-          displayValue: 'Hedvigsgatan 11',
-        },
-      ],
-    },
-
-    // Deprecated
-    variant: {
-      displayName: 'Full insurance',
-
-      displayItems: [
-        {
-          displayTitle: 'Address',
-          displayValue: 'Hedvigsgatan 11',
-        },
-      ],
-    },
-  },
-
-  priceIntent: {
-    id: '12345',
-    data: { mileage: 1500 },
-    offers: [
-      DEFAULT_OFFER,
-      {
-        id: '1234567',
-        variant: {
-          displayName: 'Half insurance',
-          typeOfContract: 'SE_CAR_HALF',
-          perils: [],
-          documents: [],
-
-          // Deprecated
-          product: {
-            id: 'car-half',
-            name: 'Half insurance',
-            displayNameFull: '',
-            pageLink: '',
-            pillowImage: {
-              id: 'car-half-pillow',
-              src: 'https://a.storyblok.com/f/165473/832x832/1fe7a75de6/hedvig-pillows-car.png',
-            },
-          },
-        },
-        product: {
-          id: 'car-half',
-          name: 'Half insurance',
-          displayNameFull: '',
-          pageLink: '',
-          pillowImage: {
-            id: 'car-half-pillow',
-            src: 'https://a.storyblok.com/f/165473/832x832/1fe7a75de6/hedvig-pillows-car.png',
-          },
-        },
-        product: {
-          id: 'car-half',
-          name: 'Car Half',
-          displayNameFull: '',
-          pageLink: '',
-          pillowImage: { id: 'car-half-pillow', src: 'https://placekitten.com/200/300' },
-        },
-        cost: {
-          net: { amount: 479, currencyCode: CurrencyCode.Sek },
-          gross: { amount: 479, currencyCode: CurrencyCode.Sek },
-          discount: { amount: 0, currencyCode: CurrencyCode.Sek },
-        },
-        priceIntentData: {},
-        displayItems: [],
-      },
-      {
-        id: '12345678',
-        variant: {
-          displayName: 'Traffic insurance',
-          typeOfContract: 'SE_CAR_TRAFFIC',
-          perils: [],
-          documents: [],
-
-          // Deprecated
-          product: {
-            id: 'car-traffic',
-            name: 'Traffic insurance',
-            displayNameFull: '',
-            pageLink: '',
-            pillowImage: {
-              id: 'car-traffic-pillow',
-              src: 'https://a.storyblok.com/f/165473/832x832/1fe7a75de6/hedvig-pillows-car.png',
-            },
-          },
-        },
-        product: {
-          id: 'car-traffic',
-          name: 'Traffic insurance',
-          displayNameFull: '',
-          pageLink: '',
-          pillowImage: {
-            id: 'car-traffic-pillow',
-            src: 'https://a.storyblok.com/f/165473/832x832/1fe7a75de6/hedvig-pillows-car.png',
-          },
-        },
-        product: {
-          id: 'car-traffic',
-          name: 'Car Traffic',
-          displayNameFull: '',
-          pageLink: '',
-          pillowImage: { id: 'car-traffic-pillow', src: 'https://placekitten.com/200/300' },
-        },
-        cost: {
-          net: { amount: 379, currencyCode: CurrencyCode.Sek },
-          gross: { amount: 379, currencyCode: CurrencyCode.Sek },
-          discount: { amount: 0, currencyCode: CurrencyCode.Sek },
-        },
-        priceIntentData: {},
-        displayItems: [],
-      },
-    ],
-    defaultOffer: DEFAULT_OFFER as typeof DEFAULT_OFFER | undefined,
-  },
+  trialContract: TRIAL_CONTRACT,
 
   shopSession: {
     id: '71723912',
@@ -205,9 +86,76 @@ export const CAR_TRIAL_DATA_QUERY = {
     },
 
     cart: {
+      id: '9990090',
       entries: [],
     },
+
+    priceIntents: [
+      {
+        id: '12345',
+        data: { mileage: 1500 },
+        offers: [
+          DEFAULT_OFFER,
+          {
+            id: '1234567',
+            variant: {
+              displayName: 'Half insurance',
+              typeOfContract: 'SE_CAR_HALF',
+              perils: [],
+              documents: [],
+            },
+            product: {
+              id: 'car-half',
+              name: 'Car Half',
+              displayNameFull: '',
+              pageLink: '',
+              pillowImage: {
+                id: 'car-half-pillow',
+                src: 'https://a.storyblok.com/f/165473/832x832/1fe7a75de6/hedvig-pillows-car.png',
+              },
+            },
+            cost: {
+              net: { amount: 479, currencyCode: CurrencyCode.Sek },
+              gross: { amount: 479, currencyCode: CurrencyCode.Sek },
+              discount: { amount: 0, currencyCode: CurrencyCode.Sek },
+            },
+            priceIntentData: {},
+            displayItems: [],
+          },
+          {
+            id: '12345678',
+            variant: {
+              displayName: 'Traffic insurance',
+              typeOfContract: 'SE_CAR_TRAFFIC',
+              perils: [],
+              documents: [],
+            },
+            product: {
+              id: 'car-traffic',
+              name: 'Car Traffic',
+              displayNameFull: '',
+              pageLink: '',
+              pillowImage: {
+                id: 'car-traffic-pillow',
+                src: 'https://a.storyblok.com/f/165473/832x832/1fe7a75de6/hedvig-pillows-car.png',
+              },
+            },
+            cost: {
+              net: { amount: 379, currencyCode: CurrencyCode.Sek },
+              gross: { amount: 379, currencyCode: CurrencyCode.Sek },
+              discount: { amount: 0, currencyCode: CurrencyCode.Sek },
+            },
+            priceIntentData: {},
+            displayItems: [],
+          },
+        ],
+        defaultOffer: {
+          id: '123456',
+          variant: {
+            typeOfContract: 'SE_CAR_FULL',
+          },
+        },
+      },
+    ],
   },
 }
-
-export type CarTrialData = typeof CAR_TRIAL_DATA_QUERY

--- a/apps/store/src/pages/api/car-trials.ts
+++ b/apps/store/src/pages/api/car-trials.ts
@@ -49,7 +49,7 @@ const handler: NextApiHandler = async (req, res) => {
 
   await priceIntentService.confirm(priceIntent.id)
 
-  // res.redirect(302, `/se/car-trials/${shopSession.id}`)
+  // res.redirect(302, `/se/test-car-extension-offer?id=${shopSession.id}`)
   res.json({
     shopSessioId: shopSession.id,
     url: `${URL}?id=${shopSession.id}`,


### PR DESCRIPTION
## Describe your changes

* Adds a `CarTrialExtension` query: at the moment it only fetches info about `shopSession` and `priceIntent`. TrialExtension information is still mocked;
* Update fixtures so it satisfied data request data format;

## Justify why they are needed

Get closer to the real feature while we don't have the API configured.