### PR TITLE
Set GTM user ID after purchase

### DIFF
--- a/apps/store/src/services/Tracking/Tracking.ts
+++ b/apps/store/src/services/Tracking/Tracking.ts
@@ -2,11 +2,11 @@ import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
 import md5 from 'md5'
 import {
-  CartFragmentFragment,
-  CountryCode,
-  ProductOfferFragment,
+  type CartFragmentFragment,
+  type CountryCode,
+  type ProductOfferFragment,
 } from '@/services/apollo/generated'
-import { EcommerceEvent, pushToGTMDataLayer, initializeGtm } from '@/services/gtm'
+import { type EcommerceEvent, pushToGTMDataLayer, initializeGtm, setUserId } from '@/services/gtm'
 import { getAdtractionProductCategories } from './adtraction'
 
 type TrackingProductData = {
@@ -217,10 +217,13 @@ export class Tracking {
   }
 
   public reportPurchase(cart: CartFragmentFragment, memberId: string, isNewMember: boolean) {
+    setUserId(memberId)
+
     const event = cartToEcommerceEvent(TrackingEvent.Purchase, cart, this.context)
     event.ecommerce.transaction_id = cart.id
     event.new_customer = isNewMember
     this.reportEcommerceEvent(event)
+
     // Also report in web-onboarding format
     this.reportSignedCustomer(cart, memberId)
     this.reportAdtractionEvent(cart, this.context)

--- a/apps/store/src/services/gtm.tsx
+++ b/apps/store/src/services/gtm.tsx
@@ -54,6 +54,7 @@ type DataLayerObject = {
   pageData?: GTMPageData
   ecommerce?: GTMEcommerceData
   shopSession?: GTMShopSessionData
+  user_id?: string
 }
 
 export type EcommerceEvent = {
@@ -122,4 +123,9 @@ export const initializeGtm = (countryCode: CountryCode) => {
       environment: getGtmEnvironment(),
     },
   })
+}
+
+// https://developers.google.com/analytics/devguides/collection/ga4/user-id?client_type=gtm#send_user_ids
+export const setUserId = (userId: string) => {
+  pushToGTMDataLayer({ user_id: userId })
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Set "user_id" for GA after completing a purchase

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- I feel like this should be done after successful login/signup but let's try it here and see if it works at least

- Required to be able to move away from custom GA events

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
