### PR TITLE
GEN-1181 | Use new exposure display name in `ProductItem` card

### DIFF
--- a/apps/store/apollo.config.js
+++ b/apps/store/apollo.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   client: {
     service: 'Octopus-fxevz@staging',
-    includes: ['schema.graphql', 'src/graphql/*.graphql'],
+    includes: ['schema.graphql', 'src/**/*.graphql'],
     excludes: ['src/services/apollo/generated.ts'],
   },
 }

--- a/apps/store/src/components/ProductItem/ProductItem.stories.tsx
+++ b/apps/store/src/components/ProductItem/ProductItem.stories.tsx
@@ -5,6 +5,9 @@ import { ActionButton, ProductItem } from './ProductItem'
 const meta: Meta<typeof ProductItem> = {
   title: 'Components / Product Item',
   component: ProductItem,
+  argTypes: {
+    startDate: { control: { disable: true } },
+  },
 }
 
 export default meta
@@ -15,7 +18,7 @@ export const Default: Story = {
     pillowSrc: 'https://placekitten.com/200/300',
     title: 'Hemförsäkring Bostadsrätt',
     startDate: {
-      label: 'Activated on 02.12.24',
+      label: 'Hedvigsgatan 12 · Activated on 02.12.24',
       tooltip: 'You can change the start date of your insurance in the app',
     },
     price: {

--- a/apps/store/src/components/ProductItem/ProductItemContainer.tsx
+++ b/apps/store/src/components/ProductItem/ProductItemContainer.tsx
@@ -7,7 +7,14 @@ import { useGetStartDateProps } from './useGetStartDateProps'
 
 type Offer = Pick<
   ProductOfferFragment,
-  'cost' | 'priceIntentData' | 'startDate' | 'displayItems' | 'deductible' | 'variant' | 'product'
+  | 'cost'
+  | 'priceIntentData'
+  | 'startDate'
+  | 'displayItems'
+  | 'deductible'
+  | 'variant'
+  | 'product'
+  | 'exposure'
 >
 
 type Props = {
@@ -23,7 +30,7 @@ export const ProductItemContainer = (props: Props) => {
   const price = getOfferPrice(props.offer.cost)
 
   const startDateProps = getStartDateProps({
-    productName: props.offer.product.name,
+    exposure: props.offer.exposure.displayNameShort,
     data: props.offer.priceIntentData,
     startDate: props.offer.startDate,
   })

--- a/apps/store/src/components/ProductItem/StartDate.tsx
+++ b/apps/store/src/components/ProductItem/StartDate.tsx
@@ -1,5 +1,5 @@
+import styled from '@emotion/styled'
 import { InfoIcon, Text, theme } from 'ui'
-import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { Tooltip } from './Tooltip'
 
 type Props = {
@@ -13,13 +13,35 @@ export const StartDate = (props: Props) => {
   }
 
   return (
-    <SpaceFlex space={0.25} align="center">
-      <Text color="textSecondary">{props.label}</Text>
-      <Tooltip message={props.tooltip}>
-        <button onClick={handleClick} style={{ marginBottom: -2 }}>
-          <InfoIcon color={theme.colors.textSecondary} />
-        </button>
-      </Tooltip>
-    </SpaceFlex>
+    <Wrapper>
+      <SingleLineText color="textSecondary" title={props.label}>
+        {props.label}
+      </SingleLineText>
+      <TooltipWrapper>
+        <Tooltip message={props.tooltip}>
+          <button onClick={handleClick} style={{ marginBottom: -2 }}>
+            <InfoIcon color={theme.colors.textSecondary} />
+          </button>
+        </Tooltip>
+      </TooltipWrapper>
+    </Wrapper>
   )
 }
+
+const Wrapper = styled.div({
+  width: '100%',
+  display: 'grid',
+  gridTemplateColumns: 'auto 1fr',
+  gap: theme.space.xxs,
+})
+
+const SingleLineText = styled(Text)({
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+})
+
+const TooltipWrapper = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+})

--- a/apps/store/src/components/ProductItem/useGetStartDateProps.ts
+++ b/apps/store/src/components/ProductItem/useGetStartDateProps.ts
@@ -4,7 +4,7 @@ import { useFormatter } from '@/utils/useFormatter'
 import { type ProductItem } from './ProductItem'
 
 type Params = {
-  productName: string
+  exposure: string
   data: Record<string, unknown>
   startDate?: string
 }
@@ -19,18 +19,12 @@ export const useGetStartDateProps = (): GetStartDateProps => {
 
   return useCallback(
     (params) => {
-      const content: Array<string> = []
-
-      const productBasedSummary = getProductBasedSummary(params.productName, params.data)
-      if (productBasedSummary) {
-        content.push(productBasedSummary)
-      }
-
-      content.push(
+      const content = [
+        params.exposure,
         params.startDate
           ? t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(new Date(params.startDate)) })
           : t('CART_ENTRY_AUTO_SWITCH'),
-      )
+      ]
 
       return {
         label: content.join(' • '),
@@ -41,30 +35,4 @@ export const useGetStartDateProps = (): GetStartDateProps => {
     },
     [t, formatter],
   )
-}
-
-// TODO: retrieve this from API or some sort of central config.
-const PET_NAME_FIELD = 'name'
-const CAR_REGISTRATION_NUMBER_FIELD = 'registrationNumber'
-
-const getProductBasedSummary = (
-  productName: string,
-  data: Record<string, unknown>,
-): string | null => {
-  switch (productName) {
-    case 'SE_PET_DOG':
-    case 'SE_PET_CAT':
-      return getStringOrNull(data[PET_NAME_FIELD])
-    case 'SE_CAR':
-      return (
-        getStringOrNull(data[CAR_REGISTRATION_NUMBER_FIELD])?.replace(/(.{3})(.{3})/, '$1 $2') ??
-        null
-      )
-    default:
-      return null
-  }
-}
-
-const getStringOrNull = (value: unknown): string | null => {
-  return typeof value === 'string' ? value : null
 }

--- a/apps/store/src/features/carDealership/CarTrialExtension.graphql
+++ b/apps/store/src/features/carDealership/CarTrialExtension.graphql
@@ -31,6 +31,9 @@ query CarTrialExtension($shopSessionId: UUID!) {
             currencyCode
           }
         }
+        exposure {
+          displayNameShort
+        }
         displayItems {
           key
           value

--- a/apps/store/src/features/carDealership/carDealershipFixtures.ts
+++ b/apps/store/src/features/carDealership/carDealershipFixtures.ts
@@ -39,6 +39,9 @@ const TRIAL_CONTRACT = {
 
 const DEFAULT_OFFER = {
   id: '123456',
+  exposure: {
+    displayNameShort: 'LPP 083',
+  },
   startDate: '2023-12-31',
   cost: {
     net: { amount: 579, currencyCode: CurrencyCode.Sek },
@@ -115,6 +118,9 @@ export const CAR_TRIAL_DATA_QUERY = {
                 src: 'https://a.storyblok.com/f/165473/832x832/1fe7a75de6/hedvig-pillows-car.png',
               },
             },
+            exposure: {
+              displayNameShort: 'LPP 083',
+            },
             cost: {
               net: { amount: 479, currencyCode: CurrencyCode.Sek },
               gross: { amount: 479, currencyCode: CurrencyCode.Sek },
@@ -140,6 +146,9 @@ export const CAR_TRIAL_DATA_QUERY = {
                 id: 'car-traffic-pillow',
                 src: 'https://a.storyblok.com/f/165473/832x832/1fe7a75de6/hedvig-pillows-car.png',
               },
+            },
+            exposure: {
+              displayNameShort: 'LPP 083',
             },
             cost: {
               net: { amount: 379, currencyCode: CurrencyCode.Sek },

--- a/apps/store/src/graphql/ProductOfferFragment.graphql
+++ b/apps/store/src/graphql/ProductOfferFragment.graphql
@@ -72,4 +72,7 @@ fragment ProductOffer on ProductOffer {
     displayTitle
     displayValue
   }
+  exposure {
+    displayNameShort
+  }
 }

--- a/packages/ui/src/components/Text/Text.tsx
+++ b/packages/ui/src/components/Text/Text.tsx
@@ -37,6 +37,7 @@ export type TextProps = {
   className?: string
   uppercase?: boolean
   strikethrough?: boolean
+  title?: string
 }
 
 const elementConfig = {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-09-25 at 13.31.23.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/4ad8af82-59fb-4a26-905a-674d91e7130f/Screenshot%202023-09-25%20at%2013.31.23.png)


![Screenshot 2023-09-25 at 13.28.26.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/1bcfc5dc-282c-40c0-a58e-4df99dc911cc/Screenshot%202023-09-25%20at%2013.28.26.png)


- Query new exposure from the API

- Display exposure in the `ProductItem` card

- Remove old logic based on product name

- Update `StartDate` component layout to handle longer text

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- This logic belongs in the backend since it's product specific

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
