### PR TITLE
chore(ConfirmationStory): removes 'ctaSection' field

### DIFF
--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled'
-import { StoryblokComponent } from '@storyblok/react'
 import { Heading, mq, Space, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
@@ -42,10 +41,6 @@ export const ConfirmationPage = (props: Props) => {
                   {cartTotalCost > 0 && <TotalAmountContainer cart={props.cart} />}
                 </ShopBreakdown>
               </Space>
-
-              {props.story.content.ctaSection?.map((nestedBlock) => (
-                <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} />
-              ))}
 
               {props.switching && <SwitchingAssistantSection {...props.switching} />}
 

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -230,7 +230,6 @@ export type ReusableStory = ISbStoryData & {
 export type ConfirmationStory = ISbStoryData & {
   content: ISbStoryData['content'] & {
     body?: Array<SbBlokData>
-    ctaSection?: Array<SbBlokData>
     title: string
     checklistTitle: string
     checklistSubtitle: string


### PR DESCRIPTION
## Describe your changes

- `ConfirmationStory`: removes `ctaSection` field

## Justify why they are needed

That field was added to `ConfirmationStory` [here](https://github.com/HedvigInsurance/racoon/pull/3513) for covering an specific use case of _Car Dealership Confirmation Page Without Extension_, where a CMS content driven section needed to be displayed:

<img width="498" alt="Screenshot 2023-11-16 at 09 58 01" src="https://github.com/HedvigInsurance/racoon/assets/19200662/7a3c11f1-89cd-4af5-aea7-73d1869a2dca">

We don't need to cover that use case anymore, therefore it's better that we remove that field.
