### PR TITLE
GEN-1269 - log(TrialExtensionForm): log when only tier level is changed

### DIFF
--- a/apps/store/src/features/carDealership/EditExtensionOfferForm.tsx
+++ b/apps/store/src/features/carDealership/EditExtensionOfferForm.tsx
@@ -34,7 +34,6 @@ export const EditExtensionOfferForm = (props: EditExtensionOfferFormProps) => {
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    datadogRum.addAction('Offer Car Save')
 
     const formData = new FormData(event.currentTarget)
     const data = {
@@ -47,6 +46,11 @@ export const EditExtensionOfferForm = (props: EditExtensionOfferFormProps) => {
     }
 
     props.onSave(option, data)
+
+    datadogRum.addAction('Offer Car Save', {
+      changedMileage: data[MILEAGE_DATA_KEY] !== props.data[MILEAGE_DATA_KEY]?.toString(),
+      changedTierLevel: option !== props.defaultTierLevel,
+    })
   }
 
   const mileageField = {


### PR DESCRIPTION
## Describe your changes

- Log cases where users modify extension offers by only changing the tier level.

## Justify why they are needed

We can use that metric to decide upon a performance optimization where we only confirm the price intent (API call) when the milieage changes.
