### PR TITLE
fix(widget-content-pages): make it work with draft content

### DIFF
--- a/apps/store/src/pages/widget/[[...slug]].tsx
+++ b/apps/store/src/pages/widget/[[...slug]].tsx
@@ -39,7 +39,7 @@ export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = a
   }
 
   const slug = `${STORYBLOK_WIDGET_FOLDER_SLUG}/${(params?.slug ?? []).join('/')}`
-  const version = draftMode ? 'draft' : 'published'
+  const version = draftMode ? 'draft' : undefined
 
   const [story, translations] = await Promise.all([
     getStoryBySlug<PageStory | WidgetFlowStory>(slug, { version, locale }),


### PR DESCRIPTION
## Describe your changes

Just realised that part was missing.

## Justify why they are needed

So we visualize widget draft content pages locally
