### PR TITLE
GEN-1245 | Show a warning dialog when user proceeds without extension

### DIFF
--- a/apps/store/public/locales/en/carDealership.json
+++ b/apps/store/public/locales/en/carDealership.json
@@ -1,22 +1,18 @@
 {
-  "ATTENTION_TOAST_CONTENT": "Keep in mind that you are uninsured from {{date}}",
   "CONNECT_PAYMENT_BANNER": "Sign before {{dueDate}} to remain insured",
   "CONNECT_PAYMENT_BUTTON": "Connect payment",
   "EDIT_CAR_TRIAL_EXTENSION_BUTTON": "Edit",
-  "EXTENSION_HEADING": "Extend your insurance",
   "INFO_TOAST_CONTENT": "No binding time. Cancel anytime in the [[Hedvig-app]].",
+  "PAY_WITHOUT_EXTENSION_DIALOG_CANCEL": "Cancel",
+  "PAY_WITHOUT_EXTENSION_DIALOG_CONFIRM": "Yes, go ahead",
+  "PAY_WITHOUT_EXTENSION_DIALOG_SUBTITLE": "We would like to remind you to sign another insurance in good time before your trial period with Hedvig has expired. Otherwise, you risk that your car will become uninsured.",
+  "PAY_WITHOUT_EXTENSION_DIALOG_TITLE": "Do you want to continue without extending?",
   "REMAIN_INSURED_BANNER": "Connect payment before {{dueDate}} for activate the insurance",
-  "REMOVE_EXTENSION_BUTTON": "No, thanks",
-  "REMOVE_EXTENSION_CONFIRM_BUTTON": "Yes, go ahead",
-  "REMOVE_EXTENSION_MODAL_CANCEL_BUTTON": "Cancel",
-  "REMOVE_EXTENSION_MODAL_PROMPT_SUBTITLE": "We would like to remind you to sign another insurance in good time before your trial period with Hedvig has expired. Otherwise, you risk that your car will become uninsured.",
-  "REMOVE_EXTENSION_MODAL_PROMPT_TITLE": "Are you sure you want to remove the insurance?",
   "SIGN_AND_PAY_BUTTON": "Sign and pay",
   "SIGN_BUTTON": "Extend insurance",
   "TRIAL_COST_EXPLANATION": "discounted for 60 days",
   "TRIAL_HEADING": "Starter offer",
   "TRIAL_TERMINATION_DATE_MESSAGE": "Expires {{date}}",
   "TRIAL_TERMINATION_DATE_TOOLTIP": "You need to sign a new contract to continue your insurance.",
-  "TRIAL_TITLE": "Car insurance 60 days",
-  "UNDO_REMOVE_EXTENSION_BUTTON": "Undo"
+  "TRIAL_TITLE": "Car insurance 60 days"
 }

--- a/apps/store/public/locales/sv-se/carDealership.json
+++ b/apps/store/public/locales/sv-se/carDealership.json
@@ -1,22 +1,18 @@
 {
-  "ATTENTION_TOAST_CONTENT": "Tänk på att du är oförsäkrad från {{date}}",
   "CONNECT_PAYMENT_BANNER": "Teckna före {{dueDate}} för att fortsätta vara försäkrad",
   "CONNECT_PAYMENT_BUTTON": "Koppla betalning",
   "EDIT_CAR_TRIAL_EXTENSION_BUTTON": "Ändra",
-  "EXTENSION_HEADING": "Förläng din försäkring",
   "INFO_TOAST_CONTENT": "Ingen bindningstid. Avsluta när du vill i [[Hedvig-appen]].",
+  "PAY_WITHOUT_EXTENSION_DIALOG_CANCEL": "Avbryt",
+  "PAY_WITHOUT_EXTENSION_DIALOG_CONFIRM": "Ja, fortsätt",
+  "PAY_WITHOUT_EXTENSION_DIALOG_SUBTITLE": "Tänk på att du och din bil blir oförsäkrade efter att ditt starterbjudande har löpt ut. Trafikförsäkring är obligatoriskt enligt lag för att du ska få köra bilen.",
+  "PAY_WITHOUT_EXTENSION_DIALOG_TITLE": "Vill du fortsätta utan att förlänga?",
   "REMAIN_INSURED_BANNER": "Koppla din betalning innan {{dueDate}} för att försäkringen ska gälla",
-  "REMOVE_EXTENSION_BUTTON": "Nej, tack",
-  "REMOVE_EXTENSION_CONFIRM_BUTTON": "Ja, fortsätt",
-  "REMOVE_EXTENSION_MODAL_CANCEL_BUTTON": "Avbryt",
-  "REMOVE_EXTENSION_MODAL_PROMPT_SUBTITLE": "Tänk på att du och din bil blir oförsäkrade efter att ditt starterbjudande har löpt ut. Trafikförsäkring är obligatoriskt enligt lag för att du ska få köra bilen.",
-  "REMOVE_EXTENSION_MODAL_PROMPT_TITLE": "Är du säker på att du vill ta bort försäkringen?",
   "SIGN_AND_PAY_BUTTON": "Signera och betala",
   "SIGN_BUTTON": "Förläng försäkring",
   "TRIAL_COST_EXPLANATION": "rabatterat pris i 60 dagar",
   "TRIAL_HEADING": "Starterbjudande",
   "TRIAL_TERMINATION_DATE_MESSAGE": "Löper ut {{date}}",
   "TRIAL_TERMINATION_DATE_TOOLTIP": "Du måste teckna ett nytt avtal för att förlänga din försäkring.",
-  "TRIAL_TITLE": "Bilförsäkring 60 dagar",
-  "UNDO_REMOVE_EXTENSION_BUTTON": "Ångra"
+  "TRIAL_TITLE": "Bilförsäkring 60 dagar"
 }

