### PR TITLE
Widget | Skip select product if only one is configured

### DIFF
--- a/apps/store/src/features/widget/SelectProductPage.tsx
+++ b/apps/store/src/features/widget/SelectProductPage.tsx
@@ -9,7 +9,7 @@ import * as RadioOptionList from '@/components/RadioOptionList/RadioOptionList'
 import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntentService'
 import { PageLink } from '@/utils/PageLink'
 import { Header } from './Header'
-import { getPriceTemplate } from './widget.helpers'
+import { createPriceIntent } from './widget.helpers'
 
 type Props = {
   flow: string
@@ -26,11 +26,10 @@ export const SelectProductPage = (props: Props) => {
     event.preventDefault()
     if (!productName) throw new Error('Missing product')
 
-    const priceIntentService = priceIntentServiceInitClientSide(apolloClient)
-    const priceIntent = await priceIntentService.create({
-      productName: productName,
-      priceTemplate: getPriceTemplate(productName),
+    const priceIntent = await createPriceIntent({
+      service: priceIntentServiceInitClientSide(apolloClient),
       shopSessionId: props.shopSessionId,
+      productName,
     })
 
     await router.push(

--- a/apps/store/src/features/widget/fetchFlowProducts.ts
+++ b/apps/store/src/features/widget/fetchFlowProducts.ts
@@ -1,13 +1,14 @@
+import { ApolloClient } from '@apollo/client'
 import { ISbStoryData } from '@storyblok/react'
 import {
   GlobalProductMetadata,
   fetchGlobalProductMetadata,
 } from '@/components/LayoutWithMenu/fetchProductMetadata'
-import { initializeApollo } from '@/services/apollo/client'
 import { getStoryById } from '@/services/storyblok/storyblok'
 import { RoutingLocale } from '@/utils/l10n/types'
 
 type Params = {
+  apolloClient: ApolloClient<unknown>
   locale: RoutingLocale
   flow: string
   draft?: boolean
@@ -17,10 +18,8 @@ type ProductMetadataStory = ISbStoryData<{ productName: string }>
 type Story = ISbStoryData<{ products: Array<ProductMetadataStory> }>
 
 export const fetchFlowProducts = async (params: Params): Promise<GlobalProductMetadata> => {
-  const apolloClient = initializeApollo({ locale: params.locale })
-
   const [allProductMetadata, story] = await Promise.all([
-    fetchGlobalProductMetadata({ apolloClient }),
+    fetchGlobalProductMetadata({ apolloClient: params.apolloClient }),
     getStoryById<Story>({
       id: params.flow,
       version: params.draft ? 'draft' : undefined,

--- a/apps/store/src/features/widget/widget.helpers.ts
+++ b/apps/store/src/features/widget/widget.helpers.ts
@@ -1,5 +1,7 @@
 import { fetchPriceTemplate } from '@/services/PriceCalculator/PriceCalculator.helpers'
 import { Template } from '@/services/PriceCalculator/PriceCalculator.types'
+import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
+import { PriceIntentService } from '@/services/priceIntent/PriceIntentService'
 
 const PRODUCT_TO_TEMPLATE = new Map<string, string>([
   ['SE_WIDGET_APARTMENT_BRF', 'SE_WIDGET_APARTMENT'],
@@ -11,4 +13,19 @@ export const getPriceTemplate = (product: string): Template => {
   const template = fetchPriceTemplate(templateName || product)
   if (!template) throw new Error(`No template found for product ${product}`)
   return template
+}
+
+type CreatePriceIntentParams = {
+  service: PriceIntentService
+  productName: string
+  shopSessionId: string
+}
+
+export const createPriceIntent = async (params: CreatePriceIntentParams): Promise<PriceIntent> => {
+  const priceIntent = await params.service.create({
+    productName: params.productName,
+    priceTemplate: getPriceTemplate(params.productName),
+    shopSessionId: params.shopSessionId,
+  })
+  return priceIntent
 }

--- a/apps/store/src/pages/widget/[flow]/[shopSessionId]/select.tsx
+++ b/apps/store/src/pages/widget/[flow]/[shopSessionId]/select.tsx
@@ -1,9 +1,14 @@
+import { stringify } from 'querystring'
 import { type GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { type ComponentProps } from 'react'
 import { fetchFlowProducts } from '@/features/widget/fetchFlowProducts'
 import { SelectProductPage } from '@/features/widget/SelectProductPage'
+import { createPriceIntent } from '@/features/widget/widget.helpers'
+import { initializeApolloServerSide } from '@/services/apollo/client'
+import { priceIntentServiceInitServerSide } from '@/services/priceIntent/PriceIntentService'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+import { PageLink } from '@/utils/PageLink'
 
 type Props = ComponentProps<typeof SelectProductPage>
 
@@ -16,14 +21,38 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
   if (!context.params) throw new Error('Missing params')
   if (!isRoutingLocale(context.locale)) throw new Error(`Invalid locale: ${context.locale}`)
 
+  const apolloClient = await initializeApolloServerSide({ ...context, locale: context.locale })
   const [translations, products] = await Promise.all([
     serverSideTranslations(context.locale),
     fetchFlowProducts({
+      apolloClient,
       locale: context.locale,
       flow: context.params.flow,
       draft: context.draftMode,
     }),
   ])
+
+  if (products.length === 0) {
+    throw new Error(`No products found for flow ${context.params.flow}`)
+  }
+
+  if (products.length === 1) {
+    const priceIntent = await createPriceIntent({
+      service: priceIntentServiceInitServerSide({ ...context, apolloClient }),
+      shopSessionId: context.params.shopSessionId,
+      productName: products[0].name,
+    })
+
+    const nextUrl = PageLink.widgetCalculatePrice({
+      locale: context.locale,
+      flow: context.params.flow,
+      shopSessionId: context.params.shopSessionId,
+      priceIntentId: priceIntent.id,
+    })
+    nextUrl.search = stringify(context.query)
+
+    return { redirect: { destination: nextUrl.href, permanent: false } }
+  }
 
   return {
     props: { ...translations, products, ...context.params },


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Skip the select product step in widget flow if there's only one product configured

- Throw an error if there's no product configured

- Refactor some other data fetching code to reuse apollo client instance

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- FYI: I will refactor this code in the next PR

- I made a function to create price intent since it is used in multiple places and we might want to change the implementation in the future so it is good to have a single place to change it

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
