### PR TITLE
CAR-41 - refact(getLayoutWithMenuProps): throw an error when something goes off

### DIFF
--- a/apps/store/src/components/LayoutWithMenu/getLayoutWithMenuProps.ts
+++ b/apps/store/src/components/LayoutWithMenu/getLayoutWithMenuProps.ts
@@ -15,8 +15,7 @@ export const getLayoutWithMenuProps = async (
   defaultApolloClient?: ApolloClient<unknown>,
 ) => {
   if (!isRoutingLocale(context.locale)) {
-    console.warn(`Locale ${context.locale} is not supported`)
-    return null
+    throw new Error(`Locale ${context.locale} is not supported`)
   }
 
   let apolloClient = defaultApolloClient

--- a/apps/store/src/pages/404.tsx
+++ b/apps/store/src/pages/404.tsx
@@ -39,7 +39,6 @@ export const getStaticProps: GetStaticProps = async (context) => {
   context.locale = locale
 
   const props = await getLayoutWithMenuProps(context)
-  if (props === null) return { notFound: true }
 
   return { props }
 }

--- a/apps/store/src/pages/car-buyer/confirmation/[contractId].tsx
+++ b/apps/store/src/pages/car-buyer/confirmation/[contractId].tsx
@@ -25,29 +25,32 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
   const contractId = params?.contractId
   if (!contractId) return { notFound: true }
 
-  const apolloClient = await initializeApolloServerSide({ req, res, locale })
-  const slug = `${STORYBLOK_CAR_DEALERSHIP_FOLDER_SLUG}/confirmation`
+  try {
+    const apolloClient = await initializeApolloServerSide({ req, res, locale })
+    const slug = `${STORYBLOK_CAR_DEALERSHIP_FOLDER_SLUG}/confirmation`
 
-  const [trialExtension, layoutWithMenuProps, story] = await Promise.all([
-    fetchTrialExtensionData(apolloClient, contractId),
-    getLayoutWithMenuProps(context, apolloClient),
-    getStoryBySlug<ConfirmationStory>(slug, { locale }),
-  ])
+    const [trialExtension, layoutWithMenuProps, story] = await Promise.all([
+      fetchTrialExtensionData(apolloClient, contractId),
+      getLayoutWithMenuProps(context, apolloClient),
+      getStoryBySlug<ConfirmationStory>(slug, { locale }),
+    ])
 
-  if (trialExtension == null) return { notFound: true }
+    if (trialExtension == null) return { notFound: true }
 
-  if (layoutWithMenuProps === null) return { notFound: true }
-
-  return addApolloState(apolloClient, {
-    props: {
-      ...layoutWithMenuProps,
-      shopSessionId: trialExtension.shopSession.id,
-      cart: trialExtension.shopSession.cart,
-      carTrialContract: trialExtension.trialContract,
-      story,
-      memberPartnerData: null,
-    },
-  })
+    return addApolloState(apolloClient, {
+      props: {
+        ...layoutWithMenuProps,
+        shopSessionId: trialExtension.shopSession.id,
+        cart: trialExtension.shopSession.cart,
+        carTrialContract: trialExtension.trialContract,
+        story,
+        memberPartnerData: null,
+      },
+    })
+  } catch (error) {
+    console.error(error)
+    return { notFound: true }
+  }
 }
 
 const fetchTrialExtensionData = async (

--- a/apps/store/src/pages/cart/index.tsx
+++ b/apps/store/src/pages/cart/index.tsx
@@ -23,12 +23,15 @@ const NextCartPage: NextPageWithLayout = () => {
 NextCartPage.getLayout = (children) => <LayoutWithMenu>{children}</LayoutWithMenu>
 
 export const getStaticProps: GetStaticProps = async (context) => {
-  const props = await getLayoutWithMenuProps(context)
-  if (props === null) return { notFound: true }
+  try {
+    const props = await getLayoutWithMenuProps(context)
 
-  return {
-    props,
-    revalidate: getRevalidate(),
+    return {
+      props,
+      revalidate: getRevalidate(),
+    }
+  } catch {
+    return { notFound: true }
   }
 }
 

--- a/apps/store/src/pages/forever/[code].tsx
+++ b/apps/store/src/pages/forever/[code].tsx
@@ -18,14 +18,18 @@ const NextPage: NextPageWithLayout<Props> = (props) => (
 export const getServerSideProps: GetServerSideProps<Props, Params> = async (context) => {
   if (!context.params?.code) return { notFound: true }
 
-  const layoutWithMenuProps = await getLayoutWithMenuProps(context)
-  if (layoutWithMenuProps === null) return { notFound: true }
+  try {
+    const layoutWithMenuProps = await getLayoutWithMenuProps(context)
 
-  return {
-    props: {
-      ...layoutWithMenuProps,
-      code: context.params.code,
-    },
+    return {
+      props: {
+        ...layoutWithMenuProps,
+        code: context.params.code,
+      },
+    }
+  } catch (error) {
+    console.error(error)
+    return { notFound: true }
   }
 }
 


### PR DESCRIPTION
## Describe your changes

- Update `getLayoutWithMenuProps` function so it throws an Error instead of returning null when it fails to execute.

## Justify why they are needed

That simplifies it usage when it comes about types
