### PR TITLE
fix(ConfirmationPage): storyblok preview

### DIFF
--- a/apps/store/src/blocks/ConfirmationPageBlock.tsx
+++ b/apps/store/src/blocks/ConfirmationPageBlock.tsx
@@ -16,4 +16,4 @@ export const ConfirmationPageBlock = ({ blok }: ConfirmationPageBlockProps) => {
   )
 }
 
-ConfirmationPageBlock.blockName = 'confirmationPage'
+ConfirmationPageBlock.blockName = 'confirmation'


### PR DESCRIPTION
## Describe your changes

- Fix `Confirmation` Content Type in Storyblok

## Justify why they are needed

Just noticed `Confirmation` content type couldn't be previewed in Storyblok because we name it differently in our code: `confirmationPage` instead of `confirmation`.
