### PR TITLE
GEN-1369 | Fix bug causing us to create duplicated price intents

### DIFF
--- a/apps/store/src/services/priceIntent/PriceIntentService.ts
+++ b/apps/store/src/services/priceIntent/PriceIntentService.ts
@@ -82,8 +82,12 @@ export class PriceIntentService {
     }
 
     // Deduplicate mutation, Apollo won't do this for us
-    const paramsEquals = (a: unknown, b: unknown) => JSON.stringify(a) === JSON.stringify(b)
-    if (!this.createPromise || !paramsEquals(this.createParams, params)) {
+    const isEqual =
+      params.shopSessionId === this.createParams?.shopSessionId &&
+      params.productName === this.createParams.productName &&
+      params.priceTemplate.name === this.createParams.priceTemplate.name
+
+    if (!this.createPromise || !isEqual) {
       this.createParams = params
       this.createPromise = this.create(params)
     }
@@ -152,8 +156,17 @@ type FetchParams = {
   shopSessionId: string
 }
 
+let PRICE_INTENT_SERVICE: PriceIntentService | null = null
+
 export const priceIntentServiceInitClientSide = (apolloClient: ApolloClient<unknown>) => {
-  return new PriceIntentService(new CookiePersister('UNUSED_DEFAULT_KEY'), apolloClient)
+  if (!PRICE_INTENT_SERVICE) {
+    PRICE_INTENT_SERVICE = new PriceIntentService(
+      new CookiePersister('UNUSED_DEFAULT_KEY'),
+      apolloClient,
+    )
+  }
+
+  return PRICE_INTENT_SERVICE
 }
 
 type ServerSideParams = {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Reuse existing price intent service instance instead of creating new ones

- Update how to compare input params when creating new price intents

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We deduplicate requests to create price intents, however, we store the promise on the class instance. We also create new instances of the class for each request. This means that we never reuse the saved promise. This PR fixes that by reusing the existing instance.

- We also compare the input params to determine if we should create a new price intent. However, the compare method was quite crude so I changed it to be more specific and only compare the fields that are relevant to the price intent.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
