### PR TITLE
GEN-1244 | Add option to toggle debug text keys to page debugger

### DIFF
--- a/apps/store/src/components/CartPage/PageDebugDialog.tsx
+++ b/apps/store/src/components/CartPage/PageDebugDialog.tsx
@@ -5,6 +5,7 @@ import { Space } from 'ui'
 import { CopyToClipboard } from '@/components/DebugDialog/CopyToClipboard'
 import { DebugDialog } from '@/components/DebugDialog/DebugDialog'
 import { DebugShopSessionSection } from '@/components/DebugDialog/DebugShopSessionSection'
+import { DebugTextKeys } from '@/components/DebugDialog/DebugTextKeys'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { PageLink } from '@/utils/PageLink'
@@ -16,6 +17,7 @@ export const PageDebugDialog = () => {
         <LinkToCartSection />
         <LinkToRetargetingSection />
         <DebugShopSessionSection />
+        <DebugTextKeys />
       </Space>
     </DebugDialog>
   )

--- a/apps/store/src/components/CheckoutPage/PageDebugDialog.tsx
+++ b/apps/store/src/components/CheckoutPage/PageDebugDialog.tsx
@@ -1,12 +1,5 @@
 'use client'
 
-import { DebugDialog } from '@/components/DebugDialog/DebugDialog'
-import { DebugShopSessionSection } from '@/components/DebugDialog/DebugShopSessionSection'
+import { DefaultDebugDialog } from '@/components/DebugDialog/DefaultDebugDialog'
 
-export const PageDebugDialog = () => {
-  return (
-    <DebugDialog>
-      <DebugShopSessionSection />
-    </DebugDialog>
-  )
-}
+export const PageDebugDialog = DefaultDebugDialog

--- a/apps/store/src/components/DebugDialog/DebugDialog.tsx
+++ b/apps/store/src/components/DebugDialog/DebugDialog.tsx
@@ -5,12 +5,14 @@ import styled from '@emotion/styled'
 import { type ReactNode, useEffect, useState } from 'react'
 import { Dialog, mq, theme } from 'ui'
 
+const CTRL_SHIFT_D = '∆'
+
 export const DebugDialog = (props: { children: ReactNode }) => {
   const [isOpen, setOpen] = useState(false)
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.ctrlKey && event.key === 'd') {
+      if ((event.ctrlKey && event.key === 'd') || event.key === CTRL_SHIFT_D) {
         datadogRum.addAction('open debug-dialog')
         setOpen(true)
       }

--- a/apps/store/src/components/DebugDialog/DebugTextKeys.tsx
+++ b/apps/store/src/components/DebugDialog/DebugTextKeys.tsx
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router'
+import { ButtonNextLink } from '@/components/ButtonNextLink'
+import { ORIGIN_URL } from '@/utils/PageLink'
+
+export const DebugTextKeys = () => {
+  const router = useRouter()
+  const debugUrl = new URL(router.asPath, ORIGIN_URL)
+  const isDebugTextkeys = debugUrl.searchParams.get('debug') === 'textkeys'
+  debugUrl.searchParams.set('debug', isDebugTextkeys ? 'none' : 'textkeys')
+
+  return (
+    <ButtonNextLink variant="secondary" href={debugUrl} replace={true}>
+      {isDebugTextkeys ? 'Reset' : 'Debug'} text keys
+    </ButtonNextLink>
+  )
+}

--- a/apps/store/src/components/DebugDialog/DefaultDebugDialog.tsx
+++ b/apps/store/src/components/DebugDialog/DefaultDebugDialog.tsx
@@ -1,10 +1,15 @@
+import { Space } from 'ui'
 import { DebugDialog } from '@/components/DebugDialog/DebugDialog'
 import { DebugShopSessionSection } from '@/components/DebugDialog/DebugShopSessionSection'
+import { DebugTextKeys } from './DebugTextKeys'
 
 export const DefaultDebugDialog = () => {
   return (
     <DebugDialog>
-      <DebugShopSessionSection />
+      <Space y={0.25}>
+        <DebugShopSessionSection />
+        <DebugTextKeys />
+      </Space>
     </DebugDialog>
   )
 }

--- a/apps/store/src/components/ProductPage/PageDebugDialog.tsx
+++ b/apps/store/src/components/ProductPage/PageDebugDialog.tsx
@@ -5,6 +5,7 @@ import { Space } from 'ui'
 import { CopyToClipboard } from '@/components/DebugDialog/CopyToClipboard'
 import { DebugDialog } from '@/components/DebugDialog/DebugDialog'
 import { DebugShopSessionSection } from '@/components/DebugDialog/DebugShopSessionSection'
+import { DebugTextKeys } from '@/components/DebugDialog/DebugTextKeys'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { PageLink } from '@/utils/PageLink'
@@ -16,6 +17,7 @@ export const PageDebugDialog = () => {
       <Space y={0.25}>
         <DebugShopSessionSection />
         <LinkToOfferSection />
+        <DebugTextKeys />
       </Space>
     </DebugDialog>
   )


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add button to page debugger to toggle showing text keys / translations

- Add option to press ctrl+shift+d to toggle showing page debugger

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Expose more useful debug features

- Add page debugger shortcut that doesn't conflict with browser (Arc)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
