### PR TITLE
GEN-1208 | Sync start date of extension with end of trial

### DIFF
--- a/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
+++ b/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
@@ -1,5 +1,6 @@
 import { storyblokEditable } from '@storyblok/react'
 import { useRouter } from 'next/router'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { useCarTrialExtensionQuery } from '@/services/apollo/generated'
 import { type SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { CAR_TRIAL_DATA_QUERY, type TrialExtension } from './carDealershipFixtures'
@@ -16,13 +17,17 @@ export const CarTrialExtensionBlock = (props: Props) => {
   if (!data) return <LoadingSkeleton {...storyblokEditable(props.blok)} />
 
   return (
-    <TrialExtensionForm
-      {...storyblokEditable(props.blok)}
-      contract={data.trialContract}
-      priceIntent={data.priceIntent}
-      shopSession={data.shopSession}
-      requirePaymentConnection={props.blok.requirePaymentConnection ?? false}
-    />
+    <GridLayout.Root>
+      <GridLayout.Content width="1/3" align="center">
+        <TrialExtensionForm
+          {...storyblokEditable(props.blok)}
+          contract={data.trialContract}
+          priceIntent={data.priceIntent}
+          shopSession={data.shopSession}
+          requirePaymentConnection={props.blok.requirePaymentConnection ?? false}
+        />
+      </GridLayout.Content>
+    </GridLayout.Root>
   )
 }
 CarTrialExtensionBlock.blockName = 'carTrialExtension'

--- a/apps/store/src/features/carDealership/ProductItemContractContainer.tsx
+++ b/apps/store/src/features/carDealership/ProductItemContractContainer.tsx
@@ -56,7 +56,7 @@ export const ProductItemContractContainerCar = (props: Props) => {
 const FIXTURE_CONTRACT = {
   cost: { amount: 299, currencyCode: CurrencyCode.Sek },
 
-  endDate: '2024-12-24',
+  endDate: '2024-12-01',
 
   displayItems: [
     {

--- a/apps/store/src/pages/api/car-trials.ts
+++ b/apps/store/src/pages/api/car-trials.ts
@@ -1,6 +1,11 @@
 import { type NextApiHandler } from 'next'
 import { initializeApolloServerSide } from '@/services/apollo/client'
-import { CountryCode } from '@/services/apollo/generated'
+import {
+  CountryCode,
+  StartDateUpdateDocument,
+  type StartDateUpdateMutation,
+  type StartDateUpdateMutationVariables,
+} from '@/services/apollo/generated'
 import { fetchPriceTemplate } from '@/services/PriceCalculator/PriceCalculator.helpers'
 import { priceIntentServiceInitServerSide } from '@/services/priceIntent/PriceIntentService'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
@@ -47,7 +52,15 @@ const handler: NextApiHandler = async (req, res) => {
     },
   })
 
-  await priceIntentService.confirm(priceIntent.id)
+  const result = await priceIntentService.confirm(priceIntent.id)
+
+  await apolloClient.mutate<StartDateUpdateMutation, StartDateUpdateMutationVariables>({
+    mutation: StartDateUpdateDocument,
+    variables: {
+      productOfferIds: result.offers.map((item) => item.id),
+      startDate: '2023-12-01',
+    },
+  })
 
   // res.redirect(302, `/se/test-car-extension-offer?id=${shopSession.id}`)
   res.json({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Set the start date of car trial extension to end date of trial

- Add grid layout to CMS block

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Closer to how we imagine it working

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
