### PR TITLE
Derive tracking migration shop session from context

### DIFF
--- a/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
+++ b/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
@@ -29,8 +29,7 @@ import { BankIdState } from '@/services/bankId/bankId.types'
 import { useBankIdContext } from '@/services/bankId/BankIdContext'
 import { setupShopSessionServiceClientSide } from '@/services/shopSession/ShopSession.helpers'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
-import { TrackingContextKey } from '@/services/Tracking/Tracking'
-import { useTracking } from '@/services/Tracking/useTracking'
+import { TrackingProvider } from '@/services/Tracking/TrackingContext'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { PageLink } from '@/utils/PageLink'
 import { type ComparisonTableData } from '../manyPets.types'
@@ -66,13 +65,8 @@ export const ManyPetsMigrationPage = ({
   const { routingLocale } = useCurrentLocale()
   const { t } = useTranslation('checkout')
 
-  const tracking = useTracking()
   const migrationSessionQueryResult = useShopSessionQuery({
     variables: { shopSessionId: migrationSessionId },
-    onCompleted() {
-      // Not currently used, but may be nice to have if we send some new events from migration session
-      tracking.setContext(TrackingContextKey.MigrationSessionId, migrationSessionId)
-    },
   })
   const { shopSession: migrationShopSession } = migrationSessionQueryResult.data ?? {}
 
@@ -93,7 +87,7 @@ export const ManyPetsMigrationPage = ({
   )
 
   return (
-    <>
+    <TrackingProvider shopSession={migrationSessionQueryResult.data?.shopSession}>
       {announcement}
       <main>
         {preOfferContent}
@@ -176,7 +170,7 @@ export const ManyPetsMigrationPage = ({
           </SignButton>
         </FloatSignButtonWrapper>
       </main>
-    </>
+    </TrackingProvider>
   )
 }
 

--- a/apps/store/src/services/Tracking/Tracking.ts
+++ b/apps/store/src/services/Tracking/Tracking.ts
@@ -49,7 +49,7 @@ export enum TrackingEvent {
   InsurelyCorrectlyFetched = 'insurely_correctly_fetched',
 }
 
-export enum TrackingContextKey {
+enum TrackingContextKey {
   City = 'city',
   CountryCode = 'countryCode',
   CustomerFirstName = 'customerFirstName',
@@ -57,7 +57,6 @@ export enum TrackingContextKey {
   CustomerEmail = 'customerEmail',
   NumberOfPeople = 'numberOfPeople',
   ShopSessionId = 'shopSessionId',
-  MigrationSessionId = 'migrationSessionId',
   ZipCode = 'zipCode',
   ProductId = 'productId',
   ProductDisplayName = 'productDisplayName',
@@ -70,17 +69,6 @@ export class Tracking {
   constructor(public context: TrackingContext = {}) {}
 
   private logger = datadogLogs.getLogger(Tracking.LOGGER_NAME)!
-
-  public setContext = (key: TrackingContextKey, value: unknown) => {
-    if (this.context[key] !== value) {
-      console.debug(`tracking context ${key}:`, value)
-    }
-    if (value != null) {
-      this.context[key] = value
-    } else {
-      delete this.context[key]
-    }
-  }
 
   public reportAppInit = (countryCode: CountryCode) => {
     initializeGtm(countryCode)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Setup separate tracking context for many pets migration page

- Remove separate (unused) migration session tracking key

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Now any events sent from the migration page will use the correct shop session data

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
