### PR TITLE
Hydrate all atoms to explicit stores

### DIFF
--- a/apps/store/src/components/LayoutWithMenu/ProductMetadataContext.tsx
+++ b/apps/store/src/components/LayoutWithMenu/ProductMetadataContext.tsx
@@ -1,13 +1,14 @@
 import { atom, useAtomValue } from 'jotai'
 import { useHydrateAtoms } from 'jotai/utils'
+import { globalStore } from '@/utils/globalStore'
 import { GlobalProductMetadata } from './fetchProductMetadata'
 
 const productsAtom = atom<GlobalProductMetadata | null>(null)
 
 export const useProductMetadata = () => {
-  return useAtomValue(productsAtom)
+  return useAtomValue(productsAtom, { store: globalStore })
 }
 
 export const useHydrateProductMetadata = (metadata: GlobalProductMetadata) => {
-  useHydrateAtoms([[productsAtom, metadata] as const])
+  useHydrateAtoms([[productsAtom, metadata]], { store: globalStore })
 }

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -31,6 +31,7 @@ import { TrackingProvider } from '@/services/Tracking/TrackingContext'
 import { trackPageViews } from '@/services/Tracking/trackPageViews'
 import { Features } from '@/utils/Features'
 import { contentFontClassName } from '@/utils/fonts'
+import { globalStore } from '@/utils/globalStore'
 import { getCountryByLocale } from '@/utils/l10n/countryUtils'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
 import { UiLocale } from '@/utils/l10n/types'
@@ -100,7 +101,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
         <GlobalLinkStyles />
         <OneTrustStyles />
         <PageTransitionProgressBar />
-        <JotaiProvider>
+        <JotaiProvider store={globalStore}>
           <ShopSessionProvider shopSessionId={pageProps[SHOP_SESSION_PROP_NAME]}>
             <ShopSessionTrackingProvider>
               <BankIdContextProvider>

--- a/apps/store/src/services/trustpilot/trustpilot.tsx
+++ b/apps/store/src/services/trustpilot/trustpilot.tsx
@@ -1,5 +1,6 @@
 import { atom, useAtomValue } from 'jotai'
 import { useHydrateAtoms } from 'jotai/utils'
+import { globalStore } from '@/utils/globalStore'
 import { type TrustpilotData } from './trustpilot.types'
 
 type JSONResponse = {
@@ -14,11 +15,11 @@ type JSONResponse = {
 const trustpilotAtom = atom<TrustpilotData | null>(null)
 
 export const useTrustpilotData = () => {
-  return useAtomValue(trustpilotAtom)
+  return useAtomValue(trustpilotAtom, { store: globalStore })
 }
 
 export const useHydrateTrustpilotData = (data: TrustpilotData | null) => {
-  useHydrateAtoms([[trustpilotAtom, data] as const])
+  useHydrateAtoms([[trustpilotAtom, data]], { store: globalStore })
 }
 
 export const fetchTrustpilotData = async () => {

--- a/apps/store/src/utils/globalStore.ts
+++ b/apps/store/src/utils/globalStore.ts
@@ -1,0 +1,3 @@
+import { createStore } from 'jotai'
+
+export const globalStore = createStore()


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add an explicit global Jotai store to the app

- Hydrate global data to the global store

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We have an issue where global product metadata is not available on PDP

- This is because the atom loads data from a different store (provider) than the one that is used to hydrate the global data

- With this approach, we can hydrate the global data to the global store and use it in the atom

- I didn't change anything about atoms that are never hydrated but we might see similar issues there in the future - let's discuss this!

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
