### PR TITLE
Add focus state to `ProductItem` expand trigger

### DIFF
--- a/apps/store/src/components/ProductItem/ProductDetailsHeader.tsx
+++ b/apps/store/src/components/ProductItem/ProductDetailsHeader.tsx
@@ -40,6 +40,13 @@ const Trigger = styled(Text)({
   alignItems: 'center',
   justifyContent: 'space-between',
   gap: theme.space.xs,
+
+  padding: theme.space.xxxs,
+  margin: `-${theme.space.xxxs}`,
+  [`${Wrapper}:focus-visible &`]: {
+    boxShadow: theme.shadow.focus,
+    borderRadius: theme.radius.xxs,
+  },
 })
 
 const AnimatedChevronIcon = styled(ChevronIcon)({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

![Screenshot 2023-12-15 at 13.21.29.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/7441a08d-16c5-4a5c-882f-8e08da4a3595.png)

## Describe your changes

- Show focus state for the expand button inside `ProductItem`

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Better accessibility for keyboard users

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
