### PR TITLE
GEN-1538 | Hide chat on all Widget pages

### DIFF
--- a/apps/store/index.d.ts
+++ b/apps/store/index.d.ts
@@ -14,7 +14,6 @@ declare module 'next' {
 
 type GlobalAppProps = SSRConfig & {
   [SHOP_SESSION_PROP_NAME]?: string
-  hideChat?: boolean
 }
 
 declare module 'next/app' {

--- a/apps/store/src/components/ProductPage/ProductPage.types.ts
+++ b/apps/store/src/components/ProductPage/ProductPage.types.ts
@@ -18,5 +18,4 @@ export type ProductPageProps = StoryblokPageProps & {
   trustpilot: TrustpilotData | null
   averageRating: AverageRating | null
   reviewComments: ReviewComments | null
-  hideChat?: boolean
 }

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -17,7 +17,7 @@ import { usePublishWidgetInitEvent } from '@/features/widget/usePublishWidgetIni
 import { useApollo } from '@/services/apollo/client'
 import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
 import { BankIdContextProvider } from '@/services/bankId/BankIdContext'
-import { CustomerFirstScript } from '@/services/CustomerFirst'
+import { CustomerFirstScript, hasHiddenChat } from '@/services/CustomerFirst'
 import { GTMAppScript } from '@/services/gtm'
 import { initDatadog } from '@/services/logger/client'
 import { PageTransitionProgressBar } from '@/services/nprogress/pageTransition'
@@ -84,7 +84,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
   const getLayout = Component.getLayout ?? ((page) => page)
 
   let Chat: ReactNode = null
-  if (!pageProps.hideChat) {
+  if (!hasHiddenChat(pageProps)) {
     Chat = Features.enabled('CUSTOM_CHAT') ? <ContactUs /> : <CustomerFirstScript />
   }
 

--- a/apps/store/src/pages/car-buyer/validation/[dealerId].tsx
+++ b/apps/store/src/pages/car-buyer/validation/[dealerId].tsx
@@ -3,6 +3,7 @@ import Head from 'next/head'
 import { type ComponentProps } from 'react'
 import { Heading } from 'ui'
 import { CarBuyerValidationPage } from '@/features/carDealership/CarBuyerValidationPage'
+import { hideChatOnPage } from '@/services/CustomerFirst'
 
 type Props = ComponentProps<typeof CarBuyerValidationPage> & { authenticated: boolean }
 type Params = { dealerId: string }
@@ -21,7 +22,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = (context) =
     props: {
       authenticated: true,
       dealerId: context.params.dealerId,
-      hideChat: true,
+      ...hideChatOnPage(),
     },
   }
 }

--- a/apps/store/src/pages/widget/[[...slug]].tsx
+++ b/apps/store/src/pages/widget/[[...slug]].tsx
@@ -6,6 +6,7 @@ import { DefaultDebugDialog } from '@/components/DebugDialog/DefaultDebugDialog'
 import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
 import { HeaderFrame, LogoArea } from '@/features/widget/Header'
 import { STORYBLOK_WIDGET_FOLDER_SLUG } from '@/features/widget/widget.constants'
+import { hideChatOnPage } from '@/services/CustomerFirst'
 import {
   getStoryBySlug,
   type StoryblokPageProps,
@@ -18,7 +19,7 @@ import { STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
 import { fetchTrustpilotData, useHydrateTrustpilotData } from '@/services/trustpilot/trustpilot'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
-type PageProps = Pick<StoryblokPageProps, 'story' | 'hideChat' | 'trustpilot'>
+type PageProps = Pick<StoryblokPageProps, 'story' | 'trustpilot'>
 
 const NextPage: NextPageWithLayout<PageProps> = (props) => {
   useHydrateTrustpilotData(props.trustpilot)
@@ -64,8 +65,8 @@ export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = a
   return {
     props: {
       ...(await serverSideTranslations(context.locale)),
+      ...hideChatOnPage(story.content.hideChat ?? false),
       [STORY_PROP_NAME]: story,
-      hideChat: story.content.hideChat ?? false,
       trustpilot: await fetchTrustpilotData(),
     },
     revalidate: getRevalidate(),

--- a/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/[priceIntentId]/calculate-price.tsx
+++ b/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/[priceIntentId]/calculate-price.tsx
@@ -14,6 +14,7 @@ import {
   useShopSessionQuery,
   useWidgetPriceIntentQuery,
 } from '@/services/apollo/generated'
+import { hideChatOnPage } from '@/services/CustomerFirst'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
@@ -58,6 +59,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
       props: {
         priceIntent,
         priceTemplate,
+        ...hideChatOnPage(),
         ...translations,
         ...context.params,
       },

--- a/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
+++ b/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
@@ -9,6 +9,7 @@ import { SignPage } from '@/features/widget/SignPage'
 import { fetchFlowStory } from '@/features/widget/widget.helpers'
 import { initializeApolloServerSide } from '@/services/apollo/client'
 import { useShopSessionQuery } from '@/services/apollo/generated'
+import { hideChatOnPage } from '@/services/CustomerFirst'
 import { priceIntentServiceInitServerSide } from '@/services/priceIntent/PriceIntentService'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
@@ -104,7 +105,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
         flow: context.params.flow,
         priceIntentId: priceIntent.id,
         // TODO: check if we want to control this via CMS
-        hideChat: true,
+        ...hideChatOnPage(),
         productName: priceIntent.product.name,
         productData,
         pageTitle: story.content.pageTitle ?? 'Hedvig',

--- a/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/confirmation.tsx
+++ b/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/confirmation.tsx
@@ -7,6 +7,7 @@ import { SuccessAnimation } from '@/components/ConfirmationPage/SuccessAnimation
 import { ConfirmationPage } from '@/features/widget/ConfirmationPage'
 import { addApolloState, initializeApolloServerSide } from '@/services/apollo/client'
 import { useShopSessionQuery } from '@/services/apollo/generated'
+import { hideChatOnPage } from '@/services/CustomerFirst'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { type WidgetFlowStory, getStoryById } from '@/services/storyblok/storyblok'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
@@ -44,6 +45,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
     props: {
       ...translations,
       ...context.params,
+      ...hideChatOnPage(),
       title: confirmationStory.content.title,
       staticContent: confirmationStory.content,
       backToAppButton: story.content.backToAppButtonLabel,

--- a/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/payment.tsx
+++ b/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/payment.tsx
@@ -5,6 +5,7 @@ import Head from 'next/head'
 import { type ComponentProps } from 'react'
 import { PaymentPage } from '@/features/widget/PaymentPage'
 import { initializeApolloServerSide } from '@/services/apollo/client'
+import { hideChatOnPage } from '@/services/CustomerFirst'
 import { createTrustlyUrl } from '@/services/trustly/createTrustlyUrl'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
@@ -31,7 +32,12 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
   ])
 
   return {
-    props: { ...translations, trustlyUrl, ...context.params },
+    props: {
+      trustlyUrl,
+      ...hideChatOnPage(),
+      ...translations,
+      ...context.params,
+    },
   }
 }
 

--- a/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/select.tsx
+++ b/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/select.tsx
@@ -11,6 +11,7 @@ import { SelectProductPage } from '@/features/widget/SelectProductPage'
 import { createPriceIntent, getPriceTemplate } from '@/features/widget/widget.helpers'
 import { initializeApolloServerSide } from '@/services/apollo/client'
 import { useShopSessionQuery } from '@/services/apollo/generated'
+import { hideChatOnPage } from '@/services/CustomerFirst'
 import { Template } from '@/services/PriceCalculator/PriceCalculator.types'
 import { priceIntentServiceInitServerSide } from '@/services/priceIntent/PriceIntentService'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
@@ -91,6 +92,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
     props: {
       ...translations,
       ...context.params,
+      ...hideChatOnPage(),
       products,
       compareInsurance,
     },

--- a/apps/store/src/services/CustomerFirst.tsx
+++ b/apps/store/src/services/CustomerFirst.tsx
@@ -5,6 +5,11 @@ import { useCallback, useEffect } from 'react'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { useBreakpoint } from '@/utils/useBreakpoint/useBreakpoint'
 
+const HIDE_CHAT_PAGE_PROP = '_hideChat'
+
+export const hideChatOnPage = (hidden?: boolean) => ({ [HIDE_CHAT_PAGE_PROP]: hidden ?? true })
+export const hasHiddenChat = (props: Record<string, unknown>) => Boolean(props[HIDE_CHAT_PAGE_PROP])
+
 const OPEN_ATOM = atom(false)
 
 export const CustomerFirstScript = () => {

--- a/apps/store/src/services/storyblok/getStoryblokPageProps.ts
+++ b/apps/store/src/services/storyblok/getStoryblokPageProps.ts
@@ -3,6 +3,7 @@ import { fetchBreadcrumbs } from '@/components/LayoutWithMenu/fetchBreadcrumbs'
 import { getLayoutWithMenuProps } from '@/components/LayoutWithMenu/getLayoutWithMenuProps'
 import { type RoutingLocale } from '@/utils/l10n/types'
 import { initializeApollo } from '../apollo/client'
+import { hideChatOnPage } from '../CustomerFirst'
 import { fetchTrustpilotData } from '../trustpilot/trustpilot'
 import { PageStory, ProductStory, getStoryBySlug } from './storyblok'
 import { STORY_PROP_NAME } from './Storyblok.constant'
@@ -45,9 +46,9 @@ export const getStoryblokPageProps = async ({
 
   return {
     ...layoutWithMenuProps,
+    ...hideChatOnPage(story.content.hideChat ?? false),
     [STORY_PROP_NAME]: story,
     breadcrumbs,
     trustpilot,
-    hideChat: story.content.hideChat ?? false,
   }
 }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -109,7 +109,6 @@ export type StoryblokPageProps = {
   [STORY_PROP_NAME]: PageStory
   [GLOBAL_STORY_PROP_NAME]: GlobalStory
   trustpilot: TrustpilotData | null
-  hideChat?: boolean
 }
 
 export type StoryblokVersion = 'draft' | 'published'


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Hide customer first chat on all widget pages

- Refactor "hide chat" page prop

- Rename page prop to `_hideChat` to avoid naming collisions

- Wrap reading and "writing" of page prop in utility functions

- Remove explicit page prop typing of "hide chat"

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- This logic was starting to get spread out all over the code base so I wanted to consolidate it into a single place

- Since the page prop can be added to any page, I think it is not necessary to explicitly type it

## Checklist before requesting a review

- [x] I have performed a self-review of my code
