### PR TITLE
GEN-1459 | Pre-fill customer data from search params

### DIFF
--- a/apps/store/src/features/widget/parseSearchParams.ts
+++ b/apps/store/src/features/widget/parseSearchParams.ts
@@ -1,0 +1,34 @@
+import Personnummer from 'personnummer'
+import { ShopSessionCustomerUpdateInput } from '@/services/apollo/generated'
+
+// Search Params from Partner Widget
+enum SearchParam {
+  Email = 'email',
+  Ssn = 'ssn',
+}
+
+type CustomerData = Omit<ShopSessionCustomerUpdateInput, 'shopSessionId'>
+
+export const parseCustomerDataSearchParams = (
+  searchParams: URLSearchParams,
+): [CustomerData, URLSearchParams] => {
+  const updatedSearchParams = new URLSearchParams(searchParams.toString())
+
+  const searchSsn = updatedSearchParams.get(SearchParam.Ssn)
+  let ssn: string | undefined = undefined
+  if (searchSsn && Personnummer.valid(searchSsn)) {
+    ssn = Personnummer.parse(searchSsn).format(true)
+    updatedSearchParams.delete(SearchParam.Ssn)
+  }
+
+  const email = searchParams.get(SearchParam.Email)
+  if (email) updatedSearchParams.delete(SearchParam.Email)
+
+  return [
+    {
+      ...(ssn && { ssn }),
+      ...(email && { email }),
+    },
+    updatedSearchParams,
+  ]
+}

--- a/apps/store/src/features/widget/shopSessionCustomerUpdate.ts
+++ b/apps/store/src/features/widget/shopSessionCustomerUpdate.ts
@@ -1,0 +1,21 @@
+import { ApolloClient } from '@apollo/client'
+import {
+  ShopSessionCustomerUpdateDocument,
+  type ShopSessionCustomerUpdateMutation,
+  type ShopSessionCustomerUpdateMutationVariables,
+} from '@/services/apollo/generated'
+
+type Params = {
+  apolloClient: ApolloClient<any>
+  variables: ShopSessionCustomerUpdateMutationVariables['input']
+}
+
+export const shopSessionCustomerUpdate = (params: Params) => {
+  return params.apolloClient.mutate<
+    ShopSessionCustomerUpdateMutation,
+    ShopSessionCustomerUpdateMutationVariables
+  >({
+    mutation: ShopSessionCustomerUpdateDocument,
+    variables: { input: params.variables },
+  })
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Pick up customer data from URL and update shop session

- Pass along remaining search params to the next route

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Support for the partner to pass along customer data in the URL when starting the flow

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
