### PR TITLE
GEN-1481 | Widget | Automatically detect cart entries to replace

### DIFF
--- a/apps/store/src/features/widget/CalculatePricePage.tsx
+++ b/apps/store/src/features/widget/CalculatePricePage.tsx
@@ -32,10 +32,12 @@ export const CalculatePricePage = (props: Props) => {
   const priceLoaderPromise = useRef<Promise<void> | null>(null)
 
   const router = useRouter()
-  const entryToReplace = typeof router.query.replace === 'string' ? router.query.replace : undefined
+  const entryToReplace = props.shopSession.cart.entries.find(
+    (item) => item.product.name === props.priceIntent.product.name,
+  )
   const [addToCart] = useAddToCart({
     shopSessionId: props.shopSession.id,
-    entryToReplace,
+    entryToReplace: entryToReplace?.id,
     async onError() {
       await priceLoaderPromise.current
       setLoading(false)

--- a/apps/store/src/features/widget/SignPage.tsx
+++ b/apps/store/src/features/widget/SignPage.tsx
@@ -85,19 +85,6 @@ export const SignPage = (props: Props) => {
     },
   })
 
-  const getEditLink = (offerId: string) => {
-    const url = PageLink.widgetCalculatePrice({
-      flow: props.flow,
-      shopSessionId: props.shopSession.id,
-      priceIntentId: props.priceIntentId,
-      locale: routingLocale,
-    })
-
-    url.searchParams.set('replace', offerId)
-
-    return url
-  }
-
   const userErrorMessage = userError?.message
 
   const mainOffer = props.shopSession.cart.entries.find(
@@ -138,7 +125,12 @@ export const SignPage = (props: Props) => {
                       <ButtonNextLink
                         variant="secondary"
                         size="medium"
-                        href={getEditLink(mainOffer.id)}
+                        href={PageLink.widgetCalculatePrice({
+                          flow: props.flow,
+                          shopSessionId: props.shopSession.id,
+                          priceIntentId: props.priceIntentId,
+                          locale: routingLocale,
+                        })}
                       >
                         {t('cart:CART_ENTRY_EDIT_BUTTON')}
                       </ButtonNextLink>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Detect if we are about to add a product that is already in the cart

- If so: first remove the existing cart item and add the new one

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- This is a more robust solution than relying on URL parameters and makes sure we support users that would press the back-button from the sign page.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
