### PR TITLE
Widget: break out reusable header component

### DIFF
--- a/apps/store/src/features/widget/Header.tsx
+++ b/apps/store/src/features/widget/Header.tsx
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled'
+import { HedvigLogo, mq } from 'ui'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { STYLES } from '@/components/GridLayout/GridLayout.helper'
+import * as ProgressIndicator from '@/components/ProgressIndicator/ProgressIndicator'
+
+type Props = {
+  step: 'YOUR_INFO' | 'SIGN' | 'PAY'
+}
+
+export const Header = (props: Props) => {
+  return (
+    <Wrapper as="header">
+      <LogoArea>
+        <HedvigLogo />
+      </LogoArea>
+
+      <ProgressArea>
+        <ProgressIndicator.Root>
+          <ProgressIndicator.Step active={props.step === 'YOUR_INFO'}>
+            Your info
+          </ProgressIndicator.Step>
+          <ProgressIndicator.Step active={props.step === 'SIGN'}>Sign</ProgressIndicator.Step>
+          <ProgressIndicator.Step active={props.step === 'PAY'}>Pay</ProgressIndicator.Step>
+        </ProgressIndicator.Root>
+      </ProgressArea>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled(GridLayout.Root)({
+  height: '4rem',
+  alignItems: 'center',
+})
+
+const LogoArea = styled.div({
+  display: 'none',
+  [mq.md]: { display: 'block', gridColumn: '1 / span 2' },
+})
+
+const ProgressArea = styled.div(STYLES['1/3'].center, {
+  gridColumn: '1 / span 12',
+})

--- a/apps/store/src/features/widget/SelectProductPage.tsx
+++ b/apps/store/src/features/widget/SelectProductPage.tsx
@@ -2,14 +2,13 @@ import { useApolloClient } from '@apollo/client'
 import styled from '@emotion/styled'
 import { useRouter } from 'next/router'
 import { useState, type FormEventHandler } from 'react'
-import { Button, Heading, HedvigLogo, Space, mq, theme } from 'ui'
+import { Button, Heading, Space, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
-import { STYLES } from '@/components/GridLayout/GridLayout.helper'
 import { type GlobalProductMetadata } from '@/components/LayoutWithMenu/fetchProductMetadata'
-import * as ProgressIndicator from '@/components/ProgressIndicator/ProgressIndicator'
 import * as RadioOptionList from '@/components/RadioOptionList/RadioOptionList'
 import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntentService'
 import { PageLink } from '@/utils/PageLink'
+import { Header } from './Header'
 import { type WidgetProductName, getPriceTemplate, isWidgetProductName } from './widget.helpers'
 
 type Props = {
@@ -50,19 +49,7 @@ export const SelectProductPage = (props: Props) => {
 
   return (
     <Space y={4}>
-      <Header as="header">
-        <LogoArea>
-          <HedvigLogo />
-        </LogoArea>
-
-        <ProgressArea>
-          <ProgressIndicator.Root>
-            <ProgressIndicator.Step active={true}>Your info</ProgressIndicator.Step>
-            <ProgressIndicator.Step>Sign</ProgressIndicator.Step>
-            <ProgressIndicator.Step>Pay</ProgressIndicator.Step>
-          </ProgressIndicator.Root>
-        </ProgressArea>
-      </Header>
+      <Header step="YOUR_INFO" />
 
       <GridLayout.Root>
         <GridLayout.Content width="1/3" align="center">
@@ -102,20 +89,6 @@ export const SelectProductPage = (props: Props) => {
     </Space>
   )
 }
-
-const Header = styled(GridLayout.Root)({
-  height: '4rem',
-  alignItems: 'center',
-})
-
-const LogoArea = styled.div({
-  display: 'none',
-  [mq.md]: { display: 'block', gridColumn: '1 / span 2' },
-})
-
-const ProgressArea = styled.div(STYLES['1/3'].center, {
-  gridColumn: '1 / span 12',
-})
 
 const CustomButton = styled(Button)({
   // Appear disabled but remain clickable (for a11y reasons)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Widget: break out a reusable Header component

- Implement on the select product page

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We will need to use this component on other pages in the flow

- We could have implemented a shared layout but this is a more flexible approach and get the job done (for now)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
