### PR TITLE
Payment Config: open Trustly in Dialog

### DIFF
--- a/apps/store/src/components/CheckoutPaymentTrustlyPage/CheckoutPaymentTrustlyPage.tsx
+++ b/apps/store/src/components/CheckoutPaymentTrustlyPage/CheckoutPaymentTrustlyPage.tsx
@@ -65,7 +65,7 @@ export const CheckoutPaymentTrustlyPage = (props: Props) => {
                 {t('PAYMENT_TRUSTLY_MESSAGE')}
               </Heading>
               <Space y={0.75}>
-                <TrustlyIframe
+                <InlineTrustlyIframe
                   url={props.trustlyUrl}
                   onSuccess={handleSuccess}
                   onFail={handleFail}
@@ -93,3 +93,5 @@ const TextLink = styled(Link)({
     boxShadow: theme.shadow.focus,
   },
 })
+
+const InlineTrustlyIframe = styled(TrustlyIframe)({ height: '60vh' })

--- a/apps/store/src/components/PaymentConnectPage/IdleState.tsx
+++ b/apps/store/src/components/PaymentConnectPage/IdleState.tsx
@@ -72,12 +72,13 @@ export const IdleState = (props: Props) => {
   )
 }
 
-const IframePlaceholder = styled.div(trustlyIframeStyles, {
+export const IframePlaceholder = styled.div(trustlyIframeStyles, {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'stretch',
   backgroundColor: theme.colors.white,
   paddingInline: theme.space.xl,
+  height: '60vh',
 })
 
 const WideSpace = styled(Space)({ width: '100%' })

--- a/apps/store/src/components/PaymentConnectPage/ReadyState.tsx
+++ b/apps/store/src/components/PaymentConnectPage/ReadyState.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { Space, Text } from 'ui'
 import { TrustlyIframe } from '@/services/trustly/TrustlyIframe'
@@ -13,10 +14,16 @@ export const ReadyState = (props: Props) => {
 
   return (
     <Space y={0.75}>
-      <TrustlyIframe url={props.trustlyUrl} onSuccess={props.onSuccess} onFail={props.onFail} />
+      <InlineTrustlyIframe
+        url={props.trustlyUrl}
+        onSuccess={props.onSuccess}
+        onFail={props.onFail}
+      />
       <Text size="xs" align="center">
         {t('PAYMENT_TRUSTLY_FOOTNOTE')}
       </Text>
     </Space>
   )
 }
+
+const InlineTrustlyIframe = styled(TrustlyIframe)({ height: '60vh' })

--- a/apps/store/src/components/PaymentConnectPage/SuccessState.tsx
+++ b/apps/store/src/components/PaymentConnectPage/SuccessState.tsx
@@ -1,7 +1,6 @@
-import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { CheckIcon, Text, theme } from 'ui'
-import { trustlyIframeStyles } from '@/services/trustly/TrustlyIframe'
+import { IframePlaceholder } from './IdleState'
 import { Layout } from './Layout'
 
 export const SuccessState = () => {
@@ -16,11 +15,3 @@ export const SuccessState = () => {
     </Layout>
   )
 }
-
-const IframePlaceholder = styled.div(trustlyIframeStyles, {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flexDirection: 'column',
-  gap: theme.space.xs,
-})

--- a/apps/store/src/features/memberArea/PaymentsSection/PaymentConnection.tsx
+++ b/apps/store/src/features/memberArea/PaymentsSection/PaymentConnection.tsx
@@ -1,0 +1,80 @@
+import { datadogRum } from '@datadog/browser-rum'
+import styled from '@emotion/styled'
+import { useState } from 'react'
+import { Button, Dialog, theme } from 'ui'
+import { useMemberAreaMemberInfoQuery, useTrustlyInitMutation } from '@/services/apollo/generated'
+import { useAppErrorHandleContext } from '@/services/appErrors/AppErrorContext'
+import { getTrustlyInitMutationVariables } from '@/services/trustly/createTrustlyUrl'
+import {
+  TRUSTLY_IFRAME_MAX_HEIGHT,
+  TRUSTLY_IFRAME_MAX_WIDTH,
+  TrustlyIframe,
+} from '@/services/trustly/TrustlyIframe'
+import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+
+type State = { type: 'IDLE' } | { type: 'READY'; trustlyUrl: string }
+
+export const PaymentConnection = ({ startButtonText }: { startButtonText: string }) => {
+  const { showError } = useAppErrorHandleContext()
+  const { routingLocale } = useCurrentLocale()
+  const [createTrustlyUrl, result] = useTrustlyInitMutation({
+    onError: showError,
+    onCompleted(data) {
+      const trustlyUrl = data.registerDirectDebit2.url
+      setState({ type: 'READY', trustlyUrl })
+    },
+  })
+  const [state, setState] = useState<State>({ type: 'IDLE' })
+
+  const handleClickStart = () => {
+    datadogRum.addAction('Payment Config Start')
+    createTrustlyUrl({ variables: getTrustlyInitMutationVariables(routingLocale) })
+  }
+
+  const handleClose = () => {
+    datadogRum.addAction('Payment Config Close')
+    setState({ type: 'IDLE' })
+  }
+
+  const { refetch } = useMemberAreaMemberInfoQuery()
+  const handleSuccess = async () => {
+    datadogRum.addAction('Payment Config Success')
+    await refetch()
+    setState({ type: 'IDLE' })
+  }
+
+  const handleFail = () => setState({ type: 'IDLE' })
+
+  return (
+    <>
+      <Button loading={result.loading} onClick={handleClickStart}>
+        {startButtonText}
+      </Button>
+
+      <Dialog.Root open={state.type === 'READY'} onOpenChange={handleClose}>
+        <DialogIframeContent centerContent={true} onClose={handleClose}>
+          <DialogIframeWindow>
+            {state.type === 'READY' && (
+              <TrustlyIframe url={state.trustlyUrl} onSuccess={handleSuccess} onFail={handleFail} />
+            )}
+          </DialogIframeWindow>
+        </DialogIframeContent>
+      </Dialog.Root>
+    </>
+  )
+}
+
+const DialogIframeContent = styled(Dialog.Content)({
+  height: '100%',
+  maxHeight: TRUSTLY_IFRAME_MAX_HEIGHT,
+  width: '100%',
+  maxWidth: TRUSTLY_IFRAME_MAX_WIDTH,
+  padding: theme.space.xs,
+  alignSelf: 'center',
+})
+
+const DialogIframeWindow = styled(Dialog.Window)({
+  height: '100%',
+  borderRadius: theme.radius.sm,
+  overflowY: 'auto',
+})

--- a/apps/store/src/services/trustly/TrustlyIframe.tsx
+++ b/apps/store/src/services/trustly/TrustlyIframe.tsx
@@ -9,9 +9,10 @@ type Props = {
   url: string
   onSuccess: () => void
   onFail: () => void
+  className?: string
 }
 
-export const TrustlyIframe = ({ url, onSuccess, onFail }: Props) => {
+export const TrustlyIframe = ({ url, onSuccess, onFail, className }: Props) => {
   const { routingLocale } = useCurrentLocale()
 
   useEffect(() => {
@@ -46,16 +47,20 @@ export const TrustlyIframe = ({ url, onSuccess, onFail }: Props) => {
     setLoading(false)
   }
 
-  return <Iframe src={url} onLoad={handleLoad} data-loading={loading} />
+  return <Iframe src={url} onLoad={handleLoad} className={className} data-loading={loading} />
 }
+
+export const TRUSTLY_IFRAME_MAX_WIDTH = 600
+const TRUSTLY_IFRAME_MIN_HEIGHT = 500
+export const TRUSTLY_IFRAME_MAX_HEIGHT = 800
 
 export const trustlyIframeStyles = css({
   width: '100%',
-  maxWidth: 600,
+  maxWidth: TRUSTLY_IFRAME_MAX_WIDTH,
 
-  minHeight: 500,
-  height: '60vh',
-  maxHeight: 800,
+  minHeight: TRUSTLY_IFRAME_MIN_HEIGHT,
+  height: '100%',
+  maxHeight: TRUSTLY_IFRAME_MAX_HEIGHT,
 
   boxShadow: theme.shadow.default,
   marginInline: 'auto',

--- a/apps/store/src/services/trustly/createTrustlyUrl.ts
+++ b/apps/store/src/services/trustly/createTrustlyUrl.ts
@@ -7,6 +7,15 @@ import {
 import { RoutingLocale } from '@/utils/l10n/types'
 import { PageLink } from '@/utils/PageLink'
 
+export const getTrustlyInitMutationVariables = (
+  locale: RoutingLocale,
+): TrustlyInitMutationVariables => {
+  return {
+    successUrl: PageLink.paymentSuccess({ locale }).href,
+    failureUrl: PageLink.paymentFailure({ locale }).href,
+  }
+}
+
 type Params = {
   apolloClient: ApolloClient<unknown>
   locale: RoutingLocale
@@ -15,10 +24,7 @@ type Params = {
 export const createTrustlyUrl = async ({ apolloClient, locale }: Params): Promise<string> => {
   const response = await apolloClient.mutate<TrustlyInitMutation, TrustlyInitMutationVariables>({
     mutation: TrustlyInitDocument,
-    variables: {
-      successUrl: PageLink.paymentSuccess({ locale }).href,
-      failureUrl: PageLink.paymentFailure({ locale }).href,
-    },
+    variables: getTrustlyInitMutationVariables(locale),
   })
 
   if (!response.data) {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-10-17 at 11.44.29.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/1cecf58f-703b-4f06-ae45-f3076572d8d7/Screenshot%202023-10-17%20at%2011.44.29.png)



- Open Trustly iFrame in a dialog instead of inline

- Refactor to be able to center the iFrame-Dialog on the screen

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Match how we handle payment connection in the mobile app

- Improve error handling and user experience

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
