### PR TITLE
GEN-1456 | Parse URL and pre-fill price intent data for widget

### DIFF
--- a/apps/store/src/features/widget/SelectProductPage.tsx
+++ b/apps/store/src/features/widget/SelectProductPage.tsx
@@ -26,19 +26,23 @@ export const SelectProductPage = (props: Props) => {
     event.preventDefault()
     if (!productName) throw new Error('Missing product')
 
-    const priceIntent = await createPriceIntent({
+    const searchParams = new URLSearchParams(window.location.search)
+
+    const [priceIntent, updatedSearchParams] = await createPriceIntent({
       service: priceIntentServiceInitClientSide(apolloClient),
       shopSessionId: props.shopSessionId,
       productName,
+      searchParams,
     })
 
-    await router.push(
-      PageLink.widgetCalculatePrice({
-        flow: props.flow,
-        shopSessionId: props.shopSessionId,
-        priceIntentId: priceIntent.id,
-      }),
-    )
+    const nextUrl = PageLink.widgetCalculatePrice({
+      flow: props.flow,
+      shopSessionId: props.shopSessionId,
+      priceIntentId: priceIntent.id,
+    })
+    nextUrl.search = updatedSearchParams.toString()
+
+    await router.push(nextUrl)
   }
 
   const handleValueChange = (value: string) => {

--- a/apps/store/src/features/widget/parseSearchParams.test.ts
+++ b/apps/store/src/features/widget/parseSearchParams.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from '@jest/globals'
+import { parsePriceIntentDataSearchParams } from './parseSearchParams'
+
+describe('parsePriceIntentDataSearchParams', () => {
+  it('should parse price intent data search params correctly', () => {
+    // Arrange
+    const searchParams = new URLSearchParams()
+    searchParams.set('street', '123 Main St')
+    searchParams.set('zipCode', '12345')
+    searchParams.set('city', 'New York')
+    searchParams.set('livingSpace', '100')
+    searchParams.set('coInsured', '2')
+
+    // Act
+    const [priceIntentData, remainingSearchParams] = parsePriceIntentDataSearchParams(searchParams)
+
+    // Assert
+    expect(priceIntentData).toEqual({
+      street: '123 Main St',
+      zipCode: '12345',
+      city: 'New York',
+      livingSpace: 100,
+      numberCoInsured: 2,
+    })
+    expect(remainingSearchParams.toString()).toBe('')
+  })
+
+  it('should handle empty search params', () => {
+    // Arrange
+    const searchParams = new URLSearchParams()
+
+    // Act
+    const [priceIntentData, remainingSearchParams] = parsePriceIntentDataSearchParams(searchParams)
+
+    // Assert
+    expect(priceIntentData).toEqual({})
+    expect(remainingSearchParams.toString()).toBe('')
+  })
+
+  it('should handle invalid values and unknown search params', () => {
+    // Arrange
+    const searchParams = new URLSearchParams()
+    searchParams.set('street', '123 Main St')
+    searchParams.set('coInsured', 'xyz')
+    searchParams.set('livingSpace', 'abc')
+    searchParams.set('unknown', 'xyz')
+
+    // Act
+    const [priceIntentData, remainingSearchParams] = parsePriceIntentDataSearchParams(searchParams)
+
+    // Assert
+    expect(priceIntentData).toEqual({ street: '123 Main St' })
+    expect(remainingSearchParams.toString()).toBe('coInsured=xyz&livingSpace=abc&unknown=xyz')
+  })
+})

--- a/apps/store/src/features/widget/parseSearchParams.ts
+++ b/apps/store/src/features/widget/parseSearchParams.ts
@@ -3,11 +3,27 @@ import { ShopSessionCustomerUpdateInput } from '@/services/apollo/generated'
 
 // Search Params from Partner Widget
 enum SearchParam {
+  // Customer Data
   Email = 'email',
   Ssn = 'ssn',
 
+  // Product Name Data
   ProductType = 'productType',
   ApartmentSubType = 'subType',
+
+  // Price Intent Data
+  StreetAddress = 'street',
+  ZipCode = 'zipCode',
+  City = 'city',
+  LivingSpace = 'livingSpace',
+  NumberCoInsured = 'coInsured',
+
+  // No longer used?
+  PhoneNumber = 'phoneNumber',
+  BirthDate = 'birthDate',
+  FirstName = 'firstName',
+  LastName = 'lastName',
+  Student = 'student', // can't find what the values are supposed to be
 }
 
 type CustomerData = Omit<ShopSessionCustomerUpdateInput, 'shopSessionId'>
@@ -63,4 +79,38 @@ const getProductName = (productType: string | null, subType: string | null): str
     case 'SWEDISH_ACCIDENT':
       return 'SE_ACCIDENT'
   }
+}
+
+export const parsePriceIntentDataSearchParams = (
+  searchParams: URLSearchParams,
+): [Record<string, unknown>, URLSearchParams] => {
+  const updatedSearchParams = new URLSearchParams(searchParams.toString())
+
+  const street = searchParams.get(SearchParam.StreetAddress)
+  updatedSearchParams.delete(SearchParam.StreetAddress)
+  const zipCode = searchParams.get(SearchParam.ZipCode)
+  updatedSearchParams.delete(SearchParam.ZipCode)
+  const city = searchParams.get(SearchParam.City)
+  updatedSearchParams.delete(SearchParam.City)
+  const searchLivingSpace = searchParams.get(SearchParam.LivingSpace)
+  const livingSpace = searchLivingSpace ? parseNumber(searchLivingSpace) : undefined
+  if (livingSpace !== undefined) updatedSearchParams.delete(SearchParam.LivingSpace)
+  const searchNumberCoInsured = searchParams.get(SearchParam.NumberCoInsured)
+  const numberCoInsured = searchNumberCoInsured ? parseNumber(searchNumberCoInsured) : undefined
+  if (numberCoInsured !== undefined) updatedSearchParams.delete(SearchParam.NumberCoInsured)
+
+  const data = {
+    ...(street && { street }),
+    ...(zipCode && { zipCode }),
+    ...(city && { city }),
+    ...(livingSpace && { livingSpace }),
+    ...(numberCoInsured && { numberCoInsured }),
+  }
+
+  return [data, updatedSearchParams]
+}
+
+const parseNumber = (value: string): number | undefined => {
+  const parsed = parseInt(value, 10)
+  return isNaN(parsed) ? undefined : parsed
 }

--- a/apps/store/src/features/widget/widget.helpers.ts
+++ b/apps/store/src/features/widget/widget.helpers.ts
@@ -2,6 +2,7 @@ import { fetchPriceTemplate } from '@/services/PriceCalculator/PriceCalculator.h
 import { Template } from '@/services/PriceCalculator/PriceCalculator.types'
 import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import { PriceIntentService } from '@/services/priceIntent/PriceIntentService'
+import { parsePriceIntentDataSearchParams } from './parseSearchParams'
 
 const PRODUCT_TO_TEMPLATE = new Map<string, string>([
   ['SE_APARTMENT_BRF', 'SE_WIDGET_APARTMENT'],
@@ -19,13 +20,29 @@ type CreatePriceIntentParams = {
   service: PriceIntentService
   productName: string
   shopSessionId: string
+  searchParams: URLSearchParams
 }
 
-export const createPriceIntent = async (params: CreatePriceIntentParams): Promise<PriceIntent> => {
+export const createPriceIntent = async (
+  params: CreatePriceIntentParams,
+): Promise<[PriceIntent, URLSearchParams]> => {
   const priceIntent = await params.service.create({
     productName: params.productName,
     priceTemplate: getPriceTemplate(params.productName),
     shopSessionId: params.shopSessionId,
   })
-  return priceIntent
+
+  const [priceIntentData, updatedSearchParams] = parsePriceIntentDataSearchParams(
+    params.searchParams,
+  )
+
+  if (Object.keys(priceIntentData).length === 0) return [priceIntent, updatedSearchParams]
+
+  await params.service.update({
+    priceIntentId: priceIntent.id,
+    data: priceIntentData,
+    customer: { shopSessionId: params.shopSessionId },
+  })
+
+  return [priceIntent, updatedSearchParams]
 }

--- a/apps/store/src/pages/widget/[flow]/[shopSessionId]/select.tsx
+++ b/apps/store/src/pages/widget/[flow]/[shopSessionId]/select.tsx
@@ -94,13 +94,14 @@ type RedirectToProductParams = {
 }
 
 const redirectToProduct = async (params: RedirectToProductParams): Promise<Redirect> => {
-  const priceIntent = await createPriceIntent({
+  const [priceIntent, updatedSearchParams] = await createPriceIntent({
     service: priceIntentServiceInitServerSide({
       ...params.context,
       apolloClient: params.apolloClient,
     }),
     shopSessionId: params.shopSessionId,
     productName: params.productName,
+    searchParams: params.searchParams,
   })
 
   const nextUrl = PageLink.widgetCalculatePrice({
@@ -109,7 +110,7 @@ const redirectToProduct = async (params: RedirectToProductParams): Promise<Redir
     shopSessionId: params.shopSessionId,
     priceIntentId: priceIntent.id,
   })
-  nextUrl.search = params.searchParams.toString()
+  nextUrl.search = updatedSearchParams.toString()
 
   return { destination: nextUrl.href, permanent: false }
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Make it possible to pass query params to pre-fill price intent data in Widget

- Pass along query params from select product step to the next step

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Support the same functionality as the old widget

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
