### PR TITLE
Create separate route for car dealership /extension

### DIFF
--- a/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
+++ b/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
@@ -82,7 +82,13 @@ type UseCarTrialQueryParams = Pick<QueryHookOptions<NonNullable<CarTrialExtensio
 const useCarTrialQuery = (params: UseCarTrialQueryParams) => {
   const router = useRouter()
   const queryParam = router.query['contractId']
-  const contractId = typeof queryParam === 'string' ? queryParam : undefined
+
+  let contractId = undefined
+  if (typeof queryParam === 'string') {
+    contractId = queryParam
+  } else if (Array.isArray(queryParam)) {
+    contractId = queryParam[0]
+  }
 
   const { data } = useCarTrialExtensionQuery({
     variables: contractId ? { contractId } : undefined,

--- a/apps/store/src/pages/car-buyer/extension/[[...contractId]].tsx
+++ b/apps/store/src/pages/car-buyer/extension/[[...contractId]].tsx
@@ -1,0 +1,31 @@
+import { type GetServerSideProps } from 'next'
+import NextCmsPage from '@/pages/[[...slug]]'
+import { getStoryblokPageProps } from '@/services/storyblok/getStoryblokPageProps'
+import { isRoutingLocale } from '@/utils/l10n/localeUtils'
+
+const EXTENSION_PAGE_SLUG = 'car-buyer/extension'
+
+type Props = Awaited<ReturnType<typeof getStoryblokPageProps>>
+
+type Params = {
+  contractId: string
+}
+
+export const getServerSideProps: GetServerSideProps<Props, Params> = async (context) => {
+  const { params, locale, draftMode = false } = context
+  if (!params) throw new Error('Missing params')
+  if (!isRoutingLocale(locale)) return { notFound: true }
+
+  const props = await getStoryblokPageProps({
+    context,
+    slug: EXTENSION_PAGE_SLUG,
+    locale,
+    draftMode,
+  })
+
+  return {
+    props,
+  }
+}
+
+export default NextCmsPage


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
This was the most logical way to solve it I think to make both preview and extension with a `contractId` work.
The route will be `car-buyer/extension/[contractId]` instead, but that's the route already setup in CRM so that's fine I think.

https://hedvig-dot-nl4bnz3gb-hedvig.vercel.app/se/car-buyer/extension
https://hedvig-dot-nl4bnz3gb-hedvig.vercel.app/se/car-buyer/extension/bdcd75d6-f396-4ff1-838f-079d7d75d09b

Replaces https://github.com/HedvigInsurance/racoon/pull/3649
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Needed for retargeting

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
