### PR TITLE
Don't log to Datadog in render function

### DIFF
--- a/apps/store/src/utils/formatter.ts
+++ b/apps/store/src/utils/formatter.ts
@@ -1,8 +1,7 @@
-import { datadogLogs } from '@datadog/browser-logs'
-import { TFunction } from 'next-i18next'
+import { type TFunction } from 'next-i18next'
 import Personnummer from 'personnummer'
-import { CurrencyCode } from '@/services/graphql/generated'
-import { IsoLocale } from '@/utils/l10n/types'
+import { type CurrencyCode } from '@/services/graphql/generated'
+import { type IsoLocale } from '@/utils/l10n/types'
 
 type MoneyFormatOptions = { locale: IsoLocale }
 
@@ -71,7 +70,7 @@ const formatSsn = (ssn: string): string => {
     // replace the last 4 digits with asterisks
     return longFormat.replace(/(\d{4})$/, '****')
   } catch (error) {
-    datadogLogs.logger.warn('Could not format SSN', { ssn, error })
+    console.warn(`Could not format SSN: ${ssn}`, error)
     return ssn
   }
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Remove log to datadog in render function, just log to console

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- We run the code on the server, which mean we can't reliably send the log to datadog (document doesn't exist)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
