### PR TITLE
GEN-1611 | Add focus state for document links in `ProductItem`

### DIFF
--- a/apps/store/src/components/ProductItem/ProductDetails.tsx
+++ b/apps/store/src/components/ProductItem/ProductDetails.tsx
@@ -32,12 +32,10 @@ export const ProductDetails = ({ items, documents, ...props }: Props) => {
       <ul>
         {documents.map(({ title, url }) => (
           <li key={title}>
-            <a href={url} target="_blank" rel="noopener noreferrer">
-              <DocumentLink color="textTranslucentSecondary">
-                {title}
-                <Sup> PDF</Sup>
-              </DocumentLink>
-            </a>
+            <DocumentLink href={url} target="_blank" rel="noopener noreferrer">
+              {title}
+              <Sup> PDF</Sup>
+            </DocumentLink>
           </li>
         ))}
       </ul>
@@ -57,10 +55,16 @@ const ListItem = styled.li({
   alignItems: 'center',
 })
 
-const DocumentLink = styled(Text)({
+const DocumentLink = styled.a({
+  fontFamily: theme.fonts.standard,
+  fontSize: theme.fontSizes.md,
   lineHeight: '1.6',
-  '&:hover': {
-    color: theme.colors.textTranslucentPrimary,
+  color: theme.colors.textTranslucentSecondary,
+
+  '&:hover': { color: theme.colors.textTranslucentPrimary },
+  '&:focus-visible': {
+    boxShadow: theme.shadow.focus,
+    borderRadius: theme.space.xxs,
   },
 })
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

![Screenshot 2023-12-15 at 13.14.19.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/90ab01ca-8c55-4a01-b7d1-d6048ad3b021.png)

## Describe your changes

- Add focus outline to the document links inside the `ProductItem` component

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Better accessibility for keyboard users

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
