### PR TITLE
GEN-1301 - chore: added a custom 'contact us' button until we wait for c1

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-collapsible": "1.0.3",
     "@radix-ui/react-dialog": "1.0.5",
     "@radix-ui/react-navigation-menu": "1.1.4",
+    "@radix-ui/react-popover": "1.0.7",
     "@radix-ui/react-radio-group": "1.1.3",
     "@radix-ui/react-select": "2.0.0",
     "@radix-ui/react-switch": "1.0.3",

--- a/apps/store/public/locales/en/contact-us.json
+++ b/apps/store/public/locales/en/contact-us.json
@@ -1,0 +1,11 @@
+{
+  "ALREADY_MEMBER_SUB_HEADING": "Already a member? Get help fast in the Hedvig app.",
+  "CHAT_HEADING": "How can we help you?",
+  "CHAT_OPTION_LABEL": "Web chat",
+  "CHAT_UNAVAILABLE_LABEL": "No agents available",
+  "CONTACT_US_BUTTON_LABEL": "Contact us",
+  "FAQ_OPTION_LABEL": "FAQ",
+  "FAQ_OPTION_VALUE": "Open in new tab",
+  "TELEPHONE_OPTION_LABEL": "Phone",
+  "TELEPHONE_OPTION_VALUE": "010 45 99 200"
+}

--- a/apps/store/public/locales/sv-se/contact-us.json
+++ b/apps/store/public/locales/sv-se/contact-us.json
@@ -1,0 +1,11 @@
+{
+  "ALREADY_MEMBER_SUB_HEADING": "Är du redan medlem? Få snabbast hjälp i Hedvig-appen",
+  "CHAT_HEADING": "Hur kan vi hjälpa dig?",
+  "CHAT_OPTION_LABEL": "Webchatt",
+  "CHAT_UNAVAILABLE_LABEL": "Chatten är stängd",
+  "CONTACT_US_BUTTON_LABEL": "Kontakta oss",
+  "FAQ_OPTION_LABEL": "Frågor och svar",
+  "FAQ_OPTION_VALUE": "Öppna i ny flik",
+  "TELEPHONE_OPTION_LABEL": "Telefonnummer",
+  "TELEPHONE_OPTION_VALUE": "010 45 99 200"
+}

--- a/apps/store/src/@types/i18next.d.ts
+++ b/apps/store/src/@types/i18next.d.ts
@@ -12,6 +12,7 @@ import type carDealership from '../../public/locales/en/carDealership.json'
 import type cart from '../../public/locales/en/cart.json'
 import type checkout from '../../public/locales/en/checkout.json'
 import type common from '../../public/locales/en/common.json'
+import type contactUs from '../../public/locales/en/contact-us.json'
 import type memberArea from '../../public/locales/en/memberArea.json'
 import type purchaseForm from '../../public/locales/en/purchase-form.json'
 
