### PR TITLE
Revert "Remove trailling slashes for all Storyblok URLs since it causes redirects"

### DIFF
--- a/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
+++ b/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
@@ -1,7 +1,7 @@
 import { ISbAlternateObject, ISbStoryData } from '@storyblok/react'
 import Head from 'next/head'
 import { SEOData } from '@/services/storyblok/storyblok'
-import { getImgSrc, removeTrailingSlash } from '@/services/storyblok/Storyblok.helpers'
+import { getImgSrc } from '@/services/storyblok/Storyblok.helpers'
 import { Features } from '@/utils/Features'
 import { organization } from '@/utils/jsonSchema'
 import { isRoutingLocale, toIsoLocale } from '@/utils/l10n/localeUtils'
@@ -80,4 +80,8 @@ const AlternateLink = ({ fullSlug }: { fullSlug: string }) => {
 const getHrefLang = (fullSlug: string) => {
   const slugLocale = fullSlug.split('/')[0]
   return isRoutingLocale(slugLocale) ? toIsoLocale(slugLocale) : 'x-default'
+}
+
+const removeTrailingSlash = (url: string) => {
+  return url.endsWith('/') ? url.slice(0, -1) : url
 }

--- a/apps/store/src/pages/sitemap.xml.js
+++ b/apps/store/src/pages/sitemap.xml.js
@@ -1,6 +1,9 @@
 import { ORIGIN_URL } from '@/utils/PageLink'
 import StoryblokClient from 'storyblok-js-client'
-import { removeTrailingSlash } from '@/services/storyblok/Storyblok.helpers'
+
+const removeTrailingSlash = (url) => {
+  return url.endsWith('/') ? url.slice(0, -1) : url
+}
 
 const generateSiteMap = (pages) => {
   return `<?xml version="1.0" encoding="UTF-8"?>

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -73,7 +73,6 @@ export const getLinkFieldURL = (link: LinkField, linkText?: string) => {
 }
 
 const makeAbsolute = (url: string) => {
-  url = removeTrailingSlash(url)
   if (/^(\/|https?:\/\/|\/\/)/.test(url)) {
     return url
   }
@@ -115,8 +114,4 @@ export const getImgSrc = (src: string) => {
     return src
   }
   return (src || '').replace('//a.storyblok.com', '//assets.hedvig.com')
-}
-
-export const removeTrailingSlash = (url: string) => {
-  return url.endsWith('/') ? url.slice(0, -1) : url
 }


### PR DESCRIPTION
Reverts HedvigInsurance/racoon#3494

Broke ProductCardBlock when comparing `const isProductLink = productMetadata?.some((product) => isSameLink(link, product.pageLink))`

Let's see if we should remove trailing slash everywhere or keep it as we had it, let's revert to start with