### PR TITLE
GEN-1467 | Show Widget specific header on landing pages

### DIFF
--- a/apps/store/src/features/widget/Header.tsx
+++ b/apps/store/src/features/widget/Header.tsx
@@ -34,7 +34,7 @@ export const Header = (props: Props) => {
   const stepIndex = STEPS.indexOf(props.step)
 
   return (
-    <Wrapper as="header">
+    <HeaderFrame>
       <LogoArea>
         <HedvigLogo />
       </LogoArea>
@@ -49,11 +49,11 @@ export const Header = (props: Props) => {
           ))}
         </ProgressIndicator.Root>
       </ProgressArea>
-    </Wrapper>
+    </HeaderFrame>
   )
 }
 
-const Wrapper = styled(GridLayout.Root)({
+export const HeaderFrame = styled(GridLayout.Root)({
   height: '4rem',
   alignItems: 'center',
 })

--- a/apps/store/src/pages/widget/[[...slug]].tsx
+++ b/apps/store/src/pages/widget/[[...slug]].tsx
@@ -1,0 +1,83 @@
+import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
+import { type GetStaticPaths, type GetStaticProps, type NextPageWithLayout } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { HedvigLogo } from 'ui'
+import { DefaultDebugDialog } from '@/components/DebugDialog/DefaultDebugDialog'
+import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
+import { HeaderFrame } from '@/features/widget/Header'
+import { STORYBLOK_WIDGET_FOLDER_SLUG } from '@/features/widget/widget.constants'
+import {
+  getStoryBySlug,
+  type StoryblokPageProps,
+  type StoryblokQueryParams,
+  getFilteredPageLinks,
+  type PageStory,
+  getRevalidate,
+} from '@/services/storyblok/storyblok'
+import { STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
+import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+
+type PageProps = Pick<StoryblokPageProps, 'story' | 'hideChat'>
+
+const NextPage: NextPageWithLayout<PageProps> = (props) => {
+  const story = useStoryblokState(props.story)
+
+  if (!story) return null
+
+  return (
+    <>
+      <HeadSeoInfo
+        // Gotcha: Sometimes Storyblok returns "" for PageStory pages that doesn't get 'abTestOrigin' configured
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        story={story.content.abTestOrigin || story}
+        robots="noindex"
+      />
+      <HeaderFrame>
+        <HedvigLogo />
+      </HeaderFrame>
+      <StoryblokComponent blok={story.content} />
+      <DefaultDebugDialog />
+    </>
+  )
+}
+
+export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = async (context) => {
+  if (!isRoutingLocale(context.locale)) throw new Error(`Invalid locale: ${context.locale}`)
+  if (!context.params) throw new Error('Missing params')
+
+  const slug = `${STORYBLOK_WIDGET_FOLDER_SLUG}/${context.params.slug.join('/')}`
+  let story: PageStory
+  try {
+    story = await getStoryBySlug<PageStory>(slug, {
+      version: context.draftMode ? 'draft' : undefined,
+      locale: context.locale,
+    })
+  } catch (error) {
+    console.error(`Failed to fetch story for slug: ${slug}`)
+    throw error
+  }
+
+  return {
+    props: {
+      ...(await serverSideTranslations(context.locale)),
+      [STORY_PROP_NAME]: story,
+      hideChat: story.content.hideChat ?? false,
+    },
+    revalidate: getRevalidate(),
+  }
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  if (process.env.SKIP_BUILD_STATIC_GENERATION === 'true') {
+    console.info('Skipping static generation for widget landing pages...')
+    return { paths: [], fallback: 'blocking' }
+  }
+
+  const pageLinks = await getFilteredPageLinks()
+  return {
+    paths: pageLinks.map((item) => ({ params: { slug: item.slugParts }, locale: item.locale })),
+    fallback: 'blocking',
+  }
+}
+
+export default NextPage


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->


![Screenshot 2023-11-20 at 13.49.00.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/2279db96-5d8d-4daa-8d15-b6194e36c63c.png)


## Describe your changes

- Create a widget-specific slug-route for landing pages

- (re)-implement CMS/static page setup with a limited set of features

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- This implementation does duplicate code but it makes it very flexible to evolve the widget

- It also makes the widget feature more independent from the rest of the site (self-contained)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
