### PR TITLE
GEN-1542 | Fix spacing between header and title in mobile

### DIFF
--- a/apps/store/src/features/widget/Header.tsx
+++ b/apps/store/src/features/widget/Header.tsx
@@ -54,8 +54,10 @@ export const Header = (props: Props) => {
 }
 
 export const HeaderFrame = styled(GridLayout.Root)({
-  height: '4rem',
-  alignItems: 'center',
+  [mq.md]: {
+    height: '4rem',
+    alignItems: 'center',
+  },
 })
 
 export const LogoArea = styled.div({

--- a/apps/store/src/features/widget/SelectProductPage.tsx
+++ b/apps/store/src/features/widget/SelectProductPage.tsx
@@ -126,6 +126,8 @@ const CustomButton = styled(Button)({
 })
 
 const HeadingWrapper = styled.div({
-  width: '50%',
-  marginInline: 'auto',
+  [mq.md]: {
+    width: '50%',
+    marginInline: 'auto',
+  },
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->


![Screenshot 2023-12-06 at 16.01.23.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/d003981d-0924-42f8-98c4-7ed5558b492e.png)


## Describe your changes

- Apply fixed header height only when header is single line

- Fix title and subtitle layout on mobile

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We introduced this issue when always showing the logo in the header

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
