### PR TITLE
CAR-37 - fix(ConfirmationPage): show total only when cart is not empty

### DIFF
--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -31,6 +31,8 @@ export const ConfirmationPage = (props: Props) => {
   const { t } = useTranslation('checkout')
   const checklistItems = props.story.content.checklist.split('\n')
 
+  const cartTotalCost = props.cart.cost.gross.amount
+
   return (
     <Wrapper>
       <Space y={4}>
@@ -49,7 +51,8 @@ export const ConfirmationPage = (props: Props) => {
                   {props.cart.entries.map((item) => (
                     <ProductItemContainer key={item.id} offer={item} />
                   ))}
-                  <TotalAmountContainer cart={props.cart} />
+                  {/* // We might have some cases of confirmation pages for shop sessions that doesn't include any products into the cart: car dealership */}
+                  {cartTotalCost > 0 && <TotalAmountContainer cart={props.cart} />}
                 </ShopBreakdown>
               </Space>
 


### PR DESCRIPTION
## Describe your changes

- Show `<TotalAmmountContainer>` only for confirmation pages about shop sessions that actually has something included into the chat.

That would avoid this issue:

![image](https://github.com/HedvigInsurance/racoon/assets/19200662/30371fee-0145-49f9-bf92-9cf94fae032f)

## Justify why they are needed

I know this is a workaround. Been talking with William and ideally we want confirmation page as a totaly CMS driven page. If we get that it would be just about not adding that "TotalBlock" for Car Dealership confirmation pages. Until we're not there, I thought that could be enough.
