### PR TITLE
GEN-1294 | Use translucent text inside `ProductItem`

### DIFF
--- a/apps/store/src/components/ProductItem/ProductDetails.tsx
+++ b/apps/store/src/components/ProductItem/ProductDetails.tsx
@@ -15,17 +15,17 @@ export const ProductDetails = ({ items, documents, ...props }: Props) => {
       <ul>
         {items.map(({ title, value }) => (
           <ListItem key={title}>
-            <Text as="p" color="textSecondary">
+            <Text as="p" color="textTranslucentSecondary">
               {title}
             </Text>
-            <Text as="p" color="textSecondary">
+            <Text as="p" color="textTranslucentSecondary">
               {value}
             </Text>
           </ListItem>
         ))}
       </ul>
 
-      <Heading as="h4" variant="standard.18">
+      <Heading as="h4" variant="standard.18" color="textTranslucentPrimary">
         {t('DOCUMENTS')}
       </Heading>
 
@@ -33,7 +33,7 @@ export const ProductDetails = ({ items, documents, ...props }: Props) => {
         {documents.map(({ title, url }) => (
           <li key={title}>
             <a href={url} target="_blank" rel="noopener noreferrer">
-              <DocumentLink color="textSecondary">
+              <DocumentLink color="textTranslucentSecondary">
                 {title}
                 <Sup> PDF</Sup>
               </DocumentLink>

--- a/apps/store/src/components/ProductItem/ProductItem.tsx
+++ b/apps/store/src/components/ProductItem/ProductItem.tsx
@@ -37,7 +37,7 @@ export const ProductItem = (props: Props) => {
             <Pillow size="small" src={props.pillowSrc} alt="" />
             <div>
               <HeaderRow>
-                <Text as="p" size="md">
+                <Text as="p" size="md" color="textTranslucentPrimary">
                   {props.title}
                 </Text>
                 {props.Icon}

--- a/packages/ui/src/components/Heading/Heading.tsx
+++ b/packages/ui/src/components/Heading/Heading.tsx
@@ -9,7 +9,15 @@ import { getHeadingVariantStyles, HeadingVariant } from './Heading.helpers'
 
 export type { PossibleHeadingVariant } from './Heading.helpers'
 
-type HeadingColors = Pick<UIColors, 'textPrimary' | 'textSecondary' | 'textNegative'>
+type HeadingColors = Pick<
+  UIColors,
+  | 'textPrimary'
+  | 'textSecondary'
+  | 'textNegative'
+  | 'textTranslucentPrimary'
+  | 'textTranslucentSecondary'
+  | 'textTranslucentTertiary'
+>
 
 export type HeadingProps = Margins & {
   as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

![Screenshot 2023-10-12 at 10.09.11.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/03b2ee00-291c-4b48-9fc7-e010836cc372/Screenshot%202023-10-12%20at%2010.09.11.png)

- See title (very subtle change but William could spot it on the screen)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Needs to work better on the colored (green) background

- Simpler to just use translucent text also for grey background

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
