### PR TITLE
Widget | Hide close button in loading price dialog

### DIFF
--- a/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
+++ b/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
 import { motion, type Transition } from 'framer-motion'
-import React, { ReactElement, type ReactNode } from 'react'
+import React, { type ReactNode } from 'react'
 import { CrossIcon, Dialog, mq, theme } from 'ui'
 
 type Props = {
   children: ReactNode
-  Header?: ReactElement
+  Header?: ReactNode
   Footer?: ReactNode
   center?: boolean
 }
@@ -13,14 +13,14 @@ type Props = {
 export const Modal = ({ children, Header, Footer, center = false }: Props) => {
   return (
     <Content frostedOverlay={true}>
-      {Header ? (
-        React.cloneElement(Header, { style: { height: HEADER_HEIGHT } })
-      ) : (
+      {Header === undefined ? (
         <ModalHeader>
           <CloseButton>
             <CrossIcon />
           </CloseButton>
         </ModalHeader>
+      ) : (
+        Header
       )}
       {center ? (
         <CenteredMain>

--- a/apps/store/src/features/widget/CalculatePricePage.tsx
+++ b/apps/store/src/features/widget/CalculatePricePage.tsx
@@ -114,7 +114,7 @@ export const CalculatePricePage = (props: Props) => {
       </Space>
 
       <FullscreenDialog.Root open={loading}>
-        <FullscreenDialog.Modal center={true}>
+        <FullscreenDialog.Modal center={true} Header={null}>
           <PriceLoaderWrapper>
             <PriceLoader />
           </PriceLoaderWrapper>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Refactor fullscreen modal to be able to override the header

- In the fullscreen price loader dialog, hide the header

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- User can't close this dialog, so the header is not needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
