### PR TITLE
feat(Tooltip): increase tapable area on mobile

### DIFF
--- a/apps/store/src/components/Tooltip/Tooltip.tsx
+++ b/apps/store/src/components/Tooltip/Tooltip.tsx
@@ -17,9 +17,9 @@ export const Tooltip = ({ children, message }: Props) => {
   return (
     <TooltipPrimitive.Provider>
       <TooltipPrimitive.Root delayDuration={0} open={open} onOpenChange={setOpen}>
-        <TooltipPrimitive.Trigger asChild={true} onClick={handleClick}>
+        <Trigger asChild={true} onClick={handleClick}>
           {children}
-        </TooltipPrimitive.Trigger>
+        </Trigger>
         <TooltipPrimitive.Portal>
           <Content sideOffset={5} onClick={(event) => event.stopPropagation()}>
             <Text size="xs" color="textNegative" align="center">
@@ -63,5 +63,29 @@ const Content = styled(TooltipPrimitive.Content)({
 
   '&[data-side="bottom"]': {
     animationName: slideDownAndFadeAnimation,
+  },
+})
+
+const Trigger = styled(TooltipPrimitive.Trigger)({
+  position: 'relative',
+
+  '&::after': {
+    content: '""',
+    position: 'absolute',
+    inset: 0,
+  },
+
+  '@media (pointer: coarse)': {
+    '::after': {
+      '--click-target-minimum': '2.75rem', // 44px --> minimal tap target size recommended by Apple
+      // Will evaluate to the number of pixels needed so the tap target is at least 44px.
+      // Consider the following example:
+      // width: 60px and height: 24px
+      // left/right = min(0px, calc((60px - 44px) / 2)) = min(0px, 8px) = 0px
+      // top/bottom = min(0px, calc((24px - 44px) / 2)) = min(0px, -10px) = -10px
+      // So the tap target will be 60px x 44px
+      '--inset-by': 'min(0px, calc((100% - var(--click-target-minimum)) / 2))',
+      inset: 'var(--inset-by)',
+    },
   },
 })


### PR DESCRIPTION
## Describe your changes

* Tooltip: increase trigger tap area for coarse pointers (e.g: finger)

The solution is presented in a CSS which I can't link here. However it was inspired by this [codepen](https://codepen.io/third774/pen/XWgXZRY)

**Desktop**

<img width="568" alt="Screenshot 2023-12-04 at 07 30 10" src="https://github.com/HedvigInsurance/racoon/assets/19200662/2a469873-7eba-4c06-9ff4-39913a430563">

**Mobile**

<img width="381" alt="Screenshot 2023-12-04 at 07 20 29" src="https://github.com/HedvigInsurance/racoon/assets/19200662/7e909a0f-25e1-4bfa-9419-d297dfaabd37">

## Justify why they are needed

Makes it more "accessible" for mobile users since it's hard to be precise while clicking on such small button as the tooltip (16px x 16px). Got this trick from a CSS course. Apple recommends at tapbable areas of at least 44px x 44px.

Ideally we wan't that included into design system, as it might influence on the designs.