### PR TITLE
CAR-42 - feat(ProductItemContractContainer): added pillow image

### DIFF
--- a/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
+++ b/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
@@ -4,7 +4,7 @@ import { storyblokEditable } from '@storyblok/react'
 import addDays from 'date-fns/addDays'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Space } from 'ui'
 import { useGlobalBanner } from '@/components/GlobalBanner/useGlobalBanner'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
@@ -12,7 +12,7 @@ import { useCarTrialExtensionQuery } from '@/services/apollo/generated'
 import { type SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { PageLink } from '@/utils/PageLink'
 import { useFormatter } from '@/utils/useFormatter'
-import { CarTrialExtension } from './carDealership.types'
+import { CarTrialExtension, TrialContract } from './carDealership.types'
 import { useUserWantsExtension } from './ExtensionOfferToggle'
 import { LoadingSkeleton } from './LoadingSkeleton'
 import { PayForTrial } from './PayForTrial'
@@ -35,24 +35,35 @@ export const CarTrialExtensionBlock = (props: Props) => {
     },
   })
 
+  const trialContact: TrialContract | null = useMemo(() => {
+    if (data?.carTrial) {
+      return {
+        ...data.carTrial.trialContract,
+        pillowSrc: data.carTrial.priceIntent.product.pillowImage.src,
+      }
+    }
+
+    return null
+  }, [data])
+
   return (
     <GridLayout.Root>
       <GridLayout.Content width="1/3" align="center">
-        {!data?.carTrial ? (
+        {!data?.carTrial || !trialContact ? (
           <LoadingSkeleton />
         ) : (
           <Space y={1.5}>
             {userWantsExtension ? (
               <TrialExtensionForm
                 {...storyblokEditable(props.blok)}
-                trialContract={data.carTrial.trialContract}
+                trialContract={trialContact}
                 priceIntent={data.carTrial.priceIntent}
                 shopSession={data.carTrial.shopSession}
                 requirePaymentConnection={props.blok.requirePaymentConnection ?? false}
               />
             ) : (
               <PayForTrial
-                trialContract={data.carTrial.trialContract}
+                trialContract={trialContact}
                 shopSessionId={data.carTrial.shopSession.id}
                 defaultOffer={data.carTrial.priceIntent.defaultOffer ?? undefined}
                 ssn={data.carTrial.shopSession.customer?.ssn ?? undefined}

--- a/apps/store/src/features/carDealership/PayForTrial.tsx
+++ b/apps/store/src/features/carDealership/PayForTrial.tsx
@@ -2,18 +2,19 @@ import { datadogRum } from '@datadog/browser-rum'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
 import { Space } from 'ui'
-import { ProductOfferFragment, TrialContractFragment } from '@/services/apollo/generated'
+import { ProductOfferFragment } from '@/services/apollo/generated'
 import { useBankIdContext } from '@/services/bankId/BankIdContext'
 import { convertToDate } from '@/utils/date'
 import { PageLink } from '@/utils/PageLink'
 import { useFormatter } from '@/utils/useFormatter'
+import { type TrialContract } from './carDealership.types'
 import { ConfirmPayWithoutExtensionButton } from './ConfirmPayWithoutExtensionButton'
 import { ExtensionOfferToggle } from './ExtensionOfferToggle'
 import { PriceBreakdown } from './PriceBreakdown'
 import { ProductItemContractContainerCar } from './ProductItemContractContainer'
 
 type Props = {
-  trialContract: TrialContractFragment
+  trialContract: TrialContract
   shopSessionId: string
   defaultOffer?: ProductOfferFragment
   ssn?: string

--- a/apps/store/src/features/carDealership/PriceIntentCarTrialExtensionFragment.graphql
+++ b/apps/store/src/features/carDealership/PriceIntentCarTrialExtensionFragment.graphql
@@ -9,6 +9,9 @@ fragment PriceIntentCarTrialExtension on PriceIntent {
     name
     displayNameShort
     pageLink
+    pillowImage {
+      src
+    }
   }
   defaultOffer {
     ...ProductOffer

--- a/apps/store/src/features/carDealership/ProductItemContractContainer.tsx
+++ b/apps/store/src/features/carDealership/ProductItemContractContainer.tsx
@@ -1,11 +1,12 @@
 import { useTranslation } from 'next-i18next'
 import { ProductItem } from '@/components/ProductItem/ProductItem'
-import { Money, TrialContractFragment } from '@/services/apollo/generated'
+import { Money } from '@/services/apollo/generated'
 import { convertToDate } from '@/utils/date'
 import { useFormatter } from '@/utils/useFormatter'
+import { type TrialContract } from './carDealership.types'
 
 type Props = {
-  contract: TrialContractFragment
+  contract: TrialContract
   crossedOverAmount?: Money
 }
 
@@ -51,6 +52,7 @@ export const ProductItemContractContainerCar = ({ contract, crossedOverAmount }:
       productDetails={productDetails}
       productDocuments={productDocuments}
       exposure={contract.exposureDisplayName}
+      pillowSrc={contract.pillowSrc}
     />
   )
 }

--- a/apps/store/src/features/carDealership/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.tsx
@@ -11,12 +11,12 @@ import {
   PriceIntentCarTrialExtensionFragment,
   ProductOfferFragment,
   ShopSessionFragment,
-  TrialContractFragment,
 } from '@/services/apollo/generated'
 import { convertToDate } from '@/utils/date'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { PageLink } from '@/utils/PageLink'
 import { useFormatter } from '@/utils/useFormatter'
+import { type TrialContract } from './carDealership.types'
 import { EditActionButton } from './EditActionButton'
 import { ExtensionOfferToggle } from './ExtensionOfferToggle'
 import { PriceBreakdown } from './PriceBreakdown'
@@ -24,7 +24,7 @@ import { ProductItemContractContainerCar } from './ProductItemContractContainer'
 import { useAcceptExtension } from './useAcceptExtension'
 
 type Props = {
-  trialContract: TrialContractFragment
+  trialContract: TrialContract
   priceIntent: PriceIntentCarTrialExtensionFragment
   shopSession: ShopSessionFragment
   requirePaymentConnection: boolean

--- a/apps/store/src/features/carDealership/carDealership.types.ts
+++ b/apps/store/src/features/carDealership/carDealership.types.ts
@@ -1,3 +1,6 @@
-import { CarTrialExtensionQuery } from '@/services/apollo/generated'
+import { CarTrialExtensionQuery, TrialContractFragment } from '@/services/apollo/generated'
 
 export type CarTrialExtension = CarTrialExtensionQuery['carTrial']
+
+// TODO: this is a workaround; ideally pillowSrc should be part of the TrialContractFragment
+export type TrialContract = TrialContractFragment & { pillowSrc?: string }


### PR DESCRIPTION
## Describe your changes

- Adds pillow image for Trial Product Item

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/0e9567e3-e718-4ce2-9d03-81e58abc2930.png)

## Justify why they are needed

Requested by design.
Observe tho that this implementation is a work around as that info is not exposed in `TrialContract` type.
