### PR TITLE
Add route for extension page

### DIFF
--- a/apps/store/src/pages/car-buyer/[contractId]/extension.tsx
+++ b/apps/store/src/pages/car-buyer/[contractId]/extension.tsx
@@ -1,0 +1,31 @@
+import { type GetServerSideProps } from 'next'
+import NextCmsPage from '@/pages/[[...slug]]'
+import { getStoryblokPageProps } from '@/services/storyblok/getStoryblokPageProps'
+import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+
+const EXTENSION_PAGE_SLUG = 'car-buyer/extension'
+
+type Props = Awaited<ReturnType<typeof getStoryblokPageProps>>
+
+type Params = {
+  contractId: string
+}
+
+export const getServerSideProps: GetServerSideProps<Props, Params> = async (context) => {
+  const { params, locale, draftMode = false } = context
+  if (!params) throw new Error('Missing params')
+  if (!isRoutingLocale(locale)) return { notFound: true }
+
+  const props = await getStoryblokPageProps({
+    context,
+    slug: EXTENSION_PAGE_SLUG,
+    locale,
+    draftMode,
+  })
+
+  return {
+    props,
+  }
+}
+
+export default NextCmsPage


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add a route for `car-buyer/[contractId]/extension` for retargeting members with a active trial that has connected payment

https://hedvig-dot-g42lzxsge-hedvig.vercel.app/se/car-buyer/bdcd75d6-f396-4ff1-838f-079d7d75d09b/extension

This won't however work for previewing the page in storyblok since the route is `car-buyer/extension` and it will target the page `car-buyer/[contractId]`. So I wonder if there's a better route pattern to choose for this case? 

<img width="1109" alt="Screenshot 2023-11-27 at 15 36 36" src="https://github.com/HedvigInsurance/racoon/assets/6661511/a43c4677-7554-4d68-8aa0-8b4de35790f3">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Needed for retargeting

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
