### PR TITLE
Add new PriceBreakdown component for car dealership

### DIFF
--- a/apps/store/public/locales/en/carDealership.json
+++ b/apps/store/public/locales/en/carDealership.json
@@ -5,6 +5,8 @@
   "EDIT_CAR_TRIAL_EXTENSION_BUTTON": "Edit",
   "EDIT_OFFER_CANCEL": "Cancel",
   "EDIT_OFFER_SAVE": "Save",
+  "EXTENSION_COST_EXPLANATION": "active from {{date}}",
+  "EXTENSION_TITLE": "Extension",
   "INITIAL_OFFER_HEADING": "Your initial offer",
   "NOTICE_TOAST_CONTENT": "Don't want to take this offer? [[Cancel it here]].",
   "PAY_WITHOUT_EXTENSION_DIALOG_CANCEL": "Cancel",
@@ -19,5 +21,6 @@
   "TRIAL_COST_EXPLANATION": "discounted price until {{date}}",
   "TRIAL_TERMINATION_DATE_MESSAGE": "Valid until {{date}}",
   "TRIAL_TERMINATION_DATE_TOOLTIP": "You need to sign a new contract to continue your insurance.",
+  "TRIAL_TITLE": "Trial offer",
   "USP_TEXT": "No binding time"
 }

--- a/apps/store/public/locales/sv-se/carDealership.json
+++ b/apps/store/public/locales/sv-se/carDealership.json
@@ -5,6 +5,8 @@
   "EDIT_CAR_TRIAL_EXTENSION_BUTTON": "Ändra",
   "EDIT_OFFER_CANCEL": "Avbryt",
   "EDIT_OFFER_SAVE": "Spara",
+  "EXTENSION_COST_EXPLANATION": "gäller från {{date}}",
+  "EXTENSION_TITLE": "Förlängning",
   "INITIAL_OFFER_HEADING": "Ditt starterbjudande",
   "NOTICE_TOAST_CONTENT": "Vill du inte ta del av starterbjudandet? [[Avsluta erbjudandet här]].",
   "PAY_WITHOUT_EXTENSION_DIALOG_CANCEL": "Avbryt",
@@ -19,5 +21,6 @@
   "TRIAL_COST_EXPLANATION": "rabatterat pris till {{date}}",
   "TRIAL_TERMINATION_DATE_MESSAGE": "Gäller till {{date}}",
   "TRIAL_TERMINATION_DATE_TOOLTIP": "Du måste teckna ett nytt avtal för att förlänga din försäkring.",
+  "TRIAL_TITLE": "Starterbjudande",
   "USP_TEXT": "Ingen bindningstid"
 }

--- a/apps/store/src/features/carDealership/PriceBreakdown.tsx
+++ b/apps/store/src/features/carDealership/PriceBreakdown.tsx
@@ -1,0 +1,68 @@
+import styled from '@emotion/styled'
+import { Text, theme } from 'ui'
+import { CurrencyCode } from '@/services/apollo/generated'
+import { useFormatter } from '@/utils/useFormatter'
+
+type Props = {
+  amount: number
+  defaultAmount?: number
+  currencyCode: CurrencyCode
+  title: string
+  subTitle: string
+  priceExplanation: string
+}
+
+export const PriceBreakdown = ({
+  amount,
+  defaultAmount,
+  currencyCode,
+  title,
+  subTitle,
+  priceExplanation,
+}: Props) => {
+  const formatter = useFormatter()
+
+  return (
+    <div>
+      <Row>
+        <Text>{title}</Text>
+        <Wrapper>
+          {defaultAmount !== undefined && (
+            <Text as="p" size="md" strikethrough={true} color="textSecondary">
+              {formatter.monthlyPrice({
+                amount: defaultAmount,
+                currencyCode: currencyCode,
+              })}
+            </Text>
+          )}
+          <Text as="p" size="md" color="textPrimary">
+            {formatter.monthlyPrice({
+              currencyCode: currencyCode,
+              amount: amount,
+            })}
+          </Text>
+        </Wrapper>
+      </Row>
+
+      <Row>
+        <Text size="xs" color="textSecondary">
+          {subTitle}
+        </Text>
+        <Text size="xs" color="textSecondary">
+          {priceExplanation}
+        </Text>
+      </Row>
+    </div>
+  )
+}
+
+const Row = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+})
+
+const Wrapper = styled.div({
+  display: 'flex',
+  columnGap: theme.space.xs,
+})

