### PR TITLE
fix(carDealership): use the correct slug for the car buyer confirmation page

### DIFF
--- a/apps/store/src/pages/car-buyer/confirmation-with-extension/[contractId].tsx
+++ b/apps/store/src/pages/car-buyer/confirmation-with-extension/[contractId].tsx
@@ -27,11 +27,12 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
   const apolloClient = await initializeApolloServerSide({ req, res, locale })
   // with-extension | without-extension
   const confirmationStorySlug = resolvedUrl.split('/')[2]
+  const slug = `car-buyer/${confirmationStorySlug}`
 
   const [trialExtension, layoutWithMenuProps, story] = await Promise.all([
     fetchTrialExtensionData(apolloClient, contractId),
     getLayoutWithMenuProps(context, apolloClient),
-    getStoryBySlug<ConfirmationStory>(confirmationStorySlug, { locale }),
+    getStoryBySlug<ConfirmationStory>(slug, { locale }),
   ])
 
   if (trialExtension == null) return { notFound: true }


### PR DESCRIPTION
## Describe your changes

- Update confirmation pages slug

## Justify why they are needed

Confirmation pages were moved in Storyblok so we need to update accordantly.
