### PR TITLE
GEN-1293 + GEN-1292 | Car dealership: add USP text under sign button

### DIFF
--- a/apps/store/public/locales/en/carDealership.json
+++ b/apps/store/public/locales/en/carDealership.json
@@ -4,7 +4,6 @@
   "EDIT_CAR_TRIAL_EXTENSION_BUTTON": "Edit",
   "EDIT_OFFER_CANCEL": "Cancel",
   "EDIT_OFFER_SAVE": "Save",
-  "INFO_TOAST_CONTENT": "No binding time. Cancel anytime in the [[Hedvig-app]].",
   "NOTICE_TOAST_CONTENT": "Don't want to take this offer? [[Cancel it here]].",
   "PAY_WITHOUT_EXTENSION_DIALOG_CANCEL": "Cancel",
   "PAY_WITHOUT_EXTENSION_DIALOG_CONFIRM": "Yes, go ahead",
@@ -19,5 +18,6 @@
   "TRIAL_HEADING": "Starter offer",
   "TRIAL_TERMINATION_DATE_MESSAGE": "Expires {{date}}",
   "TRIAL_TERMINATION_DATE_TOOLTIP": "You need to sign a new contract to continue your insurance.",
-  "TRIAL_TITLE": "Car insurance 60 days"
+  "TRIAL_TITLE": "Car insurance 60 days",
+  "USP_TEXT": "No binding time"
 }

--- a/apps/store/public/locales/sv-se/carDealership.json
+++ b/apps/store/public/locales/sv-se/carDealership.json
@@ -4,7 +4,6 @@
   "EDIT_CAR_TRIAL_EXTENSION_BUTTON": "Ändra",
   "EDIT_OFFER_CANCEL": "Avbryt",
   "EDIT_OFFER_SAVE": "Spara",
-  "INFO_TOAST_CONTENT": "Ingen bindningstid. Avsluta när du vill i [[Hedvig-appen]].",
   "NOTICE_TOAST_CONTENT": "Vill du inte ta del av starterbjudandet? [[Avsluta erbjudandet här]].",
   "PAY_WITHOUT_EXTENSION_DIALOG_CANCEL": "Avbryt",
   "PAY_WITHOUT_EXTENSION_DIALOG_CONFIRM": "Ja, fortsätt",
@@ -19,5 +18,6 @@
   "TRIAL_HEADING": "Starterbjudande",
   "TRIAL_TERMINATION_DATE_MESSAGE": "Löper ut {{date}}",
   "TRIAL_TERMINATION_DATE_TOOLTIP": "Du måste teckna ett nytt avtal för att förlänga din försäkring.",
-  "TRIAL_TITLE": "Bilförsäkring 60 dagar"
+  "TRIAL_TITLE": "Bilförsäkring 60 dagar",
+  "USP_TEXT": "Ingen bindningstid"
 }

--- a/apps/store/src/features/carDealership/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.tsx
@@ -1,13 +1,12 @@
 import { datadogRum } from '@datadog/browser-rum'
+import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { useState, useMemo } from 'react'
-import { Space, Button, Text, BankIdIcon } from 'ui'
+import { Space, Button, Text, BankIdIcon, CheckIcon, theme } from 'ui'
 import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
 import { TotalAmount } from '@/components/ShopBreakdown/TotalAmount'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { TextWithLink } from '@/components/TextWithLink'
-import { WithLink } from '@/components/TextWithLink'
-import { InfoToastBar } from '@/components/ToastBar/ToastBar'
 import { convertToDate } from '@/utils/date'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { PageLink } from '@/utils/PageLink'
@@ -96,38 +95,43 @@ export const TrialExtensionForm = (props: Props) => {
           })}
         />
 
-        <Space y={0.5}>
-          <InfoToastBar>
-            <WithLink href={PageLink.apiAppStoreRedirect()} target="_blank">
-              {t('INFO_TOAST_CONTENT')}
-            </WithLink>
-          </InfoToastBar>
+        <Space y={1}>
+          <Button onClick={handleClickSign} loading={loading}>
+            <SpaceFlex space={0.5} align="center">
+              <BankIdIcon />
+              {props.requirePaymentConnection ? t('SIGN_AND_PAY_BUTTON') : t('SIGN_BUTTON')}
+            </SpaceFlex>
+          </Button>
 
-          <Space y={1}>
-            <Button onClick={handleClickSign} loading={loading}>
-              <SpaceFlex space={0.5} align="center">
-                <BankIdIcon />
-                {props.requirePaymentConnection ? t('SIGN_AND_PAY_BUTTON') : t('SIGN_BUTTON')}
-              </SpaceFlex>
-            </Button>
+          <UspWrapper>
+            <CheckIcon size="1rem" />
+            <Text size="xs">{t('USP_TEXT')}</Text>
+          </UspWrapper>
 
-            <TextWithLink
-              as="p"
-              size={{ _: 'xs', md: 'sm' }}
-              align="center"
-              balance={true}
-              color="textSecondary"
-              href={PageLink.privacyPolicy({ locale: routingLocale })}
-              target="_blank"
-            >
-              {t('checkout:SIGN_DISCLAIMER')}
-            </TextWithLink>
-          </Space>
+          <TextWithLink
+            as="p"
+            size="xs"
+            align="center"
+            balance={true}
+            color="textSecondary"
+            href={PageLink.privacyPolicy({ locale: routingLocale })}
+            target="_blank"
+          >
+            {t('checkout:SIGN_DISCLAIMER')}
+          </TextWithLink>
         </Space>
       </Space>
     </Space>
   )
 }
+
+const UspWrapper = styled.div({
+  height: '2.5rem',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: theme.space.xs,
+})
 
 const getSelectedOffer = (
   priceIntent: TrialExtension['priceIntent'],


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes



![Screenshot 2023-10-12 at 11.57.20.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/39cacd29-e39b-495e-86eb-fca6132476fa/Screenshot%202023-10-12%20at%2011.57.20.png)



- Add USP text under sign button in trial extension form

- Remove unused info toast bar

- Make disclaimer text smaller

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Figma design updates

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
