### PR TITLE
GEN-1444 | Use Shop Session from prop in `FetchInsurance`

### DIFF
--- a/apps/store/src/components/PriceCalculator/FetchInsuranceContainer.tsx
+++ b/apps/store/src/components/PriceCalculator/FetchInsuranceContainer.tsx
@@ -1,23 +1,23 @@
+import { ComponentProps, type ReactNode } from 'react'
 import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import { Features } from '@/utils/Features'
 import { FetchInsurance } from './FetchInsurance'
 
+type ChildrenProps = Pick<ComponentProps<typeof FetchInsurance>, 'externalInsurer' | 'insurely'>
+
 type Props = {
   priceIntent: PriceIntent
+  children: (props: ChildrenProps) => ReactNode
 }
 
-export const FetchInsuranceContainer = ({ priceIntent }: Props) => {
+export const FetchInsuranceContainer = (props: Props) => {
   if (!Features.enabled('INSURELY')) return null
-  if (priceIntent.product.name === 'SE_CAR' && !Features.enabled('INSURELY_CAR')) return null
-  if (!priceIntent.externalInsurer) return null
-  if (!priceIntent.insurely) return null
+  if (props.priceIntent.product.name === 'SE_CAR' && !Features.enabled('INSURELY_CAR')) return null
+  if (!props.priceIntent.externalInsurer) return null
+  if (!props.priceIntent.insurely) return null
 
-  return (
-    <FetchInsurance
-      priceIntentId={priceIntent.id}
-      externalInsurer={priceIntent.externalInsurer}
-      insurely={priceIntent.insurely}
-      productName={priceIntent.product.displayNameShort}
-    />
-  )
+  return props.children({
+    externalInsurer: props.priceIntent.externalInsurer,
+    insurely: props.priceIntent.insurely,
+  })
 }

--- a/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
@@ -9,6 +9,7 @@ import { type Template, type Form } from '@/services/PriceCalculator/PriceCalcul
 import { type PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import { type ShopSession } from '@/services/shopSession/ShopSession.types'
 import { AutomaticField } from './AutomaticField'
+import { FetchInsurance } from './FetchInsurance'
 import { FetchInsuranceContainer } from './FetchInsuranceContainer'
 import { FormGrid } from './FormGrid'
 import { PriceCalculatorAccordion } from './PriceCalculatorAccordion'
@@ -117,7 +118,17 @@ export const PriceCalculator = (props: Props) => {
         )}
       </PriceCalculatorAccordion>
 
-      <FetchInsuranceContainer priceIntent={priceIntent} />
+      <FetchInsuranceContainer priceIntent={priceIntent}>
+        {({ externalInsurer, insurely }) => (
+          <FetchInsurance
+            shopSession={shopSession}
+            priceIntentId={priceIntent.id}
+            externalInsurer={externalInsurer}
+            insurely={insurely}
+            productName={priceIntent.product.name}
+          />
+        )}
+      </FetchInsuranceContainer>
     </>
   )
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Use Shop Session from props instead of context in `FetchInsurance` component

- Refactor `FetchInsuranceContainer` into using render-props

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- I decided to refactor `FetchInsuranceContainer` to avoid prop drilling

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