--- a/apps/store/src/features/carDealership/ConfirmPayWithoutExtensionButton.tsx
+++ b/apps/store/src/features/carDealership/ConfirmPayWithoutExtensionButton.tsx
@@ -1,60 +1,63 @@
 import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
 import { useTranslation } from 'react-i18next'
-import { Button, Text, WarningTriangleIcon, theme } from 'ui'
+import { BankIdIcon, Button, Text, WarningTriangleIcon, theme } from 'ui'
 import * as FullScreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
-import { ActionButton } from '@/components/ProductItem/ProductItem'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 
 type Props = {
   onConfirm: () => void
 }
 
-// TODO: Deprecated
-export const RemoveCarOfferActionButton = (props: Props) => {
+export const ConfirmPayWithoutExtensionButton = (props: Props) => {
   const { t } = useTranslation('carDealership')
 
   const handleClick = () => {
-    datadogRum.addAction('Car dearlership | Offer removed')
+    datadogRum.addAction('Car dearlership | Confirm pay without extension')
     props.onConfirm()
   }
 
   return (
     <FullScreenDialog.Root>
       <FullScreenDialog.Trigger asChild={true}>
-        <ActionButton variant="ghost">{t('REMOVE_EXTENSION_BUTTON')}</ActionButton>
+        <Button variant="primary">
+          <SpaceFlex space={0.5} align="center">
+            <BankIdIcon />
+            {t('CONNECT_PAYMENT_BUTTON')}
+          </SpaceFlex>
+        </Button>
       </FullScreenDialog.Trigger>
 
       <FullScreenDialog.Modal
         center={true}
         Footer={
           <>
-            <Button onClick={handleClick}>{t('REMOVE_EXTENSION_CONFIRM_BUTTON')}</Button>
+            <Button onClick={handleClick}>{t('PAY_WITHOUT_EXTENSION_DIALOG_CONFIRM')}</Button>
             <FullScreenDialog.Close asChild={true}>
               <Button type="button" variant="ghost">
-                {t('REMOVE_EXTENSION_MODAL_CANCEL_BUTTON')}
+                {t('PAY_WITHOUT_EXTENSION_DIALOG_CANCEL')}
               </Button>
             </FullScreenDialog.Close>
           </>
         }
       >
-        <Wrapper direction="vertical" space={1.5} align="center">
-          <WarningTriangleIcon color={theme.colors.signalAmberElement} />
-          <p>
+        <SpaceFlex direction="vertical" space={1} align="center">
+          <WarningTriangleIcon size="1.5rem" color={theme.colors.signalAmberElement} />
+          <TextWrapper>
             <Text size={{ _: 'md', lg: 'xl' }} align="center">
-              {t('REMOVE_EXTENSION_MODAL_PROMPT_TITLE')}
+              {t('PAY_WITHOUT_EXTENSION_DIALOG_TITLE')}
             </Text>
             <Text size={{ _: 'md', lg: 'xl' }} color="textSecondary" align="center" balance={true}>
-              {t('REMOVE_EXTENSION_MODAL_PROMPT_SUBTITLE')}
+              {t('PAY_WITHOUT_EXTENSION_DIALOG_SUBTITLE')}
             </Text>
-          </p>
-        </Wrapper>
+          </TextWrapper>
+        </SpaceFlex>
       </FullScreenDialog.Modal>
     </FullScreenDialog.Root>
   )
 }
 
-const Wrapper = styled(SpaceFlex)({
+const TextWrapper = styled.div({
   maxWidth: '38rem',
   marginInline: 'auto',
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

![Screenshot 2023-10-03 at 10.59.43.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/5f7a231b-3c42-4eac-bd6f-df5190ae69f8/Screenshot%202023-10-03%20at%2010.59.43.png)

- Display dialog with warning message when user continues without extension offer

- Remove unused translations and components (no longer part of the design)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Adpat to the new design

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
