### PR TITLE
fix(vscode-workspace): make import/order eslint plugin work properly

### DIFF
--- a/.vscode/racoon.code-workspace
+++ b/.vscode/racoon.code-workspace
@@ -24,7 +24,7 @@
   "settings": {
     "jest.disabledWorkspaceFolders": ["✨ ROOT", "📦 eslint-config-custom", "📦 tsconfig"],
     "jest.jestCommandLine": "yarn test",
-    "eslint.nodePath": ".yarn/sdks",
+    "eslint.nodePath": "../../.yarn/sdks",
     "prettier.prettierPath": "../../.yarn/sdks/prettier/index.js",
     "typescript.tsdk": ".yarn/sdks/typescript/lib",
     "typescript.enablePromptUseWorkspaceTsdk": true,


### PR DESCRIPTION
## Describe your changes

- Make "import/order" plugin work for vscode workspace.

## Justify why they are needed

Sorting import statements wasn't working for me in workspace mode. Turns out it couldn't find eslint.
