### PR TITLE
refact(productReviews): validate average ratings/review comments data

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -69,7 +69,8 @@
     "tss-react": "4.9.2",
     "ui": "workspace:",
     "uuid": "9.0.1",
-    "zen-observable-ts": "1.2.5"
+    "zen-observable-ts": "1.2.5",
+    "zod": "3.22.4"
   },
   "devDependencies": {
     "@babel/core": "7.23.2",

--- a/apps/store/src/blocks/ProductReviewCommentsBlock.tsx
+++ b/apps/store/src/blocks/ProductReviewCommentsBlock.tsx
@@ -1,4 +1,3 @@
-import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
 import { useState, useMemo, ChangeEventHandler } from 'react'
 import { Text, Space, Badge, theme } from 'ui'
@@ -24,24 +23,13 @@ export const ProductReviewCommentsBlock = () => {
     if (!reviewComments) return []
 
     const availableScores: Array<AvailableScore> = ['5', '4', '3', '2', '1']
-    const options: InputOptions = []
-    availableScores.forEach((score) => {
+    const options = availableScores.map<InputOptions[number]>((score) => {
       const commentsByScore = reviewComments.commentsByScore[score]
-      // It should not happen. Just being safe
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (commentsByScore === null) {
-        datadogLogs.logger.warn(
-          `ProductReviewCommentBlock | could not find reviews for score ${score}`,
-        )
-        return
-      }
-
-      const option: InputOptions[number] = {
+      return {
         name: getScoreFilterOptionName(score, commentsByScore.total),
         value: score,
         disabled: commentsByScore.total === 0,
       }
-      options.push(option)
     })
 
     return options

--- a/apps/store/src/services/productReviews/productReviews.ts
+++ b/apps/store/src/services/productReviews/productReviews.ts
@@ -1,5 +1,9 @@
 import { kv } from '@vercel/kv'
 import { AverageRating, ReviewComments } from './productReviews.types'
+import {
+  validateProductReviewsComments,
+  validateProductAverageRating,
+} from './productReviews.utils'
 
 // Data format and used keys are defined in the cloud function:
 // https://console.cloud.google.com/functions/details/europe-north1/product_review_v2?env=gen2&cloudshell=false&project=hedvig-dagobah
@@ -24,6 +28,12 @@ export const getProductAverageRating = async (productId: string) => {
     return null
   }
 
+  const validationResult = validateProductAverageRating(productAverageRating)
+  if (!validationResult.success) {
+    console.warn(`productAverageRating | validation error: ${validationResult.error}`)
+    return null
+  }
+
   return productAverageRating
 }
 
@@ -41,5 +51,11 @@ export const getProductReviewComments = async (productId: string) => {
     return null
   }
 
-  return productReviewComments
+  const validationResult = validateProductReviewsComments(productReviewComments)
+  if (!validationResult.success) {
+    console.warn(`productReviewComments | validation error: ${validationResult.error}`)
+    return null
+  }
+
+  return validationResult.data
 }

--- a/apps/store/src/services/productReviews/productReviews.types.ts
+++ b/apps/store/src/services/productReviews/productReviews.types.ts
@@ -1,25 +1,8 @@
+import { z } from 'zod'
+import { reviewCommentsSchema, averageRatingSchema } from './productReviews.utils'
+
 // Data format and used keys are defined in the cloud function:
 // https://console.cloud.google.com/functions/details/europe-north1/product_review_v2?env=gen2&cloudshell=false&project=hedvig-dagobah
+export type ReviewComments = z.infer<typeof reviewCommentsSchema>
 
-export type AverageRating = {
-  score: number
-  reviewCount: number
-}
-
-export type ReviewComments = {
-  count: number
-  commentsByScore: Record<
-    5 | 4 | 3 | 2 | 1,
-    {
-      total: number
-      latestComments: Array<Comment>
-    }
-  >
-}
-
-type Comment = {
-  date: string
-  score: number
-  content: string
-  author: string
-}
+export type AverageRating = z.infer<typeof averageRatingSchema>

--- a/apps/store/src/services/productReviews/productReviews.utils.ts
+++ b/apps/store/src/services/productReviews/productReviews.utils.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+
+export const averageRatingSchema = z.object({
+  score: z.number(),
+  reviewCount: z.number(),
+})
+
+const commentSchema = z.object({
+  date: z.string(),
+  score: z.number(),
+  content: z.string(),
+  author: z.string(),
+})
+
+const commentsByScoreSchema = z.object({
+  total: z.number(),
+  latestComments: z.array(commentSchema),
+})
+
+export const reviewCommentsSchema = z.object({
+  commentsByScore: z.object({
+    '5': commentsByScoreSchema,
+    '4': commentsByScoreSchema,
+    '3': commentsByScoreSchema,
+    '2': commentsByScoreSchema,
+    '1': commentsByScoreSchema,
+  }),
+})
+
+export const validateProductAverageRating = (data: unknown) => {
+  return averageRatingSchema.safeParse(data)
+}
+
+export const validateProductReviewsComments = (data: unknown) => {
+  return reviewCommentsSchema.safeParse(data)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -24151,6 +24151,7 @@ __metadata:
     webpack: 5.76.2
     whatwg-fetch: 3.6.19
     zen-observable-ts: 1.2.5
+    zod: 3.22.4
   languageName: unknown
   linkType: soft
 
@@ -26859,5 +26860,12 @@ __metadata:
   version: 3.21.4
   resolution: "zod@npm:3.21.4"
   checksum: f185ba87342ff16f7a06686767c2b2a7af41110c7edf7c1974095d8db7a73792696bcb4a00853de0d2edeb34a5b2ea6a55871bc864227dace682a0a28de33e1f
+  languageName: node
+  linkType: hard
+
+"zod@npm:3.22.4":
+  version: 3.22.4
+  resolution: "zod@npm:3.22.4"
+  checksum: 80bfd7f8039b24fddeb0718a2ec7c02aa9856e4838d6aa4864335a047b6b37a3273b191ef335bf0b2002e5c514ef261ffcda5a589fb084a48c336ffc4cdbab7f
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Describe your changes

- Update `productReviews` service by validate average rating / review comments data, logging an error when they are invalid;
- Makes `ProductReviewCommentsBlock` simplier by removing some safe verifications as we've increased the the trust on getting data in the right format.

## Justify why they are needed

After some discussions we thought that would make `ProductReviewCommentsBlock` simplier. Another approach would be to make sure nothing fish get's written into the database (vercel/kv), but I guess we can start with this as it's easier to implement and also easier to let us now when something is wrong with the data.
