### PR TITLE
CAR-42 - styles(PayForTrial): display crossed out ammount

### DIFF
--- a/apps/store/src/features/carDealership/PayForTrial.tsx
+++ b/apps/store/src/features/carDealership/PayForTrial.tsx
@@ -51,15 +51,20 @@ export const PayForTrial = ({ trialContract, shopSessionId, defaultOffer, ssn }:
     throw new Error(`Unable to parse terminationDate: ${trialContract.terminationDate}`)
   }
 
+  const crossedOutAmount = defaultOffer?.cost.net
+
   return (
     <Space y={1}>
-      <ProductItemContractContainerCar contract={trialContract} />
+      <ProductItemContractContainerCar
+        contract={trialContract}
+        crossedOutAmount={crossedOutAmount}
+      />
 
       <ExtensionOfferToggle />
 
       <PriceBreakdown
         amount={trialContract.premium.amount}
-        crossedOverAmount={defaultOffer?.cost.net.amount}
+        crossedOutAmount={crossedOutAmount?.amount}
         currencyCode={trialContract.premium.currencyCode}
         title={t('TRIAL_TITLE')}
         subTitle={trialContract.productVariant.displayNameSubtype}

--- a/apps/store/src/features/carDealership/PriceBreakdown.tsx
+++ b/apps/store/src/features/carDealership/PriceBreakdown.tsx
@@ -5,7 +5,7 @@ import { useFormatter } from '@/utils/useFormatter'
 
 type Props = {
   amount: number
-  crossedOverAmount?: number
+  crossedOutAmount?: number
   currencyCode: CurrencyCode
   title: string
   subTitle: string
@@ -14,14 +14,14 @@ type Props = {
 
 export const PriceBreakdown = ({
   amount,
-  crossedOverAmount,
+  crossedOutAmount,
   currencyCode,
   title,
   subTitle,
   priceExplanation,
 }: Props) => {
   const formatter = useFormatter()
-  const showCrossedOverAmount = crossedOverAmount !== undefined && crossedOverAmount > amount
+  const showCrossedOverAmount = crossedOutAmount !== undefined && crossedOutAmount > amount
   return (
     <div>
       <Row>
@@ -30,7 +30,7 @@ export const PriceBreakdown = ({
           {showCrossedOverAmount && (
             <Text as="p" size="md" strikethrough={true} color="textSecondary">
               {formatter.monthlyPrice({
-                amount: crossedOverAmount,
+                amount: crossedOutAmount,
                 currencyCode: currencyCode,
               })}
             </Text>

--- a/apps/store/src/features/carDealership/ProductItemContractContainer.tsx
+++ b/apps/store/src/features/carDealership/ProductItemContractContainer.tsx
@@ -7,10 +7,10 @@ import { type TrialContract } from './carDealership.types'
 
 type Props = {
   contract: TrialContract
-  crossedOverAmount?: Money
+  crossedOutAmount?: Money
 }
 
-export const ProductItemContractContainerCar = ({ contract, crossedOverAmount }: Props) => {
+export const ProductItemContractContainerCar = ({ contract, crossedOutAmount }: Props) => {
   const formatter = useFormatter()
   const { t } = useTranslation('carDealership')
 
@@ -21,11 +21,11 @@ export const ProductItemContractContainerCar = ({ contract, crossedOverAmount }:
 
   // Only show crossed over amount if default offer is more expensive than the trial
   const showCrossedOverAmount =
-    crossedOverAmount !== undefined && crossedOverAmount.amount > contract.premium.amount
+    crossedOutAmount !== undefined && crossedOutAmount.amount > contract.premium.amount
 
   let productPrice
   if (showCrossedOverAmount) {
-    productPrice = { ...crossedOverAmount, reducedAmount: contract.premium.amount }
+    productPrice = { ...crossedOutAmount, reducedAmount: contract.premium.amount }
   } else {
     productPrice = { ...contract.premium }
   }

--- a/apps/store/src/features/carDealership/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.tsx
@@ -87,7 +87,7 @@ export const TrialExtensionForm = ({
         <>
           <ProductItemContractContainerCar
             contract={trialContract}
-            crossedOverAmount={defaultOfferCost}
+            crossedOutAmount={defaultOfferCost}
           />
           <ExtensionOfferToggle />
         </>
@@ -110,7 +110,7 @@ export const TrialExtensionForm = ({
           <>
             <PriceBreakdown
               amount={trialContract.premium.amount}
-              crossedOverAmount={defaultOfferCost?.amount}
+              crossedOutAmount={defaultOfferCost?.amount}
               currencyCode={trialContract.premium.currencyCode}
               title={t('TRIAL_TITLE')}
               subTitle={trialContract.productVariant.displayNameSubtype}


### PR DESCRIPTION
## Describe your changes

- Display "crossed out amount" for Trial Product Item (when user doesn't want extension)

![Screenshot 2023-11-22 at 09.14.51.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/1e903a61-b0cf-456d-9d54-7c68f193f321.png)

## Justify why they  are needed

Requested by design under the name of consistency.
