### PR TITLE
CAR-42 - styles(InputSelect): truncate long text in select

### DIFF
--- a/apps/store/src/components/InputSelect/InputSelect.tsx
+++ b/apps/store/src/components/InputSelect/InputSelect.tsx
@@ -102,6 +102,9 @@ const StyledSelect = styled(
   paddingRight: theme.space.xxl,
   cursor: 'pointer',
   backgroundColor: theme.colors.translucent1,
+  // Truncate if there's not enough space
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
 
   ...(variantSize === 'small' && {
     height: '2.5rem',


### PR DESCRIPTION
## Describe your changes

- Truncate select text when there's not enough space


![Screenshot 2023-11-21 at 10.04.23.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/f133ba70-11e1-49a3-b1ec-3dd83c8ae755.png)


## Justify why they are needed

Requested by design
