### PR TITLE
CAR-42 - styles(carDealership): remove badge from product item

### DIFF
--- a/apps/store/public/locales/en/carDealership.json
+++ b/apps/store/public/locales/en/carDealership.json
@@ -1,7 +1,6 @@
 {
   "CONNECT_PAYMENT_BANNER": "Connect payment before {{dueDate}} for activate the insurance",
   "CONNECT_PAYMENT_BUTTON": "Connect payment",
-  "CONTRACT_CARD_BADGE": "60 days",
   "EDIT_CAR_TRIAL_EXTENSION_BUTTON": "Edit",
   "EDIT_OFFER_CANCEL": "Cancel",
   "EDIT_OFFER_SAVE": "Save",

--- a/apps/store/public/locales/sv-se/carDealership.json
+++ b/apps/store/public/locales/sv-se/carDealership.json
@@ -1,7 +1,6 @@
 {
   "CONNECT_PAYMENT_BANNER": "Koppla din betalning innan {{dueDate}} för att försäkringen ska gälla",
   "CONNECT_PAYMENT_BUTTON": "Koppla betalning",
-  "CONTRACT_CARD_BADGE": "60 dagar",
   "EDIT_CAR_TRIAL_EXTENSION_BUTTON": "Ändra",
   "EDIT_OFFER_CANCEL": "Avbryt",
   "EDIT_OFFER_SAVE": "Spara",

--- a/apps/store/src/features/carDealership/ProductItemContractContainer.tsx
+++ b/apps/store/src/features/carDealership/ProductItemContractContainer.tsx
@@ -51,7 +51,6 @@ export const ProductItemContractContainerCar = ({ contract, crossedOverAmount }:
       startDate={startDateProps}
       productDetails={productDetails}
       productDocuments={productDocuments}
-      badge={{ children: t('CONTRACT_CARD_BADGE'), color: 'signalAmberHighlight' }}
       exposure={contract.exposureDisplayName}
     />
   )


### PR DESCRIPTION
## Describe your changes

- Removes "60 dagar" badge for Trial Product Item

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/82170ba8-fc3a-46a2-a330-06cc755e60ee.png)


## Justify why they are needed

Requested by Willian. It turned out being redundant as the product is called "Bilförsäkring 60 dagar".
