### PR TITLE
QuickAddInfoDialog / Mobile fixes

### DIFF
--- a/apps/store/src/components/QuickAdd/QuickAddInfoDialog.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddInfoDialog.tsx
@@ -55,7 +55,6 @@ const DialogContent = styled(Dialog.Content)({
 
 const ScrollWrapper = styled.div({
   height: DIALOG_HEIGHT,
-  paddingInline: theme.space.md,
   overflow: 'auto',
 
   [mq.md]: {

--- a/apps/store/src/components/QuickAdd/QuickAddInfoDialog.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddInfoDialog.tsx
@@ -33,7 +33,11 @@ export const QuickAddInfoDialog = ({ children, Header }: Props) => {
   )
 }
 
-const DIALOG_HEIGHT = `min(45rem, calc(100vh - ${theme.space.xl}))`
+// Use dvh when the browser supports it to make the dialog proper height in mobile
+const DIALOG_HEIGHT = [
+  `min(45rem, calc(100vh - ${theme.space.xl}))`,
+  `min(45rem, calc(100dvh - ${theme.space.xl}))`,
+]
 
 const DialogContent = styled(Dialog.Content)({
   position: 'relative',


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Remove inline padding in mobile
- Use dynamic viewport height to avoid dialog being to tall when browser ui is visible in mobile browsers

### The issue
https://github.com/HedvigInsurance/racoon/assets/6661511/7386aa65-2b7d-4f31-881a-ad428a3ea54d


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
