### PR TITLE
Create `ProductDataContext` based on Jotai

### DIFF
--- a/apps/store/src/blocks/InsurableLimitsBlock.tsx
+++ b/apps/store/src/blocks/InsurableLimitsBlock.tsx
@@ -1,9 +1,11 @@
 import { storyblokEditable } from '@storyblok/react'
 import { InsurableLimits } from '@/components/InsurableLimits/InsurableLimits'
+import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 
 export const InsurableLimitsBlock = () => {
-  const { productData, selectedVariant } = useProductPageContext()
+  const { selectedVariant } = useProductPageContext()
+  const productData = useProductData()
 
   const selectedProductVariant = productData.variants.find(
     (item) => item.typeOfContract === selectedVariant?.typeOfContract,

--- a/apps/store/src/blocks/PerilsBlock.tsx
+++ b/apps/store/src/blocks/PerilsBlock.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { Badge, Space } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { Perils } from '@/components/Perils/Perils'
+import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
@@ -12,7 +13,8 @@ type PerilsBlockProps = SbBaseBlockProps<{
 }>
 
 export const PerilsBlock = ({ blok }: PerilsBlockProps) => {
-  const { productData, selectedVariant } = useProductPageContext()
+  const { selectedVariant } = useProductPageContext()
+  const productData = useProductData()
 
   const allPerils = useMemo(() => {
     const perilsMap = new Map(

--- a/apps/store/src/blocks/ProductAverageRatingBlock.tsx
+++ b/apps/store/src/blocks/ProductAverageRatingBlock.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import Head from 'next/head'
 import { Text, InfoIcon, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { ProductRating } from '@/components/ProductRating/ProductRating'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
@@ -13,7 +14,8 @@ type Product = ReturnType<typeof useProductPageContext>['productData']
 type AverageRating = NonNullable<ReturnType<typeof useProductPageContext>['averageRating']>
 
 export const ProductAverageRatingBlock = () => {
-  const { productData, averageRating } = useProductPageContext()
+  const { averageRating } = useProductPageContext()
+  const productData = useProductData()
 
   if (!averageRating) {
     console.warn(`AverageRatingBlock | Average rating for product ${productData.name} not found`)

--- a/apps/store/src/blocks/ProductDocumentsBlock.tsx
+++ b/apps/store/src/blocks/ProductDocumentsBlock.tsx
@@ -1,4 +1,5 @@
 import { storyblokEditable } from '@storyblok/react'
+import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { ProductDocuments } from '@/components/ProductPage/ProductDocuments'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
@@ -9,7 +10,8 @@ type Props = SbBaseBlockProps<{
 }>
 
 export const ProductDocumentsBlock = ({ blok }: Props) => {
-  const { productData, selectedVariant } = useProductPageContext()
+  const { selectedVariant } = useProductPageContext()
+  const productData = useProductData()
   const { heading, description } = blok
 
   const docs = selectedVariant?.documents ?? productData.variants[0].documents

--- a/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
+++ b/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { ConditionalWrapper, theme, mq } from 'ui'
-import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
+import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { ProductVariantSelector } from '@/components/ProductVariantSelector/ProductVariantSelector'
 import { zIndexes } from '@/utils/zIndex'
 import { NAVIGATION_LIST_HEIGHT } from './ProductPageBlock'
@@ -10,7 +10,7 @@ type ProductVariantSelectorBlockProps = {
 }
 
 export const ProductVariantSelectorBlock = ({ nested }: ProductVariantSelectorBlockProps) => {
-  const { productData } = useProductPageContext()
+  const productData = useProductData()
 
   if (productData.variants.length < 2) return null
 

--- a/apps/store/src/components/ProductData/ProductDataProvider.tsx
+++ b/apps/store/src/components/ProductData/ProductDataProvider.tsx
@@ -1,0 +1,38 @@
+import { Provider, atom, createStore, useAtomValue } from 'jotai'
+import { useHydrateAtoms } from 'jotai/utils'
+import { ReactNode, useMemo } from 'react'
+import { ProductData } from './ProductData.types'
+
+const PRODUCT_DATA_ATOM = atom<ProductData | null>(null)
+
+type Props = {
+  children: ReactNode
+  productData: ProductData
+}
+
+export const ProductDataProvider = (props: Props) => {
+  const store = useMemo(createStore, [props.productData.id])
+
+  return (
+    <Provider store={store}>
+      <HydrateProductData store={store} productData={props.productData} />
+      {props.children}
+    </Provider>
+  )
+}
+
+type HydrateProductDataProps = {
+  productData: ProductData
+  store: ReturnType<typeof createStore>
+}
+
+const HydrateProductData = (props: HydrateProductDataProps) => {
+  useHydrateAtoms([[PRODUCT_DATA_ATOM, props.productData]], { store: props.store })
+  return null
+}
+
+export const useProductData = () => {
+  const value = useAtomValue(PRODUCT_DATA_ATOM)
+  if (value === null) throw new Error('ProductData accessed without hydrating')
+  return value
+}

--- a/apps/store/src/components/ProductPage/PriceIntentContext.tsx
+++ b/apps/store/src/components/ProductPage/PriceIntentContext.tsx
@@ -9,6 +9,7 @@ import {
   useEffect,
   useState,
 } from 'react'
+import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import {
   PriceIntentFragment,
@@ -40,7 +41,8 @@ export const PriceIntentContextProvider = ({ children }: Props) => {
 }
 
 const usePriceIntentContextValue = () => {
-  const { priceTemplate, productData } = useProductPageContext()
+  const { priceTemplate } = useProductPageContext()
+  const productData = useProductData()
   const apolloClient = useApolloClient()
   const { onReady, shopSession } = useShopSession()
 

--- a/apps/store/src/components/ProductPage/ProductPage.tsx
+++ b/apps/store/src/components/ProductPage/ProductPage.tsx
@@ -1,6 +1,7 @@
 import { StoryblokComponent } from '@storyblok/react'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo } from 'react'
+import { ProductDataProvider } from '@/components/ProductData/ProductDataProvider'
 import { PriceIntentContextProvider } from '@/components/ProductPage/PriceIntentContext'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { useTracking } from '@/services/Tracking/useTracking'
@@ -21,12 +22,14 @@ export const ProductPage = ({ story, ...props }: ProductPageProps) => {
   useDiscountBanner()
 
   return (
-    <ProductPageContextProvider {...props} story={story}>
-      <PriceIntentContextProvider>
-        <StoryblokComponent blok={story.content} />
-        <PageDebugDialog />
-      </PriceIntentContextProvider>
-    </ProductPageContextProvider>
+    <ProductDataProvider productData={props.productData}>
+      <ProductPageContextProvider {...props} story={story}>
+        <PriceIntentContextProvider>
+          <StoryblokComponent blok={story.content} />
+          <PageDebugDialog />
+        </PriceIntentContextProvider>
+      </ProductPageContextProvider>
+    </ProductDataProvider>
   )
 }
 

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -14,6 +14,7 @@ import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { PriceCalculator } from '@/components/PriceCalculator/PriceCalculator'
 import { completePriceLoader, PriceLoader } from '@/components/PriceLoader'
+import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { usePriceIntent } from '@/components/ProductPage/PriceIntentContext'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import {
@@ -45,7 +46,8 @@ import { useSelectedOffer } from './useSelectedOffer'
 
 export const PurchaseForm = () => {
   const { t } = useTranslation('purchase-form')
-  const { priceTemplate, productData } = useProductPageContext()
+  const { priceTemplate } = useProductPageContext()
+  const productData = useProductData()
   const { shopSession } = useShopSession()
   const formatter = useFormatter()
   const [priceIntent, , createNewPriceIntent] = usePriceIntent()
@@ -269,7 +271,8 @@ type ProductHeroContainerProps = {
 }
 
 const ProductHeroContainer = (props: ProductHeroContainerProps) => {
-  const { content, productData } = useProductPageContext()
+  const { content } = useProductPageContext()
+  const productData = useProductData()
 
   return (
     <ProductHeroWrapper compact={props.compact ?? false}>

--- a/apps/store/src/components/ProductVariantSelector/ProductVariantSelector.tsx
+++ b/apps/store/src/components/ProductVariantSelector/ProductVariantSelector.tsx
@@ -1,11 +1,13 @@
 import { ChangeEventHandler, useMemo } from 'react'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
+import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 
 type Props = { className?: string }
 
 export const ProductVariantSelector = ({ className }: Props) => {
-  const { productData, selectedVariant, selectedVariantUpdate } = useProductPageContext()
+  const { selectedVariant, selectedVariantUpdate } = useProductPageContext()
+  const productData = useProductData()
 
   const variantOptions = useMemo(
     () =>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Use Jotai to setup a "product data context"

- Use this context to access product data on the PDP

- Use a separate Jotai store for each product to make sure that the data is
  updated correctly

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- This implementation will make it possible to reuse it outside of the PDP

- I opted for Jotai instead of React Context because it is easier to use. I still ended up with a little more boilerplate than I would have liked; mostly to make sure we always have the latest data.

- I considered "dangerouslyForceHydrate" but decided against it since the behavior can be inconsistent with concurrent rendering

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
