### PR TITLE
Price Calculator: reset state of `EditingState` after error

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -109,40 +109,36 @@ export const PurchaseForm = () => {
             />
           )
 
+          const editor = isLarge ? (
+            <motion.div
+              initial={{ opacity: 0, y: '1vh' }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.4, ...theme.transitions.framer.easeInOutCubic }}
+            >
+              <ProductHeroContainer size="small" compact={true}>
+                {editingStateForm}
+              </ProductHeroContainer>
+            </motion.div>
+          ) : (
+            <PriceCalculatorDialog
+              isOpen
+              toggleDialog={() => setFormState('IDLE')}
+              header={
+                <SpaceFlex direction="vertical" align="center" space={0.5}>
+                  <Pillow size="large" {...productData.pillowImage} />
+                  <Heading as="h2" variant="standard.18">
+                    {productData.displayNameShort}
+                  </Heading>
+                </SpaceFlex>
+              }
+            >
+              {editingStateForm}
+            </PriceCalculatorDialog>
+          )
+
           return (
             <>
-              {formState.state !== 'ERROR' && !isLarge ? (
-                <PriceCalculatorDialog
-                  isOpen
-                  toggleDialog={() => setFormState('IDLE')}
-                  header={
-                    <SpaceFlex direction="vertical" align="center" space={0.5}>
-                      <Pillow size="large" {...productData.pillowImage} />
-                      <Heading as="h2" variant="standard.18">
-                        {productData.displayNameShort}
-                      </Heading>
-                    </SpaceFlex>
-                  }
-                >
-                  {editingStateForm}
-                </PriceCalculatorDialog>
-              ) : (
-                <motion.div
-                  initial={{
-                    opacity: 0,
-                    y: '1vh',
-                  }}
-                  animate={{
-                    opacity: 1,
-                    y: 0,
-                  }}
-                  transition={{ duration: 0.4, ...theme.transitions.framer.easeInOutCubic }}
-                >
-                  <ProductHeroContainer size="small" compact={true}>
-                    {editingStateForm}
-                  </ProductHeroContainer>
-                </motion.div>
-              )}
+              {formState.state === 'ERROR' ? null : editor}
 
               <FullscreenDialog.Root
                 open={formState.state === 'ERROR'}
@@ -359,7 +355,6 @@ const EditingState = (props: EditingStateProps) => {
     },
   })
 
-  // onComplete will unmount the component, so we don't need to reset the state
   const [isLoadingPrice, setIsLoadingPrice] = useState(result.loading)
   const handleConfirm = () => {
     setIsLoadingPrice(true)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Unmount `EditingState` component (`PurchaseForm`) when we display an error dialog

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Currently, if you get and error and then press "try again" you just see the calculate loading state. This is because the `EditingState` component depends on being re-mounted to reset internal state. This works for mobile but not for desktop. This PR fixes that.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
