### PR TITLE
GEN-1475 | Hide campaign controls if they are disabled for the session

### DIFF
--- a/apps/store/src/components/ShopBreakdown/Discount.tsx
+++ b/apps/store/src/components/ShopBreakdown/Discount.tsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled'
+import { Text, theme } from 'ui'
+
+type Props = {
+  code: string
+  explanation: string
+}
+
+export const Discount = (props: Props) => {
+  return (
+    <Wrapper>
+      <Chip>
+        <Text as="span" size="xs">
+          {props.code}
+        </Text>
+      </Chip>
+      <Text>{props.explanation}</Text>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: theme.space.md,
+  paddingInline: theme.space.xxxs,
+})
+
+const Chip = styled.div({
+  borderRadius: theme.radius.xxs,
+  backgroundColor: theme.colors.gray200,
+  textTransform: 'uppercase',
+  paddingBlock: theme.space.xxs,
+  paddingInline: theme.space.xs,
+})

--- a/apps/store/src/components/ShopBreakdown/DiscountFieldContainer.tsx
+++ b/apps/store/src/components/ShopBreakdown/DiscountFieldContainer.tsx
@@ -3,6 +3,7 @@ import { ComponentProps } from 'react'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useRedeemCampaign, useUnredeemCampaign } from '@/utils/useCampaign'
 import { useGetDiscountExplanation } from '@/utils/useDiscountExplanation'
+import { Discount } from './Discount'
 import { DiscountField } from './DiscountField'
 
 type Props = {
@@ -41,6 +42,10 @@ export const DiscountFieldContainer = (props: Props) => {
         explanation: getDiscountExplanation(redeemedCampaign.discount),
       }
     : undefined
+
+  if (!props.shopSession.cart.campaignsEnabled) {
+    return campaign ? <Discount {...campaign} /> : null
+  }
 
   return (
     <DiscountField

--- a/apps/store/src/features/widget/SignPage.tsx
+++ b/apps/store/src/features/widget/SignPage.tsx
@@ -99,7 +99,7 @@ export const SignPage = (props: Props) => {
                 </Text>
               </div>
 
-              <Space y={{ base: 1, lg: 1.5 }}>
+              <Space y={1}>
                 <ShopBreakdown>
                   {props.shopSession.cart.entries.map((item) => (
                     <ProductItemContainer key={item.id} offer={item}>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->


![Screenshot 2023-11-20 at 11.47.05.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/59100527-0ec1-40a8-8b0b-c622f9c30d35.png)



## Describe your changes

- Hide campaign add/remove buttons if they are disabled for the session

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

1. We must've accidentally removed a similar solution - unclear when/why

1. We have a problem where we render the divider even if campaigns are disabled AND there's no campaign added to the session. However, that would require many more changes so let's start with this.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
