### PR TITLE
GEN-1455 | Initialize Widget from flow route

### DIFF
--- a/apps/store/src/features/widget/ShopSessionCreatePartner.graphql
+++ b/apps/store/src/features/widget/ShopSessionCreatePartner.graphql
@@ -1,0 +1,5 @@
+mutation ShopSessionCreatePartner($input: ShopSessionCreatePartnerInput!) {
+  shopSessionCreatePartner(input: $input) {
+    id
+  }
+}

--- a/apps/store/src/pages/widget/flows/[...slug].tsx
+++ b/apps/store/src/pages/widget/flows/[...slug].tsx
@@ -1,0 +1,61 @@
+import { GetServerSideProps } from 'next'
+import { STORYBLOK_WIDGET_FOLDER_SLUG } from '@/features/widget/widget.constants'
+import { initializeApolloServerSide } from '@/services/apollo/client'
+import {
+  ShopSessionCreatePartnerDocument,
+  ShopSessionCreatePartnerMutation,
+  ShopSessionCreatePartnerMutationVariables,
+} from '@/services/apollo/generated'
+import { PageStory, WidgetFlowStory, getStoryBySlug } from '@/services/storyblok/storyblok'
+import { isWidgetFlowStory } from '@/services/storyblok/Storyblok.helpers'
+import { getCountryByLocale } from '@/utils/l10n/countryUtils'
+import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+import { PageLink } from '@/utils/PageLink'
+
+type Params = { slug: Array<string> }
+
+export const getServerSideProps: GetServerSideProps<any, Params> = async (context) => {
+  if (!context.params) throw new Error('Missing params')
+  if (!isRoutingLocale(context.locale)) return { notFound: true }
+
+  const slug = `${STORYBLOK_WIDGET_FOLDER_SLUG}/flows/${context.params.slug.join('/')}`
+
+  const story = await getStoryBySlug<PageStory | WidgetFlowStory>(slug, {
+    version: context.draftMode ? 'draft' : undefined,
+    locale: context.locale,
+  })
+  const flow = String(story.id)
+
+  if (!isWidgetFlowStory(story)) {
+    console.warn('Story is not a widget flow story:', story.slug)
+    return { notFound: true }
+  }
+
+  const apolloClient = await initializeApolloServerSide({ ...context, locale: context.locale })
+  const { countryCode } = getCountryByLocale(context.locale)
+  const result = await apolloClient.mutate<
+    ShopSessionCreatePartnerMutation,
+    ShopSessionCreatePartnerMutationVariables
+  >({
+    mutation: ShopSessionCreatePartnerDocument,
+    variables: { input: { countryCode, partnerName: story.content.partner } },
+  })
+
+  const shopSessionId = result.data?.shopSessionCreatePartner.id
+  if (!shopSessionId) throw new Error('Missing shopSessionId')
+
+  return {
+    redirect: {
+      // TODO: Pass along any query params
+      destination: PageLink.widgetSelectProduct({
+        locale: context.locale,
+        flow,
+        shopSessionId,
+      }).href,
+      permanent: false,
+    },
+  }
+}
+
+const Page = () => null
+export default Page

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -86,7 +86,7 @@ export const isProductStory = (story: ISbStoryData): story is ProductStory => {
 }
 
 export const isWidgetFlowStory = (story: ISbStoryData): story is WidgetFlowStory => {
-  return story.content.component === 'widget-flow'
+  return story.content.component === 'widgetFlow'
 }
 
 export const getStoryblokImageSize = (filename: string) => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

Co-authored by @alebedev

## Describe your changes

- Setup new route to initialize widget from a CMS "widgetFlow" story

- Use new "shopSessionCreatePartner" mutation

- Fix `isWidgetFlowStory` helper

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Define single entry point for widget initialization

- Landing pages will link to this route to initialize the widget

- This overrides the other slug-route but we will address that in the next PR

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
