### PR TITLE
GEN-1385 | Add radio input to widget select product page

### DIFF
--- a/apps/store/src/features/widget/SelectProductPage.tsx
+++ b/apps/store/src/features/widget/SelectProductPage.tsx
@@ -1,0 +1,141 @@
+import { useApolloClient } from '@apollo/client'
+import styled from '@emotion/styled'
+import { useRouter } from 'next/router'
+import { useState, type ComponentProps, type FormEventHandler } from 'react'
+import { Button, Heading, HedvigLogo, Space, mq, theme } from 'ui'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { STYLES } from '@/components/GridLayout/GridLayout.helper'
+import * as ProgressIndicator from '@/components/ProgressIndicator/ProgressIndicator'
+import * as RadioOptionList from '@/components/RadioOptionList/RadioOptionList'
+import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntentService'
+import { PageLink } from '@/utils/PageLink'
+import { type WidgetProductName, getPriceTemplate, isWidgetProductName } from './widget.helpers'
+
+const PRODUCTS: Array<{
+  name: WidgetProductName
+  title: string
+  subtitle: string
+  pillow: ComponentProps<typeof RadioOptionList.ProductOption>['pillow']
+}> = [
+  {
+    name: 'SE_WIDGET_APARTMENT_RENT',
+    title: 'Hyresrätt',
+    subtitle: 'För dig som hyr bostad',
+    pillow: {
+      src: 'https://a.storyblok.com/f/165473/832x832/fb3ddd4632/hedvig-pillows-rental.png',
+    },
+  },
+]
+
+type Props = {
+  flow: string
+  shopSessionId: string
+}
+
+export const SelectProductPage = (props: Props) => {
+  const [productName, setProductName] = useState<WidgetProductName | undefined>(undefined)
+
+  const router = useRouter()
+  const apolloClient = useApolloClient()
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault()
+    if (!productName) throw new Error('Missing product')
+
+    const priceIntentService = priceIntentServiceInitClientSide(apolloClient)
+    const priceIntent = await priceIntentService.create({
+      productName: productName,
+      priceTemplate: getPriceTemplate(productName),
+      shopSessionId: props.shopSessionId,
+    })
+
+    await router.push(
+      PageLink.widgetCalculatePrice({
+        flow: props.flow,
+        shopSessionId: props.shopSessionId,
+        priceIntentId: priceIntent.id,
+      }),
+    )
+  }
+
+  const handleValueChange = (value: string) => {
+    if (!isWidgetProductName(value)) throw new Error(`Invalid product: ${value}`)
+    setProductName(value)
+  }
+
+  return (
+    <Space y={4}>
+      <Header as="header">
+        <LogoArea>
+          <HedvigLogo />
+        </LogoArea>
+
+        <ProgressArea>
+          <ProgressIndicator.Root>
+            <ProgressIndicator.Step active={true}>Your info</ProgressIndicator.Step>
+            <ProgressIndicator.Step>Sign</ProgressIndicator.Step>
+            <ProgressIndicator.Step>Pay</ProgressIndicator.Step>
+          </ProgressIndicator.Root>
+        </ProgressArea>
+      </Header>
+
+      <GridLayout.Root>
+        <GridLayout.Content width="1/3" align="center">
+          <Space y={3.5}>
+            <Heading as="h1" variant="standard.24" align="center">
+              Select your insurance
+            </Heading>
+
+            <form onSubmit={handleSubmit}>
+              <Space y={0.5}>
+                <RadioOptionList.Root
+                  value={productName}
+                  onValueChange={handleValueChange}
+                  required={true}
+                >
+                  <Space y={0.5}>
+                    {PRODUCTS.map((item) => (
+                      <RadioOptionList.ProductOption
+                        key={item.name}
+                        value={item.name}
+                        title={item.title}
+                        subtitle={item.subtitle}
+                        pillow={item.pillow}
+                      />
+                    ))}
+                  </Space>
+                </RadioOptionList.Root>
+
+                <CustomButton type="submit" variant="primary" aria-disabled={!productName}>
+                  Continue
+                </CustomButton>
+              </Space>
+            </form>
+          </Space>
+        </GridLayout.Content>
+      </GridLayout.Root>
+    </Space>
+  )
+}
+
+const Header = styled(GridLayout.Root)({
+  height: '4rem',
+  alignItems: 'center',
+})
+
+const LogoArea = styled.div({
+  display: 'none',
+  [mq.md]: { display: 'block', gridColumn: '1 / span 2' },
+})
+
+const ProgressArea = styled.div(STYLES['1/3'].center, {
+  gridColumn: '1 / span 12',
+})
+
+const CustomButton = styled(Button)({
+  // Appear disabled but remain clickable (for a11y reasons)
+  '&[aria-disabled=true]': {
+    backgroundColor: theme.colors.gray200,
+    color: theme.colors.textDisabled,
+    cursor: 'default',
+  },
+})

