### PR TITLE
CAR-38 - fix(useAcceptExtension): consider BankId state while determining loading state

### DIFF
--- a/apps/store/src/features/carDealership/useAcceptExtension.ts
+++ b/apps/store/src/features/carDealership/useAcceptExtension.ts
@@ -7,6 +7,7 @@ import {
   useCurrentMemberLazyQuery,
 } from '@/services/apollo/generated'
 import { useAppErrorHandleContext } from '@/services/appErrors/AppErrorContext'
+import { BankIdState } from '@/services/bankId/bankId.types'
 import { useBankIdContext } from '@/services/bankId/BankIdContext'
 import { PageLink } from '@/utils/PageLink'
 
@@ -106,5 +107,14 @@ export const useAcceptExtension = (params: Params) => {
     })
   }
 
-  return [addExtensionOffer, loadingRemoveAdd] as const
+  let signLoading = false
+  const { state: bankIdState } = currentOperation ?? {}
+  if (bankIdState) {
+    signLoading = [BankIdState.Starting, BankIdState.Pending, BankIdState.Success].includes(
+      bankIdState,
+    )
+  }
+  const loading = loadingRemoveAdd || signLoading
+
+  return [addExtensionOffer, loading] as const
 }


### PR DESCRIPTION
## Describe your changes

- `useAcceptExtension`: changed loading state definition by including BankId state

## Justify why they are needed

We did the same thing for ManyPets. We we're having an issue where there's no proper loading state for authenticated users that sign an car trial extension.
