### PR TITLE
Widget Sign | Adjust padding around headings

### DIFF
--- a/apps/store/src/features/widget/SignPage.tsx
+++ b/apps/store/src/features/widget/SignPage.tsx
@@ -88,20 +88,20 @@ export const SignPage = (props: Props) => {
 
   return (
     <>
-      <Wrapper y={4}>
+      <Wrapper y={3}>
         <Header step="SIGN" />
 
         <GridLayout.Root>
           <GridLayout.Content width="1/3" align="center">
             <Space y={3.5}>
-              <Headings>
+              <div>
                 <Heading as="h1" variant="standard.24" align="center">
                   {t('WIDGET_CHECKOUT_PAGE_HEADING')}
                 </Heading>
                 <Text as="p" balance={true} color="textSecondary" align="center" size="xl">
                   {t('WIDGET_CHECKOUT_PAGE_SUBHEADING')}
                 </Text>
-              </Headings>
+              </div>
 
               <Space y={{ base: 1, lg: 1.5 }}>
                 <ShopBreakdown>
@@ -229,8 +229,6 @@ const Wrapper = styled(Space)({
   paddingBottom: theme.space.lg,
   [mq.lg]: { paddingBottom: theme.space.xxl },
 })
-
-const Headings = styled.div({ maxWidth: '35ch', marginInline: 'auto' })
 
 type SignButtonProps = PropsWithChildren<{ loading: boolean; showBankIdIcon: boolean }>
 const SignButton = ({ children, loading, showBankIdIcon }: SignButtonProps) => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->


![Screenshot 2023-11-16 at 11.40.56.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/15adae8b-2b40-4f5d-b9cf-540907116e83.png)



## Describe your changes

- Allow headings on widget sign page to span the whole parent container

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We should add some way in the CMS to decide where to break the heading text into multiple lines if that is a concern I think. If we do it in CSS we will have to keep it in sync when the text updates...

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
