### PR TITLE
GEN-1616 | Show optional back button in Widget

### DIFF
--- a/apps/store/src/features/widget/CalculatePricePage.tsx
+++ b/apps/store/src/features/widget/CalculatePricePage.tsx
@@ -27,6 +27,7 @@ type Props = {
   priceIntent: WidgetPriceIntentFragment
   priceTemplate: Template
   flow: string
+  showBackButton?: boolean
 }
 
 export const CalculatePricePage = (props: Props) => {
@@ -91,7 +92,7 @@ export const CalculatePricePage = (props: Props) => {
 
   return (
     <Wrapper y={3}>
-      <Header step="YOUR_INFO" />
+      <Header step="YOUR_INFO" showBackButton={props.showBackButton} />
 
       <Space y={2.5}>
         <SpaceFlex align="center" direction="vertical">

--- a/apps/store/src/features/widget/Header.tsx
+++ b/apps/store/src/features/widget/Header.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { CheckIcon, HedvigLogo, mq } from 'ui'
+import { useRouter } from 'next/router'
+import { CheckIcon, ChevronIcon, HedvigLogo, mq, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
-import { STYLES } from '@/components/GridLayout/GridLayout.helper'
+import { STYLES as GRID_LAYOUT_STYLES } from '@/components/GridLayout/GridLayout.helper'
 import * as ProgressIndicator from '@/components/ProgressIndicator/ProgressIndicator'
 
 const STEPS = ['YOUR_INFO', 'SIGN', 'PAY', 'CONFIRMATION'] as const
@@ -10,6 +11,7 @@ type Step = (typeof STEPS)[number]
 
 type Props = {
   step: Step
+  showBackButton?: boolean
 }
 
 type ProgressStep = { key: Step; label: string }
@@ -33,9 +35,16 @@ export const Header = (props: Props) => {
 
   const stepIndex = STEPS.indexOf(props.step)
 
+  const router = useRouter()
+
   return (
     <HeaderFrame>
       <LogoArea>
+        {props.showBackButton && (
+          <BackButton type="button" onClick={() => router.back()}>
+            <ArrowBackIcon size="1.125rem" />
+          </BackButton>
+        )}
         <HedvigLogo />
       </LogoArea>
 
@@ -54,6 +63,8 @@ export const Header = (props: Props) => {
 }
 
 export const HeaderFrame = styled(GridLayout.Root)({
+  position: 'relative',
+
   [mq.md]: {
     height: '4rem',
     alignItems: 'center',
@@ -61,12 +72,56 @@ export const HeaderFrame = styled(GridLayout.Root)({
 })
 
 export const LogoArea = styled.div({
-  gridColumn: '1/span 12',
-  justifySelf: 'center',
-  paddingBlock: '1.25rem',
-  [mq.md]: { display: 'block', gridColumn: '1 / span 2', justifySelf: 'unset' },
+  position: 'relative',
+  gridColumn: '1 / span 12',
+
+  height: '4rem',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+
+  [mq.md]: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    justifyContent: 'space-between',
+  },
 })
 
-const ProgressArea = styled.div(STYLES['1/3'].center, {
+const BackButton = styled.button({
+  position: 'absolute',
+  left: 0,
+  cursor: 'pointer',
+  width: '2rem',
+  height: '2rem',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  // visually align
+  marginLeft: `-${theme.space.xs}`,
+
+  ':hover': {
+    color: theme.colors.buttonPrimaryHover,
+  },
+
+  ':active': {
+    color: theme.colors.gray500,
+  },
+
+  ':focus-visible': {
+    outline: `2px solid ${theme.colors.buttonPrimaryHover}`,
+    borderRadius: theme.radius.xxs,
+  },
+
+  [mq.md]: {
+    position: 'unset',
+  },
+})
+
+const ArrowBackIcon = styled(ChevronIcon)({
+  transform: 'rotate(90deg)',
+})
+
+const ProgressArea = styled.div(GRID_LAYOUT_STYLES['1/3'].center, {
   gridColumn: '1 / span 12',
 })

--- a/apps/store/src/features/widget/SelectProductPage.tsx
+++ b/apps/store/src/features/widget/SelectProductPage.tsx
@@ -19,6 +19,7 @@ type Props = {
   shopSessionId: string
   products: GlobalProductMetadata
   compareInsurance: boolean
+  showBackButton?: boolean
 }
 
 export const SelectProductPage = (props: Props) => {
@@ -68,7 +69,7 @@ export const SelectProductPage = (props: Props) => {
 
   return (
     <Wrapper y={2.5}>
-      <Header step="YOUR_INFO" />
+      <Header step="YOUR_INFO" showBackButton={props.showBackButton} />
 
       <GridLayout.Root>
         <GridLayout.Content width="1/3" align="center">

--- a/apps/store/src/features/widget/SignPage.tsx
+++ b/apps/store/src/features/widget/SignPage.tsx
@@ -46,6 +46,7 @@ type Props = {
   flow: string
   content?: Array<SbBlokData>
   productName: string
+  showBackButton?: boolean
 }
 
 export const SignPage = (props: Props) => {
@@ -126,7 +127,7 @@ export const SignPage = (props: Props) => {
   return (
     <>
       <Wrapper y={3}>
-        <Header step="SIGN" />
+        <Header step="SIGN" showBackButton={props.showBackButton} />
 
         <GridLayout.Root>
           <GridLayout.Content width="1/3" align="center">

--- a/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/[priceIntentId]/calculate-price.tsx
+++ b/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/[priceIntentId]/calculate-price.tsx
@@ -19,7 +19,10 @@ import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSe
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
-type Props = Pick<ComponentPropsWithoutRef<typeof CalculatePricePage>, 'flow' | 'priceTemplate'> & {
+type Props = Pick<
+  ComponentPropsWithoutRef<typeof CalculatePricePage>,
+  'flow' | 'priceTemplate' | 'showBackButton'
+> & {
   priceIntentId: string
   shopSessionId: string
 }
@@ -62,6 +65,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
         ...hideChatOnPage(),
         ...translations,
         ...context.params,
+        showBackButton: story.content.showBackButton ?? false,
       },
     })
   } catch (error) {

--- a/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
+++ b/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
@@ -110,6 +110,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
         productName: priceIntent.product.name,
         productData,
         pageTitle: story.content.pageTitle ?? 'Hedvig',
+        showBackButton: story.content.showBackButton ?? false,
       },
     }
   } catch (error) {

--- a/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/select.tsx
+++ b/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/select.tsx
@@ -95,6 +95,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
       ...hideChatOnPage(),
       products,
       compareInsurance,
+      showBackButton: story.content.showBackButton ?? false,
     },
   }
 }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -212,6 +212,7 @@ export type WidgetFlowStory = ISbStoryData<{
   showRecommendations?: boolean
   checkoutPageContent?: Array<SbBlokData>
   pageTitle?: string
+  showBackButton?: boolean
 }>
 
 export type GlobalStory = ISbStoryData & {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->


![Screenshot 2023-12-18 at 13.01.25.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/a39cdd3e-89d9-42db-bb87-548a932bdab2.png)

### OLD

![Screenshot 2023-12-18 at 10.47.57.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/7596627a-196a-4a13-af16-380200761e87.png)

![Screenshot 2023-12-18 at 10.47.39.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/440c1022-3164-4477-bfc4-8b3ee9d16ae6.png)

## Describe your changes

- Add "show back button" option in the CMS story

- Optionally show back button in the Widget header

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- When loaded in a WebView without browser chrome, the user has no way to go back to the previous page.

- This is an experiment - let's see what we think of the design.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
