### PR TITLE
fix: hide chat for CMS pages based on setting

### DIFF
--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import type { AppPropsWithLayout } from 'next/app'
 import dynamic from 'next/dynamic'
 import Head from 'next/head'
 import Router from 'next/router'
+import { type ReactNode } from 'react'
 import { Provider as BalancerProvider } from 'react-wrap-balancer'
 import { globalStyles, theme } from 'ui'
 import { AppErrorDialog } from '@/components/AppErrorDialog'
@@ -81,6 +82,11 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
   const apolloClient = useApollo(pageProps)
   const getLayout = Component.getLayout ?? ((page) => page)
 
+  let Chat: ReactNode = null
+  if (!pageProps.hideChat) {
+    Chat = Features.enabled('CUSTOM_CHAT') ? <ContactUs /> : <CustomerFirstScript />
+  }
+
   return (
     <>
       <Head>
@@ -109,7 +115,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
               </BankIdContextProvider>
             </TrackingProvider>
           </ShopSessionProvider>
-          {Features.enabled('CUSTOM_CHAT') ? <ContactUs /> : <CustomerFirstScript />}
+          {Chat}
         </JotaiProvider>
       </ApolloProvider>
     </>

--- a/apps/store/src/services/CustomerFirst.tsx
+++ b/apps/store/src/services/CustomerFirst.tsx
@@ -7,18 +7,14 @@ import { useBreakpoint } from '@/utils/useBreakpoint/useBreakpoint'
 
 const OPEN_ATOM = atom(false)
 
-type Props = {
-  hideChat?: boolean
-}
-
-export const CustomerFirstScript = ({ hideChat = false }: Props) => {
+export const CustomerFirstScript = () => {
   const isDesktop = useBreakpoint('lg')
   const { chatWidgetSrc } = useCurrentLocale()
   const { open } = useCustomerFirst()
 
   if (!chatWidgetSrc) return null
 
-  const showLauncher = hideChat ? open : isDesktop || open
+  const showLauncher = isDesktop || open
   return (
     <>
       <Global styles={{ '#chat-iframe': { display: showLauncher ? 'initial' : 'none' } }} />


### PR DESCRIPTION
## Describe your changes

- Hide/Show "Contact US" chat launched based on CSM setting (for Page content type)

## Justify why they are needed

Just realize that wasn't work as it suppose to while doing something else.
