### PR TITLE
GEN-1413 - refact(ConfirmationPage): update data requirements

### DIFF
--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -45,12 +45,7 @@ export const ConfirmationPage = (props: Props) => {
                 </ShopBreakdown>
               </Space>
 
-              {props.switching && (
-                <SwitchingAssistantSection
-                  shopSessionOutcomeId={props.shopSessionOutcomeId}
-                  {...props.switching}
-                />
-              )}
+              {props.switching && <SwitchingAssistantSection {...props.switching} />}
 
               {Features.enabled('SAS_PARTNERSHIP') && props.memberPartnerData?.sas?.eligible && (
                 <SasEurobonusSectionContainer
@@ -67,6 +62,7 @@ export const ConfirmationPage = (props: Props) => {
                     {props.story.content.checklistSubtitle}
                   </Text>
                 </div>
+
                 <CheckList>
                   {checklistItems.map((item, index) => {
                     const isLast = index === checklistItems.length - 1

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
@@ -4,11 +4,10 @@ import { StoryblokPageProps } from '@/services/storyblok/storyblok'
 export type MemberPartnerData = CurrentMemberQuery['currentMember']['partnerData']
 
 export type ConfirmationPageProps = Pick<StoryblokPageProps, 'globalStory'> & {
-  currency: string
-  cart: CartFragmentFragment
   shopSessionId: string
-  shopSessionOutcomeId: string
+  cart: CartFragmentFragment
   switching?: {
+    shopSessionOutcomeId: string
     companyDisplayName: string
   }
   memberPartnerData: MemberPartnerData | null


### PR DESCRIPTION
## Describe your changes

* Make outcome/switching data fetching optional. That way we can use same `ConfirmationPage` component for car dealership feature, where we don't need to fetch those.

## Justify why they are needed

Foundation changes for supporting _Car Dealership_ confirmation pages.