### PR TITLE
GEN-1466 | ButtonBlock option to forward query string

### DIFF
--- a/apps/store/src/blocks/ButtonBlock.tsx
+++ b/apps/store/src/blocks/ButtonBlock.tsx
@@ -1,33 +1,43 @@
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
-import { ComponentProps } from 'react'
+import { useRouter } from 'next/router'
+import { ComponentProps, useMemo } from 'react'
 import { Button, ConditionalWrapper, theme } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
+import { mergeSearchParams } from '@/utils/mergeSearchParams'
 
 export type ButtonBlockProps = SbBaseBlockProps<{
   text: string
   link: LinkField
   variant: ComponentProps<typeof Button>['variant']
   size: ComponentProps<typeof Button>['size']
+  forwardQueryString?: boolean
 }>
 
 export const ButtonBlock = ({ blok, nested }: ButtonBlockProps) => {
-  // Can't use ButtonNextLink for links to old web
-  const Component = blok.link.linktype === 'url' ? Button : ButtonNextLink
+  const router = useRouter()
+  const href = useMemo(() => {
+    if (blok.forwardQueryString) {
+      return mergeSearchParams(getLinkFieldURL(blok.link, blok.text), router.query)
+    }
+
+    return getLinkFieldURL(blok.link, blok.text)
+  }, [router.query, blok.forwardQueryString, blok.link, blok.text])
+
   return (
     <ConditionalWrapper condition={!nested} wrapWith={(children) => <Wrapper>{children}</Wrapper>}>
-      <Component
+      <ButtonNextLink
         {...storyblokEditable(blok)}
-        href={getLinkFieldURL(blok.link, blok.text)}
+        href={href}
         variant={blok.variant ?? 'primary'}
         size={blok.size ?? 'medium'}
         target={blok.link.target}
         title={blok.link.title}
       >
         {blok.text}
-      </Component>
+      </ButtonNextLink>
     </ConditionalWrapper>
   )
 }

--- a/apps/store/src/utils/mergeSearchParams.test.ts
+++ b/apps/store/src/utils/mergeSearchParams.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from '@jest/globals'
+import { mergeSearchParams } from './mergeSearchParams'
+
+describe('mergeSearchParams', () => {
+  it('should merge search params into link URL', () => {
+    const linkUrl = 'https://example.com/path'
+    const search = { foo: 'bar', baz: 'qux' }
+    const expected = 'https://example.com/path?foo=bar&baz=qux'
+    expect(mergeSearchParams(linkUrl, search)).toEqual(expected)
+  })
+
+  it('should handle empty search params', () => {
+    const linkUrl = 'https://example.com/path'
+    const search = {}
+    const expected = 'https://example.com/path'
+    expect(mergeSearchParams(linkUrl, search)).toEqual(expected)
+  })
+
+  it('should handle existing search params in link URL', () => {
+    const linkUrl = 'https://example.com/path?foo=bar'
+    const search = { baz: 'qux' }
+    const expected = 'https://example.com/path?foo=bar&baz=qux'
+    expect(mergeSearchParams(linkUrl, search)).toEqual(expected)
+  })
+
+  it('should handle special characters in search params', () => {
+    const linkUrl = 'https://example.com/path'
+    const search = { foo: 'bar/qux' }
+    const expected = 'https://example.com/path?foo=bar%2Fqux'
+    expect(mergeSearchParams(linkUrl, search)).toEqual(expected)
+  })
+
+  it('should handle repeated search params', () => {
+    const linkUrl = 'https://example.com/path'
+    const search = { foo: ['bar', 'qux'] }
+    const expected = 'https://example.com/path?foo=bar&foo=qux'
+    expect(mergeSearchParams(linkUrl, search)).toEqual(expected)
+  })
+
+  it('should handle boolean search params', () => {
+    const linkUrl = 'https://example.com/path'
+    const search = { foo: undefined }
+    const expected = 'https://example.com/path?foo='
+    expect(mergeSearchParams(linkUrl, search)).toEqual(expected)
+  })
+
+  it('should handle relative link URLs', () => {
+    const linkUrl = '/path'
+    const search = { foo: 'bar' }
+    const expected = '/path?foo=bar'
+    expect(mergeSearchParams(linkUrl, search)).toEqual(expected)
+  })
+})

--- a/apps/store/src/utils/mergeSearchParams.ts
+++ b/apps/store/src/utils/mergeSearchParams.ts
@@ -1,0 +1,18 @@
+import { ParsedUrlQuery } from 'querystring'
+import { ORIGIN_URL } from './PageLink'
+
+export const mergeSearchParams = (linkUrl: string, search: ParsedUrlQuery): string => {
+  const url = new URL(linkUrl, ORIGIN_URL)
+
+  Object.entries(search).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach((item) => url.searchParams.append(key, item))
+    } else if (typeof value === 'string') {
+      url.searchParams.set(key, value)
+    } else {
+      url.searchParams.set(key, '')
+    }
+  })
+
+  return url.href.replace(ORIGIN_URL, '')
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add option to ButtonBlock in CMS to forward query string in the link

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Needed for Widget landing page where partner wants to initialize the flow with custom parameters like address, product, etc.

- Not thrilled about the implementation, especially having to use `ORIGIN_URL` and then replacing it but did it so that we maintain the same behaviour as before.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