--- a/apps/store/src/features/carDealership/ProductItemContractContainer.tsx
+++ b/apps/store/src/features/carDealership/ProductItemContractContainer.tsx
@@ -12,8 +12,6 @@ export const ProductItemContractContainerCar = ({ contract }: Props) => {
   const formatter = useFormatter()
   const { t } = useTranslation('carDealership')
 
-  console.log('contract', contract)
-
   // TODO: displayItems is failing in carTrialExtensionQuery
   const productDetails = [
     {

--- a/apps/store/src/features/carDealership/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'next-i18next'
 import { useState, useMemo } from 'react'
 import { Space, Button, Text, BankIdIcon, CheckIcon, theme } from 'ui'
 import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
-import { TotalAmount } from '@/components/ShopBreakdown/TotalAmount'
+import { Divider } from '@/components/ShopBreakdown/ShopBreakdown'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { TextWithLink } from '@/components/TextWithLink'
 import {
@@ -19,6 +19,7 @@ import { PageLink } from '@/utils/PageLink'
 import { useFormatter } from '@/utils/useFormatter'
 import { EditActionButton } from './EditActionButton'
 import { ExtensionOfferToggle } from './ExtensionOfferToggle'
+import { PriceBreakdown } from './PriceBreakdown'
 import { ProductItemContractContainerCar } from './ProductItemContractContainer'
 import { useAcceptExtension } from './useAcceptExtension'
 
@@ -53,13 +54,13 @@ export const TrialExtensionForm = ({
     () => getSelectedOffer(priceIntent, tierLevel),
     [priceIntent, tierLevel],
   )
-  const activationDate = convertToDate(selectedOffer.startDate)
-  if (activationDate === null) {
+  const extensionActivationDate = convertToDate(selectedOffer.startDate)
+  if (extensionActivationDate === null) {
     throw new Error(`Start date must be defined for offer  ${selectedOffer.id}`)
   }
 
-  const terminationDate = convertToDate(trialContract.terminationDate)
-  if (!terminationDate) {
+  const trialTerminationDate = convertToDate(trialContract.terminationDate)
+  if (!trialTerminationDate) {
     throw new Error(`Unable to parse terminationDate: ${trialContract.terminationDate}`)
   }
 
@@ -99,15 +100,32 @@ export const TrialExtensionForm = ({
           />
         </ProductItemContainer>
 
-        <TotalAmount
-          {...selectedOffer.cost.net}
-          {...(requirePaymentConnection && {
-            discount: {
-              reducedAmount: trialContract.currentAgreement.premium.amount,
-              explanation: t('TRIAL_COST_EXPLANATION', {
-                date: formatter.dateFull(activationDate, { hideYear: true, abbreviateMonth: true }),
-              }),
-            },
+        <PriceBreakdown
+          amount={trialContract.currentAgreement.premium.amount}
+          defaultAmount={priceIntent.defaultOffer?.cost.net.amount}
+          currencyCode={trialContract.currentAgreement.premium.currencyCode}
+          title={t('TRIAL_TITLE')}
+          subTitle={trialContract.currentAgreement.productVariant.displayNameSubtype}
+          priceExplanation={t('TRIAL_COST_EXPLANATION', {
+            date: formatter.dateFull(trialTerminationDate, {
+              hideYear: true,
+              abbreviateMonth: true,
+            }),
+          })}
+        />
+
+        <Divider />
+
+        <PriceBreakdown
+          amount={selectedOffer.cost.net.amount}
+          currencyCode={selectedOffer.cost.net.currencyCode}
+          title={t('EXTENSION_TITLE')}
+          subTitle={selectedOffer.variant.displayNameSubtype}
+          priceExplanation={t('EXTENSION_COST_EXPLANATION', {
+            date: formatter.dateFull(extensionActivationDate, {
+              hideYear: true,
+              abbreviateMonth: true,
+            }),
           })}
         />
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
A new component for explaining the cost for trial and extension separately.  
I didn't want to use the `Price` component where we send in a reduced price. The logic is the other way around in this case. The trial price is the fixed price (`amount`) and the default price that we want to strike through is the price for the same tier in full price (`defaultAmount`). 

<img width="986" alt="Screenshot 2023-11-08 at 11 53 11" src="https://github.com/HedvigInsurance/racoon/assets/6661511/d0320c11-1a2a-4c15-b0c4-61346f2d151e">


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
It doesn't make sense to show a total price for explaining the price the member will pay for 2 months trial and then the extension

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