--- a/apps/store/src/features/widget/widget.helpers.ts
+++ b/apps/store/src/features/widget/widget.helpers.ts
@@ -1,0 +1,21 @@
+import { fetchPriceTemplate } from '@/services/PriceCalculator/PriceCalculator.helpers'
+import { Template } from '@/services/PriceCalculator/PriceCalculator.types'
+
+const WIDGET_PRODUCT_NAMES = ['SE_WIDGET_APARTMENT_BRF', 'SE_WIDGET_APARTMENT_RENT'] as const
+
+export type WidgetProductName = (typeof WIDGET_PRODUCT_NAMES)[number]
+
+export const isWidgetProductName = (product: string): product is WidgetProductName => {
+  return Object.values(WIDGET_PRODUCT_NAMES).includes(product as WidgetProductName)
+}
+
+const MAPPING: Record<WidgetProductName, string> = {
+  SE_WIDGET_APARTMENT_BRF: 'SE_WIDGET_APARTMENT',
+  SE_WIDGET_APARTMENT_RENT: 'SE_WIDGET_APARTMENT',
+}
+
+export const getPriceTemplate = (product: WidgetProductName): Template => {
+  const template = fetchPriceTemplate(MAPPING[product])
+  if (!template) throw new Error(`No template found for product ${product}`)
+  return template
+}

--- a/apps/store/src/pages/widget/[flow]/[shopSessionId]/select.tsx
+++ b/apps/store/src/pages/widget/[flow]/[shopSessionId]/select.tsx
@@ -1,41 +1,28 @@
-import styled from '@emotion/styled'
-import { HedvigLogo, mq } from 'ui'
-import { GridLayout } from '@/components/GridLayout/GridLayout'
-import { STYLES } from '@/components/GridLayout/GridLayout.helper'
-import * as ProgressIndicator from '@/components/ProgressIndicator/ProgressIndicator'
+import { type GetServerSideProps } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { type ComponentProps } from 'react'
+import { SelectProductPage } from '@/features/widget/SelectProductPage'
+import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
-const Page = () => {
-  return (
-    <div>
-      <Header as="header">
-        <LogoArea>
-          <HedvigLogo />
-        </LogoArea>
+type Props = ComponentProps<typeof SelectProductPage>
 
-        <ProgressArea>
-          <ProgressIndicator.Root>
-            <ProgressIndicator.Step active={true}>Your info</ProgressIndicator.Step>
-            <ProgressIndicator.Step>Sign</ProgressIndicator.Step>
-            <ProgressIndicator.Step>Pay</ProgressIndicator.Step>
-          </ProgressIndicator.Root>
-        </ProgressArea>
-      </Header>
-    </div>
-  )
+type Params = {
+  flow: string
+  shopSessionId: string
 }
 
-const Header = styled(GridLayout.Root)({
-  height: '4rem',
-  alignItems: 'center',
-})
+export const getServerSideProps: GetServerSideProps<Props, Params> = async (context) => {
+  if (!context.params) throw new Error('Missing params')
+  if (!isRoutingLocale(context.locale)) throw new Error(`Invalid locale: ${context.locale}`)
 
-const LogoArea = styled.div({
-  display: 'none',
-  [mq.md]: { display: 'block', gridColumn: '1 / span 2' },
-})
+  const translations = await serverSideTranslations(context.locale)
 
-const ProgressArea = styled.div(STYLES['1/3'].center, {
-  gridColumn: '1 / span 12',
-})
+  return {
+    props: {
+      ...translations,
+      ...context.params,
+    },
+  }
+}
 
-export default Page
+export default SelectProductPage

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -26,6 +26,11 @@ type CheckoutPaymentTrustlyPage = BaseParams & { shopSessionId: string }
 type AuthExchangeRoute = { authorizationCode: string; next?: string }
 type RetargetingRoute = { shopSessionId: string }
 type RetargetingApiRoute = { shopSessionId: string; locale: RoutingLocale }
+type WidgetParams = BaseParams & {
+  flow: string
+  shopSessionId: string
+  priceIntentId: string
+}
 
 type SessionLink = BaseParams & {
   shopSessionId: string
@@ -230,6 +235,13 @@ export const PageLink = {
   },
   fourOhFour: ({ locale }: BaseParams = {}) => {
     return new URL(`${localePrefix(locale)}/404`, ORIGIN_URL)
+  },
+
+  widgetCalculatePrice: (params: WidgetParams) => {
+    return new URL(
+      `${localePrefix(params.locale)}/widget/${params.flow}/${params.shopSessionId}/calculate`,
+      ORIGIN_URL,
+    )
   },
 } as const
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

![Screenshot 2023-11-07 at 09.22.42.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/82534d81-a22f-44d0-ace1-f892d0eb8430.png)

- Add radio input for selecting product in widget flow

- Break out page and put inside feature folder

- Add link to next step in widget flow (calculate price)

- Add helpers to fetch correct price template based on product name

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We can't test it quite yet since we don't have the widget products in the backend yet, but we can test the UI. Just go to: `/se/widget/test/test/select`.

- I will continue to work on this in the next PRs and hook up to get correct product data from backend.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