@@ -24,6 +25,7 @@ interface I18nNamespaces {
   'purchase-form': typeof purchaseForm
   carDealership: typeof carDealership
   memberArea: typeof memberArea
+  'contact-us': typeof contactUs
 }
 
 declare module 'i18next' {

--- a/apps/store/src/components/ContactUs/ContactUs.tsx
+++ b/apps/store/src/components/ContactUs/ContactUs.tsx
@@ -1,0 +1,128 @@
+import { keyframes } from '@emotion/react'
+import styled from '@emotion/styled'
+import * as Popover from '@radix-ui/react-popover'
+import { useState, useEffect } from 'react'
+import { MinusIcon, CrossIcon, theme } from 'ui'
+import * as FullScreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
+import { useBreakpoint } from '@/utils/useBreakpoint/useBreakpoint'
+import { ContactUsButton } from './ContactUsButton'
+import { Content } from './Content'
+import { Header } from './Header'
+
+const scaleIn = keyframes({
+  from: {
+    opacity: 0,
+    transform: 'scale(0)',
+  },
+  to: {
+    opacity: 1,
+    transform: 'scale(1)',
+  },
+})
+
+const scaleOut = keyframes({
+  from: {
+    opacity: 1,
+    transform: 'scale(1)',
+  },
+  to: {
+    opacity: 0,
+    transform: 'scale(0)',
+  },
+})
+
+export const ContactUs = () => {
+  const hasMounted = useHasMounted()
+  const isDesktop = useBreakpoint('xs')
+  const [open, setOpen] = useState(false)
+
+  // There's no way to determine how this component should look on the server
+  if (!hasMounted) return null
+
+  const handleClickPhoneLink = () => {
+    setOpen(false)
+  }
+
+  if (isDesktop) {
+    return (
+      <Popover.Root open={open} onOpenChange={setOpen}>
+        <Popover.Trigger asChild={true}>
+          <ContactUsButton />
+        </Popover.Trigger>
+
+        <Popover.Portal>
+          <Popover.Content side="bottom" align="end" sideOffset={8} asChild={true}>
+            <ChatWindow>
+              <Header
+                CloseBtn={
+                  <Popover.Close asChild={true}>
+                    <CloseButton>
+                      <MinusIcon size="18px" />
+                    </CloseButton>
+                  </Popover.Close>
+                }
+              />
+
+              <Content onClickPhoneLink={handleClickPhoneLink} />
+            </ChatWindow>
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
+    )
+  }
+  return (
+    <FullScreenDialog.Root open={open} onOpenChange={setOpen}>
+      <FullScreenDialog.Trigger asChild={true}>
+        <ContactUsButton />
+      </FullScreenDialog.Trigger>
+
+      <FullScreenDialog.Modal
+        Header={
+          <Header
+            CloseBtn={
+              <FullScreenDialog.Close asChild={true}>
+                <CloseButton>
+                  <CrossIcon size="24px" />
+                </CloseButton>
+              </FullScreenDialog.Close>
+            }
+          />
+        }
+      >
+        <Content onClickPhoneLink={handleClickPhoneLink} />
+      </FullScreenDialog.Modal>
+    </FullScreenDialog.Root>
+  )
+}
+
+const useHasMounted = () => {
+  const [hasMounted, setHasMounted] = useState(false)
+
+  useEffect(() => {
+    setHasMounted(true)
+  }, [])
+
+  return hasMounted
+}
+
+const ChatWindow = styled.div({
+  display: 'grid',
+  gridTemplateRows: '55px 1fr',
+  height: 500,
+  aspectRatio: '4 / 5',
+  backgroundColor: theme.colors.offWhite,
+  borderRadius: theme.radius.md,
+  transformOrigin: 'var(--radix-popover-content-transform-origin)',
+  filter: 'drop-shadow(0px 1px 1px hsl(0deg 0% 0% / 0.15))',
+
+  '&[data-state=open]': {
+    animation: `${scaleIn} 250ms ${theme.transitions.css.easeInCubic}`,
+  },
+  '&[data-state=closed]': {
+    animation: `${scaleOut} 250ms ${theme.transitions.css.easeOutCubic}`,
+  },
+})
+
+const CloseButton = styled.button({
+  cursor: 'pointer',
+})

--- a/apps/store/src/components/ContactUs/ContactUsButton.tsx
+++ b/apps/store/src/components/ContactUs/ContactUsButton.tsx
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
+import { forwardRef } from 'react'
+import { theme } from 'ui'
+import { zIndexes } from '@/utils/zIndex'
+
+export const ContactUsButton = forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<'button'>
+>((props, ref) => {
+  const { t } = useTranslation('contact-us')
+
+  return (
+    <FixedButton ref={ref} {...props}>
+      <Status />
+      {t('CONTACT_US_BUTTON_LABEL')}
+    </FixedButton>
+  )
+})
+ContactUsButton.displayName = 'ContactUsButton'
+
+const FixedButton = styled.button({
+  position: 'fixed',
+  right: theme.space.lg,
+  bottom: theme.space.lg,
+  display: 'inline-flex',
+  alignItems: 'baseline',
+  gap: theme.space.sm,
+  borderRadius: theme.radius.md,
+  padding: theme.space.md,
+  paddingBlock: theme.space.xs,
+  backgroundColor: theme.colors.opaque1,
+  fontSize: theme.fontSizes.md,
+  zIndex: zIndexes.contactUs,
+  cursor: 'pointer',
+  filter: 'drop-shadow(0px 1px 1px hsl(0deg 0% 0% / 0.15))',
+
+  '@media (hover: hover)': {
+    ':hover': {
+      backgroundColor: theme.colors.opaque2,
+    },
+  },
+})
+
+const Status = styled.span({
+  flex: '0 0 auto',
+  display: 'inline-block',
+  width: 14,
+  aspectRatio: '1 / 1',
+  borderRadius: '50%',
+  backgroundColor: theme.colors.green600,
+})

--- a/apps/store/src/components/ContactUs/Content.tsx
+++ b/apps/store/src/components/ContactUs/Content.tsx
@@ -1,0 +1,142 @@
+import { datadogRum } from '@datadog/browser-rum'
+import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
+import Link from 'next/link'
+import { Text, Space, Button, Heading, AppleIcon, AndroidIcon, theme } from 'ui'
+import { getAppStoreLink } from '@/utils/appStoreLinks'
+import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { PageLink } from '@/utils/PageLink'
+
+type Props = {
+  onClickPhoneLink?: () => void
+}
+
+export const Content = (props: Props) => {
+  const { t } = useTranslation('contact-us')
+  const { routingLocale } = useCurrentLocale()
+
+  const handleClickPhoneLink = () => {
+    datadogRum.addAction('Contact us | phone')
+    props.onClickPhoneLink?.()
+  }
+
+  const handleClickFaqLink = () => {
+    datadogRum.addAction('Contact us | faq')
+  }
+
+  const handleClickIosButton = () => {
+    datadogRum.addAction('Contact us | IOS App')
+  }
+
+  const handleClickAndroidButton = () => {
+    datadogRum.addAction('Contact us | Android App')
+  }
+
+  return (
+    <Wrapper y={2}>
+      <Text as="p" align="center" balance={true}>
+        {t('ALREADY_MEMBER_SUB_HEADING')}
+      </Text>
+
+      <AppButtons>
+        <StyledButton
+          href={getAppStoreLink('apple', routingLocale).toString()}
+          target="_blank"
+          variant="secondary"
+          size="small"
+          onClick={handleClickIosButton}
+        >
+          <AppleIcon size="18px" /> App Store
+        </StyledButton>
+
+        <StyledButton
+          href={getAppStoreLink('google', routingLocale).toString()}
+          target="_blank"
+          variant="secondary"
+          size="small"
+          onClick={handleClickAndroidButton}
+        >
+          <AndroidIcon size="18px" /> Google Play
+        </StyledButton>
+      </AppButtons>
+
+      <Paper>
+        <Space y={1}>
+          <Heading as="h1" variant="standard.18" align="center">
+            {t('CHAT_HEADING')}
+          </Heading>
+
+          <Space y={0.5}>
+            <LinkButton
+              href={PageLink.faq({ locale: routingLocale }).pathname}
+              target="_blank"
+              onClick={handleClickFaqLink}
+            >
+              <span>{t('FAQ_OPTION_LABEL')}</span>
+              <span>{t('FAQ_OPTION_VALUE')}</span>
+            </LinkButton>
+
+            <LinkButton href="#" aria-disabled="true">
+              <span>{t('CHAT_OPTION_LABEL')}</span>
+              <span>{t('CHAT_UNAVAILABLE_LABEL')}</span>
+            </LinkButton>
+
+            <LinkButton
+              href={PageLink.help({ locale: routingLocale }).pathname}
+              onClick={handleClickPhoneLink}
+            >
+              <span>{t('TELEPHONE_OPTION_LABEL')}</span>
+              <span>{t('TELEPHONE_OPTION_VALUE')}</span>
+            </LinkButton>
+          </Space>
+        </Space>
+      </Paper>
+    </Wrapper>
+  )
+}
+
+const Paper = styled.div({
+  padding: theme.space.md,
+  borderRadius: theme.radius.xs,
+  boxShadow: theme.shadow.default,
+  backgroundColor: theme.colors.offWhite,
+})
+
+const Wrapper = styled(Space)({
+  padding: theme.space.md,
+  overflowY: 'auto',
+})
+
+const LinkButton = styled(Link)({
+  display: 'flex',
+  justifyContent: 'space-between',
+  gap: theme.space.sm,
+  fontSize: theme.fontSizes.sm,
+  border: `1px solid ${theme.colors.gray200}`,
+  borderRadius: theme.radius.sm,
+  paddingBlock: theme.space.md,
+  paddingInline: theme.space.md,
+
+  '&[aria-disabled=true]': {
+    pointerEvents: 'none',
+    color: theme.colors.textDisabled,
+  },
+
+  '@media(hover: hover)': {
+    '&:not([aria-disabled=true]):hover': {
+      cursor: 'pointer',
+      backgroundColor: theme.colors.gray200,
+    },
+  },
+})
+
+const AppButtons = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: theme.space.md,
+})
+
+const StyledButton = styled(Button)({
+  gap: theme.space.xs,
+})

