### PR TITLE
GEN-1385 | Implement header for Widget Product Selector page

### DIFF
--- a/apps/store/src/components/GridLayout/GridLayout.helper.tsx
+++ b/apps/store/src/components/GridLayout/GridLayout.helper.tsx
@@ -100,7 +100,7 @@ const fiveSixthsCenterStyles: CSSObject = {
   [mq.lg]: { gridColumn: '2 / span 10' },
 }
 
-const STYLES: Record<ColumnWidth, Record<ContentAlignment, CSSObject>> = {
+export const STYLES: Record<ColumnWidth, Record<ContentAlignment, CSSObject>> = {
   '1': { left: {}, center: {}, right: {} },
   '5/6': { left: {}, center: fiveSixthsCenterStyles, right: {} },
   '2/3': {

--- a/apps/store/src/pages/widget/[flow]/[shopSessionId]/select.tsx
+++ b/apps/store/src/pages/widget/[flow]/[shopSessionId]/select.tsx
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled'
+import { HedvigLogo, mq } from 'ui'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { STYLES } from '@/components/GridLayout/GridLayout.helper'
+import * as ProgressIndicator from '@/components/ProgressIndicator/ProgressIndicator'
+
+const Page = () => {
+  return (
+    <div>
+      <Header as="header">
+        <LogoArea>
+          <HedvigLogo />
+        </LogoArea>
+
+        <ProgressArea>
+          <ProgressIndicator.Root>
+            <ProgressIndicator.Step active={true}>Your info</ProgressIndicator.Step>
+            <ProgressIndicator.Step>Sign</ProgressIndicator.Step>
+            <ProgressIndicator.Step>Pay</ProgressIndicator.Step>
+          </ProgressIndicator.Root>
+        </ProgressArea>
+      </Header>
+    </div>
+  )
+}
+
+const Header = styled(GridLayout.Root)({
+  height: '4rem',
+  alignItems: 'center',
+})
+
+const LogoArea = styled.div({
+  display: 'none',
+  [mq.md]: { display: 'block', gridColumn: '1 / span 2' },
+})
+
+const ProgressArea = styled.div(STYLES['1/3'].center, {
+  gridColumn: '1 / span 12',
+})
+
+export default Page


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-11-06 at 11.39.42.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/5551576a-c09b-4000-8270-0a8092e0b869.png)



- See title.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- I implemented it inline but it will likely end up as some sort of layout we can reuse on other pages in the flow.

- Exported grid layout styles so we can use them for more complex layouts

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
