### PR TITLE
GEN-1385 | Widget select product - filter based on CMS config

### DIFF
--- a/apps/store/src/features/widget/fetchProductMetadata.ts
+++ b/apps/store/src/features/widget/fetchProductMetadata.ts
@@ -1,0 +1,34 @@
+import { ISbStoryData } from '@storyblok/react'
+import {
+  GlobalProductMetadata,
+  fetchGlobalProductMetadata,
+} from '@/components/LayoutWithMenu/fetchProductMetadata'
+import { initializeApollo } from '@/services/apollo/client'
+import { getStoryById } from '@/services/storyblok/storyblok'
+import { RoutingLocale } from '@/utils/l10n/types'
+
+type Params = {
+  locale: RoutingLocale
+  flow: string
+  draft?: boolean
+}
+
+type ProductMetadataStory = ISbStoryData<{ productName: string }>
+type Story = ISbStoryData<{ products: Array<ProductMetadataStory> }>
+
+export const fetchProductMetadata = async (params: Params): Promise<GlobalProductMetadata> => {
+  const apolloClient = initializeApollo({ locale: params.locale })
+
+  const [allProductMetadata, story] = await Promise.all([
+    fetchGlobalProductMetadata({ apolloClient }),
+    getStoryById<Story>({
+      id: params.flow,
+      version: params.draft ? 'draft' : undefined,
+      resolve_relations: 'widgetFlow.products',
+    }),
+  ])
+
+  const selected = new Set<string>(story.content.products.map((item) => item.content.productName))
+  const productMetadata = allProductMetadata.filter((item) => selected.has(item.name))
+  return productMetadata
+}

--- a/apps/store/src/pages/widget/[flow]/[shopSessionId]/select.tsx
+++ b/apps/store/src/pages/widget/[flow]/[shopSessionId]/select.tsx
@@ -1,13 +1,10 @@
 import { type GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { type ComponentProps } from 'react'
-import {
-  GlobalProductMetadata,
-  fetchGlobalProductMetadata,
-} from '@/components/LayoutWithMenu/fetchProductMetadata'
+import { GlobalProductMetadata } from '@/components/LayoutWithMenu/fetchProductMetadata'
 import { useHydrateProductMetadata } from '@/components/LayoutWithMenu/ProductMetadataContext'
+import { fetchProductMetadata } from '@/features/widget/fetchProductMetadata'
 import { SelectProductPage } from '@/features/widget/SelectProductPage'
-import { initializeApollo } from '@/services/apollo/client'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
 type Props = ComponentProps<typeof SelectProductPage> & {
@@ -23,10 +20,13 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
   if (!context.params) throw new Error('Missing params')
   if (!isRoutingLocale(context.locale)) throw new Error(`Invalid locale: ${context.locale}`)
 
-  const apolloClient = initializeApollo({ locale: context.locale })
   const [translations, productMetadata] = await Promise.all([
     serverSideTranslations(context.locale),
-    fetchGlobalProductMetadata({ apolloClient }),
+    fetchProductMetadata({
+      locale: context.locale,
+      flow: context.params.flow,
+      draft: context.draftMode,
+    }),
   ])
 
   return {

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -375,6 +375,21 @@ export const getStoryBySlug = <StoryData extends ISbStoryData>(
   return fetchStory<StoryData>(getStoryblokApi(), `${locale}/${slug}`, params)
 }
 
+type GetStoryByIdParams = {
+  id: string
+  version?: StoryblokVersion
+  resolve_relations?: string
+}
+
+export const getStoryById = <StoryData extends ISbStoryData>(
+  params: GetStoryByIdParams,
+): Promise<StoryData> => {
+  return fetchStory<StoryData>(getStoryblokApi(), params.id, {
+    version: params.version ?? (USE_DRAFT_CONTENT ? 'draft' : 'published'),
+    resolve_relations: params.resolve_relations,
+  })
+}
+
 export const getPageLinks = async (): Promise<Array<PageLink>> => {
   const storyblokApi = getStoryblokApi()
   const {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

![Screenshot 2023-11-07 at 11.18.04.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/b5365d5a-63b7-4310-a5be-a33e2a46dd1d.png)

- Widget product select: filter products to display based on CMS config

- Add new Storyblok helper to get story by ID

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- I decided to filter products on the backend so we can reduce page load. Let's see if it causes problems since we are reusing the same Jotai atom for the product list as we are for the menu.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
