### PR TITLE
Improve layout for cost breakdown

### DIFF
--- a/apps/store/public/locales/en/memberArea.json
+++ b/apps/store/public/locales/en/memberArea.json
@@ -8,8 +8,10 @@
   "MENU_ITEM_LABEL_INSURANCE": "Your insurances",
   "MENU_ITEM_LABEL_PAYMENT": "Payment",
   "PAYMENTS_CONNECTION_TITLE": "Payment connection",
+  "PAYMENTS_DISCOUNT_LABEL": "Discount",
   "PAYMENTS_FREE_UNTIL": "Free until",
   "PAYMENTS_MONTLY_COST": "Monthly cost",
   "PAYMENTS_PAYMENT_CONNECTED": "Connected",
-  "PAYMENTS_PAYMENT_NOT_CONNECTED": "Not connected"
+  "PAYMENTS_PAYMENT_NOT_CONNECTED": "Not connected",
+  "PAYMENTS_TOTAL_LABEL": "Total"
 }

--- a/apps/store/public/locales/sv-se/memberArea.json
+++ b/apps/store/public/locales/sv-se/memberArea.json
@@ -8,8 +8,10 @@
   "MENU_ITEM_LABEL_INSURANCE": "Dina försäkringar",
   "MENU_ITEM_LABEL_PAYMENT": "Betalning",
   "PAYMENTS_CONNECTION_TITLE": "Kopplad betalning",
+  "PAYMENTS_DISCOUNT_LABEL": "Rabatt",
   "PAYMENTS_FREE_UNTIL": "Gratis till och med",
   "PAYMENTS_MONTLY_COST": "Månadskostnad",
   "PAYMENTS_PAYMENT_CONNECTED": "Betalning kopplad",
-  "PAYMENTS_PAYMENT_NOT_CONNECTED": "Ingen betalning kopplad"
+  "PAYMENTS_PAYMENT_NOT_CONNECTED": "Ingen betalning kopplad",
+  "PAYMENTS_TOTAL_LABEL": "Totalt"
 }

--- a/apps/store/src/features/memberArea/InsuranceSection/InsuranceCard.tsx
+++ b/apps/store/src/features/memberArea/InsuranceSection/InsuranceCard.tsx
@@ -80,7 +80,7 @@ const Info = styled.div({
   marginTop: 'auto',
 })
 
