### PR TITLE
GEN-1645 - feat(ProductReviews): add truspilot tab

### DIFF
--- a/apps/store/src/services/productReviews/productReviews.types.ts
+++ b/apps/store/src/services/productReviews/productReviews.types.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { reviewCommentsSchema, averageRatingSchema } from './productReviews.utils'
+import { reviewCommentsSchema, averageRatingSchema, commentSchema } from './productReviews.utils'
 
 export type Score = '5' | '4' | '3' | '2' | '1'
 
@@ -12,3 +12,5 @@ export type ReviewsDistribution = Array<ScoreDistributionTuple>
 export type ReviewComments = z.infer<typeof reviewCommentsSchema>
 
 export type AverageRating = z.infer<typeof averageRatingSchema>
+
+export type Comment = z.infer<typeof commentSchema>

--- a/apps/store/src/services/productReviews/productReviews.utils.ts
+++ b/apps/store/src/services/productReviews/productReviews.utils.ts
@@ -5,7 +5,7 @@ export const averageRatingSchema = z.object({
   reviewCount: z.number(),
 })
 
-const commentSchema = z.object({
+export const commentSchema = z.object({
   id: z.string(),
   date: z.string(),
   score: z.number(),


### PR DESCRIPTION
## Describe your changes

* Adds tab for _Trustpilot_ reviews; When clicked we'll shown _Trustpilot Widget_. _Trustpilot_ reviews will be enabled down in the stack.

<img width="487" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/cf2c7819-5534-4cf5-b3d1-8ec6d17f9efd">


## Justify why they are needed

First step to get _Trustpilot_ reviews into _ProductReviews_ feature.