### PR TITLE
GEN-1528 / Implement bundle title and pillows for QuickAdd component

### DIFF
--- a/apps/store/public/locales/en/cart.json
+++ b/apps/store/public/locales/en/cart.json
@@ -59,6 +59,7 @@
   "QUICK_ADD_EDIT": "Edit",
   "QUICK_ADD_HOUSEHOLD_SIZE_one": "Covers {{count}} person",
   "QUICK_ADD_HOUSEHOLD_SIZE_other": "Covers {{count}} people",
+  "QUICK_ADD_TITLE": "Home + {{product}}",
   "RECOMMENDATIONS_HEADING": "Discover more insurances",
   "REMOVE_ENTRY_BUTTON": "Remove",
   "REMOVE_ENTRY_MODAL_CANCEL_BUTTON": "Cancel",

--- a/apps/store/public/locales/sv-se/cart.json
+++ b/apps/store/public/locales/sv-se/cart.json
@@ -59,6 +59,7 @@
   "QUICK_ADD_EDIT": "Ändra",
   "QUICK_ADD_HOUSEHOLD_SIZE_one": "Täcker {{count}} person",
   "QUICK_ADD_HOUSEHOLD_SIZE_other": "Täcker {{count}} personer",
+  "QUICK_ADD_TITLE": "Hem + {{product}}",
   "RECOMMENDATIONS_HEADING": "Upptäck fler försäkringar",
   "REMOVE_ENTRY_BUTTON": "Ta bort",
   "REMOVE_ENTRY_MODAL_CANCEL_BUTTON": "Avbryt",

--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -78,7 +78,11 @@ export const CartPage = () => {
               </ShopBreakdown>
 
               {offerRecommendation && (
-                <QuickAddOfferContainer shopSessionId={shopSession.id} {...offerRecommendation} />
+                <QuickAddOfferContainer
+                  cart={shopSession.cart}
+                  shopSessionId={shopSession.id}
+                  {...offerRecommendation}
+                />
               )}
 
               <ButtonNextLink

--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -143,7 +143,11 @@ const CheckoutPage = (props: CheckoutPageProps) => {
 
               <Space y={2}>
                 {offerRecommendation && (
-                  <QuickAddOfferContainer shopSessionId={shopSession.id} {...offerRecommendation} />
+                  <QuickAddOfferContainer
+                    cart={shopSession.cart}
+                    shopSessionId={shopSession.id}
+                    {...offerRecommendation}
+                  />
                 )}
                 <form onSubmit={handleSubmitSign}>
                   <Space y={0.25}>

--- a/apps/store/src/components/QuickAdd/QuickAddOfferContainer.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddOfferContainer.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'next-i18next'
 import { Text } from 'ui'
 import {
+  CartFragmentFragment,
   type OfferRecommendationFragment,
   type ProductRecommendationFragment,
 } from '@/services/apollo/generated'
@@ -14,9 +15,12 @@ const CO_INSURED_DATA_KEY = 'numberCoInsured'
 
 type Props = {
   shopSessionId: string
+  cart: CartFragmentFragment
   offer: OfferRecommendationFragment
   product: ProductRecommendationFragment
 }
+
+const homeInsurances = ['SE_HOUSE', 'SE_APARTMENT_RENT', 'SE_APARTMENT_BRF', 'SE_STUDENT_APARTMENT']
 
 export const QuickAddOfferContainer = (props: Props) => {
   const { t } = useTranslation('cart')
@@ -24,6 +28,13 @@ export const QuickAddOfferContainer = (props: Props) => {
 
   // Assume Accident insurance
   const householdSize = (parseInt(props.offer.priceIntentData[CO_INSURED_DATA_KEY]) || 0) + 1
+
+  // Only display "Home + Accident" and mainOfferPillow if Home insurance is in cart
+  const homeInsuranceInCart =
+    props.cart.entries.find((entry) => homeInsurances.includes(entry.product.name)) ?? null
+  const title = homeInsuranceInCart
+    ? t('QUICK_ADD_TITLE', { product: props.product.displayNameShort })
+    : props.product.displayNameFull
   const subtitle = t('QUICK_ADD_HOUSEHOLD_SIZE', { count: householdSize })
 
   const price = getOfferPrice(props.offer.cost)
@@ -32,9 +43,10 @@ export const QuickAddOfferContainer = (props: Props) => {
 
   return (
     <QuickAdd
-      title={props.product.displayNameFull}
+      title={title}
       subtitle={subtitle}
       pillow={props.product.pillowImage}
+      mainOfferPillow={homeInsuranceInCart?.product.pillowImage}
       href={props.product.pageLink}
       price={price}
       Body={

--- a/apps/store/src/features/widget/SignPage.tsx
+++ b/apps/store/src/features/widget/SignPage.tsx
@@ -181,6 +181,7 @@ export const SignPage = (props: Props) => {
 
                 {offerRecommendation && (
                   <QuickAddOfferContainer
+                    cart={props.shopSession.cart}
                     shopSessionId={props.shopSession.id}
                     {...offerRecommendation}
                   />


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Show "Home + Accident" title and double pillows when we have a home insurance in the cart. I realised that we would still show the QuickAdd component if you remove your home from the cart and have some other product left since I suppose we don't remove the offer recommendation. So in that case, we should display it without home.

### With home in cart
  
<img width="488" alt="Screenshot 2023-12-12 at 15 09 19" src="https://github.com/HedvigInsurance/racoon/assets/6661511/e1a80926-debb-4440-91a1-cd147b8db73e">


### After removing home from cart
<img width="494" alt="Screenshot 2023-12-12 at 15 09 45" src="https://github.com/HedvigInsurance/racoon/assets/6661511/9ffac618-42f2-41e7-8d17-993c297a2768">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
