### PR TITLE
[CAR-30] Show productVariant documents in MemberArea > Insurance > Documents section

### DIFF
--- a/apps/store/src/components/InsuranceDocumentLink.tsx
+++ b/apps/store/src/components/InsuranceDocumentLink.tsx
@@ -1,0 +1,79 @@
+import styled from '@emotion/styled'
+import { mq, NeArrow, theme } from 'ui'
+
+type Props = {
+  url: string
+  displayName: string
+}
+
+export const InsuranceDocumentLink = ({ url, displayName }: Props) => {
+  const extension = getExtensionFromUrl(url)
+
+  return (
+    <DownloadFileLink href={url} target="_blank" rel="noopener nofollow">
+      <Ellipsis>
+        {displayName} <DocumentType>{extension}</DocumentType>
+      </Ellipsis>
+
+      <StyledNeArrow size="1rem" />
+    </DownloadFileLink>
+  )
+}
+const getExtensionFromUrl = (urlString: string): string => {
+  try {
+    const url = new URL(urlString)
+    if (url.pathname.includes('.')) {
+      return url.pathname.split('.').at(-1)!
+    }
+    return ''
+  } catch (err) {
+    console.warn(`Failed to parse url: ${urlString}`)
+    return ''
+  }
+}
+
+const DownloadFileLink = styled.a({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: theme.space.md,
+  // Counter the padding from the "DocumentType"
+  paddingTop: theme.space.xs,
+  height: 'auto',
+  fontSize: theme.fontSizes.md,
+  backgroundColor: theme.colors.opaque1,
+  borderRadius: theme.radius.sm,
+
+  ':hover': {
+    backgroundColor: theme.colors.gray200,
+  },
+
+  ':active': {
+    backgroundColor: theme.colors.opaque3,
+  },
+
+  ':focus-visible': {
+    boxShadow: theme.shadow.focus,
+  },
+
+  [mq.lg]: {
+    fontSize: theme.fontSizes.lg,
+  },
+})
+
+const Ellipsis = styled.span({
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+})
+
+const DocumentType = styled.sup({
+  fontVariant: 'small-caps',
+  verticalAlign: 'super',
+})
+
+const StyledNeArrow = styled(NeArrow)({
+  flexShrink: 0,
+  position: 'relative',
+  top: theme.space.xxs,
+})

--- a/apps/store/src/components/ProductPage/ProductDocuments.tsx
+++ b/apps/store/src/components/ProductPage/ProductDocuments.tsx
@@ -1,12 +1,13 @@
 import styled from '@emotion/styled'
-import { mq, NeArrow, Space, Text, theme } from 'ui'
+import { mq, Space, Text, theme } from 'ui'
 import { GridLayout, TEXT_CONTENT_MAX_WIDTH } from '@/components/GridLayout/GridLayout'
-import { InsuranceDocument } from '@/services/apollo/generated'
+import { InsuranceDocumentLink } from '@/components/InsuranceDocumentLink'
+import { InsuranceDocumentFragment } from '@/services/apollo/generated'
 
 type Props = {
   heading: string
   description: string
-  docs: Array<InsuranceDocument>
+  docs: Array<InsuranceDocumentFragment>
 }
 
 export const ProductDocuments = ({ heading, description, docs }: Props) => {
@@ -23,25 +24,11 @@ export const ProductDocuments = ({ heading, description, docs }: Props) => {
       <GridLayout.Content width="1/2" align="right">
         <Space y={{ base: 0.25, lg: 0.5 }}>
           {docs.map((doc, index) => (
-            <ProductDocument key={index} doc={doc} />
+            <InsuranceDocumentLink key={index} url={doc.url} displayName={doc.displayName} />
           ))}
         </Space>
       </GridLayout.Content>
     </Layout>
-  )
-}
-
-const ProductDocument = ({ doc }: { doc: InsuranceDocument }) => {
-  const documentType = doc.url.includes('.') ? doc.url.substring(doc.url.lastIndexOf('.') + 1) : ''
-
-  return (
-    <DownloadFileLink href={doc.url} target="_blank" rel="noopener nofollow">
-      <Ellipsis>
-        {doc.displayName} <DocumentType>{documentType}</DocumentType>
-      </Ellipsis>
-
-      <StyledNeArrow size="1rem" />
-    </DownloadFileLink>
   )
 }
 
@@ -62,48 +49,3 @@ const Content = styled.div({
   },
 })
 
-const DownloadFileLink = styled.a({
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  padding: theme.space.md,
-  // Counter the padding from the "DocumentType"
-  paddingTop: theme.space.xs,
-  height: 'auto',
-  fontSize: theme.fontSizes.md,
-  backgroundColor: theme.colors.opaque1,
-  borderRadius: theme.radius.sm,
-
-  ':hover': {
-    backgroundColor: theme.colors.gray200,
-  },
-
-  ':active': {
-    backgroundColor: theme.colors.opaque3,
-  },
-
-  ':focus-visible': {
-    boxShadow: theme.shadow.focus,
-  },
-
-  [mq.lg]: {
-    fontSize: theme.fontSizes.lg,
-  },
-})
-
-const Ellipsis = styled.span({
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-})
-
-const DocumentType = styled.sup({
-  fontVariant: 'small-caps',
-  verticalAlign: 'super',
-})
-
-const StyledNeArrow = styled(NeArrow)({
-  flexShrink: 0,
-  position: 'relative',
-  top: theme.space.xxs,
-})

