### PR TITLE
GEN-1217 | Adapt extension offer ProductItem to use a green background

### DIFF
--- a/apps/store/src/components/InputSelect/InputSelect.tsx
+++ b/apps/store/src/components/InputSelect/InputSelect.tsx
@@ -16,7 +16,7 @@ export type InputSelectProps = InputBaseProps & {
   autoFocus?: boolean
   className?: string
   size?: 'large' | 'small'
-  backgroundColor?: Extract<UIColorKeys, 'backgroundStandard'>
+  backgroundColor?: Extract<UIColorKeys, 'backgroundStandard' | 'backgroundFrostedGlass'>
 }
 
 export const InputSelect = ({
@@ -28,11 +28,13 @@ export const InputSelect = ({
   placeholder,
   label,
   size = 'large',
-  backgroundColor,
+  backgroundColor: _backgroundColor,
   ...rest
 }: InputSelectProps) => {
+  const backgroundColor = _backgroundColor ? getColor(_backgroundColor) : undefined
+
   const { highlight, animationProps } = useHighlightAnimation<HTMLSelectElement>({
-    ...(backgroundColor && { defaultColor: getColor(backgroundColor) }),
+    ...(backgroundColor && { defaultColor: backgroundColor }),
   })
 
   const handleChange: ChangeEventHandler<HTMLSelectElement> = (event) => {

--- a/apps/store/src/components/ProductItem/ProductItem.stories.tsx
+++ b/apps/store/src/components/ProductItem/ProductItem.stories.tsx
@@ -77,3 +77,11 @@ export const WithSubtitle: Story = {
     subtitle: 'Hedvigsgatan 12 · 2 people',
   },
 }
+
+export const Green: Story = {
+  args: {
+    ...Default.args,
+    variant: 'green',
+    defaultExpanded: true,
+  },
+}

--- a/apps/store/src/components/ProductItem/ProductItem.tsx
+++ b/apps/store/src/components/ProductItem/ProductItem.tsx
@@ -19,6 +19,7 @@ type Props = {
   children?: ReactNode
   subtitle?: string
   Icon?: ReactNode
+  variant?: 'green'
 }
 
 export const ProductItem = (props: Props) => {
@@ -29,8 +30,8 @@ export const ProductItem = (props: Props) => {
   }
 
   return (
-    <Card>
-      <Hoverable onClick={handleClickHoverable}>
+    <Card data-variant={props.variant}>
+      <Hoverable onClick={handleClickHoverable} data-variant={props.variant}>
         <Space y={1}>
           <Header>
             <Pillow size="small" src={props.pillowSrc} alt="" />
@@ -75,10 +76,12 @@ ActionButton.displayName = 'ActionButton'
 export const ProductItemSkeleton = styled(Skeleton)({ height: '13.5rem' })
 
 const Card = styled.div({
-  backgroundColor: theme.colors.opaque1,
   borderRadius: theme.radius.md,
   padding: theme.space.md,
   paddingBottom: 0,
+
+  backgroundColor: theme.colors.opaque1,
+  ['&[data-variant="green"]']: { backgroundColor: theme.colors.signalGreenFill },
 
   [mq.lg]: {
     padding: theme.space.lg,
@@ -92,6 +95,7 @@ const Hoverable = styled.div({
 
     [`${Card}:has(> &:hover)`]: {
       backgroundColor: theme.colors.grayTranslucent200,
+      ['&[data-variant="green"]']: { backgroundColor: theme.colors.green200 },
     },
   },
 })

--- a/apps/store/src/components/ProductItem/ProductItemContainer.tsx
+++ b/apps/store/src/components/ProductItem/ProductItemContainer.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'next-i18next'
-import { useMemo, type ReactNode } from 'react'
+import { useMemo, type ReactNode, ComponentProps } from 'react'
 import { type ProductOfferFragment } from '@/services/apollo/generated'
 import { getOfferPrice } from '@/utils/getOfferPrice'
 import { ProductItem } from './ProductItem'
@@ -21,6 +21,7 @@ type Props = {
   offer: Offer
   children?: ReactNode
   defaultExpanded?: boolean
+  variant?: ComponentProps<typeof ProductItem>['variant']
 }
 
 export const ProductItemContainer = (props: Props) => {
@@ -65,6 +66,7 @@ export const ProductItemContainer = (props: Props) => {
       productDetails={productDetails}
       productDocuments={productDocuments}
       defaultExpanded={props.defaultExpanded}
+      variant={props.variant}
     >
       {props.children}
     </ProductItem>

--- a/apps/store/src/features/carDealership/ActionButtonsCar.tsx
+++ b/apps/store/src/features/carDealership/ActionButtonsCar.tsx
@@ -1,5 +1,6 @@
 import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
 import { useState } from 'react'
 import { theme } from 'ui'
 import { ActionButton } from '@/components/ProductItem/ProductItem'
@@ -28,6 +29,7 @@ type Props = {
 }
 
 export const ActionButtonsCar = (props: Props) => {
+  const { t } = useTranslation('cart')
   const [state, setState] = useState<State>(STATE.IDLE)
 
   const [editAndConfirm, loading] = useEditAndConfirm({
@@ -83,7 +85,9 @@ export const ActionButtonsCar = (props: Props) => {
 
   return (
     <ButtonWrapper>
-      <ActionButton onClick={handleClickEdit}>Edit</ActionButton>
+      <ActionButton variant="primary" onClick={handleClickEdit}>
+        {t('EDIT_CAR_TRIAL_EXTENSION_BUTTON')}
+      </ActionButton>
       <RemoveCarOfferActionButton onConfirm={handleClickRemove} />
     </ButtonWrapper>
   )

--- a/apps/store/src/features/carDealership/ActionStateEdit.tsx
+++ b/apps/store/src/features/carDealership/ActionStateEdit.tsx
@@ -61,17 +61,17 @@ export const ActionStateEdit = (props: EditingStateProps) => {
           name={OFFER_KEY}
           onChange={handleChangeTierLevel}
           options={props.tierLevelOptions}
-          backgroundColor="backgroundStandard"
+          backgroundColor="backgroundFrostedGlass"
           defaultValue={props.defaultTierLevel}
         />
-        <CarMileageField field={mileageField} backgroundColor="backgroundStandard" />
+        <CarMileageField field={mileageField} backgroundColor="backgroundFrostedGlass" />
       </InputWrapper>
 
       <ButtonWrapper>
-        <ActionButton type="submit" variant="primary-alt" loading={props.loading}>
+        <ActionButton type="submit" variant="primary" loading={props.loading}>
           Save
         </ActionButton>
-        <ActionButton type="button" onClick={handleClickCancel}>
+        <ActionButton type="button" variant="ghost" onClick={handleClickCancel}>
           Cancel
         </ActionButton>
       </ButtonWrapper>

--- a/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
+++ b/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
@@ -14,18 +14,20 @@ type Props = SbBaseBlockProps<{
 export const CarTrialExtensionBlock = (props: Props) => {
   const data = useCarTrialQuery()
 
-  if (!data) return <LoadingSkeleton {...storyblokEditable(props.blok)} />
-
   return (
     <GridLayout.Root>
       <GridLayout.Content width="1/3" align="center">
-        <TrialExtensionForm
-          {...storyblokEditable(props.blok)}
-          contract={data.trialContract}
-          priceIntent={data.priceIntent}
-          shopSession={data.shopSession}
-          requirePaymentConnection={props.blok.requirePaymentConnection ?? false}
-        />
+        {data ? (
+          <TrialExtensionForm
+            {...storyblokEditable(props.blok)}
+            contract={data.trialContract}
+            priceIntent={data.priceIntent}
+            shopSession={data.shopSession}
+            requirePaymentConnection={props.blok.requirePaymentConnection ?? false}
+          />
+        ) : (
+          <LoadingSkeleton />
+        )}
       </GridLayout.Content>
     </GridLayout.Root>
   )

--- a/apps/store/src/features/carDealership/RemoveCarOfferActionButton.tsx
+++ b/apps/store/src/features/carDealership/RemoveCarOfferActionButton.tsx
@@ -20,7 +20,7 @@ export const RemoveCarOfferActionButton = (props: Props) => {
   return (
     <FullScreenDialog.Root>
       <FullScreenDialog.Trigger asChild={true}>
-        <ActionButton>{t('REMOVE_ENTRY_BUTTON')}</ActionButton>
+        <ActionButton variant="ghost">{t('REMOVE_CAR_TRIAL_EXTENSION_BUTTON')}</ActionButton>
       </FullScreenDialog.Trigger>
 
       <FullScreenDialog.Modal

--- a/apps/store/src/features/carDealership/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.tsx
@@ -154,7 +154,7 @@ export const TrialExtensionForm = (props: Props) => {
 
         <Space y={2}>
           <Space y={1}>
-            <ProductItemContainer offer={selectedOffer} defaultExpanded={true}>
+            <ProductItemContainer offer={selectedOffer} defaultExpanded={true} variant="green">
               <ActionButtonsCar
                 priceIntent={props.priceIntent}
                 offer={selectedOffer}

--- a/packages/ui/src/lib/theme/colors/colors.ts
+++ b/packages/ui/src/lib/theme/colors/colors.ts
@@ -310,7 +310,7 @@ export const colors = {
   // Semantic colors
   // Background
   backgroundStandard: gray[25],
-  backgroundFrostedGlass: grayTranslucent[25],
+  backgroundFrostedGlass: 'hsla(0, 0%, 98%, 0.75)',
 
   // Border
   borderOpaque1: gray[200],


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-09-28 at 13.56.03.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/ebeabffe-ca8f-456e-b9c2-b2e0dfa4bfc1/Screenshot%202023-09-28%20at%2013.56.03.png)


- Add variant of `ProductItem` with a green background


![Screenshot 2023-09-28 at 14.14.42.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/aaa7b305-c1f6-45af-974f-3d303acb0486/Screenshot%202023-09-28%20at%2014.14.42.png)


- Add new variant of `InputSelect` with frosted glass background

- Update frosted glass background color to match Figma (not used anywhere else)

- Wrap LoadingState for trial extension block inside the grid layout

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Adopt new design from Figma

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
