### PR TITLE
Widget | Fix showing CMS content on sign page

### DIFF
--- a/apps/store/src/features/widget/SignPage.tsx
+++ b/apps/store/src/features/widget/SignPage.tsx
@@ -193,12 +193,14 @@ export const SignPage = (props: Props) => {
                 </form>
               </Space>
             </Space>
-
-            {props.content?.map((nestedBlock) => (
-              <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} />
-            ))}
           </GridLayout.Content>
         </GridLayout.Root>
+
+        <div>
+          {props.content?.map((nestedBlock) => (
+            <StoryblokComponent key={nestedBlock._uid} blok={nestedBlock} />
+          ))}
+        </div>
       </Wrapper>
 
       <FullscreenDialog.Root open={showSignError} onOpenChange={setShowSignError}>

--- a/apps/store/src/features/widget/fetchSignPageContent.ts
+++ b/apps/store/src/features/widget/fetchSignPageContent.ts
@@ -11,7 +11,6 @@ export const fetchSignPageContent = async (params: Params) => {
   const story = await getStoryById<WidgetFlowStory>({
     id: params.flow,
     version: params.draft ? 'draft' : undefined,
-    resolve_relations: 'widgetFlow.checkoutPageContent',
   })
 
   return story.content.checkoutPageContent


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

  
![Screenshot 2023-11-17 at 14.40.10.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/27b51cc1-4a73-4dba-95e7-2fb66e942d64.png)



## Describe your changes

- Remove resolve relations setting from widget CMS fetcher function

- Move CMS content outside of grid layout container

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Enable showing CMS content on the sign page in the widget

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
