### PR TITLE
GEN-1161 | ComparisonTable: horizontally scroll tabs on mobile

### DIFF
--- a/apps/store/src/components/ComparisonTable/MobileComparisonTable.tsx
+++ b/apps/store/src/components/ComparisonTable/MobileComparisonTable.tsx
@@ -88,7 +88,8 @@ const TabsRoot = styled(RadixTabs.Root)({
 const TabsList = styled(RadixTabs.List)({
   display: 'flex',
   gap: theme.space.xs,
-  marginBottom: theme.space.xs,
+  paddingBottom: theme.space.sm,
+  overflowX: 'auto',
 })
 
 const TabButton = styled(Button)({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

![Screenshot 2023-10-20 at 10.51.38.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/812ff90c-06c1-4c40-b4b5-dd678c6d8abe/Screenshot%202023-10-20%20at%2010.51.38.png)


- Add horizontal scrolling when tabs overflow on mobile

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Reported by Peter

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
