### PR TITLE
chore: replace :first-child for :first-of-type

### DIFF
--- a/apps/store/src/blocks/TextBlock.tsx
+++ b/apps/store/src/blocks/TextBlock.tsx
@@ -39,8 +39,9 @@ export const TextBlock = ({ blok }: TextBlockProps) => {
 
 const StyledText = styled(Text)(
   {
-    'p:not(:first-child)': {
+    'p:not(:first-of-type)': {
       marginTop: theme.space.md,
+      backgroundColor: theme.colors.red100,
     },
   },
   listStyles,

--- a/apps/store/src/features/memberArea/InsuranceSection/InsuranceDetailsSection.tsx
+++ b/apps/store/src/features/memberArea/InsuranceSection/InsuranceDetailsSection.tsx
@@ -146,7 +146,7 @@ const Row = styled.div({
   justifyContent: 'space-between',
   height: '3rem',
 
-  ':not(:first-child)': {
+  ':not(:first-of-type)': {
     borderTop: '1px solid hsla(0, 0%, 7%, 0.1)',
   },
 })


### PR DESCRIPTION
## Describe your changes

Replaces `:first-child` to `:first-of-type`

## Justify why they are needed

We've getting some warning about this as `:first-child` selector can be problematic while using emotion during SSR. More info can be found [here](https://infinum.com/handbook/frontend/react/common-ssr-errors).
