### PR TITLE
Refactor Storybook grid decorator and set grid with on multiple stories

### DIFF
--- a/apps/store/.storybook/decorators.tsx
+++ b/apps/store/.storybook/decorators.tsx
@@ -21,11 +21,13 @@ export const themeDecorator: Decorator = (Story) => (
  * },
  */
 export const gridDecorator: Decorator = (Story, options) => {
-  const width = options.parameters.grid
-  if (!width) return <Story />
+  if (!options.parameters.grid) return <Story />
+  const width = options.parameters.grid.width
+  const align = options.parameters.grid.align ?? 'left'
+
   return (
     <GridLayout.Root style={{ paddingInline: 0 }}>
-      <GridLayout.Content width={width} align="center">
+      <GridLayout.Content width={width} align={align}>
         <Story />
       </GridLayout.Content>
     </GridLayout.Root>

--- a/apps/store/src/components/Accordion/Accordion.stories.tsx
+++ b/apps/store/src/components/Accordion/Accordion.stories.tsx
@@ -51,7 +51,7 @@ const ACCORDION_ITEMS = [
 export default {
   component: Accordion.Root,
   parameters: {
-    grid: '1/2',
+    grid: { width: '1/2' },
     design: {
       allowFullscreen: true,
       type: 'figma',

--- a/apps/store/src/components/ComparisonTable/ComparisonTable.stories.tsx
+++ b/apps/store/src/components/ComparisonTable/ComparisonTable.stories.tsx
@@ -12,6 +12,7 @@ export default {
       type: 'figma',
       url: 'https://www.figma.com/file/qUhLjrKl98PAzHov9ilaDH/Hedvig-UI-Kit?type=design&node-id=3273-18638&mode=design&t=RSlyuJ47E727hGaQ-4',
     },
+    grid: { width: '1/2' },
   },
 } as Meta<typeof ComparisonTable.Root>
 

--- a/apps/store/src/components/ComparisonTable/DesktopComparisonTable.stories.tsx
+++ b/apps/store/src/components/ComparisonTable/DesktopComparisonTable.stories.tsx
@@ -26,6 +26,7 @@ export default {
       type: 'figma',
       url: 'https://www.figma.com/file/qUhLjrKl98PAzHov9ilaDH/Hedvig-UI-Kit?type=design&node-id=3273-18638&mode=design&t=RSlyuJ47E727hGaQ-4',
     },
+    grid: { width: '1/2' },
   },
 } as Meta<typeof DesktopComparisonTable>
 

--- a/apps/store/src/components/InfoCard/InfoCard.stories.tsx
+++ b/apps/store/src/components/InfoCard/InfoCard.stories.tsx
@@ -5,6 +5,7 @@ import { AttentionCard, ErrorCard, InfoCard } from './InfoCard'
 const meta: Meta<typeof InfoCard> = {
   title: 'Components / Info Card',
   component: InfoCard,
+  parameters: { grid: { width: '1/3' } },
 }
 
 export default meta
@@ -12,7 +13,8 @@ type Story = StoryObj<typeof InfoCard>
 
 export const Variants: Story = {
   args: {
-    children: 'A short message about something that needs attention, an error, info or...',
+    children:
+      'A short message about something that needs attention, an error, info or a success message.',
   },
 
   render: (args) => (

--- a/apps/store/src/components/ProductCard/ProductCard.stories.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.stories.tsx
@@ -10,6 +10,7 @@ export default {
       viewports: INITIAL_VIEWPORTS,
       defaultViewport: 'iphone12',
     },
+    grid: { width: '1/3' },
   },
 } as Meta<typeof ProductCard>
 

--- a/apps/store/src/components/ProductItem/ProductDetails.stories.tsx
+++ b/apps/store/src/components/ProductItem/ProductDetails.stories.tsx
@@ -4,6 +4,7 @@ import { ProductDetails } from './ProductDetails'
 const meta: Meta<typeof ProductDetails> = {
   title: 'Components / Product Item / Product Details',
   component: ProductDetails,
+  parameters: { grid: { width: '1/3' } },
 }
 
 export default meta

--- a/apps/store/src/components/ProductItem/ProductDetailsHeader.stories.tsx
+++ b/apps/store/src/components/ProductItem/ProductDetailsHeader.stories.tsx
@@ -5,6 +5,7 @@ import { ProductDetailsHeader } from './ProductDetailsHeader'
 const meta: Meta<typeof ProductDetailsHeader> = {
   title: 'Components / Product Item / Product Details Header',
   component: ProductDetailsHeader,
+  parameters: { grid: { width: '1/3' } },
 }
 
 export default meta

--- a/apps/store/src/components/ProductItem/ProductItem.stories.tsx
+++ b/apps/store/src/components/ProductItem/ProductItem.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof ProductItem> = {
   argTypes: {
     startDate: { control: { disable: true } },
   },
-  parameters: { grid: '1/3' },
+  parameters: { grid: { width: '1/2' } },
 }
 
 export default meta

--- a/apps/store/src/components/ProgressIndicator/ProgressIndicator.stories.tsx
+++ b/apps/store/src/components/ProgressIndicator/ProgressIndicator.stories.tsx
@@ -13,6 +13,7 @@ type Args = React.ComponentProps<typeof ProgressIndicator.Root> & {
 const meta: Meta<Args> = {
   title: 'Components / Progress Indicator',
   component: ProgressIndicator.Root,
+  parameters: { grid: { width: '1/3' } },
   render: (args) => (
     <ProgressIndicator.Root>
       {args.items.map((item, index) => (

--- a/apps/store/src/components/QuickAdd/QuickAdd.stories.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAdd.stories.tsx
@@ -7,6 +7,7 @@ import { ProductDetail, QuickAdd } from './QuickAdd'
 const meta: Meta<typeof QuickAdd> = {
   title: 'Components / Quick Add',
   component: QuickAdd,
+  parameters: { grid: { width: '1/3' } },
 }
 
 export default meta

--- a/apps/store/src/components/QuickPurchaseForm/QuickPurchaseForm.stories.tsx
+++ b/apps/store/src/components/QuickPurchaseForm/QuickPurchaseForm.stories.tsx
@@ -9,6 +9,7 @@ export default {
       viewports: INITIAL_VIEWPORTS,
       defaultViewport: 'iphonese2',
     },
+    grid: { width: '1/3' },
   },
 } as Meta<typeof QuickPurchaseForm>
 

--- a/apps/store/src/components/RadioOptionList/RadioOptionList.stories.tsx
+++ b/apps/store/src/components/RadioOptionList/RadioOptionList.stories.tsx
@@ -49,4 +49,5 @@ export const WithProductOptions: Story = {
       },
     ],
   },
+  parameters: { grid: { width: '1/3' } },
 }

--- a/apps/store/src/components/ShopBreakdown/DiscountField.stories.tsx
+++ b/apps/store/src/components/ShopBreakdown/DiscountField.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta<typeof DiscountField> = {
     onAdd: { action: 'onAdd', table: { disable: true } },
     onRemove: { action: 'onRemove', table: { disable: true } },
   },
+  parameters: { grid: { width: '1/3' } },
 }
 
 export default meta

--- a/apps/store/src/components/ShopBreakdown/ShopBreakdown.stories.tsx
+++ b/apps/store/src/components/ShopBreakdown/ShopBreakdown.stories.tsx
@@ -15,6 +15,7 @@ const meta: Meta<typeof ShopBreakdown> = {
       },
     },
   },
