### PR TITLE
Reset auth tokens before Widget Flow

### DIFF
--- a/apps/store/src/pages/widget/flows/[...slug].tsx
+++ b/apps/store/src/pages/widget/flows/[...slug].tsx
@@ -8,6 +8,7 @@ import {
   type ShopSessionCreatePartnerMutation,
   type ShopSessionCreatePartnerMutationVariables,
 } from '@/services/apollo/generated'
+import { getAccessToken, resetAuthTokens } from '@/services/authApi/persist'
 import {
   type PageStory,
   type WidgetFlowStory,
@@ -41,6 +42,11 @@ export const getServerSideProps: GetServerSideProps<any, Params> = async (contex
   if (!isWidgetFlowStory(story)) {
     console.warn('Story is not a widget flow story:', story.slug)
     return { notFound: true }
+  }
+
+  if (getAccessToken(context)) {
+    console.info(`Widget | Discarding auth token from previous session`)
+    resetAuthTokens(context)
   }
 
   const apolloClient = await initializeApolloServerSide({ ...context, locale: context.locale })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Reset auth state before widget flow

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- This is supposed to be a standalone flow so to avoid strange states, let's reset the auth state before starting the flow

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
