### PR TITLE
GEN-1581, GEN-856 | Add og:type and og:url meta tags

### DIFF
--- a/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
+++ b/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
@@ -1,5 +1,6 @@
 import { ISbAlternateObject, ISbStoryData } from '@storyblok/react'
 import Head from 'next/head'
+import { useRouter } from 'next/router'
 import { SEOData } from '@/services/storyblok/storyblok'
 import { getImgSrc } from '@/services/storyblok/Storyblok.helpers'
 import { Features } from '@/utils/Features'
@@ -18,10 +19,18 @@ export const HeadSeoInfo = ({ story, robots }: Props) => {
   // Make it possible to override robots value for A/B test cases
   const robotsContent = robots ?? story.content.robots
 
+  const router = useRouter()
+  // Remove trailing slash from path
+  const pathname = [router.asPath.replace(/\/$/, ''), router.locale].join('/')
+  const pageURL = new URL(pathname, ORIGIN_URL)
+
   return (
     <>
       <Head>
-        {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+        <meta property="og:type" content="website" />
+
+        <link rel="canonical" href={canonicalUrl ?? pageURL.toString()} />
+        <meta property="og:url" content={pageURL.toString()} />
         <meta name="robots" content={robotsContent} />
         {seoMetaDescription && (
           <>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add "og:type" and "og:url" meta tags

- Always add canonical meta tags, default to page URL

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Request by Peter

- OG:URL Tag: This tag is part of the Open Graph protocol, mainly used for social media platforms like Facebook. It ensures that when a link is shared, the correct page information (like title, description, and image) is displayed. The OG:URL tag should point to the URL you want to be associated with your content when it is shared on social media.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
