### PR TITLE
Add support for line breaks in Lokalise

### DIFF
--- a/apps/store/public/locales/en/widget.json
+++ b/apps/store/public/locales/en/widget.json
@@ -6,7 +6,7 @@
   "SELECT_PAGE_TITLE": "Select insurance and calculate your price",
   "USP_TEXT": "No binding time",
   "WIDGET_CHECKOUT_PAGE_HEADING": "Your offer",
-  "WIDGET_CHECKOUT_PAGE_SUBHEADING": "Choose a start date and sign below",
+  "WIDGET_CHECKOUT_PAGE_SUBHEADING": "Choose a start date \nand sign below",
   "WIDGET_PROGRESS_PAY": "Pay",
   "WIDGET_PROGRESS_SIGN": "Sign",
   "WIDGET_PROGRESS_YOUR_INFO": "Your info"

--- a/apps/store/public/locales/sv-se/widget.json
+++ b/apps/store/public/locales/sv-se/widget.json
@@ -6,7 +6,7 @@
   "SELECT_PAGE_TITLE": "Välj försäkring och beräkna ditt pris",
   "USP_TEXT": "Ingen bindningstid",
   "WIDGET_CHECKOUT_PAGE_HEADING": "Ditt erbjudande",
-  "WIDGET_CHECKOUT_PAGE_SUBHEADING": "Välj startdatum och signera nedan",
+  "WIDGET_CHECKOUT_PAGE_SUBHEADING": "Välj startdatum och \nsignera nedan",
   "WIDGET_PROGRESS_PAY": "Betala",
   "WIDGET_PROGRESS_SIGN": "Signera",
   "WIDGET_PROGRESS_YOUR_INFO": "Din info"

--- a/packages/ui/src/components/Heading/Heading.tsx
+++ b/packages/ui/src/components/Heading/Heading.tsx
@@ -47,6 +47,7 @@ const HeadingBase = styled(
     fontWeight: 400,
     lineHeight: 1.2,
     textAlign: align ?? 'left',
+    whiteSpace: 'pre-wrap',
     ...getMargins(props),
     ...getHeadingVariantStyles(variant),
   }

--- a/packages/ui/src/components/Text/Text.tsx
+++ b/packages/ui/src/components/Text/Text.tsx
@@ -49,6 +49,7 @@ export const TextBase = styled(
   elementConfig,
 )<TextProps>(({ align, color, size = 'md', uppercase = false, strikethrough = false }) => ({
   color: color ? theme.colors[color] : 'inherit',
+  whiteSpace: 'pre-wrap',
   ...getFontSize(size),
   ...(align && { textAlign: align }),
   ...(uppercase && { textTransform: 'uppercase' }),


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Make sure line breaks in Lokalise are rendered to better control text output. This is useable for texts that should have the same line break for all viewport sizes. If they will differ, we should adjust it with balance and width settings instead.

### Before
<img width="400" alt="Screenshot 2023-11-29 at 17 08 12" src="https://github.com/HedvigInsurance/racoon/assets/6661511/73c09bc9-91a8-43d4-a492-d4955a811ac4">

### After
<img width="391" alt="Screenshot 2023-11-29 at 17 07 47" src="https://github.com/HedvigInsurance/racoon/assets/6661511/a8708305-3352-4517-853a-c01f17a4037e">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Better control of setting text in the app
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
