### PR TITLE
GEN-1312 | Update to use `variant.displayNameSubtype`

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/ProductTierSelector.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ProductTierSelector.tsx
@@ -21,7 +21,9 @@ export const ProductTierSelector = ({ offers, selectedOffer, onValueChange }: Pr
     <TierSelector.Root defaultOpen={true}>
       <TierSelector.Header>
         <Text>{t('TIER_SELECTOR_SELECTED_LABEL', { ns: 'purchase-form' })}</Text>
-        <ToggleText>{selectedOffer.variant.displayName}</ToggleText>
+        <ToggleText>
+          {selectedOffer.variant.displayNameSubtype || selectedOffer.variant.displayName}
+        </ToggleText>
       </TierSelector.Header>
 
       <TierSelector.Content>
@@ -30,7 +32,7 @@ export const ProductTierSelector = ({ offers, selectedOffer, onValueChange }: Pr
             <TierLevelRadioGroup.Item
               key={offer.id}
               value={offer.id}
-              title={offer.variant.displayName}
+              title={offer.variant.displayNameSubtype || offer.variant.displayName}
               price={formatter.monthlyPrice(offer.cost.net)}
               description={getVariantDescription(offer.variant.typeOfContract)}
             />

--- a/apps/store/src/components/ProductVariantSelector/ProductVariantSelector.tsx
+++ b/apps/store/src/components/ProductVariantSelector/ProductVariantSelector.tsx
@@ -9,9 +9,9 @@ export const ProductVariantSelector = ({ className }: Props) => {
 
   const variantOptions = useMemo(
     () =>
-      productData.variants.map(({ displayName, typeOfContract }) => ({
-        name: displayName,
-        value: typeOfContract,
+      productData.variants.map((item) => ({
+        name: item.displayNameSubtype || item.displayName,
+        value: item.typeOfContract,
       })),
     [productData],
   )

--- a/apps/store/src/features/carDealership/CarTrialExtension.graphql
+++ b/apps/store/src/features/carDealership/CarTrialExtension.graphql
@@ -59,6 +59,7 @@ query CarTrialExtension($shopSessionId: UUID!) {
         variant {
           typeOfContract
           displayName
+          displayNameSubtype
           perils {
             ...Peril
           }

--- a/apps/store/src/graphql/ProductData.graphql
+++ b/apps/store/src/graphql/ProductData.graphql
@@ -14,6 +14,7 @@ query ProductData($productName: String!) {
     variants {
       typeOfContract
       displayName
+      displayNameSubtype
       perils {
         ...Peril
       }

--- a/apps/store/src/graphql/ProductOfferFragment.graphql
+++ b/apps/store/src/graphql/ProductOfferFragment.graphql
@@ -14,6 +14,7 @@ fragment ProductOffer on ProductOffer {
   variant {
     typeOfContract
     displayName
+    displayNameSubtype
     perils {
       ...Peril
     }

--- a/apps/store/src/mocks/productData.ts
+++ b/apps/store/src/mocks/productData.ts
@@ -20,6 +20,7 @@ export const productData: ProductData = {
       __typename: 'ProductVariant',
       typeOfContract: 'SE_APARTMENT_BRF',
       displayName: 'Home Insurance Homeowner',
+      displayNameSubtype: 'Homeowner',
       perils: [
         {
           __typename: 'Peril',


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Adopt new `ProductVariant.displayNameSubtype` field when available

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- The regular display name has changes and is too long for the UI

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
