### PR TITLE
Raise Renovate rate limit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,5 +22,10 @@
     }
   ],
   "prCreation": "not-pending",
+  "prConcurrentLimit": 12,
+  // Default: 2, this is way too low for trying to go through daily PR flow in short window
+  // Effectively we may have only 1-2 renovate during daily window, so let's jam all valid PRs
+  // ASAP. Set a limit here if we observe long build queue that interferes with daily work
+  "prHourlyLimit": 0,
   "stabilityDays": 2
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Raise hourly limit on Renovate PR creation.  This seems to be a bottleneck in current setup.  See comment in config for more details

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
