### PR TITLE
Don't remove request ID from URL after sending widget event

### DIFF
--- a/apps/store/src/features/widget/usePublishWidgetInitEvent.ts
+++ b/apps/store/src/features/widget/usePublishWidgetInitEvent.ts
@@ -12,9 +12,5 @@ export const usePublishWidgetInitEvent = () => {
     if (typeof requestId !== 'string') return
 
     publishWidgetEvent.event({ requestId })
-
-    const newQuery = { ...router.query }
-    delete newQuery[EXTERNAL_REQUEST_ID_QUERY_PARAM]
-    router.replace({ query: newQuery }, undefined, { shallow: true })
   }, [requestId, router])
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Send widget event with request ID but don't remove from URL

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We need to pick this up after the redirect to the start of the widget flow and send when creating the shop session.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
