### PR TITLE
Inline payment connection UI

### DIFF
--- a/apps/store/src/components/PaymentConnectPage/ReadyState.tsx
+++ b/apps/store/src/components/PaymentConnectPage/ReadyState.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from 'next-i18next'
 import { Space, Text } from 'ui'
 import { TrustlyIframe } from '@/services/trustly/TrustlyIframe'
-import { Layout } from './Layout'
 
 type Props = {
   trustlyUrl: string
@@ -13,13 +12,11 @@ export const ReadyState = (props: Props) => {
   const { t } = useTranslation('checkout')
 
   return (
-    <Layout>
-      <Space y={0.75}>
-        <TrustlyIframe url={props.trustlyUrl} onSuccess={props.onSuccess} onFail={props.onFail} />
-        <Text size="xs" align="center">
-          {t('PAYMENT_TRUSTLY_FOOTNOTE')}
-        </Text>
-      </Space>
-    </Layout>
+    <Space y={0.75}>
+      <TrustlyIframe url={props.trustlyUrl} onSuccess={props.onSuccess} onFail={props.onFail} />
+      <Text size="xs" align="center">
+        {t('PAYMENT_TRUSTLY_FOOTNOTE')}
+      </Text>
+    </Space>
   )
 }

--- a/apps/store/src/features/memberArea/MemberPage.tsx
+++ b/apps/store/src/features/memberArea/MemberPage.tsx
@@ -48,7 +48,6 @@ export const MemberPage = () => {
         </Navigation>
 
         <div>
-          <p>TODO: Body</p>
           {loading && 'Loading...'}
           {data && <MemberInfo data={data} />}
         </div>
@@ -68,10 +67,7 @@ const MemberInfo = ({ data }: MemberInfoProps) => {
       <Heading as={'h2'} variant="standard.32">
         {greeting}
       </Heading>
-      <PaymentsSection hasActivePaymentConnection={currentMember.hasActivePaymentConnection} />
-      <pre style={{ width: '100%' }}>
-        <code>{JSON.stringify(currentMember, null, 2)}</code>
-      </pre>
+      <PaymentsSection />
     </>
   )
 }

--- a/apps/store/src/features/memberArea/PaymentsSection.tsx
+++ b/apps/store/src/features/memberArea/PaymentsSection.tsx
@@ -1,28 +1,90 @@
-import Link from 'next/link'
+import { useApolloClient } from '@apollo/client'
+import { useCallback, useState } from 'react'
 import { Button, Heading, Text } from 'ui'
+import { ReadyState } from '@/components/PaymentConnectPage/ReadyState'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
-import { PageLink } from '@/utils/PageLink'
+import { useMemberAreaMemberInfoQuery } from '@/services/apollo/generated'
+import { createTrustlyUrl } from '@/services/trustly/createTrustlyUrl'
+import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 
-export const PaymentsSection = ({
-  hasActivePaymentConnection,
-}: {
-  hasActivePaymentConnection: boolean
-}) => {
+export const PaymentsSection = () => {
+  const { data, refetch } = useMemberAreaMemberInfoQuery()
+
+  if (data == null) {
+    console.warn('PaymentsSection expects data to be always present')
+    return null
+  }
+  const { currentMember } = data
+
   return (
     <SpaceFlex direction="vertical">
       <Heading as="h3" variant="standard.24">
-        Payment
+        Payment connection
       </Heading>
-      {hasActivePaymentConnection ? (
-        <Text>Configured ✅</Text>
+      {currentMember.hasActivePaymentConnection ? (
+        <>
+          <Text>✅&nbsp;Configured</Text>
+          <PaymentConfiguration startButtonText={'Change'} onSuccess={refetch} />
+        </>
       ) : (
         <>
           <Text>Not configured yet</Text>
-          <Link href={PageLink.paymentConnect()} target="_blank">
-            <Button>Configure</Button>
-          </Link>
+          <PaymentConfiguration startButtonText="Configure" onSuccess={refetch} />
         </>
       )}
     </SpaceFlex>
+  )
+}
+
+type PaymentConfigurationState =
+  | { type: 'IDLE' }
+  | { type: 'LOADING' }
+  | { type: 'ERROR' }
+  | { type: 'READY'; trustlyUrl: string }
+
+const PaymentConfiguration = ({
+  startButtonText,
+  onSuccess,
+}: {
+  startButtonText: string
+  onSuccess: () => void
+}) => {
+  const { routingLocale } = useCurrentLocale()
+  const apolloClient = useApolloClient()
+  const [state, setState] = useState<PaymentConfigurationState>({ type: 'IDLE' })
+
+  const handleStart = useCallback(async () => {
+    try {
+      const trustlyUrl = await createTrustlyUrl({ apolloClient, locale: routingLocale })
+      setState({ type: 'READY', trustlyUrl })
+    } catch (err: unknown) {
+      console.warn('Failed to create Trustly URL', err)
+      setState({ type: 'ERROR' })
+    }
+  }, [apolloClient, routingLocale])
+
+  const handleTrustlyError = () => {
+    window.alert('Something went wrong')
+    setState({ type: 'IDLE' })
+  }
+
+  if (state.type === 'READY') {
+    return (
+      <div style={{ minWidth: '70vw' }}>
+        <ReadyState
+          trustlyUrl={state.trustlyUrl}
+          onSuccess={onSuccess}
+          onFail={handleTrustlyError}
+        />
+      </div>
+    )
+  }
+  return (
+    <>
+      <Button loading={state.type === 'LOADING'} size="small" onClick={handleStart}>
+        {startButtonText}
+      </Button>
+      {state.type === 'ERROR' && <Text>Something went wrong, please try again</Text>}
+    </>
   )
 }

--- a/apps/store/src/pages/payment/connect.tsx
+++ b/apps/store/src/pages/payment/connect.tsx
@@ -5,6 +5,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useState } from 'react'
 import { ErrorDialog } from '@/components/PaymentConnectPage/ErrorDialog'
 import { IdleState } from '@/components/PaymentConnectPage/IdleState'
+import { Layout } from '@/components/PaymentConnectPage/Layout'
 import { ReadyState } from '@/components/PaymentConnectPage/ReadyState'
 import { SuccessState } from '@/components/PaymentConnectPage/SuccessState'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
@@ -58,7 +59,9 @@ const PaymentConnectPage = () => {
   return (
     <>
       {state.trustlyUrl && (
-        <ReadyState trustlyUrl={state.trustlyUrl} onSuccess={handleSuccess} onFail={handleFail} />
+        <Layout>
+          <ReadyState trustlyUrl={state.trustlyUrl} onSuccess={handleSuccess} onFail={handleFail} />
+        </Layout>
       )}
 
       <ErrorDialog open={state.type === 'FAILED'} onRetry={handleRetry} />


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

![Screenshot 2023-10-04 at 16.10.36.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/3e34c7cc-b668-4da2-a0d8-fe6e6b1f6287/Screenshot%202023-10-04%20at%2016.10.36.png)

## Describe your changes

Integrate Trustly iframe inline into PaymentsSection

Make section fetch its own data to be able to refresh when connection is updated

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
