### PR TITLE
GEN-1577 | Align optional Widget parameters with our API

### DIFF
--- a/apps/store/src/features/widget/parseSearchParams.test.ts
+++ b/apps/store/src/features/widget/parseSearchParams.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals'
-import { parsePriceIntentDataSearchParams } from './parseSearchParams'
+import { parsePriceIntentDataSearchParams, parseProductNameSearchParams } from './parseSearchParams'
 
 describe('parsePriceIntentDataSearchParams', () => {
   it('should parse price intent data search params correctly', () => {
@@ -9,7 +9,7 @@ describe('parsePriceIntentDataSearchParams', () => {
     searchParams.set('zipCode', '12345')
     searchParams.set('city', 'New York')
     searchParams.set('livingSpace', '100')
-    searchParams.set('coInsured', '2')
+    searchParams.set('numberCoInsured', '2')
 
     // Act
     const [priceIntentData, remainingSearchParams] = parsePriceIntentDataSearchParams(searchParams)
@@ -40,7 +40,7 @@ describe('parsePriceIntentDataSearchParams', () => {
     // Arrange
     const searchParams = new URLSearchParams()
     searchParams.set('street', '123 Main St')
-    searchParams.set('coInsured', 'xyz')
+    searchParams.set('numberCoInsured', 'xyz')
     searchParams.set('livingSpace', 'abc')
     searchParams.set('unknown', 'xyz')
 
@@ -49,13 +49,13 @@ describe('parsePriceIntentDataSearchParams', () => {
 
     // Assert
     expect(priceIntentData).toEqual({ street: '123 Main St' })
-    expect(remainingSearchParams.toString()).toBe('coInsured=xyz&livingSpace=abc&unknown=xyz')
+    expect(remainingSearchParams.toString()).toBe('numberCoInsured=xyz&livingSpace=abc&unknown=xyz')
   })
 
   it('should handle boolean values', () => {
     // Arrange
     const searchParams = new URLSearchParams()
-    searchParams.set('student', 'yes')
+    searchParams.set('isStudent', '1')
 
     // Act
     const [priceIntentData, remainingSearchParams] = parsePriceIntentDataSearchParams(searchParams)
@@ -63,5 +63,47 @@ describe('parsePriceIntentDataSearchParams', () => {
     // Assert
     expect(priceIntentData).toEqual({ isStudent: true })
     expect(remainingSearchParams.toString()).toBe('')
+  })
+
+  it('should handle legacy parameters', () => {
+    // Arrange
+    const searchParams = new URLSearchParams()
+    searchParams.set('street', '123 Main St')
+    searchParams.set('student', 'yes')
+    searchParams.set('coInsured', '2')
+
+    // Act
+    const [priceIntentData, remainingSearchParams] = parsePriceIntentDataSearchParams(searchParams)
+
+    // Assert
+    expect(priceIntentData).toEqual({ street: '123 Main St', isStudent: true, numberCoInsured: 2 })
+    expect(remainingSearchParams.toString()).toBe('')
+  })
+
+  it('should handle legacy product parameters', () => {
+    // Arrange
+    const searchParams = new URLSearchParams()
+    searchParams.set('productType', 'SWEDISH_APARTMENT')
+    searchParams.set('subType', 'BRF')
+
+    // Act
+    const [productName] = parseProductNameSearchParams(searchParams)
+
+    // Assert
+    expect(productName).toBe('SE_APARTMENT_BRF')
+  })
+
+  it('should handle mixed legacy and new product parameters', () => {
+    // Arrange
+    const searchParams = new URLSearchParams()
+    searchParams.set('productType', 'SWEDISH_APARTMENT')
+    searchParams.set('subType', 'BRF')
+    searchParams.set('productName', 'SE_APARTMENT_RENT')
+
+    // Act
+    const [productName] = parseProductNameSearchParams(searchParams)
+
+    // Assert
+    expect(productName).toBe('SE_APARTMENT_RENT')
   })
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Update widget URL parsing to expect parameter names that align with our API

- coInsured -> numberCoInsured

- student -> isStudent

- productType -> productName

- Deprecate the legacy parameter names

- Update tests to reflect the new parameter names

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- The legacy parameter names are not aligned with our API. This causes confusion for new developers and makes it difficult to maintain the code. The integrating partners don't really care about the names.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
