### PR TITLE
Add tabs to InsuranceDetails

### DIFF
--- a/apps/store/src/features/memberArea/InsuranceSection/InsuranceDetailsSection.tsx
+++ b/apps/store/src/features/memberArea/InsuranceSection/InsuranceDetailsSection.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled'
+import * as RadixTabs from '@radix-ui/react-tabs'
 import { useRouter } from 'next/router'
-import { Heading, Text, theme } from 'ui'
+import { Button, Heading, Space, Text, theme } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
+import { MemberContractFragment } from '@/services/apollo/generated'
 import { useMemberAreaInfo } from '../useMemberAreaInfo'
 import { InsuranceCard } from './InsuranceCard'
 import { TravelCertificateButton } from './TravelCertificateButton'
@@ -16,38 +18,89 @@ export const InsuranceDetailsSection = () => {
       {contract && (
         <div>
           <Overview>
-            <InsuranceCard key={contract.id} contract={contract} />
-
-            <Heading as="h2" variant="standard.24" mt={theme.space.lg}>
-              Overview
-            </Heading>
-            <div>
-              {contract.currentAgreement.displayItems.map((displayItem) => (
-                <Row key={displayItem.displayTitle}>
-                  <Text size={{ _: 'sm', lg: 'md' }}>{displayItem.displayTitle}</Text>
-                  <Text size={{ _: 'sm', lg: 'md' }}>{displayItem.displayValue}</Text>
-                </Row>
-              ))}
-            </div>
-            <Documents>
-              {contract.currentAgreement.certificateUrl && (
-                <ButtonNextLink
-                  href={contract.currentAgreement.certificateUrl}
-                  target="_blank"
-                  variant="secondary"
-                  size="small"
-                >
-                  Insurance certificate
-                </ButtonNextLink>
-              )}
-              <TravelCertificateButton contractId={contract.id} />
-            </Documents>
+            <Space y={2}>
+              <InsuranceCard key={contract.id} contract={contract} />
+              <InsuranceTabs contract={contract} />
+            </Space>
           </Overview>
         </div>
       )}
     </>
   )
 }
+
+type InsuranceTabsProps = {
+  contract: MemberContractFragment
+}
+
+const InsuranceTabs = ({ contract }: InsuranceTabsProps) => {
+  return (
+    <RadixTabs.Tabs defaultValue="overview">
+      <TabsList>
+        <RadixTabs.Trigger asChild={true} value="overview">
+          <TabButton variant="secondary" size="medium">
+            Overview
+          </TabButton>
+        </RadixTabs.Trigger>
+        <RadixTabs.Trigger asChild={true} value="coverage">
+          <TabButton variant="secondary" size="medium">
+            Coverage
+          </TabButton>
+        </RadixTabs.Trigger>
+        <RadixTabs.Trigger asChild={true} value="documents">
+          <TabButton variant="secondary" size="medium">
+            Documents
+          </TabButton>
+        </RadixTabs.Trigger>
+      </TabsList>
+
+      <RadixTabs.TabsContent value="overview">
+        <Heading as="h2" variant="standard.24" mt={theme.space.lg}>
+          Overview
+        </Heading>
+        {contract.currentAgreement.displayItems.map((displayItem) => (
+          <Row key={displayItem.displayTitle}>
+            <Text size={{ _: 'sm', lg: 'md' }}>{displayItem.displayTitle}</Text>
+            <Text color="textSecondary" size={{ _: 'sm', lg: 'md' }}>
+              {displayItem.displayValue}
+            </Text>
+          </Row>
+        ))}
+      </RadixTabs.TabsContent>
+
+      <RadixTabs.TabsContent value="coverage">Coverage</RadixTabs.TabsContent>
+
+      <RadixTabs.TabsContent value="documents">
+        <Documents>
+          {contract.currentAgreement.certificateUrl && (
+            <ButtonNextLink
+              href={contract.currentAgreement.certificateUrl}
+              target="_blank"
+              variant="secondary"
+              size="small"
+            >
+              Insurance certificate
+            </ButtonNextLink>
+          )}
+          <TravelCertificateButton contractId={contract.id} />
+        </Documents>
+      </RadixTabs.TabsContent>
+    </RadixTabs.Tabs>
+  )
+}
+
+const TabsList = styled(RadixTabs.List)({
+  display: 'flex',
+  gap: theme.space.xs,
+  marginBottom: theme.space.xs,
+})
+
+const TabButton = styled(Button)({
+  flex: 1,
+  '&[data-state=active]': {
+    backgroundColor: theme.colors.translucent2,
+  },
+})
 
 const Overview = styled.div({ maxWidth: '400px' })
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add tabs and split up insurance content
Next: add coverage content

https://github.com/HedvigInsurance/racoon/assets/6661511/426be252-2944-450f-aeb7-1c2177cf917c


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