--- a/apps/store/src/features/memberArea/InsuranceSection/InsuranceDetailsSection.tsx
+++ b/apps/store/src/features/memberArea/InsuranceSection/InsuranceDetailsSection.tsx
@@ -3,7 +3,7 @@ import * as RadixTabs from '@radix-ui/react-tabs'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
 import { Button, Heading, Space, Text, theme } from 'ui'
-import { ButtonNextLink } from '@/components/ButtonNextLink'
+import { InsuranceDocumentLink } from '@/components/InsuranceDocumentLink'
 import { Perils } from '@/components/Perils/Perils'
 import { MemberContractFragment } from '@/services/apollo/generated'
 import { useMemberAreaInfo } from '../useMemberAreaInfo'
@@ -87,20 +87,32 @@ const InsuranceTabs = ({ contract }: InsuranceTabsProps) => {
       </RadixTabs.TabsContent>
 
       <RadixTabs.TabsContent value="documents">
-        <Documents>
-          {contract.currentAgreement.certificateUrl && (
-            <ButtonNextLink
-              href={contract.currentAgreement.certificateUrl}
-              target="_blank"
-              variant="secondary"
-              size="small"
-            >
-              {t('INSURANCE_DETAILS_CERTIFICATE_BUTTON')}
-            </ButtonNextLink>
-          )}
-        </Documents>
+        <Documents currentAgreement={contract.currentAgreement} />
       </RadixTabs.TabsContent>
     </RadixTabs.Tabs>
+  )
+}
+
+type Agreement = MemberContractFragment['currentAgreement']
+
+const Documents = ({ currentAgreement }: { currentAgreement: Agreement }) => {
+  const { t } = useTranslation('memberArea')
+  return (
+    <DocumentList>
+      {currentAgreement.certificateUrl && (
+        <InsuranceDocumentLink
+          displayName={t('INSURANCE_DETAILS_CERTIFICATE_BUTTON')}
+          url={currentAgreement.certificateUrl}
+        />
+      )}
+      {currentAgreement.productVariant.documents.map((document) => (
+        <InsuranceDocumentLink
+          key={document.url}
+          url={document.url}
+          displayName={document.displayName}
+        />
+      ))}
+    </DocumentList>
   )
 }
 
@@ -119,9 +131,9 @@ const TabButton = styled(Button)({
 
 const Overview = styled.div({ maxWidth: '400px' })
 
-const Documents = styled.div({
-  display: 'grid',
-  gridTemplateColumns: 'repeat(2, 1fr)',
+const DocumentList = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
   gap: theme.space.md,
   marginTop: theme.space.lg,
 })

--- a/apps/store/src/features/memberArea/MemberAreaMemberInfo.graphql
+++ b/apps/store/src/features/memberArea/MemberAreaMemberInfo.graphql
@@ -31,6 +31,9 @@ fragment MemberContract on Contract {
       displayName
       typeOfContract
       termsVersion
+      documents {
+        ...InsuranceDocument
+      }
       insurableLimits {
         label
         limit

--- a/apps/store/src/graphql/InsuranceDocumentFragment.graphql
+++ b/apps/store/src/graphql/InsuranceDocumentFragment.graphql
@@ -1,0 +1,4 @@
+fragment InsuranceDocument on InsuranceDocument {
+    displayName
+    url
+}

--- a/apps/store/src/graphql/ProductData.graphql
+++ b/apps/store/src/graphql/ProductData.graphql
@@ -25,10 +25,10 @@ query ProductData($productName: String!) {
         description
       }
       documents {
-        type
-        displayName
-        url
+        ...InsuranceDocument
       }
     }
   }
 }
+
+

--- a/apps/store/src/mocks/productData.ts
+++ b/apps/store/src/mocks/productData.ts
@@ -1,5 +1,5 @@
 import { ProductData } from '@/components/ProductPage/ProductPage.types'
-import { InsurableLimitType, InsuranceDocumentType } from '@/services/apollo/generated'
+import { InsurableLimitType } from '@/services/apollo/generated'
 
 export const productData: ProductData = {
   __typename: 'Product',
@@ -278,19 +278,16 @@ export const productData: ProductData = {
       documents: [
         {
           __typename: 'InsuranceDocument',
-          type: InsuranceDocumentType.TermsAndConditions,
           displayName: 'SE Apartment Terms and Conditions',
           url: 'https://promise-cms.s3.eu-central-1.amazonaws.com/SE_APARTMENT_BRF_T_and_C_2022_11_01_HEDVIG_4b078e6dc8.pdf',
         },
         {
           __typename: 'InsuranceDocument',
-          type: InsuranceDocumentType.PreSaleInfo,
           displayName: 'SE Apartment BRF IPID',
           url: 'https://promise-cms.s3.eu-central-1.amazonaws.com/SE_APARTMENT_BRF_IPID_2022_11_01_20c6e37d9f.pdf',
         },
         {
           __typename: 'InsuranceDocument',
-          type: InsuranceDocumentType.PreSaleInfo,
           displayName: 'SE Apartment BRF Presale',
           url: 'https://promise-cms.s3.eu-central-1.amazonaws.com/SE_APARTMENT_BRF_PRESALE_2022_11_01_990f775ff6.pdf',
         },


### PR DESCRIPTION
![Screenshot 2023-11-09 at 11.33.07.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/a1061fa3-d1d0-4d25-a381-60b0af9814f3.png)

<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Show insurance documents in member area after insurance certificate

Extract InsuranceDocumentLink as reusable component and make it separate from GraphQL model

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Part of Car Trial flow

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
