### PR TITLE
styles(car-dealership-banner): wrap content into multiple lines

### DIFF
--- a/apps/store/src/components/GlobalBanner/GlobalBanner.tsx
+++ b/apps/store/src/components/GlobalBanner/GlobalBanner.tsx
@@ -17,16 +17,12 @@ const GlobalBanner = () => {
 
   return (
     <Banner variant={banner.variant} handleClose={handleClose}>
-      <Ellipsis dangerouslySetInnerHTML={{ __html: banner.content }} />
+      <Content dangerouslySetInnerHTML={{ __html: banner.content }} />
     </Banner>
   )
 }
 
-const Ellipsis = styled.span({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-
+const Content = styled.span({
   // GlobalBanner receives a HTML formatted string.
   // This is meant to style important text wrapped into <b> tags
   '& > b': {

--- a/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
+++ b/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
@@ -34,7 +34,11 @@ export const CarTrialExtensionBlock = (props: Props) => {
         dueDate.setDate(dueDate.getDate() + FOURTEEN_DAYS)
 
         if (today <= dueDate) {
-          addBanner(t('CONNECT_PAYMENT_BANNER', { dueDate: `<b>${dateFull(dueDate)}</b>` }), 'info')
+          addBanner(
+            t('CONNECT_PAYMENT_BANNER', { dueDate: `<b>${dateFull(dueDate)}</b>` }),
+            'info',
+            { force: true },
+          )
         }
       } else {
         addBanner(
@@ -42,6 +46,7 @@ export const CarTrialExtensionBlock = (props: Props) => {
             dueDate: `<b>${dateFull(new Date(data.trialContract.terminationDate))}</b>`,
           }),
           'warning',
+          { force: true },
         )
       }
     },


### PR DESCRIPTION
## Describe your changes

- Banner: avoid truncating content and wrap it into multiple lines
- Make sure banner get's shown for car dealership extension offer page


<img width="394" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/27bcd4d6-23f8-47d8-b050-1a132048b669">
