### PR TITLE
fix(ConfirmationPage): make sure image section doesn't override other content

### DIFF
--- a/apps/store/src/components/ConfirmationPage/ImageSection.tsx
+++ b/apps/store/src/components/ConfirmationPage/ImageSection.tsx
@@ -19,6 +19,8 @@ const Wrapper = styled.section({
   pointerEvents: 'none',
 
   position: 'relative',
+  // Make the image appear like a background image
+  zIndex: '-1',
   top: '-20vw',
   height: '100vw',
 


### PR DESCRIPTION
## Describe your changes

Make sure image section doesn't override other content.

**Before**

<img width="1152" alt="Screenshot 2023-11-01 at 18 03 36" src="https://github.com/HedvigInsurance/racoon/assets/19200662/e4b891a3-97a3-4805-913e-1343268246e3">


**After**

<img width="1152" alt="Screenshot 2023-11-01 at 18 03 26" src="https://github.com/HedvigInsurance/racoon/assets/19200662/d196f61d-f000-4d72-bf31-f2bf139ecae9">

## Justify why they are needed

Noticed an issue with Confirmation Page image section as it was override app links.
