### PR TITLE
Extract CMS content from Confirmation Page into component

### DIFF
--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -1,26 +1,16 @@
 import styled from '@emotion/styled'
 import { StoryblokComponent } from '@storyblok/react'
-import { useTranslation } from 'next-i18next'
-import { Fragment } from 'react'
-import { AndroidIcon, AppleIcon, Button, Heading, mq, Space, Text, theme } from 'ui'
-import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
+import { Heading, mq, Space, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
-import { ImageWithPlaceholder } from '@/components/ImageWithPlaceholder/ImageWithPlaceholder'
 import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
 import { ShopBreakdown } from '@/components/ShopBreakdown/ShopBreakdown'
 import { TotalAmountContainer } from '@/components/ShopBreakdown/TotalAmountContainer'
 import { ProductItemContractContainerCar } from '@/features/carDealership/ProductItemContractContainer'
 import { SasEurobonusSectionContainer } from '@/features/sas/SasEurobonusSection'
 import { ConfirmationStory } from '@/services/storyblok/storyblok'
-import { getImgSrc } from '@/services/storyblok/Storyblok.helpers'
-import { getAppStoreLink } from '@/utils/appStoreLinks'
 import { Features } from '@/utils/Features'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
-import { SpaceFlex } from '../SpaceFlex/SpaceFlex'
-import { CheckList, CheckListItem } from './CheckList'
 import { ConfirmationPageProps } from './ConfirmationPage.types'
-import qrCodeImage from './download-app-qrcode.png'
-import { ImageSection } from './ImageSection'
+import { StaticContent } from './StaticContent'
 import { SwitchingAssistantSection } from './SwitchingAssistantSection/SwitchingAssistantSection'
 
 type Props = ConfirmationPageProps & {
@@ -28,9 +18,6 @@ type Props = ConfirmationPageProps & {
 }
 
 export const ConfirmationPage = (props: Props) => {
-  const { t } = useTranslation('checkout')
-  const checklistItems = props.story.content.checklist.split('\n')
-
   const cartTotalCost = props.cart.cost.gross.amount
 
   return (
@@ -51,7 +38,7 @@ export const ConfirmationPage = (props: Props) => {
                   {props.cart.entries.map((item) => (
                     <ProductItemContainer key={item.id} offer={item} />
                   ))}
-                  {/* // We might have some cases of confirmation pages for shop sessions that doesn't include any products into the cart: car dealership */}
+                  {/* We might have some cases of confirmation pages for shop sessions that doesn't include any products into the cart: car dealership */}
                   {cartTotalCost > 0 && <TotalAmountContainer cart={props.cart} />}
                 </ShopBreakdown>
               </Space>
@@ -67,59 +54,11 @@ export const ConfirmationPage = (props: Props) => {
                   initialValue={props.memberPartnerData.sas.eurobonusNumber ?? ''}
                 />
               )}
-
-              <Space y={{ base: 1.5, lg: 2 }}>
-                <div>
-                  <Heading as="h2" variant="standard.24">
-                    {props.story.content.checklistTitle}
-                  </Heading>
-                  <Text as="p" color="textSecondary" size="xl">
-                    {props.story.content.checklistSubtitle}
-                  </Text>
-                </div>
-
-                <CheckList>
-                  {checklistItems.map((item, index) => {
-                    const isLast = index === checklistItems.length - 1
-                    return isLast ? (
-                      <Fragment key={item}>
-                        <CheckListItem.Disabled title={item} />
-                        <DownloadAppWrapper>
-                          <SpaceFlex direction="vertical" align="center">
-                            <ImageWithPlaceholder
-                              src={qrCodeImage}
-                              alt={t('APP_DOWNLOAD_QRCODE_ALT')}
-                              width={168}
-                              height={168}
-                              priority={true}
-                            />
-                          </SpaceFlex>
-
-                          <Text align="center">{t('APP_DOWNLOAD_QRCODE_TEXT')}</Text>
-
-                          <AppStoreButtons />
-                        </DownloadAppWrapper>
-                      </Fragment>
-                    ) : (
-                      <CheckListItem.Checked key={item} title={item} />
-                    )
-                  })}
-                </CheckList>
-              </Space>
             </Space>
           </GridLayout.Content>
         </GridLayout.Root>
 
-        <div>
-          <ImageSection
-            image={{
-              src: getImgSrc(props.story.content.footerImage.filename),
-              alt: props.story.content.footerImage.alt,
-            }}
-          />
-
-          <ConfirmationPageBlock blok={props.story.content} />
-        </div>
+        <StaticContent content={props.story.content} />
       </Space>
     </Wrapper>
   )
@@ -127,55 +66,5 @@ export const ConfirmationPage = (props: Props) => {
 
 const Wrapper = styled.div({
   paddingTop: theme.space.md,
-  paddingBottom: theme.space.xxxl,
-
-  [mq.lg]: {
-    paddingBlock: theme.space.xxxl,
-  },
-})
-
-const DownloadAppWrapper = styled.div({
-  paddingTop: theme.space.xxxl,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: theme.space.xl,
-})
-
-const AppStoreButtons = () => {
-  const { routingLocale } = useCurrentLocale()
-
-  return (
-    <ButtonWrapper>
-      <Button
-        href={getAppStoreLink('apple', routingLocale).toString()}
-        target="_blank"
-        rel="noopener noreferrer"
-        variant="secondary"
-        size="medium"
-      >
-        <SpaceFlex space={0.5} align="center">
-          <AppleIcon />
-          App Store
-        </SpaceFlex>
-      </Button>
-      <Button
-        href={getAppStoreLink('google', routingLocale).toString()}
-        target="_blank"
-        rel="noopener noreferrer"
-        variant="secondary"
-        size="medium"
-      >
-        <SpaceFlex space={0.5} align="center">
-          <AndroidIcon />
-          Google Play
-        </SpaceFlex>
-      </Button>
-    </ButtonWrapper>
-  )
-}
-
-const ButtonWrapper = styled.div({
-  display: 'grid',
-  gridTemplateColumns: 'repeat(2, 1fr)',
-  gridGap: theme.space.xs,
+  [mq.lg]: { paddingTop: theme.space.xxxl },
 })

--- a/apps/store/src/components/ConfirmationPage/StaticContent.tsx
+++ b/apps/store/src/components/ConfirmationPage/StaticContent.tsx
@@ -1,0 +1,128 @@
+import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
+import { Fragment } from 'react'
+import { AndroidIcon, AppleIcon, Button, Heading, Space, Text, theme } from 'ui'
+import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { ImageWithPlaceholder } from '@/components/ImageWithPlaceholder/ImageWithPlaceholder'
+import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
+import { type ConfirmationStory } from '@/services/storyblok/storyblok'
+import { getImgSrc } from '@/services/storyblok/Storyblok.helpers'
+import { getAppStoreLink } from '@/utils/appStoreLinks'
+import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { CheckList, CheckListItem } from './CheckList'
+import qrCodeImage from './download-app-qrcode.png'
+import { ImageSection } from './ImageSection'
+
+type Props = {
+  content: ConfirmationStory['content']
+}
+
+export const StaticContent = (props: Props) => {
+  const { t } = useTranslation('checkout')
+  const checklistItems = props.content.checklist.split('\n')
+
+  return (
+    <Space y={4}>
+      <GridLayout.Root>
+        <GridLayout.Content width="1/3" align="center">
+          <Space y={{ base: 1.5, lg: 2 }}>
+            <div>
+              <Heading as="h2" variant="standard.24">
+                {props.content.checklistTitle}
+              </Heading>
+              <Text as="p" color="textSecondary" size="xl">
+                {props.content.checklistSubtitle}
+              </Text>
+            </div>
+
+            <CheckList>
+              {checklistItems.map((item, index) => {
+                const isLast = index === checklistItems.length - 1
+                return isLast ? (
+                  <Fragment key={item}>
+                    <CheckListItem.Disabled title={item} />
+                    <DownloadAppWrapper>
+                      <SpaceFlex direction="vertical" align="center">
+                        <ImageWithPlaceholder
+                          src={qrCodeImage}
+                          alt={t('APP_DOWNLOAD_QRCODE_ALT')}
+                          width={168}
+                          height={168}
+                          priority={true}
+                        />
+                      </SpaceFlex>
+
+                      <Text align="center">{t('APP_DOWNLOAD_QRCODE_TEXT')}</Text>
+
+                      <AppStoreButtons />
+                    </DownloadAppWrapper>
+                  </Fragment>
+                ) : (
+                  <CheckListItem.Checked key={item} title={item} />
+                )
+              })}
+            </CheckList>
+          </Space>
+        </GridLayout.Content>
+      </GridLayout.Root>
+
+      <div>
+        <ImageSection
+          image={{
+            src: getImgSrc(props.content.footerImage.filename),
+            alt: props.content.footerImage.alt,
+          }}
+        />
+
+        <ConfirmationPageBlock blok={props.content} />
+      </div>
+    </Space>
+  )
+}
+
+const DownloadAppWrapper = styled.div({
+  paddingTop: theme.space.xxxl,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.space.xl,
+})
+
+const AppStoreButtons = () => {
+  const { routingLocale } = useCurrentLocale()
+
+  return (
+    <ButtonWrapper>
+      <Button
+        href={getAppStoreLink('apple', routingLocale).toString()}
+        target="_blank"
+        rel="noopener noreferrer"
+        variant="secondary"
+        size="medium"
+      >
+        <SpaceFlex space={0.5} align="center">
+          <AppleIcon />
+          App Store
+        </SpaceFlex>
+      </Button>
+      <Button
+        href={getAppStoreLink('google', routingLocale).toString()}
+        target="_blank"
+        rel="noopener noreferrer"
+        variant="secondary"
+        size="medium"
+      >
+        <SpaceFlex space={0.5} align="center">
+          <AndroidIcon />
+          Google Play
+        </SpaceFlex>
+      </Button>
+    </ButtonWrapper>
+  )
+}
+
+const ButtonWrapper = styled.div({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, 1fr)',
+  gridGap: theme.space.xs,
+})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

![Screenshot 2023-11-15 at 13.49.54.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/ac2b77fc-7a14-4e5c-aed8-999075398941.png)


## Describe your changes

- Extract all CMS/static content from the Confirmation page into it's own component

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We want to reuse it on the widget confirmation page

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
