### PR TITLE
Ability to get travel and insurance certificates

### DIFF
--- a/apps/store/src/components/ButtonNextLink.tsx
+++ b/apps/store/src/components/ButtonNextLink.tsx
@@ -5,7 +5,7 @@ import { Button } from 'ui'
 type ButtonProps = ComponentProps<typeof Button>
 
 type Props = LinkProps &
-  Partial<Pick<HTMLAnchorElement, 'target' | 'title'>> &
+  Partial<Pick<HTMLAnchorElement, 'target' | 'title' | 'download'>> &
   Pick<ButtonProps, 'variant' | 'size' | 'loading' | 'onClick' | 'children' | 'className'>
 
 export const ButtonNextLink = (props: Props) => {

--- a/apps/store/src/features/memberArea/TravelCertificateCreate.graphql
+++ b/apps/store/src/features/memberArea/TravelCertificateCreate.graphql
@@ -1,0 +1,6 @@
+mutation TravelCertificateCreate($input: TravelCertificateCreateInput!) {
+  travelCertificateCreate(input: $input) {
+    id
+    signedUrl
+  }
+}

--- a/apps/store/src/features/memberArea/components/InsuranceCard.tsx
+++ b/apps/store/src/features/memberArea/components/InsuranceCard.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled'
 import { Text, theme } from 'ui'
+import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { MemberContractFragment } from '@/services/apollo/generated'
+import { TravelCertificateButton } from './TravelCertificateButton'
 
 type InsuranceCardProps = {
   contract: MemberContractFragment
@@ -8,6 +10,7 @@ type InsuranceCardProps = {
 
 export const InsuranceCard = ({ contract }: InsuranceCardProps) => {
   const { currentAgreement, exposureDisplayName } = contract
+
   return (
     <Card>
       <Info>
@@ -15,6 +18,17 @@ export const InsuranceCard = ({ contract }: InsuranceCardProps) => {
           {currentAgreement.productVariant.displayName}
         </Text>
         <Text color="textTranslucentTertiary">{exposureDisplayName}</Text>
+        {currentAgreement.certificateUrl && (
+          <ButtonNextLink
+            href={currentAgreement.certificateUrl}
+            download={''}
+            variant="secondary"
+            size="small"
+          >
+            Insurance certificate
+          </ButtonNextLink>
+        )}
+        <TravelCertificateButton contractId={contract.id} />
       </Info>
       <PillowBackground />
     </Card>

--- a/apps/store/src/features/memberArea/components/TravelCertificateButton.tsx
+++ b/apps/store/src/features/memberArea/components/TravelCertificateButton.tsx
@@ -1,0 +1,58 @@
+import Link from 'next/link'
+import { useCallback } from 'react'
+import { Button } from 'ui'
+import {
+  useMemberAreaMemberInfoQuery,
+  useTravelCertificateCreateMutation,
+} from '@/services/apollo/generated'
+import { formatAPIDate } from '@/utils/date'
+
+export const TravelCertificateButton = ({ contractId }: { contractId: string }) => {
+  // Using same query as expected parent components instead of prop-drilling currentMember.email
+  // Not sure it's production-quality solution
+  const { data } = useMemberAreaMemberInfoQuery()
+  const [sendRequest, result] = useTravelCertificateCreateMutation()
+
+  const handleRequestCertificate = useCallback(() => {
+    alert(
+      `Demo version!
+      
+      In real life there should be dialog asking you for certificate parameters. We will use defaults for now`,
+    )
+    sendRequest({
+      variables: {
+        input: {
+          contractId,
+          email: data!.currentMember.email,
+          isMemberIncluded: true,
+          startDate: formatAPIDate(new Date()),
+          coInsured: [],
+        },
+      },
+    })
+  }, [contractId, data, sendRequest])
+
+  if (data == null) {
+    console.warn('Expected to have MemberAreaMemberInfoQuery.data')
+    return null
+  }
+
+  if (result.data != null) {
+    return (
+      <Link href={result.data.travelCertificateCreate.signedUrl} download={true}>
+        📄Certificate is ready! Click to download
+      </Link>
+    )
+  }
+
+  return (
+    <Button
+      variant="secondary"
+      size="small"
+      onClick={handleRequestCertificate}
+      loading={result.loading}
+    >
+      Travel certificate
+    </Button>
+  )
+}


### PR DESCRIPTION
![Screenshot 2023-10-04 at 18.06.35.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/e90377bd-fe49-44c8-a9d0-f7c24a112ebb/Screenshot%202023-10-04%20at%2018.06.35.png)

<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add insurance certificate links
- Add travel certificate integration that uses default data and blows up for non-Home contracts

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
