### PR TITLE
GEN-1610 | Set min/max value for pet birth date fields

### DIFF
--- a/apps/store/src/components/PriceCalculator/AutomaticField.tsx
+++ b/apps/store/src/components/PriceCalculator/AutomaticField.tsx
@@ -5,7 +5,7 @@ import { TextField } from '@/components/TextField/TextField'
 import { InputField as InputFieldType } from '@/services/PriceCalculator/Field.types'
 import { JSONData } from '@/services/PriceCalculator/PriceCalculator.types'
 import { PriceIntent } from '@/services/priceIntent/priceIntent.types'
-import { convertToDate } from '@/utils/date'
+import { convertToDate, formatAPIDate } from '@/utils/date'
 import { Features } from '@/utils/Features'
 import { InputDay } from '../InputDay/InputDay'
 import { CarMileageField } from './CarMileageField'
@@ -71,8 +71,8 @@ export const AutomaticField = ({ field, priceIntent, onSubmit, loading, autoFocu
           label={translateLabel(field.label)}
           required={field.required}
           defaultSelected={convertToDate(field.value ?? field.defaultValue) ?? undefined}
-          fromDate={convertToDate(field.min) ?? undefined}
-          toDate={convertToDate(field.max) ?? undefined}
+          fromDate={field.min === 'TODAY' ? new Date() : convertToDate(field.min) ?? undefined}
+          toDate={field.max === 'TODAY' ? new Date() : convertToDate(field.max) ?? undefined}
           autoFocus={autoFocus}
         />
       ) : (
@@ -81,8 +81,8 @@ export const AutomaticField = ({ field, priceIntent, onSubmit, loading, autoFocu
           label={translateLabel(field.label)}
           required={field.required}
           defaultValue={field.value ?? field.defaultValue}
-          min={field.min}
-          max={field.max}
+          min={field.min === 'TODAY' ? formatAPIDate(new Date()) : field.min}
+          max={field.max === 'TODAY' ? formatAPIDate(new Date()) : field.max}
           autoFocus={autoFocus}
         />
       )

--- a/apps/store/src/services/PriceCalculator/data/SE_PET_CAT.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_PET_CAT.ts
@@ -58,6 +58,10 @@ export const SE_PET_CAT: Template = {
             name: 'birthDate',
             label: { key: tKey('FIELD_BIRTH_DATE_PET_LABEL') },
             required: true,
+            // Arbitrary date range to be able to show year dropdown
+            // UW filter breeches are handled by the backend
+            min: '1990-01-01',
+            max: 'TODAY',
           },
           layout: LAYOUT.FULL_WIDTH,
         },

--- a/apps/store/src/services/PriceCalculator/data/SE_PET_DOG.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_PET_DOG.ts
@@ -55,6 +55,10 @@ export const SE_PET_DOG: Template = {
             name: 'birthDate',
             label: { key: tKey('FIELD_BIRTH_DATE_PET_LABEL') },
             required: true,
+            // Arbitrary date range to be able to show year dropdown
+            // UW filter breeches are handled by the backend
+            min: '1990-01-01',
+            max: 'TODAY',
           },
           layout: LAYOUT.FULL_WIDTH,
         },


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

![Screenshot 2023-12-14 at 16.36.54.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/6d54236e-0269-47de-a9fb-ae6d2f3d051d.png)

## Describe your changes

- See title.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- This is needed to display dropdowns for year/month in the date picker. The values are somewhat arbitrary, but should work for 99% of all cases.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
