### PR TITLE
GEN-1239 - styles(TrialExtensionForm): hide trial offer for users with payment connected

### DIFF
--- a/apps/store/public/locales/en/carDealership.json
+++ b/apps/store/public/locales/en/carDealership.json
@@ -12,7 +12,7 @@
   "REMOVE_EXTENSION_MODAL_PROMPT_SUBTITLE": "We would like to remind you to sign another insurance in good time before your trial period with Hedvig has expired. Otherwise, you risk that your car will become uninsured.",
   "REMOVE_EXTENSION_MODAL_PROMPT_TITLE": "Are you sure you want to remove the insurance?",
   "SIGN_AND_PAY_BUTTON": "Sign and pay",
-  "SIGN_BUTTON": "Sign insurance",
+  "SIGN_BUTTON": "Extend insurance",
   "TRIAL_COST_EXPLANATION": "to {{date}} then {{amount}}",
   "TRIAL_HEADING": "Starter offer",
   "TRIAL_TERMINATION_DATE_MESSAGE": "Expires {{date}}",

--- a/apps/store/public/locales/sv-se/carDealership.json
+++ b/apps/store/public/locales/sv-se/carDealership.json
@@ -12,7 +12,7 @@
   "REMOVE_EXTENSION_MODAL_PROMPT_SUBTITLE": "Tänk på att du och din bil blir oförsäkrade efter att ditt starterbjudande har löpt ut. Trafikförsäkring är obligatoriskt enligt lag för att du ska få köra bilen.",
   "REMOVE_EXTENSION_MODAL_PROMPT_TITLE": "Är du säker på att du vill ta bort försäkringen?",
   "SIGN_AND_PAY_BUTTON": "Signera och betala",
-  "SIGN_BUTTON": "Teckna försäkring",
+  "SIGN_BUTTON": "Förläng försäkring",
   "TRIAL_COST_EXPLANATION": "till {{date}} sedan {{amount}}",
   "TRIAL_HEADING": "Starterbjudande",
   "TRIAL_TERMINATION_DATE_MESSAGE": "Löper ut {{date}}",

--- a/apps/store/src/features/carDealership/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.tsx
@@ -97,10 +97,10 @@ export const TrialExtensionForm = (props: Props) => {
   if (!userWantsExtension) {
     return (
       <Space y={4}>
-        <Space y={1.5}>
-          <Text align="center">{t('TRIAL_HEADING')}</Text>
-          <ProductItemContractContainerCar contract={props.contract} />
-        </Space>
+        <TrialOffer
+          contract={props.contract}
+          requirePaymentConnection={props.requirePaymentConnection}
+        />
 
         <Space y={1.5}>
           <Text align="center">{t('EXTENSION_HEADING')}</Text>
@@ -140,17 +140,20 @@ export const TrialExtensionForm = (props: Props) => {
 
   return (
     <Space y={4}>
-      <Space y={1.5}>
-        <Text align="center">{t('TRIAL_HEADING')}</Text>
-        <ProductItemContractContainerCar contract={props.contract} />
-      </Space>
+      <TrialOffer
+        contract={props.contract}
+        requirePaymentConnection={props.requirePaymentConnection}
+      />
 
       <Space y={1.5}>
         <Text align="center">{t('EXTENSION_HEADING')}</Text>
-
         <Space y={2}>
           <Space y={1}>
-            <ProductItemContainer offer={selectedOffer} defaultExpanded={true} variant="green">
+            <ProductItemContainer
+              offer={selectedOffer}
+              defaultExpanded={true}
+              variant={props.requirePaymentConnection ? 'green' : undefined}
+            >
               <ActionButtonsCar
                 priceIntent={props.priceIntent}
                 offer={selectedOffer}
@@ -202,6 +205,24 @@ export const TrialExtensionForm = (props: Props) => {
           </Space>
         </Space>
       </Space>
+    </Space>
+  )
+}
+
+type TrialOfferProps = {
+  contract: TrialExtension['trialContract']
+  requirePaymentConnection: boolean
+}
+
+const TrialOffer = (props: TrialOfferProps) => {
+  const { t } = useTranslation('carDealership')
+
+  if (!props.requirePaymentConnection) return null
+
+  return (
+    <Space y={1.5}>
+      <Text align="center">{t('TRIAL_HEADING')}</Text>
+      <ProductItemContractContainerCar contract={props.contract} />
     </Space>
   )
 }


### PR DESCRIPTION
## Describe your changes

- Hide "Trial Offer" for users that **have payment connected**;
- Update sign button copy: extend insurance
- Display extend offer in green variant only for members that **don't have payment connected**

<img width="1159" alt="Screenshot 2023-10-02 at 15 29 30" src="https://github.com/HedvigInsurance/racoon/assets/19200662/86b720ec-3c56-4afb-9967-3e1f50ee80c3">

## Justify why they are needed

Design has changed
