### PR TITLE
Parse API date without converting between time zones

### DIFF
--- a/apps/store/src/utils/date.ts
+++ b/apps/store/src/utils/date.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns'
+
 export const convertToDate = (value: unknown): Date | null => {
   if (typeof value === 'string') {
     const date = new Date(value)
@@ -9,7 +11,7 @@ export const convertToDate = (value: unknown): Date | null => {
 }
 
 export const formatAPIDate = (date: Date): string => {
-  return date.toISOString().split('T')[0]
+  return format(date, 'yyyy-MM-dd')
 }
 
 export const formatInputDateValue = formatAPIDate


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Use date-fns to convert between Date and API date string

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We noticed issues earlier where someone would pick a day in the date picker only to see the previous day selected.

- Previously we converted using `toISOString` which means that JS would convert the date to UTC and then convert it to a string. This is not what we want, we want to convert the date to a string in the local timezone.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
