### PR TITLE
Make sure click outside dialog content closes the dialog

### DIFF
--- a/apps/store/src/components/QuickAdd/QuickAddInfoDialog.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddInfoDialog.tsx
@@ -18,18 +18,16 @@ export const QuickAddInfoDialog = ({ children, Header }: Props) => {
           {t('QUICK_ADD_INCLUDED_DIALOG_BUTTON')}
         </Button>
       </Dialog.Trigger>
-      <DialogContent frostedOverlay={true}>
-        <Wrapper>
-          <ScrollWrapper>
-            <CloseButton onClick={() => setOpen(false)}>
-              <CrossIconSmall size="1rem" />
-            </CloseButton>
-            <Space y={4}>
-              {Header && <DialogHeader>{Header}</DialogHeader>}
-              <DialogBody>{children}</DialogBody>
-            </Space>
-          </ScrollWrapper>
-        </Wrapper>
+      <DialogContent centerContent={true} frostedOverlay={true}>
+        <ScrollWrapper>
+          <CloseButton onClick={() => setOpen(false)}>
+            <CrossIconSmall size="1rem" />
+          </CloseButton>
+          <Space y={4}>
+            {Header && <DialogHeader>{Header}</DialogHeader>}
+            <DialogBody>{children}</DialogBody>
+          </Space>
+        </ScrollWrapper>
       </DialogContent>
     </Dialog.Root>
   )
@@ -38,13 +36,8 @@ export const QuickAddInfoDialog = ({ children, Header }: Props) => {
 const DIALOG_HEIGHT = `min(45rem, calc(100vh - ${theme.space.xl}))`
 
 const DialogContent = styled(Dialog.Content)({
-  display: 'grid',
-  placeItems: 'center',
-  height: '100vh',
-})
-
-const Wrapper = styled.div({
   position: 'relative',
+  alignSelf: 'center',
   width: `min(35.5rem, calc(100vw - ${theme.space.xl}))`,
   height: DIALOG_HEIGHT,
   paddingInline: theme.space.md,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Make sure `Dialog.Content` isn't covering the whole screen

https://github.com/HedvigInsurance/racoon/assets/6661511/9c68a796-4e34-4ce7-9b76-1d454c2b4550

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
