### PR TITLE
GEN-1559 | Parse student pre-fill query parameter

### DIFF
--- a/apps/store/src/features/widget/parseSearchParams.test.ts
+++ b/apps/store/src/features/widget/parseSearchParams.test.ts
@@ -18,11 +18,10 @@ describe('parsePriceIntentDataSearchParams', () => {
     expect(priceIntentData).toEqual({
       street: '123 Main St',
       zipCode: '12345',
-      city: 'New York',
       livingSpace: 100,
       numberCoInsured: 2,
     })
-    expect(remainingSearchParams.toString()).toBe('')
+    expect(remainingSearchParams.toString()).toBe('city=New+York')
   })
 
   it('should handle empty search params', () => {
@@ -51,5 +50,18 @@ describe('parsePriceIntentDataSearchParams', () => {
     // Assert
     expect(priceIntentData).toEqual({ street: '123 Main St' })
     expect(remainingSearchParams.toString()).toBe('coInsured=xyz&livingSpace=abc&unknown=xyz')
+  })
+
+  it('should handle boolean values', () => {
+    // Arrange
+    const searchParams = new URLSearchParams()
+    searchParams.set('student', 'yes')
+
+    // Act
+    const [priceIntentData, remainingSearchParams] = parsePriceIntentDataSearchParams(searchParams)
+
+    // Assert
+    expect(priceIntentData).toEqual({ isStudent: true })
+    expect(remainingSearchParams.toString()).toBe('')
   })
 })

--- a/apps/store/src/features/widget/parseSearchParams.ts
+++ b/apps/store/src/features/widget/parseSearchParams.ts
@@ -18,16 +18,12 @@ enum SearchParam {
   // Price Intent Data
   StreetAddress = 'street',
   ZipCode = 'zipCode',
-  City = 'city',
   LivingSpace = 'livingSpace',
   NumberCoInsured = 'coInsured',
+  Student = 'student',
 
   // No longer used?
   PhoneNumber = 'phoneNumber',
-  BirthDate = 'birthDate',
-  FirstName = 'firstName',
-  LastName = 'lastName',
-  Student = 'student', // can't find what the values are supposed to be
 
   // Shop Session Create Partner Data
   ExternalMemberId = 'externalMemberId',
@@ -96,23 +92,27 @@ export const parsePriceIntentDataSearchParams = (
 
   const street = searchParams.get(SearchParam.StreetAddress)
   updatedSearchParams.delete(SearchParam.StreetAddress)
+
   const zipCode = searchParams.get(SearchParam.ZipCode)
   updatedSearchParams.delete(SearchParam.ZipCode)
-  const city = searchParams.get(SearchParam.City)
-  updatedSearchParams.delete(SearchParam.City)
+
   const searchLivingSpace = searchParams.get(SearchParam.LivingSpace)
   const livingSpace = searchLivingSpace ? parseNumber(searchLivingSpace) : undefined
   if (livingSpace !== undefined) updatedSearchParams.delete(SearchParam.LivingSpace)
+
   const searchNumberCoInsured = searchParams.get(SearchParam.NumberCoInsured)
   const numberCoInsured = searchNumberCoInsured ? parseNumber(searchNumberCoInsured) : undefined
   if (numberCoInsured !== undefined) updatedSearchParams.delete(SearchParam.NumberCoInsured)
 
+  const isStudent = parseBoolean(searchParams.get(SearchParam.Student)?.toLowerCase())
+  if (isStudent !== undefined) updatedSearchParams.delete(SearchParam.Student)
+
   const data = {
     ...(street && { street }),
     ...(zipCode && { zipCode }),
-    ...(city && { city }),
     ...(livingSpace && { livingSpace }),
     ...(numberCoInsured && { numberCoInsured }),
+    ...(isStudent !== undefined && { isStudent }),
   }
 
   return [data, updatedSearchParams]
@@ -121,6 +121,17 @@ export const parsePriceIntentDataSearchParams = (
 const parseNumber = (value: string): number | undefined => {
   const parsed = parseInt(value, 10)
   return isNaN(parsed) ? undefined : parsed
+}
+
+const parseBoolean = (value: unknown): boolean | undefined => {
+  switch (value) {
+    case 'yes':
+      return true
+    case 'no':
+      return false
+    default:
+      return undefined
+  }
 }
 
 export const parseShopSessionCreatePartnerSearchParams = (

--- a/apps/store/src/services/PriceCalculator/PriceCalculator.helpers.ts
+++ b/apps/store/src/services/PriceCalculator/PriceCalculator.helpers.ts
@@ -47,11 +47,13 @@ export const prefillData = ({ form, data, valueField }: FillDataParams): Form =>
       ...section,
       items: section.items.map((item) => {
         const dataValue = data[item.field.name]
+        const parsedValue = item.field.type === 'radio' ? dataValue?.toString() : dataValue
+
         return {
           ...item,
           field: {
             ...item.field,
-            [valueField]: dataValue ?? item.field[valueField],
+            [valueField]: parsedValue ?? item.field[valueField],
           },
         }
       }),


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Parse "student" query parameter from the URL

- Deserialize data value into a string for all radio inputs

- Remove unused query parameters like city, firstName, lastName, etc.

- Update tests

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We want to be able to pre-fill the "is student" input

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
