### PR TITLE
GEN-1541 | Show partner specific product data in widget flow

### DIFF
--- a/apps/store/src/components/ProductData/ProductData.graphql
+++ b/apps/store/src/components/ProductData/ProductData.graphql
@@ -1,5 +1,5 @@
-query ProductData($productName: String!) {
-  product(productName: $productName) {
+query ProductData($productName: String!, $partnerName: String) {
+  product(productName: $productName, partnerName: $partnerName) {
     id
     name
     displayNameFull
@@ -30,5 +30,3 @@ query ProductData($productName: String!) {
     }
   }
 }
-
-

--- a/apps/store/src/components/ProductData/fetchProductData.ts
+++ b/apps/store/src/components/ProductData/fetchProductData.ts
@@ -6,19 +6,21 @@ import {
 } from '@/services/apollo/generated'
 import { ProductData } from './ProductData.types'
 
-type Params = {
+type Params = ProductDataQueryVariables & {
   apolloClient: ApolloClient<unknown>
-  productName: string
 }
 
-export const fetchProductData = async (params: Params): Promise<ProductData> => {
-  const { data } = await params.apolloClient.query<ProductDataQuery, ProductDataQueryVariables>({
+export const fetchProductData = async ({
+  apolloClient,
+  ...variables
+}: Params): Promise<ProductData> => {
+  const { data } = await apolloClient.query<ProductDataQuery, ProductDataQueryVariables>({
     query: ProductDataDocument,
-    variables: { productName: params.productName },
+    variables,
   })
 
   if (!data.product) {
-    throw new Error(`Unable to fetch product data: ${params.productName}`)
+    throw new Error(`Unable to fetch product data: ${variables.productName}`)
   }
 
   return data.product

--- a/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
+++ b/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
@@ -90,6 +90,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
     const productData = await fetchProductData({
       apolloClient,
       productName: priceIntent.product.name,
+      partnerName: story.content.partner,
     })
 
     return {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

![Screenshot 2023-12-07 at 15.46.05.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/61d6943c-6516-47a0-9ca1-1711f2260f46.png)

## Describe your changes

- Pass partner name from widget flow story when fetching product data

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We want to display the partner specific product data in the widget (for AVY)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
