### PR TITLE
Add support for rel attribute on Button and TextWithLink

### DIFF
--- a/apps/store/src/blocks/ButtonBlock.tsx
+++ b/apps/store/src/blocks/ButtonBlock.tsx
@@ -37,6 +37,7 @@ export const ButtonBlock = ({ blok, nested }: ButtonBlockProps) => {
         variant={blok.variant ?? 'primary'}
         size={blok.size ?? 'medium'}
         target={blok.link.target}
+        rel={blok.link.rel}
         title={blok.link.title}
         loading={blok.showLoading && loading}
       >

--- a/apps/store/src/blocks/TrustpilotBlock.tsx
+++ b/apps/store/src/blocks/TrustpilotBlock.tsx
@@ -26,6 +26,9 @@ export const TrustpilotBlock = ({ blok }: Props) => {
 
   const isInternalLink = blok.link.linktype === 'story'
 
+  // If no rel is provided, we default to noopener for external links
+  const rel = blok.link.rel ?? isInternalLink ? undefined : 'noopener'
+
   return (
     <Wrapper {...storyblokEditable(blok)}>
       <StyledTrustpilotLogo />
@@ -33,7 +36,7 @@ export const TrustpilotBlock = ({ blok }: Props) => {
       <ScoreText as="span">{t('TRUSTPILOT_SCORE', { score: data.score })}</ScoreText>
 
       <ReviewText as="span" size="md" color="textSecondaryOnGray">
-        <a href={getLinkFieldURL(blok.link)} target={isInternalLink ? '_self' : '_blank'}>
+        <a href={getLinkFieldURL(blok.link)} target={isInternalLink ? '_self' : '_blank'} rel={rel}>
           {t('TRUSTPILOT_REVIEWS_COUNT', {
             numberOfReviews: numberGrouping(data.totalReviews),
           })}

--- a/apps/store/src/components/TextWithLink.tsx
+++ b/apps/store/src/components/TextWithLink.tsx
@@ -4,14 +4,16 @@ import { type ComponentProps } from 'react'
 import { Text } from 'ui'
 import { nestedLinkStyles } from './RichText/RichText.styles'
 
-type WithLinkProps = Pick<ComponentProps<typeof Link>, 'href' | 'target'> & { children: string }
+type WithLinkProps = Pick<ComponentProps<typeof Link>, 'href' | 'target' | 'rel'> & {
+  children: string
+}
 
 type Props = WithLinkProps & ComponentProps<typeof Text>
 
-export const TextWithLink = ({ children, href, target, ...otherProps }: Props) => {
+export const TextWithLink = ({ children, href, target, rel, ...otherProps }: Props) => {
   return (
     <Text {...otherProps}>
-      <WithLink href={href} target={target}>
+      <WithLink href={href} target={target} rel={rel}>
         {children}
       </WithLink>
     </Text>
@@ -26,10 +28,13 @@ export const WithLink = (props: WithLinkProps) => {
 
   const [linkText, afterLink] = rest.split(']]', 2)
 
+  // If no rel is provided, we default to noopener for external links
+  const rel = props.rel ?? props.target === '_blank' ? 'noopener' : undefined
+
   return (
     <NestedLink>
       {beforeLink}
-      <Link href={props.href} target={props.target}>
+      <Link href={props.href} target={props.target} rel={rel}>
         {linkText}
       </Link>
       {afterLink}

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -22,7 +22,7 @@ type CustomButtonProps = {
 export type Props = ButtonHTMLAttributes<HTMLButtonElement> & CustomButtonProps
 
 export const Button = forwardRef<HTMLButtonElement, Props>((props, ref) => {
-  const { variant = 'primary', loading, children, target, title, ...baseProps } = props
+  const { variant = 'primary', loading, children, target, title, rel, ...baseProps } = props
 
   const buttonChildren = (
     <>
@@ -44,7 +44,8 @@ export const Button = forwardRef<HTMLButtonElement, Props>((props, ref) => {
     ref,
     disabled: props.disabled || loading,
     ...(loading && { 'data-loading': true }),
-    ...(target === '_blank' && { target: '_blank', rel: 'noreferrer' }),
+    ...(target === '_blank' && { target: '_blank', rel: 'noopener' }),
+    ...(rel ? { rel: rel } : {}),
     ...(title ? { title: title } : {}),
   } as const
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add support for rel attribute on Button, TexWithLink and ButtonBlock

When we have `target=_blank"` Peter wants the default `rel` value to be `noopener` and if he adds custom attributs from Storyblok he wants to override that value. 

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Updated behaviour requested by Peter

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
