### PR TITLE
GEN-1540 - fix(widget): make ssn section non editable

### DIFF
--- a/apps/store/src/components/PriceCalculator/PriceCalculatorAccordion.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorAccordion.tsx
@@ -95,6 +95,7 @@ export const PriceCalculatorAccordion = ({
               value={section.id}
               previewFieldName={section.preview?.fieldName}
               previewLabel={section.preview?.label}
+              editable={section.editable}
               items={section.items}
             >
               {content}

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorAccordionSection.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorAccordionSection.tsx
@@ -18,6 +18,7 @@ type Props = {
   value: string
   previewFieldName?: string
   previewLabel?: Label
+  editable?: boolean
   items: Array<SectionItem>
 }
 
@@ -26,7 +27,8 @@ export const PriceCalculatorAccordionSection = (props: Props) => {
   const translateLabel = useTranslateFieldLabel()
 
   const showMutedHeading = !(props.active || props.valid)
-  const showEditButton = props.valid && !props.active
+  const isSectionEditable = props.editable ?? true
+  const showEditButton = isSectionEditable && props.valid && !props.active
 
   const stepIconState = useMemo(() => {
     if (props.active) return 'filled'

--- a/apps/store/src/services/PriceCalculator/PriceCalculator.types.ts
+++ b/apps/store/src/services/PriceCalculator/PriceCalculator.types.ts
@@ -33,8 +33,9 @@ export type TemplateSection = {
   id: string
   title: Label
   submitLabel: Label
-  tooltip?: Label
   items: Array<SectionItem>
+  editable?: boolean
+  tooltip?: Label
   preview?: {
     fieldName: string
     label?: Label

--- a/apps/store/src/services/PriceCalculator/data/SE_WIDGET_APARTMENT.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_WIDGET_APARTMENT.ts
@@ -11,7 +11,10 @@ import { Template } from '../PriceCalculator.types'
 export const SE_WIDGET_APARTMENT: Template = {
   name: 'SE_WIDGET_APARTMENT',
   sections: [
-    ssnSeSection,
+    {
+      ...ssnSeSection,
+      editable: false,
+    },
     {
       ...yourApartmentSection,
       items: [


### PR DESCRIPTION
## Describe your changes

* Lock editing SSN section for Widget flows

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/d80979eb-5292-48f1-85b6-1b21ba3a6608.png)

## Justify why they are needed

It's not clear what we should do for such cases so we decided to lock editing for SSN section so we can launch Widget.