+  parameters: { grid: { width: '1/3' } },
 }
 
 export default meta

--- a/apps/store/src/components/ShopBreakdown/TotalAmount.stories.tsx
+++ b/apps/store/src/components/ShopBreakdown/TotalAmount.stories.tsx
@@ -5,6 +5,7 @@ import { TotalAmount } from './TotalAmount'
 const meta: Meta<typeof TotalAmount> = {
   title: 'Components / Shop Breakdown / Total Amount',
   component: TotalAmount,
+  parameters: { grid: { width: '1/3' } },
 }
 
 export default meta

--- a/apps/store/src/components/ToastBar/ToastBar.stories.tsx
+++ b/apps/store/src/components/ToastBar/ToastBar.stories.tsx
@@ -5,6 +5,7 @@ import { InfoToastBar, AttentionToastBar, ErrorToastBar } from './ToastBar'
 const meta: Meta<typeof InfoToastBar> = {
   title: 'Components / Toast Bar',
   component: InfoToastBar,
+  parameters: { grid: { width: '1/3' } },
 }
 
 export default meta

--- a/apps/store/src/components/Video/Video.stories.tsx
+++ b/apps/store/src/components/Video/Video.stories.tsx
@@ -9,6 +9,7 @@ export default {
       viewports: INITIAL_VIEWPORTS,
       defaultViewport: 'iphone12',
     },
+    grid: { width: '1/2' },
   },
 } as Meta<typeof Video>
 
@@ -17,9 +18,7 @@ const Template: StoryFn<typeof Video> = (args) => <Video {...args} />
 export const Default = Template.bind({})
 Default.args = {
   autoPlay: true,
-  sources: [
-    { url: 'https://cdn.dev.hedvigit.com/assets/videos/HEDVIG_FILM01_1x1_15sec_CLEAN.mp4' },
-  ],
+  sources: [{ url: 'https://cdn.hedvig.com/hedvig-dot-com/videos/pillow-hero.webm' }],
 }
 
 export const ProductVideo = Template.bind({})

--- a/apps/store/src/features/carDealership/TrialExtensionForm.stories.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof TrialExtensionForm> = {
   title: 'Car Dealership / Trial Extension Form',
   component: TrialExtensionForm,
   parameters: {
-    grid: '1/3',
+    grid: { width: '1/2' },
   },
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add `align` prop to the grid decorator and update stories with grid settings.
This avoids components being super wide which makes it hard to compare the component with the design.

### Before
<img width="1717" alt="Screenshot 2023-12-07 at 08 41 46" src="https://github.com/HedvigInsurance/racoon/assets/6661511/0de3fe8a-a921-47bf-b454-5e5655d89c5e">

### After
<img width="1359" alt="Screenshot 2023-12-07 at 08 42 37" src="https://github.com/HedvigInsurance/racoon/assets/6661511/6ca46d84-c55a-471c-b5a3-04315438ccf6">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Render the components in a more suitable size and closer to implementation

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