-const getPillowSrc = (typeOfContract: string) => {
+export const getPillowSrc = (typeOfContract: string) => {
   switch (typeOfContract) {
     case 'SE_HOUSE':
       return 'https://a.storyblok.com/f/165473/832x832/a50cf6d846/hedvig-pillows-house-villa.png'

--- a/apps/store/src/features/memberArea/PaymentsSection/InsuranceCost.tsx
+++ b/apps/store/src/features/memberArea/PaymentsSection/InsuranceCost.tsx
@@ -1,0 +1,66 @@
+import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
+import { Heading, Text, theme } from 'ui'
+import { Pillow } from '@/components/Pillow/Pillow'
+import { Price } from '@/components/Price'
+import { useFormatter } from '@/utils/useFormatter'
+import { getPillowSrc } from '../InsuranceSection/InsuranceCard'
+import { useMemberAreaInfo } from '../useMemberAreaInfo'
+
+export const InsuranceCost = () => {
+  const { insuranceCost, activeContracts } = useMemberAreaInfo()
+  const formatter = useFormatter()
+  const { t } = useTranslation('memberArea')
+  const reducedAmount =
+    insuranceCost.monthlyDiscount.amount > 0 ? insuranceCost.monthlyNet.amount : undefined
+
+  return (
+    <div style={{ width: '100%' }}>
+      <Heading as="h3" variant="standard.24">
+        {t('PAYMENTS_MONTLY_COST')}
+      </Heading>
+      {activeContracts.map((contract) => {
+        return (
+          <Row key={contract.id}>
+            <Pillow
+              size="small"
+              src={getPillowSrc(contract.currentAgreement.productVariant.typeOfContract)}
+            />
+            <Text>{contract.currentAgreement.productVariant.displayName}</Text>
+          </Row>
+        )
+      })}
+
+      {insuranceCost.monthlyDiscount.amount > 0 && (
+        <Row style={{ justifyContent: 'space-between' }}>
+          <Text>{t('PAYMENTS_DISCOUNT_LABEL')}</Text>
+          <Text>{formatter.monthlyPrice(insuranceCost.monthlyDiscount)}</Text>
+        </Row>
+      )}
+
+      <Row style={{ justifyContent: 'space-between' }}>
+        <Text>{t('PAYMENTS_TOTAL_LABEL')}</Text>
+        <div>
+          <Price
+            currencyCode={insuranceCost.monthlyGross.currencyCode}
+            amount={insuranceCost.monthlyGross.amount}
+            reducedAmount={reducedAmount}
+          />
+        </div>
+      </Row>
+
+      {insuranceCost.freeUntil && (
+        <Text>{`${t('PAYMENTS_FREE_UNTIL')} ${formatter.dateFull(insuranceCost.freeUntil)}`}</Text>
+      )}
+    </div>
+  )
+}
+
+const Row = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.space.md,
+  width: '100%',
+  paddingBlock: theme.space.md,
+  borderBottom: `1px solid ${theme.colors.gray200}`,
+})

--- a/apps/store/src/features/memberArea/PaymentsSection/PaymentsSection.tsx
+++ b/apps/store/src/features/memberArea/PaymentsSection/PaymentsSection.tsx
@@ -1,4 +1,5 @@
 import { useApolloClient } from '@apollo/client'
+import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { useCallback, useState } from 'react'
 import { Button, Heading, Text } from 'ui'
@@ -10,56 +11,31 @@ import { useMemberAreaInfo } from '@/features/memberArea/useMemberAreaInfo'
 import { useMemberAreaMemberInfoQuery } from '@/services/apollo/generated'
 import { createTrustlyUrl } from '@/services/trustly/createTrustlyUrl'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
-import { useFormatter } from '@/utils/useFormatter'
+import { InsuranceCost } from './InsuranceCost'
 
 export const PaymentsSection = () => {
   return (
-    <SpaceFlex direction="vertical">
-      <GeneralInfo />
+    <Wrapper direction="vertical">
       <InsuranceCost />
       <PaymentConnection />
       {/* NOTE that URL is locale-specific */}
       <ButtonNextLink href={'/se-en/help/faq'} locale={false} size="small" variant="secondary">
         Payments FAQ
       </ButtonNextLink>
-    </SpaceFlex>
+      <GeneralInfo />
+    </Wrapper>
   )
 }
 
 // Might be a CMS block in the future
 const GeneralInfo = () => {
   return (
-    <div style={{ maxWidth: '450px' }}>
-      <InfoCard>
-        At Hedvig, you pay at the end of the month for the current month. Your monthly payment is
-        handled via digital direct debit on the 27th of every month (or the closest following bank
-        day). We work with Trustly as our payment partner and you can connect your direct debit on
-        this page below
-      </InfoCard>
-    </div>
-  )
-}
-
-const InsuranceCost = () => {
-  const { insuranceCost } = useMemberAreaInfo()
-  const formatter = useFormatter()
-  const { t } = useTranslation('memberArea')
-
-  return (
-    <>
-      <Heading as="h3" variant="standard.24">
-        {t('PAYMENTS_MONTLY_COST')}
-      </Heading>
-      {insuranceCost.monthlyDiscount.amount > 0 && (
-        <Text color="textSecondary" strikethrough={true}>
-          {formatter.monthlyPrice(insuranceCost.monthlyGross)}
-        </Text>
-      )}
-      <Text>{formatter.monthlyPrice(insuranceCost.monthlyNet)}</Text>
-      {insuranceCost.freeUntil && (
-        <Text>{`${t('PAYMENTS_FREE_UNTIL')} ${formatter.dateFull(insuranceCost.freeUntil)}`}</Text>
-      )}
-    </>
+    <InfoCard>
+      At Hedvig, you pay at the end of the month for the current month. Your monthly payment is
+      handled via digital direct debit on the 27th of every month (or the closest following bank
+      day). We work with Trustly as our payment partner and you can connect your direct debit on
+      this page below
+    </InfoCard>
   )
 }
 
@@ -138,3 +114,8 @@ const PaymentConfiguration = ({ startButtonText }: { startButtonText: string }) 
     </>
   )
 }
+
+const Wrapper = styled(SpaceFlex)({
+  width: '100%',
+  maxWidth: '29rem',
+})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Improve payments section
- List insurances
- Refactor cost breakdown (discounts and totalt)

I noticed that I wouldn't get any discounts on `CurrentMember` though (the image is a hardcoded example). I signed up with a valid staging discount code (percentage for 12 months) but `insuranceCost` just gets the full price i.e. discount is 0, net and gross the same amount. 

<img width="839" alt="Screenshot 2023-10-16 at 15 59 50" src="https://github.com/HedvigInsurance/racoon/assets/6661511/5997099f-fcf0-4e28-af4e-29aa41ae0463">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Improve visibility on what the member pays for

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
