### PR TITLE
Use cache version when fetching page links from Storyblok

### DIFF
--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -42,19 +42,19 @@ export const fetchStory = async <StoryData extends ISbStoryData>(
   slug: string,
   params: StoryblokFetchParams,
 ): Promise<StoryData> => {
-  let cv: number | undefined
-  if (params.version === 'published') {
-    const cacheVersion = STORYBLOK_CACHE_VERSION ? parseInt(STORYBLOK_CACHE_VERSION) : NaN
-    const isCacheVersionValid = !isNaN(cacheVersion)
-    cv = isCacheVersionValid ? cacheVersion : undefined
-  }
   const response = await storyblokClient.getStory(slug, {
     ...params,
-    cv,
+    cv: params.version === 'published' ? getCacheVersion() : undefined,
     resolve_links: 'url',
   })
 
   return response.data.story as StoryData
+}
+
+export const getCacheVersion = (): number | undefined => {
+  const cacheVersion = STORYBLOK_CACHE_VERSION ? parseInt(STORYBLOK_CACHE_VERSION) : NaN
+  const isCacheVersionValid = !isNaN(cacheVersion)
+  return isCacheVersionValid ? cacheVersion : undefined
 }
 
 const MISSING_LINKS = new Set()

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -88,7 +88,7 @@ import { Features } from '@/utils/Features'
 import { getLocaleOrFallback, isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { Language, RoutingLocale } from '@/utils/l10n/types'
 import { GLOBAL_STORY_PROP_NAME, STORY_PROP_NAME } from './Storyblok.constant'
-import { fetchStory, StoryblokFetchParams } from './Storyblok.helpers'
+import { fetchStory, getCacheVersion, StoryblokFetchParams } from './Storyblok.helpers'
 
 const USE_DRAFT_CONTENT = process.env.NEXT_PUBLIC_STORYBLOK_DRAFT_CONTENT === 'true'
 
@@ -400,7 +400,12 @@ export const getPageLinks = async (params?: GetPageLinksParams): Promise<Array<P
     data: { links },
   } = await storyblokApi.get('cdn/links/', {
     ...(params?.startsWith && { starts_with: params.startsWith }),
-    ...(USE_DRAFT_CONTENT && { version: 'draft' }),
+    ...(USE_DRAFT_CONTENT
+      ? { version: 'draft' }
+      : {
+          version: 'published',
+          cv: getCacheVersion(),
+        }),
   })
   const pageLinks: Array<PageLink> = []
   Object.values(links as Record<string, LinkData>).forEach((link) => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Consider cache version when fetching published page links

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- This should avoid some rate limiting issues

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
