### PR TITLE
Make calls to Storyblok in sequence to avoid rate limit

### DIFF
--- a/apps/store/src/pages/widget/[[...slug]].tsx
+++ b/apps/store/src/pages/widget/[[...slug]].tsx
@@ -73,11 +73,14 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
     return { paths: [], fallback: 'blocking' }
   }
 
-  const nestedPageLinks = await Promise.all(
-    (context.locales ?? []).map((locale) =>
-      getPageLinks({ startsWith: `${locale}/${STORYBLOK_WIDGET_FOLDER_SLUG}` }),
-    ),
-  )
+  // Call in sequence to avoid hitting Storyblok rate limit
+  const nestedPageLinks: Array<Array<{ slugParts: Array<string>; locale: string }>> = []
+  for (const locale of context.locales ?? []) {
+    const pageLinks = await getPageLinks({
+      startsWith: `${locale}/${STORYBLOK_WIDGET_FOLDER_SLUG}`,
+    })
+    nestedPageLinks.push(pageLinks)
+  }
 
   return {
     paths: nestedPageLinks


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Call Storyblok API in sequence to get page links

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We are hitting Storyblok API rate limit even if we are sending cache version in the request

- I also tried sending a single request using the `by_slugs` option but couldn't get it to work as expected

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
