### PR TITLE
GEN-1469 | Detect pre-selected product from URL in widget flow

### DIFF
--- a/apps/store/src/features/widget/parseSearchParams.ts
+++ b/apps/store/src/features/widget/parseSearchParams.ts
@@ -5,6 +5,9 @@ import { ShopSessionCustomerUpdateInput } from '@/services/apollo/generated'
 enum SearchParam {
   Email = 'email',
   Ssn = 'ssn',
+
+  ProductType = 'productType',
+  ApartmentSubType = 'subType',
 }
 
 type CustomerData = Omit<ShopSessionCustomerUpdateInput, 'shopSessionId'>
@@ -31,4 +34,33 @@ export const parseCustomerDataSearchParams = (
     },
     updatedSearchParams,
   ]
+}
+
+export const parseProductNameSearchParams = (
+  searchParams: URLSearchParams,
+): [string | null, URLSearchParams] => {
+  const updatedSearchParams = new URLSearchParams(searchParams.toString())
+
+  const productType = updatedSearchParams.get(SearchParam.ProductType)
+  if (productType) updatedSearchParams.delete(SearchParam.ProductType)
+
+  const subType = updatedSearchParams.get(SearchParam.ApartmentSubType)
+  if (subType) updatedSearchParams.delete(SearchParam.ApartmentSubType)
+
+  const productName = getProductName(productType, subType)
+
+  return [productName || productType, updatedSearchParams]
+}
+
+// Legacy, used by Partner Widget
+// TODO: migrate to use our new product names directly in the URL
+const getProductName = (productType: string | null, subType: string | null): string | undefined => {
+  switch (productType) {
+    case 'SWEDISH_APARTMENT':
+      return subType === 'BRF' ? 'SE_APARTMENT_BRF' : 'SE_APARTMENT_RENT'
+    case 'SWEDISH_HOUSE':
+      return 'SE_HOUSE'
+    case 'SWEDISH_ACCIDENT':
+      return 'SE_ACCIDENT'
+  }
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Parse URL search params and detect if we have a pre-selected product, then skip product selection screen

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- I refactored the server-side code a bit to make it easier to read the code

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
