### PR TITLE
Don't show price breakdown for only extension page

### DIFF
--- a/apps/store/src/features/carDealership/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'next-i18next'
 import { useState, useMemo } from 'react'
 import { Space, Button, Text, BankIdIcon, CheckIcon, theme } from 'ui'
 import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
+import { TotalAmount } from '@/components/ShopBreakdown/TotalAmount'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { TextWithLink } from '@/components/TextWithLink'
 import {
@@ -105,34 +106,42 @@ export const TrialExtensionForm = ({
           />
         </ProductItemContainer>
 
-        <PriceBreakdown
-          amount={trialContract.premium.amount}
-          crossedOverAmount={defaultOfferCost?.amount}
-          currencyCode={trialContract.premium.currencyCode}
-          title={t('TRIAL_TITLE')}
-          subTitle={trialContract.productVariant.displayNameSubtype}
-          priceExplanation={t('TRIAL_COST_EXPLANATION', {
-            date: formatter.dateFull(trialTerminationDate, {
-              hideYear: true,
-              abbreviateMonth: true,
-            }),
-          })}
-        />
+        {requirePaymentConnection ? (
+          <>
+            <PriceBreakdown
+              amount={trialContract.premium.amount}
+              crossedOverAmount={defaultOfferCost?.amount}
+              currencyCode={trialContract.premium.currencyCode}
+              title={t('TRIAL_TITLE')}
+              subTitle={trialContract.productVariant.displayNameSubtype}
+              priceExplanation={t('TRIAL_COST_EXPLANATION', {
+                date: formatter.dateFull(trialTerminationDate, {
+                  hideYear: true,
+                  abbreviateMonth: true,
+                }),
+              })}
+            />
 
-        <Divider />
-
-        <PriceBreakdown
-          amount={selectedOffer.cost.net.amount}
-          currencyCode={selectedOffer.cost.net.currencyCode}
-          title={t('EXTENSION_TITLE')}
-          subTitle={selectedOffer.variant.displayNameSubtype}
-          priceExplanation={t('EXTENSION_COST_EXPLANATION', {
-            date: formatter.dateFull(extensionActivationDate, {
-              hideYear: true,
-              abbreviateMonth: true,
-            }),
-          })}
-        />
+            <Divider />
+            <PriceBreakdown
+              amount={selectedOffer.cost.net.amount}
+              currencyCode={selectedOffer.cost.net.currencyCode}
+              title={t('EXTENSION_TITLE')}
+              subTitle={selectedOffer.variant.displayNameSubtype}
+              priceExplanation={t('EXTENSION_COST_EXPLANATION', {
+                date: formatter.dateFull(extensionActivationDate, {
+                  hideYear: true,
+                  abbreviateMonth: true,
+                }),
+              })}
+            />
+          </>
+        ) : (
+          <TotalAmount
+            amount={selectedOffer.cost.net.amount}
+            currencyCode={selectedOffer.cost.net.currencyCode}
+          />
+        )}
 
         <Space y={1}>
           <Button onClick={handleClickSign} loading={loading}>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Display total amount when displaying only the extension 

### Before
<img width="608" alt="Screenshot 2023-11-14 at 16 34 22" src="https://github.com/HedvigInsurance/racoon/assets/6661511/abe971c4-9fe4-489a-a37c-13cea1163d68">

### After
<img width="624" alt="Screenshot 2023-11-14 at 16 34 05" src="https://github.com/HedvigInsurance/racoon/assets/6661511/2ca1b462-84e5-4f82-87ee-8089cb29a9e1">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
