### PR TITLE
Create reusable Radio Option List component

### DIFF
--- a/apps/store/src/components/RadioOptionList/RadioOptionList.stories.tsx
+++ b/apps/store/src/components/RadioOptionList/RadioOptionList.stories.tsx
@@ -1,0 +1,52 @@
+import { type Meta, type StoryObj } from '@storybook/react'
+import { ComponentProps } from 'react'
+import { Space } from 'ui'
+import * as RadioOptionList from './RadioOptionList'
+
+type Args = ComponentProps<typeof RadioOptionList.Root> & {
+  items: Array<
+    ComponentProps<typeof RadioOptionList.ProductOption> & {
+      icon?: boolean
+    }
+  >
+}
+
+const meta: Meta<Args> = {
+  title: 'Components / Radio Option List',
+  component: RadioOptionList.Root,
+  render: (args) => (
+    <RadioOptionList.Root>
+      <Space y={0.5}>
+        {args.items.map((itemProps, index) => (
+          <RadioOptionList.ProductOption key={index} {...itemProps} />
+        ))}
+      </Space>
+    </RadioOptionList.Root>
+  ),
+}
+
+export default meta
+type Story = StoryObj<Args>
+
+export const WithProductOptions: Story = {
+  args: {
+    items: [
+      {
+        title: 'Hyresrätt',
+        subtitle: 'För dig som hyr bostad',
+        pillow: {
+          src: 'https://a.storyblok.com/f/165473/832x832/fb3ddd4632/hedvig-pillows-rental.png',
+        },
+        value: 'RENT',
+      },
+      {
+        title: 'Bostadsrätt',
+        subtitle: 'För dig som äger din lägenhet',
+        pillow: {
+          src: 'https://a.storyblok.com/f/165473/832x832/fb3ddd4632/hedvig-pillows-rental.png',
+        },
+        value: 'BRF',
+      },
+    ],
+  },
+}

--- a/apps/store/src/components/RadioOptionList/RadioOptionList.tsx
+++ b/apps/store/src/components/RadioOptionList/RadioOptionList.tsx
@@ -1,0 +1,82 @@
+import styled from '@emotion/styled'
+import * as RadioGroup from '@radix-ui/react-radio-group'
+import { MouseEventHandler, type ComponentProps } from 'react'
+import { Text, theme } from 'ui'
+import { Pillow } from '@/components/Pillow/Pillow'
+import { useHighlightAnimation } from '@/utils/useHighlightAnimation'
+
+type RootProps = RadioGroup.RadioGroupProps
+
+export const Root = (props: RootProps) => {
+  return <RadioGroup.Root {...props}>{props.children}</RadioGroup.Root>
+}
+
+type ProductOptionProps = RadioGroup.RadioGroupItemProps & {
+  title: string
+  subtitle: string
+  pillow: ComponentProps<typeof Pillow>
+}
+
+export const ProductOption = (props: ProductOptionProps) => {
+  const { highlight, animationProps } = useHighlightAnimation<HTMLLabelElement>()
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    highlight()
+    props.onClick?.(event)
+  }
+
+  return (
+    <ProductOptionItem {...animationProps}>
+      <Pillow {...props.pillow} size="small" />
+      <div>
+        <Text as="p" size="md">
+          {props.title}
+        </Text>
+        <Text as="p" size="xs" color="textTranslucentSecondary">
+          {props.subtitle}
+        </Text>
+      </div>
+      <Item {...props} onClick={handleClick}>
+        <Indicator />
+      </Item>
+    </ProductOptionItem>
+  )
+}
+
+const ProductOptionItem = styled.label({
+  display: 'grid',
+  gridTemplateColumns: 'auto 1fr auto',
+  columnGap: theme.space.sm,
+  alignItems: 'center',
+  backgroundColor: theme.colors.opaque1,
+  borderRadius: theme.radius.md,
+  height: '4.5rem',
+  width: '100%',
+  cursor: 'pointer',
+  paddingInline: theme.space.md,
+})
+
+const Item = styled(RadioGroup.Item)({
+  width: '1.375rem',
+  height: '1.375rem',
+
+  cursor: 'pointer',
+  border: `1px solid ${theme.colors.borderTranslucent3}`,
+  borderRadius: '50%',
+
+  '&[data-state=checked]': {
+    borderColor: theme.colors.gray1000,
+  },
+
+  '&:focus-visible': {
+    boxShadow: theme.shadow.focusAlt,
+  },
+})
+
+const Indicator = styled(RadioGroup.Indicator)({
+  display: 'block',
+  backgroundColor: theme.colors.gray1000,
+  borderRadius: '50%',
+  width: '100%',
+  height: '100%',
+})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes


![Screenshot 2023-11-06 at 14.44.59.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/45e9061e-f32c-425b-be08-b1280bb63c58.png)



- Create a reusable Radio Option List component (based on design system)

- Support the product option item

- Add storybook story

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Needed for the hedvig widget implementation

- We already use it in the price calculator. We should extract it from there and make it reusable. However, I thought this would be an easier first step to review.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
