### PR TITLE
Widget | Include price intent ID in sign page URL

### DIFF
--- a/apps/store/src/features/widget/CalculatePricePage.tsx
+++ b/apps/store/src/features/widget/CalculatePricePage.tsx
@@ -44,6 +44,7 @@ export const CalculatePricePage = (props: Props) => {
         PageLink.widgetSign({
           flow: props.flow,
           shopSessionId: props.shopSession.id,
+          priceIntentId: props.priceIntent.id,
         }),
       )
     },

--- a/apps/store/src/pages/widget/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
+++ b/apps/store/src/pages/widget/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
@@ -27,6 +27,7 @@ const NextWidgetSignPage = (props: Props) => {
 type Params = {
   flow: string
   shopSessionId: string
+  priceIntentId: string
 }
 
 export const getServerSideProps: GetServerSideProps<Props, Params> = async (context) => {
@@ -71,6 +72,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
         shopSessionId: context.params.shopSessionId,
         content: signPageContent,
         flow: context.params.flow,
+        priceIntentId: context.params.priceIntentId,
         // TODO: check if we want to control this via CMS
         hideChat: true,
       },

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -36,7 +36,6 @@ type WidgetParams = BaseParams & {
   shopSessionId: string
   priceIntentId: string
 }
-type WidgetSignParams = Omit<WidgetParams, 'priceIntentId'>
 
 type SessionLink = BaseParams & {
   shopSessionId: string
@@ -274,9 +273,16 @@ export const PageLink = {
       ORIGIN_URL,
     )
   },
-  widgetSign: (params: WidgetSignParams) => {
+  widgetSign: (params: WidgetParams) => {
     return new URL(
-      [localePrefix(params.locale), 'widget', params.flow, params.shopSessionId, 'sign'].join('/'),
+      [
+        localePrefix(params.locale),
+        'widget',
+        params.flow,
+        params.shopSessionId,
+        params.priceIntentId,
+        'sign',
+      ].join('/'),
       ORIGIN_URL,
     )
   },


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- include price intent ID in the URL for the sign page (widget)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- we need this information to be able to navigate back to the price caluclator step

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