--- a/apps/store/src/components/ContactUs/Header.tsx
+++ b/apps/store/src/components/ContactUs/Header.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled'
+import { Text, HedvigSymbol, theme } from 'ui'
+
+type HeaderProps = {
+  CloseBtn: React.ReactElement
+}
+
+export const Header = ({ CloseBtn }: HeaderProps) => {
+  return (
+    <StyledHeader>
+      <HedvigSymbol size="24px" />
+      <Text as="span">Hedvig</Text>
+      {CloseBtn}
+    </StyledHeader>
+  )
+}
+
+const StyledHeader = styled.header({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: theme.space.xs,
+  color: theme.colors.white,
+  backgroundColor: theme.colors.black,
+  paddingBlock: theme.space.sm,
+  paddingInline: theme.space.md,
+  borderTopLeftRadius: 'inherit',
+  borderTopRightRadius: 'inherit',
+})

--- a/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
+++ b/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
@@ -1,22 +1,27 @@
 import styled from '@emotion/styled'
 import { motion, type Transition } from 'framer-motion'
-import { type ReactNode } from 'react'
+import React, { ReactElement, type ReactNode } from 'react'
 import { CrossIcon, Dialog, mq, theme } from 'ui'
 
 type Props = {
-  children: React.ReactNode
-  Footer?: React.ReactNode
+  children: ReactNode
+  Header?: ReactElement
+  Footer?: ReactNode
   center?: boolean
 }
 
