### PR TITLE
GEN-1645 - feat(ProductReviews): add trustpilot widget

### DIFF
--- a/apps/store/src/blocks/TrustpilotReviewsBlock.tsx
+++ b/apps/store/src/blocks/TrustpilotReviewsBlock.tsx
@@ -1,50 +1,19 @@
-import { datadogLogs } from '@datadog/browser-logs'
-import Script from 'next/script'
-import { useRef } from 'react'
 import { theme } from 'ui'
+import { TrustpilotWidget } from '@/services/trustpilot/TruspilotWidget'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 
-const TRUSTPILOT_TEMPLATE_ID = '539ad60defb9600b94d7df2c'
-
 export const TrustpilotReviewsBlock = () => {
-  const trustboxRef = useRef<HTMLDivElement | null>(null)
-  const { locale, language } = useCurrentLocale()
-
-  const handleLoad = () => {
-    if (trustboxRef.current) {
-      window.Trustpilot?.loadFromElement(trustboxRef.current, true)
-    } else {
-      datadogLogs.logger.warn('[TrustpilotReviews]: could not found reference to trustbox element')
-    }
-  }
-
-  const handleError = () => {
-    datadogLogs.logger.warn('[TrustpilotReviews]: Failed to load Trustpilot script')
-  }
+  const { language } = useCurrentLocale()
 
   return (
-    <>
-      <Script
-        type="text/javascript"
-        src="//widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js"
-        onLoad={handleLoad}
-        onError={handleError}
-      />
-
-      <div
-        ref={trustboxRef}
-        style={{ paddingInline: theme.space.md }}
-        data-locale={locale}
-        data-template-id={TRUSTPILOT_TEMPLATE_ID}
-        data-businessunit-id={process.env.NEXT_PUBLIC_TRUSTPILOT_HEDVIG_BUSINESS_UNIT_ID}
-        data-style-width="100%"
-        data-style-height="750px"
-        data-theme="light"
-        data-stars="1,2,3,4,5"
-        data-review-languages={language}
-        data-text-color={theme.colors.textPrimary}
-      />
-    </>
+    <TrustpilotWidget
+      variant="testimonials"
+      style={{ paddingInline: theme.space.md }}
+      data-style-width="100%"
+      data-style-height="750px"
+      data-stars="1,2,3,4,5"
+      data-review-languages={language}
+    />
   )
 }
 

--- a/apps/store/src/components/ProductReviews/ProductReviews.tsx
+++ b/apps/store/src/components/ProductReviews/ProductReviews.tsx
@@ -7,6 +7,7 @@ import { getReviewsDistribution } from '@/services/productReviews/getReviewsDist
 import { MAX_SCORE } from '@/services/productReviews/productReviews.constants'
 import type { Score } from '@/services/productReviews/productReviews.types'
 import type { Comment, ReviewsDistribution } from '@/services/productReviews/productReviews.types'
+import { TrustpilotWidget } from '@/services/trustpilot/TruspilotWidget'
 import { useTrustpilotData } from '@/services/trustpilot/trustpilot'
 import { useProductPageContext } from '../ProductPage/ProductPageContext'
 import { Rating } from './Rating'
@@ -76,14 +77,16 @@ export const ProductReviews = (props: Props) => {
           </SpaceFlex>
         )}
 
-        <div>
-          {selectedTab === Tabs.PRODUCT &&
-            reviewsDistribution.map(([score, percentage]) => (
+        {selectedTab === Tabs.PRODUCT && (
+          <div>
+            {reviewsDistribution.map(([score, percentage]) => (
               <ReviewsDistributionByScore key={score} score={score} percentage={percentage} />
             ))}
-          {/* TODO: change this with actual Trustpilot widget */}
-          {selectedTab === Tabs.TRUSTPILOT && <div>Trustpilot</div>}
-        </div>
+          </div>
+        )}
+        {selectedTab === Tabs.TRUSTPILOT && (
+          <StyledTrustpilotWidget variant="mini" data-style-height="112px" />
+        )}
 
         {selectedTab === Tabs.PRODUCT && (
           <Dialog.Root>
@@ -177,6 +180,17 @@ const Wrapper = styled(Space)({
   width: 'min(28.5rem, 100%)',
   marginInline: 'auto',
   paddingInline: theme.space.md,
+})
+
+const StyledTrustpilotWidget = styled(TrustpilotWidget)({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: theme.space.lg,
+  // Optical alignment so widget gets horizontally centered
+  paddingLeft: '2.5rem',
+  backgroundColor: theme.colors.opaque1,
+  borderRadius: theme.radius.md,
 })
 
 const DialogContent = styled(Dialog.Content)({

--- a/apps/store/src/services/trustpilot/TruspilotWidget.tsx
+++ b/apps/store/src/services/trustpilot/TruspilotWidget.tsx
@@ -1,0 +1,62 @@
+import { datadogLogs } from '@datadog/browser-logs'
+import Script from 'next/script'
+import { useEffect, useRef, type ComponentPropsWithoutRef } from 'react'
+import { theme } from 'ui'
+import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+
+const VARIANT_TEMPLATE_ID_MAP: Record<Variant, string> = {
+  mini: '53aa8807dec7e10d38f59f32',
+  testimonials: '539ad60defb9600b94d7df2c',
+}
+
+type Variant = 'mini' | 'testimonials'
+
+type Props = ComponentPropsWithoutRef<'div'> & {
+  variant: Variant
+  darkMode?: boolean
+  className?: string
+}
+
+export const TrustpilotWidget = ({ className, variant, darkMode = false, ...others }: Props) => {
+  const trustboxRef = useRef<HTMLDivElement | null>(null)
+  const { locale } = useCurrentLocale()
+
+  useEffect(() => {
+    handleLoad()
+  }, [])
+
+  const handleLoad = () => {
+    if (trustboxRef.current) {
+      window.Trustpilot?.loadFromElement(trustboxRef.current, true)
+    } else {
+      datadogLogs.logger.warn('[TrustpilotWidget]: could not found reference to trustbox element')
+    }
+  }
+
+  const handleError = () => {
+    datadogLogs.logger.warn('[TrustpilotWidget]: Failed to load Trustpilot script')
+  }
+
+  return (
+    <>
+      <Script
+        type="text/javascript"
+        src="//widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js"
+        onLoad={handleLoad}
+        onError={handleError}
+      />
+
+      <div
+        ref={trustboxRef}
+        className={className}
+        data-locale={locale}
+        data-theme={darkMode ? 'dark' : 'light'}
+        data-text-color={theme.colors.textPrimary}
+        {...others}
+        // template-id and businessunit-id should not be overriden
+        data-template-id={VARIANT_TEMPLATE_ID_MAP[variant]}
+        data-businessunit-id={process.env.NEXT_PUBLIC_TRUSTPILOT_HEDVIG_BUSINESS_UNIT_ID}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## Describe your changes

* Show _Trustpilot widget_ when _Trustpilot_ tab is clicked

<img width="461" alt="Screenshot 2023-12-27 at 14 11 35" src="https://github.com/HedvigInsurance/racoon/assets/19200662/cfa454d9-4d4e-4b8c-b713-c37d25d9c0bd">

## Justify why they are needed

Part of adding _Trustpilot_ reviews into _ProductReviews_ block.
