### PR TITLE
Move post-login redirect to server side, keep BankID dialog open until onSuccess resolves

### DIFF
--- a/apps/store/src/features/memberArea/pages/LoginPage.tsx
+++ b/apps/store/src/features/memberArea/pages/LoginPage.tsx
@@ -14,10 +14,10 @@ const SSN_FIELD_NAME = 'ssn'
 export const LoginPage = () => {
   const router = useRouter()
   const handleLoginSuccess = async () => {
-    const { next: nextPathname = '/member/insurances', ...targetQuery } = router.query
-    const redirectTarget = { pathname: String(nextPathname), query: targetQuery }
-    console.log(`Logged in, redirecting to ${JSON.stringify(redirectTarget)}`)
-    await router.replace(redirectTarget)
+    console.log('Login success, reloading and let server side do the redirect')
+    window.location.reload()
+    // Never resolve, keep BankID dialog open
+    return new Promise(() => {})
   }
 
   return (

--- a/apps/store/src/pages/member/login.tsx
+++ b/apps/store/src/pages/member/login.tsx
@@ -1,17 +1,25 @@
 import { GetServerSidePropsContext } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { LoginPage } from '@/features/memberArea/pages/LoginPage'
+import { getAccessToken } from '@/services/authApi/persist'
 import { Features } from '@/utils/Features'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+import { ORIGIN_URL } from '@/utils/PageLink'
 
-// eslint-disable-next-line @typescript-eslint/require-await
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const { locale } = context
+  const { locale, req, res, resolvedUrl } = context
 
   if (!Features.enabled('MEMBER_AREA')) return { notFound: true }
   if (!isRoutingLocale(locale)) return { notFound: true }
 
-  // TODO: If logged in - redirect to next, preserving other query params, default to /member
+  const isAuthenticated = getAccessToken({ req, res })
+  if (isAuthenticated) {
+    const redirectTarget = new URL(resolvedUrl, ORIGIN_URL)
+    redirectTarget.pathname = redirectTarget.searchParams.get('next') ?? '/member/insurances'
+    redirectTarget.searchParams.delete('next')
+    console.log(`Logged in, redirecting to ${redirectTarget.toString()}`)
+    return { redirect: { destination: redirectTarget.toString(), permanent: false } }
+  }
 
   const translations = await serverSideTranslations(locale)
   return {

--- a/apps/store/src/services/bankId/bankId.types.ts
+++ b/apps/store/src/services/bankId/bankId.types.ts
@@ -35,7 +35,7 @@ export type BankIdLoginOptions = {
   onSuccess: () => void
 }
 
-export type StartLoginOptions = { ssn: string; onSuccess?: () => void }
+export type StartLoginOptions = { ssn: string; onSuccess?: () => void | Promise<void> }
 
 export type CheckoutSignOptions = {
   customerAuthenticationStatus: ShopSessionAuthenticationStatus

--- a/apps/store/src/services/bankId/useBankIdLogin.ts
+++ b/apps/store/src/services/bankId/useBankIdLogin.ts
@@ -35,10 +35,11 @@ export const useBankIdLogin = ({ dispatch }: HookOptions) => {
 
       startLogin({
         ...options,
-        onSuccess() {
+        async onSuccess() {
           datadogRum.addAction('bankIdLogin complete')
           onLoginPromptCompletedRef.current?.()
-          options.onSuccess?.()
+          // Wrap into Promise.resolve to allow both sync and async callbacks
+          await Promise.resolve(options.onSuccess?.())
           dispatch({ type: 'success' })
         },
       })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Improve login flow
- Post-login redirect is now server-side to make sure it works for people going to login page while being authenticated
- Keep BankID dialog open until next page loads, prevents flash of login form before redirect

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
