### PR TITLE
GEN-1219 | Car dealership: login and navigate to payment

### DIFF
--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -64,6 +64,9 @@ export const PageLink = {
     const pathname = `${localePrefix(locale)}/confirmation/${shopSessionId}`
     return new URL(pathname, ORIGIN_URL)
   },
+  paymentConnect: (params?: BaseParams) => {
+    return new URL(`${localePrefix(params?.locale)}/payment/connect`, ORIGIN_URL)
+  },
   paymentSuccess: ({ locale }: Required<BaseParams>) => {
     return new URL(`${locale}/payment-success`, ORIGIN_URL)
   },


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Car dealership: when a user doesn't want to sign an extension, we should let them sign in and then navigate to connect payment

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Everyone who lands on this page will be a member, so we don't need to handle non-members

- Users that have already connected payment will not have the option to remove extension offer (not yet implemented)

- I added the logic inline since it's not a lot of code and will make it easier to refactor later

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
