### PR TITLE
Replace useStoryblokState with our own useEditableStory hook which does not have revert-to-original bug

### DIFF
--- a/apps/store/src/pages/[[...slug]].tsx
+++ b/apps/store/src/pages/[[...slug]].tsx
@@ -1,4 +1,4 @@
-import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
+import { StoryblokComponent } from '@storyblok/react'
 import { type GetStaticPaths, type GetStaticProps, type NextPageWithLayout } from 'next'
 import { DefaultDebugDialog } from '@/components/DebugDialog/DefaultDebugDialog'
 import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
@@ -23,6 +23,7 @@ import {
 } from '@/services/storyblok/storyblok'
 import { STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
 import { isProductStory } from '@/services/storyblok/Storyblok.helpers'
+import { useEditableStory } from '@/services/storyblok/useEditableStory'
 import { useHydrateTrustpilotData } from '@/services/trustpilot/trustpilot'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
@@ -39,7 +40,7 @@ const NextPage: NextPageWithLayout<PageProps> = (props) => {
 }
 
 const NextStoryblokPage = (props: NextContentPageProps) => {
-  const story = useStoryblokState(props.story)
+  const story = useEditableStory(props.story)
   if (!story) return null
   const abTestOriginStory = story.content.abTestOrigin
   // Always use robots value from the source page in A/B test cases
@@ -62,7 +63,7 @@ const NextStoryblokPage = (props: NextContentPageProps) => {
 const NextProductPage = (props: ProductPageProps) => {
   const { story: initialStory, ...pageProps } = props
 
-  const story = useStoryblokState(initialStory)
+  const story = useEditableStory(initialStory)
   if (!story) return null
 
   return (

--- a/apps/store/src/pages/cart/resume/[shopSessionId].tsx
+++ b/apps/store/src/pages/cart/resume/[shopSessionId].tsx
@@ -1,4 +1,4 @@
-import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
+import { StoryblokComponent } from '@storyblok/react'
 import { type GetServerSideProps, type NextPageWithLayout } from 'next'
 import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
 import { getLayoutWithMenuProps } from '@/components/LayoutWithMenu/getLayoutWithMenuProps'
@@ -7,6 +7,7 @@ import { addApolloState, initializeApolloServerSide } from '@/services/apollo/cl
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { PageStory, getStoryBySlug } from '@/services/storyblok/storyblok'
+import { useEditableStory } from '@/services/storyblok/useEditableStory'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
 type Props = {
@@ -18,7 +19,7 @@ type Params = {
 }
 
 const NextPage: NextPageWithLayout<Props> = (props) => {
-  const story = useStoryblokState(props.story)
+  const story = useEditableStory(props.story)
   if (!story) return null
 
   return (

--- a/apps/store/src/pages/manypets/[[...slug]].tsx
+++ b/apps/store/src/pages/manypets/[[...slug]].tsx
@@ -1,4 +1,4 @@
-import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
+import { StoryblokComponent } from '@storyblok/react'
 import { GetStaticPaths, GetStaticProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { DefaultDebugDialog } from '@/components/DebugDialog/DefaultDebugDialog'
@@ -11,13 +11,14 @@ import {
   StoryblokQueryParams,
 } from '@/services/storyblok/storyblok'
 import { STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
+import { useEditableStory } from '@/services/storyblok/useEditableStory'
 import { Features } from '@/utils/Features'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
 type PageProps = { story: PageStory }
 
 const ManyPetsCmsPage = ({ story: initialStory }: PageProps) => {
-  const story = useStoryblokState(initialStory)
+  const story = useEditableStory(initialStory)
   if (!story) return null
 
   return (

--- a/apps/store/src/pages/reusable-blocks/[...slug].tsx
+++ b/apps/store/src/pages/reusable-blocks/[...slug].tsx
@@ -1,7 +1,8 @@
-import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
+import { StoryblokComponent } from '@storyblok/react'
 import { GetServerSideProps, NextPage } from 'next'
 import Head from 'next/head'
 import { getStoryBySlug, ReusableStory, StoryblokQueryParams } from '@/services/storyblok/storyblok'
+import { useEditableStory } from '@/services/storyblok/useEditableStory'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
 type ReusableBlockPageProps = {
@@ -9,7 +10,7 @@ type ReusableBlockPageProps = {
 }
 
 const NextReusableBlockPage: NextPage<ReusableBlockPageProps> = (props) => {
-  const story = useStoryblokState(props.story)
+  const story = useEditableStory(props.story)
   if (!story) return null
 
   return (

--- a/apps/store/src/pages/widget/[[...slug]].tsx
+++ b/apps/store/src/pages/widget/[[...slug]].tsx
@@ -1,4 +1,4 @@
-import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
+import { StoryblokComponent } from '@storyblok/react'
 import { type GetStaticPaths, type GetStaticProps, type NextPageWithLayout } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { HedvigLogo } from 'ui'
@@ -16,6 +16,7 @@ import {
   getPageLinks,
 } from '@/services/storyblok/storyblok'
 import { STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
+import { useEditableStory } from '@/services/storyblok/useEditableStory'
 import { fetchTrustpilotData, useHydrateTrustpilotData } from '@/services/trustpilot/trustpilot'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
@@ -23,7 +24,7 @@ type PageProps = Pick<StoryblokPageProps, 'story' | 'trustpilot'>
 
 const NextPage: NextPageWithLayout<PageProps> = (props) => {
   useHydrateTrustpilotData(props.trustpilot)
-  const story = useStoryblokState(props.story)
+  const story = useEditableStory(props.story)
 
   if (!story) return null
 

--- a/apps/store/src/pages/widget/preview/[[...slug]].tsx
+++ b/apps/store/src/pages/widget/preview/[[...slug]].tsx
@@ -1,4 +1,4 @@
-import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
+import { StoryblokComponent } from '@storyblok/react'
 import type { GetStaticProps, GetStaticPaths } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { fetchProductData } from '@/components/ProductData/fetchProductData'
@@ -13,6 +13,7 @@ import {
   getStoryBySlug,
 } from '@/services/storyblok/storyblok'
 import { isWidgetFlowStory } from '@/services/storyblok/Storyblok.helpers'
+import { useEditableStory } from '@/services/storyblok/useEditableStory'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
 const EXAMPLE_PRODUCT_NAME = 'SE_APARTMENT_RENT'
@@ -23,7 +24,7 @@ type PageProps = {
 }
 
 const WidgetCmsPage = (props: PageProps) => {
-  const story = useStoryblokState(props.story)
+  const story = useEditableStory(props.story)
 
   if (!story) return null
 

--- a/apps/store/src/services/storyblok/useEditableStory.ts
+++ b/apps/store/src/services/storyblok/useEditableStory.ts
@@ -1,0 +1,30 @@
+import { registerStoryblokBridge } from '@storyblok/js'
+import { TUseStoryblokState } from '@storyblok/react'
+import { useEffect, useRef, useState } from 'react'
+
+// Non-buggy version of useStoryblokState which was broken recently
+// https://github.com/storyblok/storyblok-react/issues/112#issuecomment-1864426869
+export const useEditableStory: TUseStoryblokState = (initialStory = null) => {
+  const [story, setStory] = useState(initialStory)
+  const isBridgeEnabled = typeof (window as any)?.storyblokRegisterEvent !== 'undefined'
+  const storyId = (initialStory as any).internalId || story?.id
+  const mountedRef = useRef(false)
+
+  useEffect(() => {
+    if (!isBridgeEnabled || !initialStory) return
+    mountedRef.current = true
+    setStory(initialStory)
+    registerStoryblokBridge(storyId, (newStory) => {
+      if (!mountedRef.current) return
+      setStory(newStory)
+    })
+    // TODO: Unsubscribe properly when storyblok/react supports it
+    // https://github.com/storyblok/storyblok-react/issues/112
+    return () => {
+      mountedRef.current = false
+    }
+    // initialStory is unstable and cannot be used as dependency
+    // eslint-disable-next-line
+  }, [isBridgeEnabled, storyId])
+  return story
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

Fix live preview when editing Storyblok content

There's a bug in built-in solution, found it and provided our own correct implementation

## Justify why they are needed

Restores editing experience

## Checklist before requesting a review

- [x] I have performed a self-review of my code
