### PR TITLE
GEN-1313 - fix(ProductItem): show product item association according to design

### DIFF
--- a/apps/store/public/locales/en/cart.json
+++ b/apps/store/public/locales/en/cart.json
@@ -51,6 +51,7 @@
   "EDIT_CONFIRMATION_MODAL_CANCEL": "Cancel",
   "EDIT_CONFIRMATION_MODAL_CONTINUE": "Continue",
   "EDIT_CONFIRMATION_MODAL_PROMPT": "You need to calculate a new price when you edit your information.",
+  "EXPOSURE_LABEL": "Valid for",
   "GO_TO_STORE_BUTTON": "Browse our insurances",
   "QUICK_ADD_BUTTON": "Add",
   "QUICK_ADD_DISMISS": "No, thanks",

--- a/apps/store/public/locales/sv-se/cart.json
+++ b/apps/store/public/locales/sv-se/cart.json
@@ -51,6 +51,7 @@
   "EDIT_CONFIRMATION_MODAL_CANCEL": "Avbryt",
   "EDIT_CONFIRMATION_MODAL_CONTINUE": "Fortsätt",
   "EDIT_CONFIRMATION_MODAL_PROMPT": "Du behöver göra en ny prisberäkning för att ändra dina uppgifter.",
+  "EXPOSURE_LABEL": "Giltlig för",
   "GO_TO_STORE_BUTTON": "Se våra försäkringar",
   "QUICK_ADD_BUTTON": "Lägg till",
   "QUICK_ADD_DISMISS": "Nej tack",

--- a/apps/store/src/components/ProductItem/ProductItem.stories.tsx
+++ b/apps/store/src/components/ProductItem/ProductItem.stories.tsx
@@ -73,10 +73,10 @@ export const ActiveContract: Story = {
   },
 }
 
-export const WithSubtitle: Story = {
+export const WithExposure: Story = {
   args: {
     ...Default.args,
-    subtitle: 'Hedvigsgatan 12 · 2 people',
+    exposure: 'Hedvigsgatan 12',
   },
 }
 

--- a/apps/store/src/components/ProductItem/ProductItem.tsx
+++ b/apps/store/src/components/ProductItem/ProductItem.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
-import { type ComponentProps, useState, forwardRef, type ReactNode } from 'react'
+import { useTranslation } from 'next-i18next'
+import React, { type ComponentProps, useState, forwardRef, type ReactNode } from 'react'
 import { Badge, Button, ButtonProps, Space, Text, mq, theme } from 'ui'
 import * as Collapsible from '@/components/Collapsible'
 import { Pillow } from '@/components/Pillow/Pillow'
@@ -17,12 +18,13 @@ type Props = {
   productDocuments: ComponentProps<typeof ProductDetails>['documents']
   defaultExpanded?: boolean
   children?: ReactNode
-  subtitle?: string
+  exposure?: string
   variant?: 'green'
   badge?: ComponentProps<typeof Badge>
 }
 
 export const ProductItem = (props: Props) => {
+  const { t } = useTranslation('cart')
   const [expanded, setExpanded] = useState(props.defaultExpanded ?? false)
 
   const handleClickHoverable = () => {
@@ -46,10 +48,11 @@ export const ProductItem = (props: Props) => {
             </div>
           </Header>
 
-          {props.subtitle && (
-            <Text as="p" size="md" color="textTranslucentSecondary">
-              {props.subtitle}
-            </Text>
+          {props.exposure && (
+            <Exposure>
+              <span>{t('EXPOSURE_LABEL')}</span>
+              <span>{props.exposure}</span>
+            </Exposure>
           )}
         </Space>
       </Hoverable>
@@ -124,9 +127,19 @@ const AlignedBadge = styled(Badge)({
   right: 0,
 })
 
+const Exposure = styled.div({
+  display: 'flex',
+  gap: theme.space.sm,
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  fontSize: theme.fontSizes.md,
+  color: theme.colors.textTranslucentSecondary,
+})
+
 const StyledProductDetailsHeader = styled(ProductDetailsHeader)({
   paddingBlock: theme.space.md,
 })
+
 const StyledProductDetails = styled(ProductDetails)({
   paddingBottom: theme.space.md,
 })

--- a/apps/store/src/components/ProductItem/ProductItemContainer.tsx
+++ b/apps/store/src/components/ProductItem/ProductItemContainer.tsx
@@ -31,7 +31,6 @@ export const ProductItemContainer = (props: Props) => {
   const price = getOfferPrice(props.offer.cost)
 
   const startDateProps = getStartDateProps({
-    exposure: props.offer.exposure.displayNameShort,
     data: props.offer.priceIntentData,
     startDate: props.offer.startDate,
   })
@@ -67,6 +66,7 @@ export const ProductItemContainer = (props: Props) => {
       productDocuments={productDocuments}
       defaultExpanded={props.defaultExpanded}
       variant={props.variant}
+      exposure={props.offer.exposure.displayNameShort}
     >
       {props.children}
     </ProductItem>

--- a/apps/store/src/components/ProductItem/useGetStartDateProps.ts
+++ b/apps/store/src/components/ProductItem/useGetStartDateProps.ts
@@ -4,7 +4,6 @@ import { useFormatter } from '@/utils/useFormatter'
 import { type ProductItem } from './ProductItem'
 
 type Params = {
-  exposure: string
   data: Record<string, unknown>
   startDate?: string
 }
@@ -19,15 +18,10 @@ export const useGetStartDateProps = (): GetStartDateProps => {
 
   return useCallback(
     (params) => {
-      const content = [
-        params.exposure,
-        params.startDate
+      return {
+        label: params.startDate
           ? t('CART_ENTRY_DATE_LABEL', { date: formatter.fromNow(new Date(params.startDate)) })
           : t('CART_ENTRY_AUTO_SWITCH'),
-      ]
-
-      return {
-        label: content.join(' • '),
         tooltip: params.startDate
           ? t('CART_ITEM_TOOLTIP_SELF_SWITCH')
           : t('CART_ITEM_TOOLTIP_AUTO_SWITCH'),

--- a/apps/store/src/features/carDealership/ProductItemContractContainer.tsx
+++ b/apps/store/src/features/carDealership/ProductItemContractContainer.tsx
@@ -47,6 +47,7 @@ export const ProductItemContractContainerCar = (props: Props) => {
       productDetails={productDetails}
       productDocuments={productDocuments}
       badge={{ children: t('CONTRACT_CARD_BADGE'), color: 'signalAmberHighlight' }}
+      exposure={FIXTURE_CONTRACT.exposure.displayNameShort}
     />
   )
 }
@@ -58,7 +59,7 @@ const FIXTURE_CONTRACT = {
   endDate: '2024-12-01',
 
   exposure: {
-    displayNameFull: 'ABC 123 · Volkswagen Polo',
+    displayNameShort: 'ABC 123',
   },
 
   displayItems: [


### PR DESCRIPTION
## Describe your changes

- Changes how product item association are displayed: close to details table.

<img width="598" alt="Screenshot 2023-10-16 at 14 20 36" src="https://github.com/HedvigInsurance/racoon/assets/19200662/3f27510f-cb20-4214-973b-c98e2e586c2e">

## Justify why they are needed

Being on the same line as start date was causing issues when there was no enough space to render all info without truncating text.

More info [here](https://hedviginsurance.slack.com/archives/C02JPS466NS/p1697445802184469)
