### PR TITLE
Remove spacing before read more button to align properly

### DIFF
--- a/apps/store/public/locales/en/cart.json
+++ b/apps/store/public/locales/en/cart.json
@@ -1,6 +1,6 @@
 {
   "ACCIDENT_OFFER_DESCRIPTION": "Up to 1 million SEK in compensation for injuries and lost working ability in the event of an accident. No deductible.",
-  "ACCIDENT_OFFER_DESCRIPTION_BUNDLE": "Upgrade your coverage with an Accident insurance. Get compensated for dental, scars and much more.",
+  "ACCIDENT_OFFER_DESCRIPTION_BUNDLE": "Upgrade your coverage with an Accident insurance. Get compensated for dental, scars and much more. ",
   "ACCIDENT_OFFER_PRICE_LABEL": "Your offer:",
   "ACCIDENT_OFFER_USP_1": "Extra coverage for injuries and accidents",
   "ACCIDENT_OFFER_USP_2": "Up to 1 million SEK in compensation",

--- a/apps/store/public/locales/sv-se/cart.json
+++ b/apps/store/public/locales/sv-se/cart.json
@@ -1,6 +1,6 @@
 {
   "ACCIDENT_OFFER_DESCRIPTION": "Få upp till 1 miljon kronor i ersättning för skador och förlorad arbetsförmåga vid olycka. Ingen självrisk.",
-  "ACCIDENT_OFFER_DESCRIPTION_BUNDLE": "Uppgradera ditt skydd med olycksfallsförsäkring. Få ersättning för olyckor, tandskador, ärr och mycket mer.",
+  "ACCIDENT_OFFER_DESCRIPTION_BUNDLE": "Uppgradera ditt skydd med olycksfallsförsäkring. Få ersättning för olyckor, tandskador, ärr och mycket mer. ",
   "ACCIDENT_OFFER_PRICE_LABEL": "Ditt erbjudande:",
   "ACCIDENT_OFFER_USP_1": "Extra skydd för skador efter olyckor",
   "ACCIDENT_OFFER_USP_2": "Upp till 1 000 000kr i ersättning",

--- a/apps/store/src/components/QuickAdd/QuickAddInfoDialog.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddInfoDialog.tsx
@@ -86,7 +86,6 @@ const DialogBody = styled.div({
 })
 
 const TextButton = styled.button({
-  marginLeft: theme.space.xxs,
   cursor: 'pointer',
   textDecoration: 'underline',
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Remove spacing before read more button to align properly
<img width="679" alt="Screenshot 2023-12-21 at 09 53 59" src="https://github.com/HedvigInsurance/racoon/assets/6661511/7c47be77-d919-4f4f-a62d-12170b718ef9">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