-export const Modal = ({ children, Footer, center = false }: Props) => {
+export const Modal = ({ children, Header, Footer, center = false }: Props) => {
   return (
     <Content frostedOverlay={true}>
-      <Header>
-        <CloseButton>
-          <CrossIcon />
-        </CloseButton>
-      </Header>
+      {Header ? (
+        React.cloneElement(Header, { style: { height: HEADER_HEIGHT } })
+      ) : (
+        <ModalHeader>
+          <CloseButton>
+            <CrossIcon />
+          </CloseButton>
+        </ModalHeader>
+      )}
       {center ? (
         <CenteredMain>
           <AnimateContentWrapper>{children}</AnimateContentWrapper>
@@ -48,7 +53,7 @@ const Content = styled(Dialog.Content)({
 })
 
 const HEADER_HEIGHT = '3.5rem'
-const Header = styled.header({
+const ModalHeader = styled.header({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'flex-end',

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -10,11 +10,11 @@ import { Provider as BalancerProvider } from 'react-wrap-balancer'
 import { globalStyles, theme } from 'ui'
 import { AppErrorDialog } from '@/components/AppErrorDialog'
 import { BankIdDialog } from '@/components/BankIdDialog'
+import { ContactUs } from '@/components/ContactUs/ContactUs'
 import { GlobalLinkStyles } from '@/components/RichText/RichText.styles'
 import { useApollo } from '@/services/apollo/client'
 import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
 import { BankIdContextProvider } from '@/services/bankId/BankIdContext'
-import { CustomerFirstScript } from '@/services/CustomerFirst'
 import { GTMAppScript } from '@/services/gtm'
 import { initDatadog } from '@/services/logger/client'
 import { PageTransitionProgressBar } from '@/services/nprogress/pageTransition'
@@ -107,7 +107,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
               </BankIdContextProvider>
             </TrackingProvider>
           </ShopSessionProvider>
-          <CustomerFirstScript hideChat={pageProps.hideChat} />
+          <ContactUs />
         </JotaiProvider>
       </ApolloProvider>
     </>

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -87,6 +87,14 @@ export const PageLink = {
     }
     return url
   },
+  help: ({ locale }: { locale: RoutingLocale }) => {
+    const url = HELP_URL[locale]
+    if (!url) {
+      datadogLogs.logger.error('Missing help page link for locale', { locale })
+      return PageLink.home({ locale })
+    }
+    return url
+  },
 
   memberArea: ({ locale }: BaseParams = {}) => {
     return new URL(`${localePrefix(locale)}/member`, ORIGIN_URL)
@@ -233,6 +241,11 @@ const CUSTOMER_SERVICE_URL: Partial<Record<RoutingLocale, URL>> = {
 const FAQ_URL: Partial<Record<RoutingLocale, URL>> = {
   se: new URL('/se/hjalp/faq', ORIGIN_URL),
   'se-en': new URL('/se-en/help/faq', ORIGIN_URL),
+}
+
+const HELP_URL: Partial<Record<RoutingLocale, URL>> = {
+  se: new URL('/se/hjalp', ORIGIN_URL),
+  'se-en': new URL('/se-en/help', ORIGIN_URL),
 }
 
 const DEDUCTIBLE_HELP_URL: Partial<Record<RoutingLocale, URL>> = {

--- a/apps/store/src/utils/zIndex.tsx
+++ b/apps/store/src/utils/zIndex.tsx
@@ -1,4 +1,4 @@
-const zIndexOrder = ['body', 'tabs', 'scrollPast', 'header'] as const
+const zIndexOrder = ['body', 'tabs', 'scrollPast', 'header', 'contactUs'] as const
 
 type ZIndexValues = (typeof zIndexOrder)[number]
 type ZIndexRecord = Record<ZIndexValues, number>

--- a/packages/ui/src/lib/globalStyles.ts
+++ b/packages/ui/src/lib/globalStyles.ts
@@ -75,4 +75,9 @@ export const globalStyles = css`
   :where([hidden]) {
     display: none;
   }
+
+  /* Isolate app stacking context so it doesn't mess up with portals */
+  #__next {
+    isolation: isolate;
+  }
 `

--- a/packages/ui/src/lib/theme/transitions.ts
+++ b/packages/ui/src/lib/theme/transitions.ts
@@ -9,4 +9,12 @@ export const transitions = {
 
     easeOutCubic: { ease: [0.22, 0.61, 0.36, 1] },
   },
+
+  css: {
+    easeInOutCubic: 'cubic-bezier(0.65, 0.05, 0.36, 1)',
+
+    easeInCubic: 'cubic-bezier(0.55, 0.06, 0.68, 0.19);',
+
+    easeOutCubic: 'cubic-bezier(0.22, 0.61, 0.36, 1);',
+  },
 } as const

--- a/yarn.lock
+++ b/yarn.lock
@@ -7622,6 +7622,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-popover@npm:1.0.7":
+  version: 1.0.7
+  resolution: "@radix-ui/react-popover@npm:1.0.7"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": 1.0.1
+    "@radix-ui/react-compose-refs": 1.0.1
+    "@radix-ui/react-context": 1.0.1
+    "@radix-ui/react-dismissable-layer": 1.0.5
+    "@radix-ui/react-focus-guards": 1.0.1
+    "@radix-ui/react-focus-scope": 1.0.4
+    "@radix-ui/react-id": 1.0.1
+    "@radix-ui/react-popper": 1.1.3
+    "@radix-ui/react-portal": 1.0.4
+    "@radix-ui/react-presence": 1.0.1
+    "@radix-ui/react-primitive": 1.0.3
+    "@radix-ui/react-slot": 1.0.2
+    "@radix-ui/react-use-controllable-state": 1.0.1
+    aria-hidden: ^1.1.1
+    react-remove-scroll: 2.5.5
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 3ec15c0923ea457f586aa34f77e17fabffa02dffeab622951560ec21c38df2f43718ff088d24bf9fd1d9cd0db62436fc19cae5b122d90f72de4945a1f508dc59
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-popper@npm:1.1.2":
   version: 1.1.2
   resolution: "@radix-ui/react-popper@npm:1.1.2"
@@ -23994,6 +24028,7 @@ __metadata:
     "@radix-ui/react-collapsible": 1.0.3
     "@radix-ui/react-dialog": 1.0.5
     "@radix-ui/react-navigation-menu": 1.1.4
+    "@radix-ui/react-popover": 1.0.7
     "@radix-ui/react-radio-group": 1.1.3
     "@radix-ui/react-select": 2.0.0
     "@radix-ui/react-switch": 1.0.3


### PR DESCRIPTION
## Describe your changes

Adds a custom "contact us" button.

https://github.com/HedvigInsurance/racoon/assets/19200662/bc6812ef-0dca-4dc6-9335-8954e2f6ca19

## Justify why they are needed

It takes a long time to get something updated from c1 and we want better support for lazy loading. This can be used while chat is unavailable while makes the app perform better.