### PR TITLE
GEN-1624 | Fix not being able to tap month dropdown (iOS)

### DIFF
--- a/apps/store/src/components/InputDay/InputDay.tsx
+++ b/apps/store/src/components/InputDay/InputDay.tsx
@@ -108,6 +108,9 @@ export const InputDay = (props: Props) => {
 
       <Popover.Portal>
         <PopoverContent side="bottom" align="start" sideOffset={-4} alignOffset={-4}>
+          {/* Fix issue on iOS where month dropdown is focused and can't be tapped */}
+          <div tabIndex={1} aria-hidden={true} />
+
           <StyledDayPicker
             {...dayPickerProps}
             mode="single"


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add hidden element that gets focus when the popover is opened

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Solve the issue where the month dropdown is autofocused and not initially tappable on iOS Safari

- I couldn't find any option in radix to be able to override this behavior

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
