### PR TITLE
Widget | Display campaign on confirmation page

### DIFF
--- a/apps/store/src/components/ShopBreakdown/DiscountField.stories.tsx
+++ b/apps/store/src/components/ShopBreakdown/DiscountField.stories.tsx
@@ -40,7 +40,7 @@ export const ActiveError: Story = {
 export const ActiveAdded: Story = {
   args: {
     ...Active.args,
-    campaign: {
+    discount: {
       code: 'SUMMER',
       explanation: '3 months for free',
     },

--- a/apps/store/src/components/ShopBreakdown/DiscountField.tsx
+++ b/apps/store/src/components/ShopBreakdown/DiscountField.tsx
@@ -9,7 +9,7 @@ import { AddedCampaignForm } from './AddedCampaignForm'
 
 type Props = {
   defaultActive?: boolean
-  campaign?: {
+  discount?: {
     code: string
     explanation: string
   }
@@ -26,7 +26,7 @@ export const DiscountField = (props: Props) => {
 
   const handleOpenChange = (open: boolean) => {
     setActive(open)
-    if (!open && props.campaign) {
+    if (!open && props.discount) {
       props.onRemove()
     }
   }
@@ -40,13 +40,13 @@ export const DiscountField = (props: Props) => {
         </Collapsible.Trigger>
       </Wrapper>
       <Collapsible.Content style={{ paddingTop: theme.space.md }}>
-        {props.campaign ? (
+        {props.discount ? (
           <AddedCampaignForm
-            campaignCode={props.campaign.code}
+            campaignCode={props.discount.code}
             onRemove={props.onRemove}
             loading={props.loadingRemove}
           >
-            {props.campaign.explanation}
+            {props.discount.explanation}
           </AddedCampaignForm>
         ) : (
           <AddCampaignForm

--- a/apps/store/src/components/ShopBreakdown/DiscountFieldContainer.tsx
+++ b/apps/store/src/components/ShopBreakdown/DiscountFieldContainer.tsx
@@ -1,10 +1,10 @@
 import { datadogLogs } from '@datadog/browser-logs'
-import { ComponentProps } from 'react'
+import { type ComponentProps } from 'react'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useRedeemCampaign, useUnredeemCampaign } from '@/utils/useCampaign'
-import { useGetDiscountExplanation } from '@/utils/useDiscountExplanation'
 import { Discount } from './Discount'
 import { DiscountField } from './DiscountField'
+import { useDiscountProps } from './useDiscountExplanation'
 
 type Props = {
   shopSession: ShopSession
@@ -35,22 +35,16 @@ export const DiscountFieldContainer = (props: Props) => {
   const redeemedCampaign = props.shopSession.cart.redeemedCampaign
   const hasCampaign = !!redeemedCampaign
 
-  const getDiscountExplanation = useGetDiscountExplanation()
-  const campaign = hasCampaign
-    ? {
-        code: redeemedCampaign.code,
-        explanation: getDiscountExplanation(redeemedCampaign.discount),
-      }
-    : undefined
+  const discount = useDiscountProps(redeemedCampaign)
 
   if (!props.shopSession.cart.campaignsEnabled) {
-    return campaign ? <Discount {...campaign} /> : null
+    return discount ? <Discount {...discount} /> : null
   }
 
   return (
     <DiscountField
       defaultActive={hasCampaign}
-      campaign={campaign}
+      discount={discount}
       onAdd={handleAdd}
       loadingAdd={loadingRedeem}
       onRemove={handleRemove}

--- a/apps/store/src/components/ShopBreakdown/useDiscountExplanation.ts
+++ b/apps/store/src/components/ShopBreakdown/useDiscountExplanation.ts
@@ -1,0 +1,19 @@
+import { type ComponentProps } from 'react'
+import { ShopSession } from '@/services/shopSession/ShopSession.types'
+import { useGetDiscountExplanation } from '@/utils/useDiscountExplanation'
+import { Discount } from './Discount'
+
+type RedeemedCampaign = ShopSession['cart']['redeemedCampaign']
+
+export const useDiscountProps = (
+  campaign: RedeemedCampaign,
+): ComponentProps<typeof Discount> | undefined => {
+  const getDiscountExplanation = useGetDiscountExplanation()
+
+  if (!campaign) return
+
+  return {
+    code: campaign.code,
+    explanation: getDiscountExplanation(campaign.discount),
+  }
+}

--- a/apps/store/src/features/widget/ConfirmationPage.tsx
+++ b/apps/store/src/features/widget/ConfirmationPage.tsx
@@ -3,7 +3,10 @@ import { Button, Heading, Space, mq, theme } from 'ui'
 import { StaticContent } from '@/components/ConfirmationPage/StaticContent'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
+import { Discount } from '@/components/ShopBreakdown/Discount'
+import { Divider } from '@/components/ShopBreakdown/ShopBreakdown'
 import { TotalAmountContainer } from '@/components/ShopBreakdown/TotalAmountContainer'
+import { useDiscountProps } from '@/components/ShopBreakdown/useDiscountExplanation'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { ConfirmationStory } from '@/services/storyblok/storyblok'
 import { Header } from './Header'
@@ -21,6 +24,8 @@ export const ConfirmationPage = (props: Props) => {
     publishWidgetEvent({ status: 'close' })
   }
 
+  const discount = useDiscountProps(props.shopSession.cart.redeemedCampaign)
+
   return (
     <Wrapper y={4}>
       <Header step="CONFIRMATION" />
@@ -34,6 +39,14 @@ export const ConfirmationPage = (props: Props) => {
               {props.shopSession.cart.entries.map((item) => (
                 <ProductItemContainer key={item.id} offer={item} />
               ))}
+
+              {discount && (
+                <>
+                  <Discount {...discount} />
+                  <Divider />
+                </>
+              )}
+
               <TotalAmountContainer cart={props.shopSession.cart} />
               {props.backToAppButton && (
                 <Button onClick={handleClickBackToApp}>{props.backToAppButton}</Button>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

![Screenshot 2023-11-20 at 14.38.15.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/63bee0b8-47d3-46f8-9eb8-c8c1638188ae.png)

## Describe your changes

- Add component to widget confirmation page to show included discount

- Add new hook to get discount from redeemed campaign field in API

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Implement figma design

- I saw an opportunity to avoid some code duplication

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
