### PR TITLE
fix(TotalAmountContainer): get reduced cost from 'discount' field

### DIFF
--- a/apps/store/src/components/ShopBreakdown/TotalAmountContainer.tsx
+++ b/apps/store/src/components/ShopBreakdown/TotalAmountContainer.tsx
@@ -1,6 +1,12 @@
 import { useTranslation } from 'next-i18next'
+import { useCallback } from 'react'
 import { TotalAmount } from '@/components/ShopBreakdown/TotalAmount'
-import { CampaignDiscount, CampaignDiscountType, Money } from '@/services/apollo/generated'
+import {
+  CampaignDiscount,
+  CampaignDiscountType,
+  CartCost,
+  Money,
+} from '@/services/apollo/generated'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useFormatter } from '@/utils/useFormatter'
 
@@ -9,15 +15,14 @@ type Props = {
 }
 
 export const TotalAmountContainer = (props: Props) => {
-  const getDiscountDurationExplanation = useGetDiscountDurationExplanation()
+  const { getDiscountDurationExplanation, getReducedAmmount } = useDiscount()
 
   const apiDiscount = props.cart.redeemedCampaign?.discount
   const totalCost = props.cart.cost.gross
-  const reducedCost = props.cart.cost.net
 
   const discount = apiDiscount
     ? {
-        reducedAmount: reducedCost.amount,
+        reducedAmount: getReducedAmmount(apiDiscount.type, props.cart.cost),
         explanation: getDiscountDurationExplanation(apiDiscount, totalCost),
       }
     : undefined
@@ -31,24 +36,44 @@ export const TotalAmountContainer = (props: Props) => {
   )
 }
 
-const useGetDiscountDurationExplanation = () => {
+const useDiscount = () => {
   const { t } = useTranslation('cart')
   const formatter = useFormatter()
 
-  return (discount: CampaignDiscount, total: Money) => {
-    switch (discount.type) {
-      case CampaignDiscountType.FreeMonths:
-      case CampaignDiscountType.MonthlyPercentage:
-        return t('DISCOUNT_DURATION_EXPLANATION', {
-          count: discount.months,
-          monthlyPrice: formatter.monthlyPrice(total),
-          // Avoid double escaping / in price.  Safe since we're not using dangerouslySetInnerHtml
-          interpolation: { escapeValue: false },
-        })
-      case CampaignDiscountType.MonthlyCost:
-      case CampaignDiscountType.IndefinitePercentage:
-      default:
-        return ''
-    }
-  }
+  const getDiscountDurationExplanation = useCallback(
+    (discount: CampaignDiscount, total: Money) => {
+      switch (discount.type) {
+        case CampaignDiscountType.FreeMonths:
+        case CampaignDiscountType.MonthlyPercentage:
+          return t('DISCOUNT_DURATION_EXPLANATION', {
+            count: discount.months,
+            monthlyPrice: formatter.monthlyPrice(total),
+            // Avoid double escaping / in price.  Safe since we're not using dangerouslySetInnerHtml
+            interpolation: { escapeValue: false },
+          })
+        case CampaignDiscountType.MonthlyCost:
+        case CampaignDiscountType.IndefinitePercentage:
+        default:
+          return ''
+      }
+    },
+    [t, formatter],
+  )
+
+  const getReducedAmmount = useCallback(
+    (campaignType: CampaignDiscountType, cartCost: CartCost) => {
+      switch (campaignType) {
+        case CampaignDiscountType.FreeMonths:
+          return cartCost.discount.amount
+        case CampaignDiscountType.MonthlyPercentage:
+        case CampaignDiscountType.MonthlyCost:
+        case CampaignDiscountType.IndefinitePercentage:
+        default:
+          return cartCost.net.amount
+      }
+    },
+    [],
+  )
+
+  return { getDiscountDurationExplanation, getReducedAmmount }
 }


### PR DESCRIPTION
## Describe your changes

CheckoutPage: display 'free months' discounts properly by getting reduce cost from `cost.discount` field.

**Before**

<img width="1063" alt="Screenshot 2023-10-31 at 17 32 14" src="https://github.com/HedvigInsurance/racoon/assets/19200662/6a65e003-3f78-45bd-8226-e610a2aa663e">

**After**

<img width="1063" alt="Screenshot 2023-10-31 at 17 33 21" src="https://github.com/HedvigInsurance/racoon/assets/19200662/b25b30ac-dc2a-482a-86a8-6e4c2d9d7bb8">

## Justify why they are needed

We're getting the reduced cost from `cost.net` field which is not correct.
