### PR TITLE
GEN-1231 - feat(ActionButtonsCar): remove 'edit' button for users with payment connected

### DIFF
--- a/apps/store/src/features/carDealership/ActionButtonsCar.tsx
+++ b/apps/store/src/features/carDealership/ActionButtonsCar.tsx
@@ -26,6 +26,7 @@ type Props = {
   offer: Offer
   onUpdate: (tierLevel: string) => void
   onRemove: () => void
+  requirePaymentConnection: boolean
 }
 
 export const ActionButtonsCar = (props: Props) => {
@@ -85,10 +86,15 @@ export const ActionButtonsCar = (props: Props) => {
 
   return (
     <ButtonWrapper>
-      <ActionButton variant="primary" onClick={handleClickEdit}>
+      <ActionButton
+        variant={props.requirePaymentConnection ? 'primary' : 'ghost'}
+        onClick={handleClickEdit}
+      >
         {t('EDIT_CAR_TRIAL_EXTENSION_BUTTON')}
       </ActionButton>
-      <RemoveCarOfferActionButton onConfirm={handleClickRemove} />
+      {props.requirePaymentConnection && (
+        <RemoveCarOfferActionButton onConfirm={handleClickRemove} />
+      )}
     </ButtonWrapper>
   )
 }

--- a/apps/store/src/features/carDealership/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.tsx
@@ -161,6 +161,7 @@ export const TrialExtensionForm = (props: Props) => {
                 offer={selectedOffer}
                 onRemove={handleRemove}
                 onUpdate={handleUpdate}
+                requirePaymentConnection={props.requirePaymentConnection}
               />
             </ProductItemContainer>
 


### PR DESCRIPTION
## Describe your changes

- Removes 'edit' button for users that have payment connected

<img width="1175" alt="Screenshot 2023-10-02 at 10 30 11" src="https://github.com/HedvigInsurance/racoon/assets/19200662/25996e7d-9d32-4f2a-a6b8-699cf2964d43">

## Justify why they are needed

UI changed
