### PR TITLE
GEN-1485 | Centralize Storyblok cache version handling

### DIFF
--- a/apps/store/src/pages/api/draft.ts
+++ b/apps/store/src/pages/api/draft.ts
@@ -1,10 +1,10 @@
 // Next.js Draft Mode
 // nextjs.org/docs/pages/building-your-application/configuring/draft-mode#step-1-create-and-access-the-api-route
 
-import { ISbStoryData } from '@storyblok/react'
+import { ISbStoryData, ISbStoriesParams } from '@storyblok/react'
 import { NextApiRequest, NextApiResponse } from 'next'
 import StoryblokClient from 'storyblok-js-client'
-import { StoryblokFetchParams, fetchStory } from '@/services/storyblok/Storyblok.helpers'
+import { fetchStory } from '@/services/storyblok/storyblok'
 import { ORIGIN_URL } from '@/utils/PageLink'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -44,7 +44,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 }
 
 type PreviewParams = {
-  version: StoryblokFetchParams['version']
+  version: ISbStoriesParams['version']
   pageId: string
 }
 

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -1,8 +1,6 @@
-import { StoryblokClient } from '@storyblok/js'
 import { type SbBlokData, type ISbStoryData } from '@storyblok/react'
 import { Features } from '@/utils/Features'
-import { type Language } from '@/utils/l10n/types'
-import { LinkField, ProductStory, WidgetFlowStory, StoryblokVersion } from './storyblok'
+import { LinkField, ProductStory, WidgetFlowStory } from './storyblok'
 
 export const filterByBlockType = <BlockData extends SbBlokData>(
   blocks: Array<BlockData> = [],
@@ -28,33 +26,6 @@ export const checkBlockType = <BlockData extends SbBlokData>(
 ): BlockData | null => {
   if (block.component === targetType) return block as BlockData
   else return null
-}
-
-export type StoryblokFetchParams = {
-  version: StoryblokVersion
-  language?: Language
-  resolve_relations?: string
-}
-
-const STORYBLOK_CACHE_VERSION = process.env.STORYBLOK_CACHE_VERSION
-export const fetchStory = async <StoryData extends ISbStoryData>(
-  storyblokClient: StoryblokClient,
-  slug: string,
-  params: StoryblokFetchParams,
-): Promise<StoryData> => {
-  const response = await storyblokClient.getStory(slug, {
-    ...params,
-    cv: params.version === 'published' ? getCacheVersion() : undefined,
-    resolve_links: 'url',
-  })
-
-  return response.data.story as StoryData
-}
-
-export const getCacheVersion = (): number | undefined => {
-  const cacheVersion = STORYBLOK_CACHE_VERSION ? parseInt(STORYBLOK_CACHE_VERSION) : NaN
-  const isCacheVersionValid = !isNaN(cacheVersion)
-  return isCacheVersionValid ? cacheVersion : undefined
 }
 
 const MISSING_LINKS = new Set()


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Centralize Storyblok cache version handling

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Storyblok cache version handling is currently spread across multiple files and is not consistent

- Now we will use it for all calls to Storyblok consistently which should avoid rate limiting and speed up the calls

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
