### PR TITLE
GEN-1357 - fix(sign): display "failed" to sign modal

### DIFF
--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -78,7 +78,6 @@ const CheckoutPage = (props: CheckoutPageProps) => {
         getCheckoutStepLink({ step: nextCheckoutStep, shopSessionId: shopSession.id }),
       )
     },
-    // TODO: Never used inside, remove and refactor
     onError() {
       setShowSignError(true)
     },

--- a/apps/store/src/components/CheckoutPage/useHandleSubmitCheckout.ts
+++ b/apps/store/src/components/CheckoutPage/useHandleSubmitCheckout.ts
@@ -16,7 +16,7 @@ type Options = {
 
 export const useHandleSubmitCheckout = (options: Options) => {
   const { t } = useTranslation('common')
-  const { customerAuthenticationStatus, shopSessionId, ssn, onSuccess } = options
+  const { customerAuthenticationStatus, shopSessionId, ssn, onSuccess, onError } = options
   const [updateCustomer, updateCustomerResult] = useUpdateCustomer({ shopSessionId })
 
   const { currentOperation, startCheckoutSign } = useBankIdContext()
@@ -28,7 +28,7 @@ export const useHandleSubmitCheckout = (options: Options) => {
       const formData = new FormData(event.currentTarget)
       await updateCustomer(formData)
     }
-    startCheckoutSign({ customerAuthenticationStatus, shopSessionId, ssn, onSuccess })
+    startCheckoutSign({ customerAuthenticationStatus, shopSessionId, ssn, onSuccess, onError })
   }
 
   let userError = updateCustomerResult.userError

--- a/apps/store/src/services/bankId/bankId.types.ts
+++ b/apps/store/src/services/bankId/bankId.types.ts
@@ -1,3 +1,4 @@
+import { type ApolloError } from '@apollo/client'
 import { ShopSessionAuthenticationStatus } from '@/services/apollo/generated'
 
 export enum BankIdState {
@@ -42,4 +43,5 @@ export type CheckoutSignOptions = {
   shopSessionId: string
   ssn: string
   onSuccess: () => void | Promise<void>
+  onError?: (error: ApolloError | Error) => void
 }


### PR DESCRIPTION
## Describe your changes

I've noticed we keep pooling sign status and did not display an error message when signing failed due some member creation error.

<img width="1227" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/cbb56371-b5f0-4c69-9356-8411039a987e">

This pass down `onError` cb to `startSign` function so we can use it to change the state of "error modal", making it appear.

**Before**

https://github.com/HedvigInsurance/racoon/assets/19200662/e969716b-d7a6-4162-b5e0-327dfdc7ede6

**After**

https://github.com/HedvigInsurance/racoon/assets/19200662/eb1f698a-211b-4850-a482-1e9f4d5a0154

