### PR TITLE
GEN-1544 | Refresh recommendations after adding to cart

### DIFF
--- a/apps/store/src/components/ProductRecommendationList/useProductRecommendations.ts
+++ b/apps/store/src/components/ProductRecommendationList/useProductRecommendations.ts
@@ -22,6 +22,7 @@ export const useProductRecommendations = (customShopSessionId?: string): ReturnT
   const shopSessionId = customShopSessionId ?? shopSession?.id
 
   const result = useProductRecommendationsQuery({
+    fetchPolicy: 'cache-and-network',
     variables: shopSessionId ? { shopSessionId } : undefined,
     skip: !shopSessionId,
     onCompleted(data) {

--- a/apps/store/src/utils/useAddToCart.ts
+++ b/apps/store/src/utils/useAddToCart.ts
@@ -1,6 +1,5 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { useCallback } from 'react'
-import { useProductRecommendations } from '@/components/ProductRecommendationList/useProductRecommendations'
 import {
   useCartEntryAddMutation,
   ProductRecommendationsDocument,
@@ -18,11 +17,6 @@ type Params = {
 }
 
 export const useAddToCart = (params: Params) => {
-  // ProductRecommendationsQuery needs to be an active query
-  // before we can "re"fetch it after adding a new product into
-  // the cart
-  useProductRecommendations()
-
   const options = {
     refetchQueries: [ProductRecommendationsDocument],
     awaitRefetchQueries: true,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Update fetch policy for recommendations query to `cache-and-network`

- Remove unnecessary recommendation query from add to cart hook

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- When "refetchQueries" is used in combination with "cache-and-network" fetch policy, the query is first fetched from cache and then executed in the background to check for new results.

- I found this solution in this [Medium article](https://medium.com/nexl-engineering/react-apollo-cache-set-up-refetch-refetchqueries-and-fetchpolicy-explained-with-examples-80cae6573401).

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
