### PR TITLE
CAR-39 - fix(carDealership): hide banner after accepting extension/connecting payment

### DIFF
--- a/apps/store/src/features/carDealership/PayForTrial.tsx
+++ b/apps/store/src/features/carDealership/PayForTrial.tsx
@@ -2,6 +2,7 @@ import { datadogRum } from '@datadog/browser-rum'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
 import { Space } from 'ui'
+import { useGlobalBanner } from '@/components/GlobalBanner/useGlobalBanner'
 import { ProductOfferFragment } from '@/services/apollo/generated'
 import { useBankIdContext } from '@/services/bankId/BankIdContext'
 import { convertToDate } from '@/utils/date'
@@ -24,6 +25,7 @@ export const PayForTrial = ({ trialContract, shopSessionId, defaultOffer, ssn }:
   const router = useRouter()
   const { t } = useTranslation('carDealership')
   const formatter = useFormatter()
+  const { dismissBanner } = useGlobalBanner()
   const { startLogin } = useBankIdContext()
   const handleConfirmPay = () => {
     datadogRum.addAction('Car dealership | Decline extension offer')
@@ -39,6 +41,7 @@ export const PayForTrial = ({ trialContract, shopSessionId, defaultOffer, ssn }:
         const nextUrl = PageLink.carDealershipConfirmation({
           contractId: trialContract.id,
         }).pathname
+        dismissBanner()
         await router.push(
           PageLink.checkoutPaymentTrustly({ shopSessionId: shopSessionId, nextUrl }),
         )

--- a/apps/store/src/features/carDealership/useAcceptExtension.ts
+++ b/apps/store/src/features/carDealership/useAcceptExtension.ts
@@ -1,6 +1,7 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
+import { useGlobalBanner } from '@/components/GlobalBanner/useGlobalBanner'
 import {
   ShopSessionFragment,
   useCarDealershipRemoveAddMutation,
@@ -22,6 +23,7 @@ type Params = {
 export const useAcceptExtension = (params: Params) => {
   const { startCheckoutSign, currentOperation } = useBankIdContext()
   const router = useRouter()
+  const { dismissBanner } = useGlobalBanner()
   const { showError } = useAppErrorHandleContext()
   const [getCurrentMember] = useCurrentMemberLazyQuery()
 
@@ -62,11 +64,13 @@ export const useAcceptExtension = (params: Params) => {
           LOGGER.info('Member has active payment connection', {
             promptedPayment: params.requirePaymentConnection,
           })
+          dismissBanner()
           await router.push(nextUrl)
         } else {
           LOGGER.info('Member does not have active payment connection', {
             promptedPayment: params.requirePaymentConnection,
           })
+          dismissBanner()
           await router.push(
             PageLink.checkoutPaymentTrustly({ shopSessionId: params.shopSession.id, nextUrl }),
           )


### PR DESCRIPTION
## Describe your changes

- Hide banner after accepting extension or connecting a payment method.

## Justify why they are needed

I've tried other ways but without success. I guess it's not perfect but at least it works.
