### PR TITLE
Fix error when getting locale from URL

### DIFF
--- a/apps/store/src/utils/l10n/localeUtils.test.ts
+++ b/apps/store/src/utils/l10n/localeUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals'
-import { isIsoLocale, isRoutingLocale } from './localeUtils'
+import { getUrlLocale, isIsoLocale, isRoutingLocale } from './localeUtils'
 
 describe('isIsoLocale', () => {
   it.each([
@@ -23,5 +23,30 @@ describe('isRoutingLocale', () => {
     [undefined, false],
   ])('asserts %p expecting %p', (locale: string | undefined, expected: boolean) => {
     expect(isRoutingLocale(locale)).toBe(expected)
+  })
+})
+
+describe('getUrlLocale', () => {
+  it('returns routing locale from Norwegian URL', () => {
+    expect(getUrlLocale('/no')).toBe('no')
+    expect(getUrlLocale('/no/')).toBe('no')
+    expect(getUrlLocale('/no/checkout')).toBe('no')
+    expect(getUrlLocale('/no/checkout/')).toBe('no')
+    expect(getUrlLocale('/no/checkout/confirm')).toBe('no')
+    expect(getUrlLocale('/no/checkout/confirm/')).toBe('no')
+  })
+
+  it('returns routing locale from Swedish URL', () => {
+    expect(getUrlLocale('/se')).toBe('se')
+    expect(getUrlLocale('/se/')).toBe('se')
+    expect(getUrlLocale('/se/checkout')).toBe('se')
+  })
+
+  it('returns Swedish routing locale by default', () => {
+    expect(getUrlLocale('/')).toBe('se')
+    expect(getUrlLocale('/checkout')).toBe('se')
+    expect(getUrlLocale('/checkout/')).toBe('se')
+    expect(getUrlLocale('')).toBe('se')
+    expect(getUrlLocale('/en/cart')).toBe('se')
   })
 })

--- a/apps/store/src/utils/l10n/localeUtils.ts
+++ b/apps/store/src/utils/l10n/localeUtils.ts
@@ -49,7 +49,7 @@ export const getLocaleOrFallback = (locale?: UiLocale): LocaleData => {
 }
 
 export const getUrlLocale = (url: string): RoutingLocale => {
-  const routingLocale = url.split('/')[0]
+  const routingLocale = url.split('/')[1]
   return getLocaleOrFallback(routingLocale as UiLocale).routingLocale
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Fix error in `getUrlLocale` function

- Get the second part of the url which is the locale

- Add tests for the function

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- The function was not working properly which caused us to detect a country change when it was not the case. We never noticed this since we were only like in Sweden which is already the default market.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
