### PR TITLE
GEN-1488 | Add support to remove cross-sell in widget

### DIFF
--- a/apps/store/src/features/widget/ProductItem.tsx
+++ b/apps/store/src/features/widget/ProductItem.tsx
@@ -4,7 +4,7 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import React, { type ComponentProps, useState, forwardRef, type ReactNode } from 'react'
-import { Button, ButtonProps, InfoIcon, Space, Text, mq, theme } from 'ui'
+import { Button, ButtonProps, CrossIconSmall, InfoIcon, Space, Text, mq, theme } from 'ui'
 import * as Collapsible from '@/components/Collapsible'
 import { InputDate } from '@/components/InputDate/InputDate'
 import { Pillow } from '@/components/Pillow/Pillow'
@@ -28,6 +28,7 @@ type Props = {
   startDate?: string
   onChangeStartDate: (value: string) => void
   loading: boolean
+  onDelete?: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
 export const ProductItem = (props: Props) => {
@@ -57,6 +58,12 @@ export const ProductItem = (props: Props) => {
                 <Text as="p" size="md" color="textTranslucentPrimary">
                   {props.title}
                 </Text>
+
+                {props.onDelete && (
+                  <DeleteButton onClick={props.onDelete}>
+                    <CrossIconSmall color={theme.colors.textSecondary} />
+                  </DeleteButton>
+                )}
               </HeaderRow>
               <SpaceFlex align="center" space={0.25}>
                 <Text as="p" color="textTranslucentSecondary">
@@ -106,6 +113,7 @@ const Card = styled.div({
   borderRadius: theme.radius.md,
   padding: theme.space.md,
   paddingBottom: 0,
+  position: 'relative',
 
   backgroundColor: theme.colors.opaque1,
   ['&[data-variant="green"]']: { backgroundColor: theme.colors.signalGreenFill },
@@ -155,4 +163,19 @@ const Footer = styled.div({
   gridAutoFlow: 'column',
   columnGap: theme.space.xs,
   paddingBottom: theme.space.md,
+})
+
+const DeleteButton = styled.button({
+  width: '1.5rem',
+  height: '1.5rem',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  borderRadius: '50%',
+  backgroundColor: theme.colors.buttonSecondary,
+  cursor: 'pointer',
+
+  '&:hover': {
+    backgroundColor: theme.colors.buttonSecondaryHover,
+  },
 })

--- a/apps/store/src/features/widget/ProductItemContainer.tsx
+++ b/apps/store/src/features/widget/ProductItemContainer.tsx
@@ -23,6 +23,7 @@ type Props = {
   children?: ReactNode
   defaultExpanded?: boolean
   variant?: ComponentProps<typeof ProductItem>['variant']
+  onDelete?: ComponentProps<typeof ProductItem>['onDelete']
 }
 
 export const ProductItemContainer = (props: Props) => {
@@ -78,6 +79,7 @@ export const ProductItemContainer = (props: Props) => {
       startDate={props.offer.startDate}
       onChangeStartDate={handleChangeStartDate}
       loading={result.loading}
+      onDelete={props.onDelete}
     >
       {props.children}
     </ProductItem>

--- a/packages/ui/src/lib/theme/colors/colors.ts
+++ b/packages/ui/src/lib/theme/colors/colors.ts
@@ -369,6 +369,17 @@ export const colors = {
   signalBlueHighlight: signal.blue.highlight,
   signalBlueElement: signal.blue.element,
   signalBlueText: signal.blue.text,
+
+  // Buttons
+  buttonPrimary: gray[1000],
+  buttonPrimaryHover: gray[900],
+  buttonPrimaryDisabled: gray[400],
+  buttonPrimaryAlt: green[50],
+  buttonPrimaryAltHover: green[200],
+  buttonPrimaryAltDisabled: gray[400],
+  buttonSecondary: gray[50],
+  buttonSecondaryHover: gray[300],
+  buttonSecondaryDisabled: gray[50],
 } as const
 
 export type UIColors = typeof colors


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/OgXegTwxM9IeuXHZyw5h/3e485c1d-93fc-4e2e-903b-f3a495d6eb5d.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/OgXegTwxM9IeuXHZyw5h/3e485c1d-93fc-4e2e-903b-f3a495d6eb5d.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/3e485c1d-93fc-4e2e-903b-f3a495d6eb5d.mov">Screen Recording 2023-11-22 at 14.11.38.mov</video>

## Describe your changes

- Add delete button to `ProductItem` based on design

- Differentiate main product from cross-sell products in the Widget Sign page

- Animate adding/removing products from the Widget Sign page

- Add semantic button colors from Figma

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Match Figma design

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
