### PR TITLE
Add useMemberAreaInfo to use Apollo as context provider

### DIFF
--- a/apps/store/src/features/memberArea/PaymentsSection.tsx
+++ b/apps/store/src/features/memberArea/PaymentsSection.tsx
@@ -8,6 +8,7 @@ import { createTrustlyUrl } from '@/services/trustly/createTrustlyUrl'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 
 export const PaymentsSection = () => {
+  // Not using simplified hook, we need access to refetch
   const { data, refetch } = useMemberAreaMemberInfoQuery()
 
   if (data == null) {

--- a/apps/store/src/features/memberArea/components/InsuranceCard.tsx
+++ b/apps/store/src/features/memberArea/components/InsuranceCard.tsx
@@ -19,12 +19,7 @@ export const InsuranceCard = ({ contract }: InsuranceCardProps) => {
         </Text>
         <Text color="textTranslucentTertiary">{exposureDisplayName}</Text>
         {currentAgreement.certificateUrl && (
-          <ButtonNextLink
-            href={currentAgreement.certificateUrl}
-            download={''}
-            variant="secondary"
-            size="small"
-          >
+          <ButtonNextLink href={currentAgreement.certificateUrl} variant="secondary" size="small">
             Insurance certificate
           </ButtonNextLink>
         )}

--- a/apps/store/src/features/memberArea/components/InsurancesSection.tsx
+++ b/apps/store/src/features/memberArea/components/InsurancesSection.tsx
@@ -1,14 +1,10 @@
 import styled from '@emotion/styled'
 import { Heading, mq } from 'ui'
-import { MemberAreaMemberInfoQuery } from '@/services/apollo/generated'
+import { useMemberAreaInfo } from '../useMemberAreaInfo'
 import { InsuranceCard } from './InsuranceCard'
 
-type MemberInfoProps = {
-  data: MemberAreaMemberInfoQuery
-}
-
-export const Insurances = ({ data }: MemberInfoProps) => {
-  const { currentMember } = data
+export const Insurances = () => {
+  const currentMember = useMemberAreaInfo()
   const greeting = `Hello, ${currentMember.firstName} ${currentMember.lastName}`
   return (
     <>
@@ -19,7 +15,7 @@ export const Insurances = ({ data }: MemberInfoProps) => {
         Your insurances
       </Heading>
       <Grid>
-        {data.currentMember.activeContracts.map((contract) => (
+        {currentMember.activeContracts.map((contract) => (
           <InsuranceCard key={contract.id} contract={contract} />
         ))}
       </Grid>

--- a/apps/store/src/features/memberArea/components/TravelCertificateButton.tsx
+++ b/apps/store/src/features/memberArea/components/TravelCertificateButton.tsx
@@ -1,16 +1,12 @@
 import Link from 'next/link'
 import { useCallback } from 'react'
 import { Button } from 'ui'
-import {
-  useMemberAreaMemberInfoQuery,
-  useTravelCertificateCreateMutation,
-} from '@/services/apollo/generated'
+import { useMemberAreaInfo } from '@/features/memberArea/useMemberAreaInfo'
+import { useTravelCertificateCreateMutation } from '@/services/apollo/generated'
 import { formatAPIDate } from '@/utils/date'
 
 export const TravelCertificateButton = ({ contractId }: { contractId: string }) => {
-  // Using same query as expected parent components instead of prop-drilling currentMember.email
-  // Not sure it's production-quality solution
-  const { data } = useMemberAreaMemberInfoQuery()
+  const currentMember = useMemberAreaInfo()
   const [sendRequest, result] = useTravelCertificateCreateMutation()
 
   const handleRequestCertificate = useCallback(() => {
@@ -23,19 +19,14 @@ export const TravelCertificateButton = ({ contractId }: { contractId: string }) 
       variables: {
         input: {
           contractId,
-          email: data!.currentMember.email,
+          email: currentMember.email,
           isMemberIncluded: true,
           startDate: formatAPIDate(new Date()),
           coInsured: [],
         },
       },
     })
-  }, [contractId, data, sendRequest])
-
-  if (data == null) {
-    console.warn('Expected to have MemberAreaMemberInfoQuery.data')
-    return null
-  }
+  }, [contractId, currentMember, sendRequest])
 
   if (result.data != null) {
     return (

--- a/apps/store/src/features/memberArea/pages/InsurancePage.tsx
+++ b/apps/store/src/features/memberArea/pages/InsurancePage.tsx
@@ -4,14 +4,8 @@ import { useMemberAreaMemberInfoQuery } from '@/services/apollo/generated'
 import { LayoutWithMenu } from '../components/LayoutWithMenu'
 
 export const InsurancePage: NextPageWithLayout = () => {
-  const { data, loading } = useMemberAreaMemberInfoQuery()
-
-  return (
-    <>
-      {loading && 'Loading...'}
-      {data && <Insurances data={data} />}
-    </>
-  )
+  const { loading } = useMemberAreaMemberInfoQuery()
+  return <>{loading ? 'Loading...' : <Insurances />}</>
 }
 
 InsurancePage.getLayout = (children) => <LayoutWithMenu>{children}</LayoutWithMenu>

--- a/apps/store/src/features/memberArea/pages/PaymentsPage.tsx
+++ b/apps/store/src/features/memberArea/pages/PaymentsPage.tsx
@@ -1,9 +1,11 @@
 import { NextPageWithLayout } from 'next'
+import { useMemberAreaMemberInfoQuery } from '@/services/apollo/generated'
 import { LayoutWithMenu } from '../components/LayoutWithMenu'
 import { PaymentsSection } from '../PaymentsSection'
 
 export const PaymentsPage: NextPageWithLayout = () => {
-  return <PaymentsSection />
+  const { loading } = useMemberAreaMemberInfoQuery()
+  return <>{loading ? 'Loading...' : <PaymentsSection />}</>
 }
 
 PaymentsPage.getLayout = (children) => <LayoutWithMenu>{children}</LayoutWithMenu>

--- a/apps/store/src/features/memberArea/useMemberAreaInfo.ts
+++ b/apps/store/src/features/memberArea/useMemberAreaInfo.ts
@@ -1,0 +1,12 @@
+import {
+  MemberAreaMemberInfoQuery,
+  useMemberAreaMemberInfoQuery,
+} from '@/services/apollo/generated'
+
+export const useMemberAreaInfo = (): MemberAreaMemberInfoQuery['currentMember'] => {
+  const { data } = useMemberAreaMemberInfoQuery()
+  if (!data) {
+    throw Error('Incorrect use, MemberAreaMemberInfoQuery must be loaded at this point')
+  }
+  return data.currentMember
+}

--- a/apps/store/src/pages/member/payments.tsx
+++ b/apps/store/src/pages/member/payments.tsx
@@ -1,4 +1,5 @@
 import { GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { PaymentsPage } from '@/features/memberArea/pages/PaymentsPage'
 import { addApolloState, initializeApolloServerSide } from '@/services/apollo/client'
 import { getAccessToken } from '@/services/authApi/persist'
@@ -23,9 +24,11 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async (context)
   }
 
   const apolloClient = await initializeApolloServerSide({ locale, req, res })
-
+  const translations = await serverSideTranslations(locale)
   return addApolloState(apolloClient, {
-    props: {},
+    props: {
+      ...translations,
+    },
   })
 }
 export default PaymentsPage


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add type-safe useMemberAreInfo hook that relies on Apollo to provide fresh data without making same query multiple times

It will crash if used before member data is loaded, which makes deep component simpler - just don't use them until you have the data

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
