### PR TITLE
GEN-1413 - feat(car-dealership): added confirmation page with extension

### DIFF
--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -7,6 +7,8 @@ import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { ImageWithPlaceholder } from '@/components/ImageWithPlaceholder/ImageWithPlaceholder'
 import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
 import { ShopBreakdown } from '@/components/ShopBreakdown/ShopBreakdown'
+import { TotalAmountContainer } from '@/components/ShopBreakdown/TotalAmountContainer'
+import { ProductItemContractContainerCar } from '@/features/carDealership/ProductItemContractContainer'
 import { SasEurobonusSectionContainer } from '@/features/sas/SasEurobonusSection'
 import { ConfirmationStory } from '@/services/storyblok/storyblok'
 import { getImgSrc } from '@/services/storyblok/Storyblok.helpers'
@@ -38,10 +40,15 @@ export const ConfirmationPage = (props: Props) => {
                 <Heading as="h1" variant="standard.24" align="center">
                   {props.story.content.title}
                 </Heading>
+
                 <ShopBreakdown>
+                  {props.carTrialContract && (
+                    <ProductItemContractContainerCar contract={props.carTrialContract} />
+                  )}
                   {props.cart.entries.map((item) => (
                     <ProductItemContainer key={item.id} offer={item} />
                   ))}
+                  <TotalAmountContainer cart={props.cart} />
                 </ShopBreakdown>
               </Space>
 

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
@@ -1,4 +1,8 @@
-import { CartFragmentFragment, CurrentMemberQuery } from '@/services/apollo/generated'
+import {
+  CartFragmentFragment,
+  TrialContractFragment,
+  CurrentMemberQuery,
+} from '@/services/apollo/generated'
 import { StoryblokPageProps } from '@/services/storyblok/storyblok'
 
 export type MemberPartnerData = CurrentMemberQuery['currentMember']['partnerData']
@@ -6,9 +10,10 @@ export type MemberPartnerData = CurrentMemberQuery['currentMember']['partnerData
 export type ConfirmationPageProps = Pick<StoryblokPageProps, 'globalStory'> & {
   shopSessionId: string
   cart: CartFragmentFragment
+  memberPartnerData: MemberPartnerData | null
   switching?: {
     shopSessionOutcomeId: string
     companyDisplayName: string
   }
-  memberPartnerData: MemberPartnerData | null
+  carTrialContract?: TrialContractFragment
 }

--- a/apps/store/src/pages/car-buyer/confirmation-with-extension/[contractId].tsx
+++ b/apps/store/src/pages/car-buyer/confirmation-with-extension/[contractId].tsx
@@ -1,0 +1,79 @@
+import { ApolloClient } from '@apollo/client'
+import { GetServerSideProps } from 'next'
+import { ComponentPropsWithoutRef } from 'react'
+import { ConfirmationPage } from '@/components/ConfirmationPage/ConfirmationPage'
+import { getLayoutWithMenuProps } from '@/components/LayoutWithMenu/getLayoutWithMenuProps'
+import { initializeApolloServerSide, addApolloState } from '@/services/apollo/client'
+import {
+  CarTrialExtensionDocument,
+  CarTrialExtensionQuery,
+  CarTrialExtensionQueryVariables,
+} from '@/services/apollo/generated'
+import { ConfirmationStory, getStoryBySlug } from '@/services/storyblok/storyblok'
+import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+
+type Props = ComponentPropsWithoutRef<typeof ConfirmationPage>
+
+type Params = { contractId: string }
+
+export const getServerSideProps: GetServerSideProps<Props, Params> = async (context) => {
+  const { req, res, locale, params, resolvedUrl } = context
+
+  if (!isRoutingLocale(locale)) return { notFound: true }
+
+  const contractId = params?.contractId
+  if (!contractId) return { notFound: true }
+
+  const apolloClient = await initializeApolloServerSide({ req, res, locale })
+  // with-extension | without-extension
+  const confirmationStorySlug = resolvedUrl.split('/')[2]
+
+  const [trialExtension, layoutWithMenuProps, story] = await Promise.all([
+    fetchTrialExtensionData(apolloClient, contractId),
+    getLayoutWithMenuProps(context, apolloClient),
+    getStoryBySlug<ConfirmationStory>(confirmationStorySlug, { locale }),
+  ])
+
+  if (trialExtension == null) return { notFound: true }
+
+  if (layoutWithMenuProps === null) return { notFound: true }
+
+  return addApolloState(apolloClient, {
+    props: {
+      ...layoutWithMenuProps,
+      shopSessionId: trialExtension.shopSession.id,
+      cart: trialExtension.shopSession.cart,
+      carTrialContract: trialExtension.trialContract,
+      story,
+      memberPartnerData: null,
+    },
+  })
+}
+
+const fetchTrialExtensionData = async (
+  apolloClient: ApolloClient<unknown>,
+  contractId: string,
+): Promise<CarTrialExtensionQuery['carTrial'] | null> => {
+  try {
+    const { data } = await apolloClient.query<
+      CarTrialExtensionQuery,
+      CarTrialExtensionQueryVariables
+    >({
+      query: CarTrialExtensionDocument,
+      variables: {
+        contractId,
+      },
+    })
+
+    const ssn = data.carTrial?.shopSession.customer?.ssn
+    if (!ssn) {
+      throw new Error(`No SSN in Shop Session ${contractId}`)
+    }
+
+    return data.carTrial
+  } catch (err) {
+    return null
+  }
+}
+
+export { default } from '@/pages/confirmation/[shopSessionId]'

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -21,6 +21,7 @@ export const ORIGIN_URL =
 type BaseParams = { locale?: RoutingLocale }
 
 type ConfirmationPage = BaseParams & { shopSessionId: string }
+type CarDealershipConfirmationPage = BaseParams & { contractId: string }
 type CheckoutPage = BaseParams & { expandCart?: boolean }
 type CheckoutPaymentTrustlyPage = BaseParams & { shopSessionId: string }
 type AuthExchangeRoute = { authorizationCode: string; next?: string }
@@ -81,6 +82,13 @@ export const PageLink = {
   },
   confirmation: ({ locale, shopSessionId }: ConfirmationPage) => {
     const pathname = `${localePrefix(locale)}/confirmation/${shopSessionId}`
+    return new URL(pathname, ORIGIN_URL)
+  },
+  carDealershipConfirmationWithExtension: ({
+    locale,
+    contractId,
+  }: CarDealershipConfirmationPage) => {
+    const pathname = `${localePrefix(locale)}/car-buyer/confirmation-with-extension/${contractId}`
     return new URL(pathname, ORIGIN_URL)
   },
 


### PR DESCRIPTION
## Describe your changes

* `ConfirmationPage`
  * 🆕 Adds _Total_ section under `ShopBreakdown` - For all _Confirmation_ pages
  * 🚘 Adds `carTrialContract` prop: When present it should render your current Car Trial Contract as a product item: Car Dealership feature.
  * 🚘 Adds _Confirmation Page With Extension_ for car dealership: It uses `ConfirmationPage` for the UI but it fetches CMS settings for _Car Dealership Confirmation Page With Extension_ along with car trial info.
* `PageLink`
  * 🚘 Adds a page link for the mentioned confirmation page. 

## Justify why they are needed

Car dealership feature.
