### PR TITLE
GEN-1271 | Separate PayForTrial from ExtensionForm component

### DIFF
--- a/apps/store/src/features/carDealership/ExtensionOfferToggle.tsx
+++ b/apps/store/src/features/carDealership/ExtensionOfferToggle.tsx
@@ -1,0 +1,32 @@
+import { atom, useAtom, useAtomValue } from 'jotai'
+import { useTranslation } from 'next-i18next'
+import { CampaignIcon, Text, theme } from 'ui'
+import { ToggleCard } from '@/components/ToggleCard/ToggleCard'
+
+export const ExtensionOfferToggle = () => {
+  const { t } = useTranslation('carDealership')
+  const [userWantsExtension, setUserWantsExtension] = useSetUserWantsExtension()
+
+  return (
+    <ToggleCard
+      label={t('TOGGLE_EXTENSION_LABEL')}
+      defaultChecked={userWantsExtension}
+      onCheckedChange={setUserWantsExtension}
+      Icon={<CampaignIcon size="1rem" color={theme.colors.signalGreenElement} />}
+    >
+      <Text as="p" color="textTranslucentSecondary" size="xs">
+        {t('TOGGLE_EXTENSION_DESCRIPTION')}
+      </Text>
+    </ToggleCard>
+  )
+}
+
+const ATOM = atom(true)
+
+const useSetUserWantsExtension = () => {
+  return useAtom(ATOM)
+}
+
+export const useUserWantsExtension = () => {
+  return useAtomValue(ATOM)
+}

--- a/apps/store/src/features/carDealership/PayForTrial.tsx
+++ b/apps/store/src/features/carDealership/PayForTrial.tsx
@@ -1,0 +1,55 @@
+import { datadogRum } from '@datadog/browser-rum'
+import { useTranslation } from 'next-i18next'
+import { useRouter } from 'next/router'
+import { Space, Text } from 'ui'
+import { TotalAmount } from '@/components/ShopBreakdown/TotalAmount'
+import { WithLink } from '@/components/TextWithLink'
+import { AttentionToastBar } from '@/components/ToastBar/ToastBar'
+import { useBankIdContext } from '@/services/bankId/BankIdContext'
+import { PageLink } from '@/utils/PageLink'
+import { type TrialExtension } from './carDealershipFixtures'
+import { ConfirmPayWithoutExtensionButton } from './ConfirmPayWithoutExtensionButton'
+import { ExtensionOfferToggle } from './ExtensionOfferToggle'
+import { ProductItemContractContainerCar } from './ProductItemContractContainer'
+
+type Props = {
+  contract: TrialExtension['trialContract']
+  ssn: string
+}
+
+export const PayForTrial = (props: Props) => {
+  const { t } = useTranslation(['carDealership', 'checkout'])
+
+  const router = useRouter()
+  const { startLogin } = useBankIdContext()
+  const handleConfirmPay = () => {
+    datadogRum.addAction('Car dealership | Decline extension offer')
+
+    startLogin({
+      ssn: props.ssn,
+      async onSuccess() {
+        console.log('Car dealership | BankID login success')
+        await router.push(PageLink.paymentConnect())
+      },
+    })
+  }
+
+  return (
+    <Space y={1}>
+      <Space y={1.5}>
+        <Text align="center">{t('TRIAL_HEADING')}</Text>
+        <ProductItemContractContainerCar contract={props.contract} />
+      </Space>
+
+      <ExtensionOfferToggle />
+
+      <TotalAmount {...props.contract.premium} />
+      <AttentionToastBar>
+        <WithLink href={PageLink.apiAppStoreRedirect()} target="_blank">
+          {t('NOTICE_TOAST_CONTENT')}
+        </WithLink>
+      </AttentionToastBar>
+      <ConfirmPayWithoutExtensionButton onConfirm={handleConfirmPay} />
+    </Space>
+  )
+}

--- a/apps/store/src/features/carDealership/carDealershipFixtures.ts
+++ b/apps/store/src/features/carDealership/carDealershipFixtures.ts
@@ -7,6 +7,7 @@ export type TrialExtension = {
   trialContract: typeof TRIAL_CONTRACT
   shopSession: CarTrialExtensionQuery['shopSession']
   priceIntent: CarTrialExtensionQuery['shopSession']['priceIntents'][number]
+  ssn: string
 }
 
 const TRIAL_CONTRACT = {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Break out a "PayForTrial" component from the "TrialExtensionForm"

- Add a reusable "ExtensionOfferToggle" based on jotai

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- These components don't have much to do with one another so it makes sense to break them out into their own components

- Using jotai to avoid prop drilling

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
