### PR TITLE
Provide Tracking context via React.Context

### DIFF
--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -23,7 +23,7 @@ import { initDatadog } from '@/services/logger/client'
 import { PageTransitionProgressBar } from '@/services/nprogress/pageTransition'
 import { OneTrustStyles } from '@/services/OneTrust'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
-import { ShopSessionProvider } from '@/services/shopSession/ShopSessionContext'
+import { ShopSessionProvider, useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { initStoryblok } from '@/services/storyblok/storyblok'
 import { trackExperimentImpression } from '@/services/Tracking/trackExperimentImpression'
 import { Tracking } from '@/services/Tracking/Tracking'
@@ -102,7 +102,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
         <PageTransitionProgressBar />
         <JotaiProvider>
           <ShopSessionProvider shopSessionId={pageProps[SHOP_SESSION_PROP_NAME]}>
-            <TrackingProvider value={tracking}>
+            <ShopSessionTrackingProvider>
               <BankIdContextProvider>
                 <BalancerProvider>
                   <AppErrorProvider>
@@ -113,13 +113,18 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
                 </BalancerProvider>
                 <BankIdDialog />
               </BankIdContextProvider>
-            </TrackingProvider>
+            </ShopSessionTrackingProvider>
           </ShopSessionProvider>
           {Chat}
         </JotaiProvider>
       </ApolloProvider>
     </>
   )
+}
+
+const ShopSessionTrackingProvider = (props: { children: ReactNode }) => {
+  const { shopSession } = useShopSession()
+  return <TrackingProvider shopSession={shopSession}>{props.children}</TrackingProvider>
 }
 
 export default appWithTranslation(MyApp)

--- a/apps/store/src/pages/widget/[flow]/[shopSessionId]/[priceIntentId]/calculate-price.tsx
+++ b/apps/store/src/pages/widget/[flow]/[shopSessionId]/[priceIntentId]/calculate-price.tsx
@@ -15,6 +15,7 @@ import {
   useWidgetPriceIntentQuery,
 } from '@/services/apollo/generated'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
+import { TrackingProvider } from '@/services/Tracking/TrackingContext'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
 type Props = Pick<ComponentPropsWithoutRef<typeof CalculatePricePage>, 'flow' | 'priceTemplate'> & {
@@ -88,7 +89,9 @@ const Page = (props: Props) => {
       <Head>
         <title>{`Hedvig | ${t('CALCULATE_PRICE_PAGE_TITLE')}`}</title>
       </Head>
-      <CalculatePricePage {...props} shopSession={shopSession} priceIntent={priceIntent} />
+      <TrackingProvider shopSession={shopSession}>
+        <CalculatePricePage {...props} shopSession={shopSession} priceIntent={priceIntent} />
+      </TrackingProvider>
     </>
   )
 }

--- a/apps/store/src/services/Tracking/TrackingContext.tsx
+++ b/apps/store/src/services/Tracking/TrackingContext.tsx
@@ -1,20 +1,18 @@
-import { createContext, ProviderProps, useEffect } from 'react'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
-import { Tracking, TrackingContextKey } from '@/services/Tracking/Tracking'
+import { type ReactNode, createContext, useMemo } from 'react'
+import { type ShopSession } from '@/services/shopSession/ShopSession.types'
+import { type Tracking } from './Tracking'
 
-export const TrackingContext = createContext(new Tracking())
+export const TrackingContext = createContext<Tracking['context']>({})
 
-export const TrackingProvider = ({ value: tracking, children }: ProviderProps<Tracking>) => {
-  useTrackShopSession(tracking)
-
-  return <TrackingContext.Provider value={tracking}>{children}</TrackingContext.Provider>
+type Props = {
+  children: ReactNode
+  shopSession?: ShopSession
 }
 
-export const useTrackShopSession = (tracking: Tracking) => {
-  const { onReady } = useShopSession()
-  useEffect(() => {
-    return onReady((shopSession) => {
-      tracking.setContext(TrackingContextKey.ShopSessionId, shopSession.id)
-    })
-  }, [onReady, tracking])
+export const TrackingProvider = (props: Props) => {
+  const data = useMemo<Tracking['context']>(() => {
+    return { shopSessionId: props.shopSession?.id }
+  }, [props.shopSession?.id])
+
+  return <TrackingContext.Provider value={data}>{props.children}</TrackingContext.Provider>
 }

--- a/apps/store/src/services/Tracking/trackPageViews.ts
+++ b/apps/store/src/services/Tracking/trackPageViews.ts
@@ -1,6 +1,6 @@
 import router from 'next/router'
 import { trackExperimentImpression } from '@/services/Tracking/trackExperimentImpression'
-import { Tracking } from '@/services/Tracking/Tracking'
+import { type Tracking } from '@/services/Tracking/Tracking'
 
 export const trackPageViews = (tracking: Tracking) => {
   router.ready(() => {

--- a/apps/store/src/services/Tracking/useTracking.ts
+++ b/apps/store/src/services/Tracking/useTracking.ts
@@ -1,6 +1,11 @@
-import { useContext } from 'react'
+import { useContext, useMemo } from 'react'
+import { Tracking } from './Tracking'
 import { TrackingContext } from './TrackingContext'
 
 export const useTracking = () => {
-  return useContext(TrackingContext)
+  const data = useContext(TrackingContext)
+
+  return useMemo(() => {
+    return new Tracking(data)
+  }, [data])
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Use react context to provide shop session as context to `useTracking` hook for all child components

- Use multiple tracking contexts based on which shop session is relevant

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We need to keep track of different shop sessions to correctly track events. It started getting really hard to keep track of this with the widget. This is a more explicit approach that still allows us to nest different tracking providers.

- There's some things missing from this implementation but I open it as a PR to get feedback on the approach.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
