### PR TITLE
GEN-1500 | Show success animation before confirmation page

### DIFF
--- a/apps/store/src/pages/widget/[flow]/[shopSessionId]/confirmation.tsx
+++ b/apps/store/src/pages/widget/[flow]/[shopSessionId]/confirmation.tsx
@@ -1,7 +1,9 @@
 import { type GetServerSideProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import Head from 'next/head'
 import { type ComponentProps } from 'react'
 import { fetchConfirmationStory } from '@/components/ConfirmationPage/fetchConfirmationStory'
+import { SuccessAnimation } from '@/components/ConfirmationPage/SuccessAnimation/SuccessAnimation'
 import { ConfirmationPage } from '@/features/widget/ConfirmationPage'
 import { addApolloState, initializeApolloServerSide } from '@/services/apollo/client'
 import { useShopSessionQuery } from '@/services/apollo/generated'
@@ -55,9 +57,16 @@ const Page = (props: Props) => {
   })
   const shopSession = shopSessionResult.data?.shopSession
 
-  if (!shopSession) return null
-
-  return <ConfirmationPage {...props} shopSession={shopSession} />
+  return (
+    <>
+      <Head>
+        <title>{props.title}</title>
+      </Head>
+      <SuccessAnimation>
+        {shopSession && <ConfirmationPage {...props} shopSession={shopSession} />}
+      </SuccessAnimation>
+    </>
+  )
 }
 
 export default Page


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Show success animation before confirmation page in widget flow

- Add page title for confirmation page in widget flow

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- I kept the success animation inside the confirmation page folder since it still kind of belongs to the confirmation page.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
