### PR TITLE
GEN-1602 - use Swedish timezone for date visualization

### DIFF
--- a/apps/store/src/utils/formatter.ts
+++ b/apps/store/src/utils/formatter.ts
@@ -37,9 +37,8 @@ type DateFormatOptions = { locale: IsoLocale } & { t: TFunction }
 const formatDateFromNow = (date: Date, options: DateFormatOptions): string => {
   const today = new Date()
   const isSameDay =
-    date.getDate() === today.getDate() &&
-    date.getMonth() === today.getMonth() &&
-    date.getFullYear() === today.getFullYear()
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()) ===
+    Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate())
 
   if (isSameDay) {
     return options.t('DATE_SAME_DAY')
@@ -50,6 +49,7 @@ const formatDateFromNow = (date: Date, options: DateFormatOptions): string => {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
+    timeZone: 'Europe/Stockholm',
   })
 
   return result.replace(/-/g, '.')
@@ -104,6 +104,7 @@ export class Formatter {
       year: options?.hideYear ? undefined : 'numeric',
       month: options?.abbreviateMonth ? 'short' : 'long',
       day: 'numeric',
+      timeZone: 'Europe/Stockholm',
     })
 
     // Removes '.' used for abbreviations


### PR DESCRIPTION
## Describe your changes

* Update `fromNow` and `dateFull` formatters so they use dates in UTC representation

## Justify why they are needed

We were getting an issue with date field where the selected date wasn't the one displayed in the field when accessing the app in a different timezone:

https://github.com/HedvigInsurance/racoon/assets/19200662/e73bb391-c1a6-4ee0-9667-c770b27c373e

**Why was that happening**

_Extract from a AI tool_
> The behavior you're observing is due to how JavaScript handles date and time data. JavaScript's Date object is based on a timestamp, which is the number of milliseconds since the Unix Epoch (January 1, 1970 00:00:00 UTC). This timestamp is always in UTC.
> When you create a Date object using the ISO 8601 date format (e.g., 'YYYY-mm-dd'), JavaScript interprets the date as being in UTC. This is because the ISO 8601 standard specifies that dates without a timezone are in UTC [3](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date).
> **However, when you display the date, JavaScript converts it to the local time of the user's system. This is why you see different results when you simulate different timezones in your browser. The date object itself is still in UTC, but when it's displayed, it's converted to the local timezone.**

Additionally, when creating dates using ISO format without providing a time, midnight will be used by default - 00:00:00. Brazil is on GMT-3:00 timezone so when picking something like: '2023-12-15' the date input shows '2023-12-14' because when displaying that date using Brazil timezone the result is '2023-12-14T21:00:00'.

https://github.com/HedvigInsurance/racoon/assets/19200662/55049ce9-8df9-4ebd-a38f-e3d349286fb8

I've also updated `dateFull` formatter as other places like ProductItem card was also displaying the "wrong" date when using local timezone. Below is a screenshot of ProductItem card for a rental insurance with '2023-12-15' as the start date:

<img width="533" alt="Screenshot 2023-12-13 at 08 02 43" src="https://github.com/HedvigInsurance/racoon/assets/19200662/0c6d3cd5-7783-498f-9648-a62ce9d6631c">



