### PR TITLE
Fetch Trustpilot data on Widget landing pages

### DIFF
--- a/apps/store/src/pages/widget/[[...slug]].tsx
+++ b/apps/store/src/pages/widget/[[...slug]].tsx
@@ -15,11 +15,13 @@ import {
   getPageLinks,
 } from '@/services/storyblok/storyblok'
 import { STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
+import { fetchTrustpilotData, useHydrateTrustpilotData } from '@/services/trustpilot/trustpilot'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
-type PageProps = Pick<StoryblokPageProps, 'story' | 'hideChat'>
+type PageProps = Pick<StoryblokPageProps, 'story' | 'hideChat' | 'trustpilot'>
 
 const NextPage: NextPageWithLayout<PageProps> = (props) => {
+  useHydrateTrustpilotData(props.trustpilot)
   const story = useStoryblokState(props.story)
 
   if (!story) return null
@@ -64,6 +66,7 @@ export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = a
       ...(await serverSideTranslations(context.locale)),
       [STORY_PROP_NAME]: story,
       hideChat: story.content.hideChat ?? false,
+      trustpilot: await fetchTrustpilotData(),
     },
     revalidate: getRevalidate(),
   }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Fetch Trustpilot reviews from the Trustpilot API on Widget landing pages
- Hydrate data into Jotai

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We might want to make these landing pages behave even more similar to regular static pages but for now this is easy enough to maintain

- We want to use the trustpilot block on the landing pages

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
