### PR TITLE
GEN-1464 | Include CMS content on widget confirmation page

### DIFF
--- a/apps/store/src/features/widget/ConfirmationPage.tsx
+++ b/apps/store/src/features/widget/ConfirmationPage.tsx
@@ -1,12 +1,16 @@
 import { Button, Heading, Space } from 'ui'
+import { StaticContent } from '@/components/ConfirmationPage/StaticContent'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
 import { TotalAmountContainer } from '@/components/ShopBreakdown/TotalAmountContainer'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
+import { ConfirmationStory } from '@/services/storyblok/storyblok'
 import { Header } from './Header'
 import { publishWidgetEvent } from './publishWidgetEvent'
 
 type Props = {
+  staticContent: ConfirmationStory['content']
+  title: string
   shopSession: ShopSession
   backToAppButton?: string
 }
@@ -23,8 +27,7 @@ export const ConfirmationPage = (props: Props) => {
         <GridLayout.Content width="1/3" align="center">
           <Space y={4}>
             <Heading as="h1" variant="standard.24" align="center">
-              {/* TODO: lokalise */}
-              Ditt köp är klart!
+              {props.title}
             </Heading>
             <Space y={1}>
               {props.shopSession.cart.entries.map((item) => (
@@ -38,6 +41,8 @@ export const ConfirmationPage = (props: Props) => {
           </Space>
         </GridLayout.Content>
       </GridLayout.Root>
+
+      <StaticContent content={props.staticContent} />
     </Space>
   )
 }

--- a/apps/store/src/pages/widget/[flow]/[shopSessionId]/confirmation.tsx
+++ b/apps/store/src/pages/widget/[flow]/[shopSessionId]/confirmation.tsx
@@ -1,6 +1,7 @@
 import { type GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { type ComponentProps } from 'react'
+import { fetchConfirmationStory } from '@/components/ConfirmationPage/fetchConfirmationStory'
 import { ConfirmationPage } from '@/features/widget/ConfirmationPage'
 import { addApolloState, initializeApolloServerSide } from '@/services/apollo/client'
 import { useShopSessionQuery } from '@/services/apollo/generated'
@@ -27,12 +28,13 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
     locale: context.locale,
   })
   const shopSessionService = setupShopSessionServiceServerSide({ apolloClient })
-  const [translations, story] = await Promise.all([
+  const [translations, story, confirmationStory] = await Promise.all([
     serverSideTranslations(context.locale),
     getStoryById<WidgetFlowStory>({
       id: context.params.flow,
       version: context.draftMode ? 'draft' : undefined,
     }),
+    fetchConfirmationStory(context.locale),
     shopSessionService.fetchById(context.params.shopSessionId),
   ])
 
@@ -40,6 +42,8 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
     props: {
       ...translations,
       ...context.params,
+      title: confirmationStory.content.title,
+      staticContent: confirmationStory.content,
       backToAppButton: story.content.backToAppButtonLabel,
     },
   })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->


![Screenshot 2023-11-15 at 13.50.09.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/6a38d85c-3cac-4c28-b163-c40da72e0482.png)


## Describe your changes

- Fetch confirmation story in the widget flow

- Include static content on the widget confirmation page

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Match figma design

- Let's discuss if the design of the widget confirmation page is suppose to evolve separately from the regular confirmation page - then we need to rethink this.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
