### PR TITLE
Keep locale during login flow

### DIFF
--- a/apps/store/src/features/memberArea/pages/protectedPageServerSideProps.ts
+++ b/apps/store/src/features/memberArea/pages/protectedPageServerSideProps.ts
@@ -19,9 +19,9 @@ export const protectedPageServerSideProps: GetServerSideProps<PageProps> = async
   const accessToken = getAccessToken({ req, res })
   if (!accessToken) {
     console.log('Not authenticated, redirecting to login page')
-    const redirectTarget = new URL(context.resolvedUrl, ORIGIN_URL)
+    const redirectTarget = new URL(`${locale}/${context.resolvedUrl}`, ORIGIN_URL)
     redirectTarget.searchParams.set('next', redirectTarget.pathname)
-    redirectTarget.pathname = '/member/login'
+    redirectTarget.pathname = `${locale}/member/login`
     return { redirect: { destination: redirectTarget.toString(), permanent: false } }
   }
 

--- a/apps/store/src/pages/member/login.tsx
+++ b/apps/store/src/pages/member/login.tsx
@@ -15,7 +15,8 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
   const isAuthenticated = getAccessToken({ req, res })
   if (isAuthenticated) {
     const redirectTarget = new URL(resolvedUrl, ORIGIN_URL)
-    redirectTarget.pathname = redirectTarget.searchParams.get('next') ?? '/member/insurances'
+    redirectTarget.pathname =
+      redirectTarget.searchParams.get('next') ?? `${locale}/member/insurances`
     redirectTarget.searchParams.delete('next')
     console.log(`Logged in, redirecting to ${redirectTarget.toString()}`)
     return { redirect: { destination: redirectTarget.toString(), permanent: false } }

--- a/packages/ui/src/components/HedvigSymbol/HedvigSymbol.tsx
+++ b/packages/ui/src/components/HedvigSymbol/HedvigSymbol.tsx
@@ -17,8 +17,8 @@ export const HedvigSymbol = ({ color = 'currentColor', size = '1.5rem' }: Hedvig
       fill="#FAFAFA"
     />
     <path
-      fill-rule="evenodd"
-      clip-rule="evenodd"
+      fillRule="evenodd"
+      clipRule="evenodd"
       d="M0 20C0 8.94515 8.94516 0 20 0C31.0549 0 40 8.94515 40 20C40 31.0549 31.0549 40 20 40C8.94516 40 0 31.0549 0 20ZM2.70043 20C2.70043 29.5359 10.4641 37.2996 20 37.2996C29.5359 37.2996 37.2996 29.5359 37.2996 20C37.2996 10.4641 29.5359 2.70042 20 2.70042C10.4641 2.70042 2.70043 10.4641 2.70043 20Z"
       fill="#FAFAFA"
     />


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix /se-en/member/* redirecting to /se/... during login flow

NextJs does not include locale in `resovledUrl`, but expects it to be present ti redirect.destination to work correctly.  This is odd and perhaps worth investigating some time in the future.  For now just adding locale explicitly to path

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
