### PR TITLE
Add tooltip with info about car ownership

### DIFF
--- a/apps/store/public/locales/en/purchase-form.json
+++ b/apps/store/public/locales/en/purchase-form.json
@@ -121,6 +121,7 @@
   "SECTION_TITLE_YOUR_DOG": "Your dog",
   "SECTION_TITLE_YOUR_FAMILY": "Number of people",
   "SECTION_TITLE_YOUR_HOME": "Your home",
+  "SECTION_TOOLTIP_YOUR_CAR": "You need to be the owner of the car to buy an insurance for it.",
   "SELF_SWICHER_MESSAGE": "Hedvig will be activated {{date}}. If your current insurance expires within a week, you need to cancel it yourself.",
   "SE_CAR_FULL_DESCRIPTION": "All in traffic and half, plus carriage damage",
   "SE_CAR_HALF_DESCRIPTION": "Theft & burglary, fire, glass damage, etc.",

--- a/apps/store/public/locales/sv-se/purchase-form.json
+++ b/apps/store/public/locales/sv-se/purchase-form.json
@@ -121,6 +121,7 @@
   "SECTION_TITLE_YOUR_DOG": "Din hund",
   "SECTION_TITLE_YOUR_FAMILY": "Antal personer",
   "SECTION_TITLE_YOUR_HOME": "Ditt hem",
+  "SECTION_TOOLTIP_YOUR_CAR": "Du behöver stå som ägare på bilen för att teckna en försäkring.",
   "SELF_SWICHER_MESSAGE": "Hedvig aktiveras {{date}}. Om din nuvarande försäkring går ut inom en vecka behöver du säga upp den själv.",
   "SE_CAR_FULL_DESCRIPTION": "Allt i trafik och halv, plus vagnskada",
   "SE_CAR_HALF_DESCRIPTION": "Stöld & inbrott, brand, glasskador, m.m.",

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorAccordion.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorAccordion.tsx
@@ -91,6 +91,7 @@ export const PriceCalculatorAccordion = ({
               active={section.id === activeSectionId}
               valid={section.state === 'valid'}
               title={translateLabel(section.title)}
+              tooltip={section.tooltip}
               value={section.id}
               previewFieldName={section.preview?.fieldName}
               previewLabel={section.preview?.label}

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorAccordionSection.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorAccordionSection.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { ReactNode, useMemo } from 'react'
-import { Heading, Text, theme } from 'ui'
+import { Heading, InfoIcon, Text, theme } from 'ui'
 import { Label, SectionItem } from '@/services/PriceCalculator/PriceCalculator.types'
 import { useAutoFormat } from '@/utils/useFormatter'
+import { Tooltip } from '../ProductItem/Tooltip'
 import * as Accordion from './Accordion'
 import { StepIcon } from './StepIcon'
 import { useTranslateFieldLabel } from './useTranslateFieldLabel'
@@ -13,6 +14,7 @@ type Props = {
   active: boolean
   valid: boolean
   title: string
+  tooltip?: Label
   value: string
   previewFieldName?: string
   previewLabel?: Label
@@ -64,6 +66,14 @@ export const PriceCalculatorAccordionSection = (props: Props) => {
               {props.title}
             </Heading>
           </GridTitle>
+
+          {props.tooltip && !showEditButton && (
+            <Tooltip message={translateLabel(props.tooltip)}>
+              <button>
+                <InfoIcon color={theme.colors.textSecondary} size="1.25rem" />
+              </button>
+            </Tooltip>
+          )}
 
           <GridEdit hidden={!showEditButton}>
             <Accordion.Trigger>

--- a/apps/store/src/services/PriceCalculator/PriceCalculator.types.ts
+++ b/apps/store/src/services/PriceCalculator/PriceCalculator.types.ts
@@ -33,6 +33,7 @@ export type TemplateSection = {
   id: string
   title: Label
   submitLabel: Label
+  tooltip?: Label
   items: Array<SectionItem>
   preview?: {
     fieldName: string

--- a/apps/store/src/services/PriceCalculator/data/SE_CAR.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_CAR.ts
@@ -18,6 +18,7 @@ export const SE_CAR: Template = {
       id: 'your-car',
       title: { key: tKey('SECTION_TITLE_YOUR_CAR') },
       submitLabel: { key: tKey('SUBMIT_LABEL_PROCEED') },
+      tooltip: { key: tKey('SECTION_TOOLTIP_YOUR_CAR') },
       items: [
         {
           field: carRegistrationNumberField,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add tooltip with info about car ownership in car purchase form

https://github.com/HedvigInsurance/racoon/assets/6661511/5f06132a-a15a-44bb-aa6b-af926216eb8e

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
We need to inform that you need to be the owner of the car to sign insurance
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
