### PR TITLE
Add check for crossed over price to catch cases where offer would be cheaper than trial

### DIFF
--- a/apps/store/src/features/carDealership/PayForTrial.tsx
+++ b/apps/store/src/features/carDealership/PayForTrial.tsx
@@ -52,7 +52,7 @@ export const PayForTrial = ({ trialContract, defaultOffer, ssn }: Props) => {
 
       <PriceBreakdown
         amount={trialContract.currentAgreement.premium.amount}
-        defaultAmount={defaultOffer?.cost.net.amount}
+        crossedOverAmount={defaultOffer?.cost.net.amount}
         currencyCode={trialContract.currentAgreement.premium.currencyCode}
         title={t('TRIAL_TITLE')}
         subTitle={trialContract.currentAgreement.productVariant.displayNameSubtype}

--- a/apps/store/src/features/carDealership/PriceBreakdown.tsx
+++ b/apps/store/src/features/carDealership/PriceBreakdown.tsx
@@ -5,7 +5,7 @@ import { useFormatter } from '@/utils/useFormatter'
 
 type Props = {
   amount: number
-  defaultAmount?: number
+  crossedOverAmount?: number
   currencyCode: CurrencyCode
   title: string
   subTitle: string
@@ -14,23 +14,23 @@ type Props = {
 
 export const PriceBreakdown = ({
   amount,
-  defaultAmount,
+  crossedOverAmount,
   currencyCode,
   title,
   subTitle,
   priceExplanation,
 }: Props) => {
   const formatter = useFormatter()
-
+  const showCrossedOverAmount = crossedOverAmount !== undefined && crossedOverAmount > amount
   return (
     <div>
       <Row>
         <Text>{title}</Text>
         <Wrapper>
-          {defaultAmount !== undefined && (
+          {showCrossedOverAmount && (
             <Text as="p" size="md" strikethrough={true} color="textSecondary">
               {formatter.monthlyPrice({
-                amount: defaultAmount,
+                amount: crossedOverAmount,
                 currencyCode: currencyCode,
               })}
             </Text>

--- a/apps/store/src/features/carDealership/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'next-i18next'
 import { useState, useMemo } from 'react'
 import { Space, Button, Text, BankIdIcon, CheckIcon, theme } from 'ui'
 import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
-import { Divider } from '@/components/ShopBreakdown/ShopBreakdown'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { TextWithLink } from '@/components/TextWithLink'
 import {
@@ -55,7 +54,7 @@ export const TrialExtensionForm = ({
     [priceIntent, tierLevel],
   )
   const extensionActivationDate = convertToDate(selectedOffer.startDate)
-  if (extensionActivationDate === null) {
+  if (!extensionActivationDate) {
     throw new Error(`Start date must be defined for offer  ${selectedOffer.id}`)
   }
 
@@ -102,7 +101,7 @@ export const TrialExtensionForm = ({
 
         <PriceBreakdown
           amount={trialContract.currentAgreement.premium.amount}
-          defaultAmount={priceIntent.defaultOffer?.cost.net.amount}
+          crossedOverAmount={priceIntent.defaultOffer?.cost.net.amount}
           currencyCode={trialContract.currentAgreement.premium.currencyCode}
           title={t('TRIAL_TITLE')}
           subTitle={trialContract.currentAgreement.productVariant.displayNameSubtype}
@@ -166,6 +165,19 @@ const UspWrapper = styled.div({
   justifyContent: 'center',
   gap: theme.space.xs,
 })
+
+export const Divider = () => {
+  return (
+    <div
+      style={{
+        height: 1,
+        borderBottomWidth: 1,
+        borderBottomStyle: 'solid',
+        borderBottomColor: theme.colors.borderOpaque1,
+      }}
+    />
+  )
+}
 
 const getSelectedOffer = (
   priceIntent: PriceIntentCarTrialExtensionFragment,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Make sure we never show crossed over price that's cheaper than the trial amount. Fred mentioned rare cases where offer would be cheaper than trial and this also would happen if default offer was not set to match trial tier.

Alos adressed comments from first PR

Avoid this case:
<img width="694" alt="Screenshot 2023-11-08 at 15 58 59" src="https://github.com/HedvigInsurance/racoon/assets/6661511/48bc09c1-0b93-4e8f-b4c4-9905e4c4bcb4">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
