### PR TITLE
Fix pre-rendering widget landing pages

### DIFF
--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -390,11 +390,16 @@ export const getStoryById = <StoryData extends ISbStoryData>(
   })
 }
 
-export const getPageLinks = async (): Promise<Array<PageLink>> => {
+type GetPageLinksParams = {
+  startsWith?: string
+}
+
+export const getPageLinks = async (params?: GetPageLinksParams): Promise<Array<PageLink>> => {
   const storyblokApi = getStoryblokApi()
   const {
     data: { links },
   } = await storyblokApi.get('cdn/links/', {
+    ...(params?.startsWith && { starts_with: params.startsWith }),
     ...(USE_DRAFT_CONTENT && { version: 'draft' }),
   })
   const pageLinks: Array<PageLink> = []
@@ -432,12 +437,6 @@ export const getFilteredPageLinks = async () => {
 
 export const getGlobalStory = (options: StoryOptions): Promise<GlobalStory> => {
   return getStoryBySlug<GlobalStory>('global', options)
-}
-
-const PRODUCTS_SLUG = 'products'
-export const getFilteredProductLinks = async () => {
-  const allLinks = await getPageLinks()
-  return allLinks.filter(({ slugParts }) => slugParts[0] === PRODUCTS_SLUG)
 }
 
 export const getStoriesBySlug = async (


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Only pre-render static pages under the "widget" folder

- Add optional prop to "getPageLinks" to filter by path prefix

- Remove unused function "getFilteredProductLinks"

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Fix bug when pre-rendering static widget landing pages

- Before it was trying to render all the static pages although it should be restricted to pages under the "widget" folder

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
