### PR TITLE
GEN-1230 | Enable multi company select in `InsurelyBlock`

### DIFF
--- a/apps/store/index.d.ts
+++ b/apps/store/index.d.ts
@@ -36,6 +36,7 @@ type MerchantCallbackData = { accountId: string }
 type TrustlyOptions = { locale: string }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Window {
     TrustlyWidget: {
       init: TrustlyInitFunction
@@ -72,6 +73,7 @@ type InsurelyConfig = {
   language?: 'en' | 'no' | 'sv' | 'da'
   dataAggregation?: {
     hideResultsView?: boolean
+    multiSelect?: boolean
   }
 }
 

--- a/apps/store/src/blocks/InsurelyBlock.tsx
+++ b/apps/store/src/blocks/InsurelyBlock.tsx
@@ -39,6 +39,7 @@ export const InsurelyBlock = (props: Props) => {
       showCloseButton: false,
       hideResultsView: false,
       salesSupportToolSessionId: typeof sessionId === 'string' ? sessionId : undefined,
+      multiCompanySelect: true,
     })
   }, [router.isReady, router.query.sessionId])
 

--- a/apps/store/src/services/Insurely/Insurely.tsx
+++ b/apps/store/src/services/Insurely/Insurely.tsx
@@ -89,6 +89,7 @@ type InsurelyConfig = {
   showCloseButton?: boolean
   hideResultsView?: boolean
   salesSupportToolSessionId?: string
+  multiCompanySelect?: boolean
 }
 
 export const setInsurelyConfig = (config: InsurelyConfig) => {
@@ -104,8 +105,8 @@ export const setInsurelyConfig = (config: InsurelyConfig) => {
       dataAggregation: {
         ...insurelyConfig?.dataAggregation,
         ...(config.salesSupportToolSessionId && { sstSessionId: config.salesSupportToolSessionId }),
-        hideResultsView:
-          config.hideResultsView ?? insurelyConfig?.dataAggregation?.hideResultsView ?? true,
+        ...(config.hideResultsView !== undefined && { hideResultsView: config.hideResultsView }),
+        ...(config.multiCompanySelect !== undefined && { multiSelect: config.multiCompanySelect }),
       },
     },
     prefill: {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add option to enable selecting multiple companies in Insurely config

- Enable option in `InsurelyBlock` (used by sales support tool)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- New feature from Insurely

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
