### PR TITLE
GEN-1458 | Preview Widget Checkout in Storyblok

### DIFF
--- a/apps/store/src/pages/widget/flows/[...slug].tsx
+++ b/apps/store/src/pages/widget/flows/[...slug].tsx
@@ -1,16 +1,20 @@
-import { GetServerSideProps } from 'next'
+import { type GetServerSideProps } from 'next'
 import { STORYBLOK_WIDGET_FOLDER_SLUG } from '@/features/widget/widget.constants'
 import { initializeApolloServerSide } from '@/services/apollo/client'
 import {
   ShopSessionCreatePartnerDocument,
-  ShopSessionCreatePartnerMutation,
-  ShopSessionCreatePartnerMutationVariables,
+  type ShopSessionCreatePartnerMutation,
+  type ShopSessionCreatePartnerMutationVariables,
 } from '@/services/apollo/generated'
-import { PageStory, WidgetFlowStory, getStoryBySlug } from '@/services/storyblok/storyblok'
+import {
+  type PageStory,
+  type WidgetFlowStory,
+  getStoryBySlug,
+} from '@/services/storyblok/storyblok'
 import { isWidgetFlowStory } from '@/services/storyblok/Storyblok.helpers'
 import { getCountryByLocale } from '@/utils/l10n/countryUtils'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
-import { PageLink } from '@/utils/PageLink'
+import { ORIGIN_URL, PageLink } from '@/utils/PageLink'
 
 type Params = { slug: Array<string> }
 
@@ -18,8 +22,14 @@ export const getServerSideProps: GetServerSideProps<any, Params> = async (contex
   if (!context.params) throw new Error('Missing params')
   if (!isRoutingLocale(context.locale)) return { notFound: true }
 
-  const slug = `${STORYBLOK_WIDGET_FOLDER_SLUG}/flows/${context.params.slug.join('/')}`
+  const url = new URL(context.req.url ?? '', ORIGIN_URL)
+  const runningInStoryblokEditor = url.searchParams.has('_storyblok')
+  if (runningInStoryblokEditor) {
+    url.pathname = url.pathname.replace('/widget/flows', `${context.locale}/widget/preview`)
+    return { redirect: { destination: url.href, permanent: false } }
+  }
 
+  const slug = `${STORYBLOK_WIDGET_FOLDER_SLUG}/flows/${context.params.slug.join('/')}`
   const story = await getStoryBySlug<PageStory | WidgetFlowStory>(slug, {
     version: context.draftMode ? 'draft' : undefined,
     locale: context.locale,

--- a/apps/store/src/pages/widget/preview/[[...slug]].tsx
+++ b/apps/store/src/pages/widget/preview/[[...slug]].tsx
@@ -4,8 +4,8 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { STORYBLOK_WIDGET_FOLDER_SLUG } from '@/features/widget/widget.constants'
 import {
   PageStory,
-  WidgetFlowStory,
-  StoryblokQueryParams,
+  type WidgetFlowStory,
+  type StoryblokQueryParams,
   getRevalidate,
   getStoryBySlug,
 } from '@/services/storyblok/storyblok'
@@ -24,9 +24,7 @@ const WidgetCmsPage = (props: PageProps) => {
   // pros[STORY_PROP_NAME] gets properly typed here.
   const story = useStoryblokState(props[STORY_PROP_NAME] as any)
 
-  if (!story) {
-    return null
-  }
+  if (!story) return null
 
   return <StoryblokComponent blok={story.content} />
 }
@@ -34,11 +32,10 @@ const WidgetCmsPage = (props: PageProps) => {
 export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = async (context) => {
   const { locale, params, draftMode } = context
 
-  if (!isRoutingLocale(locale)) {
-    return { notFound: true }
-  }
+  if (!params) throw new Error('Missing params')
+  if (!isRoutingLocale(locale)) return { notFound: true }
 
-  const slug = `${STORYBLOK_WIDGET_FOLDER_SLUG}/${(params?.slug ?? []).join('/')}`
+  const slug = `${STORYBLOK_WIDGET_FOLDER_SLUG}/flows/${params.slug.join('/')}`
   const version = draftMode ? 'draft' : undefined
 
   const [story, translations] = await Promise.all([
@@ -46,9 +43,7 @@ export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = a
     serverSideTranslations(locale),
   ])
 
-  const props = {
-    ...translations,
-  }
+  const props = { ...translations }
 
   if (isWidgetFlowStory(story)) {
     return {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Bring back support for previewing the widget sign/checkout page in Storyblok

- Check if widget flow route is loaded in Storyblok editor and redirect to preview route

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Make it possible to preview the widget sign/checkout page in Storyblok

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
