### PR TITLE
GEN-1413 - feat(car-dealership): added confirmation page without extension

### DIFF
--- a/apps/store/src/blocks/ConfirmationPageBlock.tsx
+++ b/apps/store/src/blocks/ConfirmationPageBlock.tsx
@@ -2,13 +2,13 @@ import { storyblokEditable, StoryblokComponent, SbBlokData } from '@storyblok/re
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
 type ConfirmationPageBlockProps = SbBaseBlockProps<{
-  body: Array<SbBlokData>
+  body?: Array<SbBlokData>
 }>
 
 export const ConfirmationPageBlock = ({ blok }: ConfirmationPageBlockProps) => {
   return (
     <div {...storyblokEditable(blok)}>
-      {blok.body.map((nestedBlock) => (
+      {blok.body?.map((nestedBlock) => (
         // TODO: try inlining this, we're not using confirmationPage block type
         <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
       ))}

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { StoryblokComponent } from '@storyblok/react'
 import { useTranslation } from 'next-i18next'
 import { Fragment } from 'react'
 import { AndroidIcon, AppleIcon, Button, Heading, mq, Space, Text, theme } from 'ui'
@@ -51,6 +52,10 @@ export const ConfirmationPage = (props: Props) => {
                   <TotalAmountContainer cart={props.cart} />
                 </ShopBreakdown>
               </Space>
+
+              {props.story.content.ctaSection?.map((nestedBlock) => (
+                <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} />
+              ))}
 
               {props.switching && <SwitchingAssistantSection {...props.switching} />}
 

--- a/apps/store/src/pages/car-buyer/confirmation-without-extension/[contractId].tsx
+++ b/apps/store/src/pages/car-buyer/confirmation-without-extension/[contractId].tsx
@@ -1,0 +1,1 @@
+export { default, getServerSideProps } from '../confirmation-with-extension/[contractId]'

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -229,7 +229,8 @@ export type ReusableStory = ISbStoryData & {
 
 export type ConfirmationStory = ISbStoryData & {
   content: ISbStoryData['content'] & {
-    body: Array<SbBlokData>
+    body?: Array<SbBlokData>
+    ctaSection?: Array<SbBlokData>
     title: string
     checklistTitle: string
     checklistSubtitle: string

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -91,6 +91,15 @@ export const PageLink = {
     const pathname = `${localePrefix(locale)}/car-buyer/confirmation-with-extension/${contractId}`
     return new URL(pathname, ORIGIN_URL)
   },
+  carDealershipConfirmationWithoutExtension: ({
+    locale,
+    contractId,
+  }: CarDealershipConfirmationPage) => {
+    const pathname = `${localePrefix(
+      locale,
+    )}/car-buyer/confirmation-without-extension/${contractId}`
+    return new URL(pathname, ORIGIN_URL)
+  },
 
   faq: ({ locale }: { locale: RoutingLocale }) => {
     const url = FAQ_URL[locale]


### PR DESCRIPTION
## Describe your changes

* `ConfirmationPage`
  * 🆕 Adds `ctaSecion` prop: It should include CMS content to be rendered right below `ShopBreakdown`. We need to render some CMS content there for _Confirmation Without Extension_ 
  * 🚘 Adds _Confirmation Page Without Extension_ for car dealership: It uses everything implemented in its counterpart - _Confirmation With Extension_. The only difference is from which Storyblok story it get's its settings.
* `PageLink`
  * 🚘 Adds a page link for the mentioned confirmation page. 

## Justify why they are needed

Car dealership feature.

