### PR TITLE
GEN-1441 | Get product data from context when tracking Insurely events

### DIFF
--- a/apps/store/src/components/PriceCalculator/useFetchInsurance.ts
+++ b/apps/store/src/components/PriceCalculator/useFetchInsurance.ts
@@ -1,7 +1,6 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { atom, useAtom, useSetAtom } from 'jotai'
 import { useCallback } from 'react'
-import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { useTracking } from '@/services/Tracking/useTracking'
 
 type State = 'INITIAL' | 'PROMPT' | 'COMPARE' | 'SUCCESS' | 'DISMISSED'
@@ -19,7 +18,6 @@ export const useFetchInsuranceState = () => {
 export const useShowFetchInsurance = ({ priceIntentId }: Params) => {
   const setState = useSetAtom(STATE_ATOM)
   const tracking = useTracking()
-  const { productData } = useProductPageContext()
 
   return useCallback(
     ({ force = false }: { force?: boolean } = {}) => {
@@ -31,10 +29,7 @@ export const useShowFetchInsurance = ({ priceIntentId }: Params) => {
           window.sessionStorage.setItem(sessionStorageKey, 'true')
 
           datadogLogs.logger.info('Display FetchInsurancePrompt', { priceIntentId })
-          tracking.reportInsurelyPrompted({
-            id: productData.id,
-            displayNameFull: productData.displayNameFull,
-          })
+          tracking.reportInsurelyPrompted()
 
           return 'PROMPT'
         }
@@ -42,36 +37,28 @@ export const useShowFetchInsurance = ({ priceIntentId }: Params) => {
         return currentState
       })
     },
-    [setState, priceIntentId, tracking, productData],
+    [setState, priceIntentId, tracking],
   )
 }
 
 export const useFetchInsuranceCompare = () => {
   const setState = useSetAtom(STATE_ATOM)
   const tracking = useTracking()
-  const { productData } = useProductPageContext()
 
   return useCallback(() => {
-    tracking.reportInsurelyAccepted({
-      id: productData.id,
-      displayNameFull: productData.displayNameFull,
-    })
+    tracking.reportInsurelyAccepted()
 
     setState('COMPARE')
-  }, [setState, tracking, productData])
+  }, [setState, tracking])
 }
 
 export const useFetchInsuranceSuccess = () => {
   const setState = useSetAtom(STATE_ATOM)
   const tracking = useTracking()
-  const { productData } = useProductPageContext()
 
   return useCallback(() => {
-    tracking.reportInsurelyCorrectlyFetched({
-      id: productData.id,
-      displayNameFull: productData.displayNameFull,
-    })
+    tracking.reportInsurelyCorrectlyFetched()
 
     setState('SUCCESS')
-  }, [setState, tracking, productData])
+  }, [setState, tracking])
 }

--- a/apps/store/src/components/ProductPage/PriceIntentContext.tsx
+++ b/apps/store/src/components/ProductPage/PriceIntentContext.tsx
@@ -19,6 +19,7 @@ import {
 import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntentService'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useTracking } from '@/services/Tracking/useTracking'
 import { getOffersByPrice } from '@/utils/getOffersByPrice'
 import { useCartEntryToReplace } from './ProductPage'
 import { usePreloadedPriceIntentId } from './PurchaseForm/usePreloadedPriceIntentId'
@@ -61,6 +62,7 @@ const usePriceIntentContextValue = () => {
     [apolloClient, priceTemplate, productData.name],
   )
 
+  const tracking = useTracking()
   const result = usePriceIntentQuery({
     skip: !priceIntentId,
     variables: priceIntentId ? { priceIntentId } : undefined,
@@ -77,6 +79,8 @@ const usePriceIntentContextValue = () => {
         updatePriceIntent(shopSession)
         return
       }
+
+      tracking.setProductContext(productData)
     },
   })
   const priceIntent = result.data?.priceIntent

--- a/apps/store/src/services/Tracking/Tracking.ts
+++ b/apps/store/src/services/Tracking/Tracking.ts
@@ -60,6 +60,8 @@ export enum TrackingContextKey {
   ShopSessionId = 'shopSessionId',
   MigrationSessionId = 'migrationSessionId',
   ZipCode = 'zipCode',
+  ProductId = 'productId',
+  ProductDisplayName = 'productDisplayName',
 }
 
 // Simple version with 2 destinations (GTM and Datadog) implemented inline
@@ -89,6 +91,11 @@ export class Tracking {
     )
     this.setContext(TrackingContextKey.ZipCode, priceIntent.data.zipCode)
     this.setContext(TrackingContextKey.City, priceIntent.data.city)
+  }
+
+  public setProductContext = (product: TrackingProductData) => {
+    this.setContext(TrackingContextKey.ProductId, product.id)
+    this.setContext(TrackingContextKey.ProductDisplayName, product.displayNameFull)
   }
 
   public reportAppInit = (context: AppTrackingContext) => {
@@ -254,23 +261,31 @@ export class Tracking {
     this.reportAdtractionEvent(cart, this.context)
   }
 
-  public reportInsurelyPrompted(productData: TrackingProductData) {
+  private productData(): TrackingProductData {
+    const id = typeof this.context.productId === 'string' ? this.context.productId : ''
+    const displayNameFull =
+      typeof this.context.productDisplayName === 'string' ? this.context.productDisplayName : ''
+
+    return { id, displayNameFull }
+  }
+
+  public reportInsurelyPrompted() {
     this.reportEcommerceEvent(
-      productDataToEcommerceEvent(TrackingEvent.InsurelyPrompted, productData, this.context),
+      productDataToEcommerceEvent(TrackingEvent.InsurelyPrompted, this.productData(), this.context),
     )
   }
 
-  public reportInsurelyAccepted(productData: TrackingProductData) {
+  public reportInsurelyAccepted() {
     this.reportEcommerceEvent(
-      productDataToEcommerceEvent(TrackingEvent.InsurelyAccepted, productData, this.context),
+      productDataToEcommerceEvent(TrackingEvent.InsurelyAccepted, this.productData(), this.context),
     )
   }
 
-  public reportInsurelyCorrectlyFetched(productData: TrackingProductData) {
+  public reportInsurelyCorrectlyFetched() {
     this.reportEcommerceEvent(
       productDataToEcommerceEvent(
         TrackingEvent.InsurelyCorrectlyFetched,
-        productData,
+        this.productData(),
         this.context,
       ),
     )


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->


![Screenshot 2023-11-10 at 12.54.14.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/90cfa766-035f-4c4a-a67b-9fea2b83ed32.png)



## Describe your changes

- Update tracking context when we receive a new price intent

- Use product data from context when submitting Insurely events

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Make `PriceCalculator` reusable outside PDP

- I realize that we use product data for other events as well. This opens up the question of when to update the tracking context. It would make sense that it would be done as we load the PDP but there's no easy hook for that in Next.js (unfortunately). I would say we start with this update and discuss the way forward in a separate ticket.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
