### PR TITLE
GEN-1528 / Display main offer title and pillow on QuickAdd component

### DIFF
--- a/apps/store/src/components/Pillow/Pillow.tsx
+++ b/apps/store/src/components/Pillow/Pillow.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 import { getImgSrc } from '@/services/storyblok/Storyblok.helpers'
 
 type PillowProps = {
-  size?: 'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'
+  size?: 'mini' | 'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'
   src?: string
   alt?: string | null
   priority?: boolean
@@ -45,6 +45,8 @@ const FallbackPillow = ({ size, ...props }: Pick<PillowProps, 'size'>) => {
 
 const getSize = (size: PillowProps['size']) => {
   switch (size) {
+    case 'mini':
+      return { width: '1.5rem', height: '1.5rem' }
     case 'xxsmall':
       return { width: '1.75rem', height: '1.75rem' }
     case 'xsmall':

--- a/apps/store/src/components/QuickAdd/QuickAdd.stories.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAdd.stories.tsx
@@ -15,10 +15,13 @@ type Story = StoryObj<typeof QuickAdd>
 
 export const Default: Story = {
   args: {
-    title: 'Accident insurance',
+    title: 'Home + Accident',
     subtitle: 'Covers 2 people',
     pillow: {
-      src: 'https://a.storyblok.com/f/165473/832x832/a61cfbf4ae/hedvig-pillows-cat.png',
+      src: 'https://assets.hedvig.com/f/165473/832x832/1bb4813dd1/hedvig-pillows-accident.png',
+    },
+    mainOfferPillow: {
+      src: 'https://assets.hedvig.com/f/165473/832x832/cdaaa91242/hedvig-pillows-home.png',
     },
     href: '/se',
     price: {

--- a/apps/store/src/components/QuickAdd/QuickAdd.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAdd.tsx
@@ -11,6 +11,7 @@ type Props = {
   title: string
   subtitle: string
   pillow: ComponentProps<typeof Pillow>
+  mainOfferPillow?: ComponentProps<typeof Pillow>
   badge?: ComponentProps<typeof Badge>
   href: string
   price?: ComponentProps<typeof Price>
@@ -24,7 +25,14 @@ export const QuickAdd = (props: Props) => {
     <Card>
       <Space y={1}>
         <SpaceFlex space={1} align="center">
-          <Pillow size="small" {...props.pillow} />
+          {props.mainOfferPillow ? (
+            <PillowWrapper>
+              <Pillow size="mini" {...props.mainOfferPillow} />
+              <Pillow size="mini" {...props.pillow} />
+            </PillowWrapper>
+          ) : (
+            <Pillow size="small" {...props.pillow} />
+          )}
           <div>
             <StyledLink href={props.href}>
               <Text as="span" color="textTranslucentPrimary">
@@ -77,6 +85,15 @@ const Card = styled.div({
 const StyledLink = styled(Link)({
   '&:hover': {
     textDecoration: 'underline',
+  },
+})
+
+const PillowWrapper = styled.div({
+  width: '3rem',
+  height: '3rem',
+
+  '& > *:last-of-type': {
+    marginLeft: 'auto',
   },
 })
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add new size for Pillow component
- Add prop for passing main offer pillow and display multiple pillows

<img width="620" alt="Screenshot 2023-12-11 at 14 13 57" src="https://github.com/HedvigInsurance/racoon/assets/6661511/b2105d81-822a-4c48-bd1e-a545228c27f0">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Update accident x-sell project

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
