### PR TITLE
GEN-1645 - refact(ProductReviews): extract ReviewTabs component

### DIFF
--- a/apps/store/src/components/ProductReviews/ProductReviews.tsx
+++ b/apps/store/src/components/ProductReviews/ProductReviews.tsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { useState, type MouseEventHandler } from 'react'
+import { useState } from 'react'
 import { Dialog, Button, Space, CrossIcon, theme, mq } from 'ui'
-import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { getReviewsDistribution } from '@/services/productReviews/getReviewsDistribution'
 import { MAX_SCORE } from '@/services/productReviews/productReviews.constants'
 import type {
@@ -18,13 +17,7 @@ import { Rating } from './Rating'
 import { ReviewComment, type Review } from './ReviewComment'
 import { ReviewsDistributionByScore } from './ReviewsDistributionByScore'
 import { ReviewsFilter } from './ReviewsFilter'
-
-const Tabs = {
-  PRODUCT: 'product',
-  TRUSTPILOT: 'trustpilot',
-} as const
-
-type Tab = (typeof Tabs)[keyof typeof Tabs]
+import { ReviewTabs, TABS, type Tab } from './ReviewTabs'
 
 type Props = {
   tooltipText?: string
@@ -33,17 +26,10 @@ type Props = {
 export const ProductReviews = (props: Props) => {
   const { t } = useTranslation('common')
 
-  const { averageRating } = useProductPageContext()
-  const trustpilotData = useTrustpilotData()
   const getReviewsData = useGetReviewsData()
 
   const [selectedScore, setSelectedScore] = useState<Score>(5)
-  const [selectedTab, setSelectedTab] = useState<Tab>(Tabs.PRODUCT)
-
-  const handleTabChange: MouseEventHandler<HTMLButtonElement> = (event) => {
-    const tab = event.currentTarget.value as Tab
-    setSelectedTab(tab)
-  }
+  const [selectedTab, setSelectedTab] = useState<Tab>(TABS.PRODUCT)
 
   const reviewsData = getReviewsData(selectedTab, selectedScore)
   if (!reviewsData) {
@@ -62,37 +48,16 @@ export const ProductReviews = (props: Props) => {
       />
 
       <Space y={1}>
-        {averageRating && trustpilotData && (
-          <SpaceFlex space={0.5}>
-            <Button
-              value={Tabs.PRODUCT}
-              size="medium"
-              variant={selectedTab === Tabs.PRODUCT ? 'primary-alt' : 'secondary'}
-              fullWidth={true}
-              onClick={handleTabChange}
-            >
-              {t('PRODUCT_REVIEWS_TAB_LABEL', { score: averageRating.score })}
-            </Button>
-            <Button
-              value={Tabs.TRUSTPILOT}
-              size="medium"
-              variant={selectedTab === Tabs.TRUSTPILOT ? 'primary-alt' : 'secondary'}
-              fullWidth={true}
-              onClick={handleTabChange}
-            >
-              {t('TRUSTPILOT_REVIEWS_TAB_LABEL', { score: trustpilotData.score })}
-            </Button>
-          </SpaceFlex>
-        )}
+        <ReviewTabs selectedTab={selectedTab} onTabChange={setSelectedTab} />
 
-        {selectedTab === Tabs.PRODUCT && (
+        {selectedTab === TABS.PRODUCT && (
           <div>
             {reviewsDistribution.map(([score, percentage]) => (
               <ReviewsDistributionByScore key={score} score={score} percentage={percentage} />
             ))}
           </div>
         )}
-        {selectedTab === Tabs.TRUSTPILOT && (
+        {selectedTab === TABS.TRUSTPILOT && (
           <StyledTrustpilotWidget variant="mini" data-style-height="112px" />
         )}
 
@@ -118,26 +83,9 @@ export const ProductReviews = (props: Props) => {
                 />
 
                 <Space y={1}>
-                  {averageRating && trustpilotData && (
-                    <SpaceFlex space={0.5}>
-                      <Button
-                        value={Tabs.PRODUCT}
-                        size="medium"
-                        variant={selectedTab === Tabs.PRODUCT ? 'primary-alt' : 'secondary'}
-                        fullWidth={true}
-                        onClick={handleTabChange}
-                      >{`Omdömen (${averageRating.score})`}</Button>
-                      <Button
-                        value={Tabs.TRUSTPILOT}
-                        size="medium"
-                        variant={selectedTab === Tabs.TRUSTPILOT ? 'primary-alt' : 'secondary'}
-                        fullWidth={true}
-                        onClick={handleTabChange}
-                      >{`Trustpilot (${trustpilotData.score})`}</Button>
-                    </SpaceFlex>
-                  )}
+                  <ReviewTabs selectedTab={selectedTab} onTabChange={setSelectedTab} />
 
-                  {selectedTab === Tabs.PRODUCT && (
+                  {selectedTab === TABS.PRODUCT && (
                     <ReviewsFilter
                       reviewsDistribution={reviewsDistribution}
                       selectedScore={selectedScore}
@@ -170,23 +118,23 @@ const useGetReviewsData = () => {
     }
 
     const rating = { score: 0, totalOfReviews: 0 }
-    if (selectedTab === Tabs.PRODUCT && averageRating) {
+    if (selectedTab === TABS.PRODUCT && averageRating) {
       rating.score = averageRating.score
       rating.totalOfReviews = averageRating.reviewCount
-    } else if (selectedTab === Tabs.TRUSTPILOT && trustpilotData) {
+    } else if (selectedTab === TABS.TRUSTPILOT && trustpilotData) {
       rating.score = trustpilotData.score
       rating.totalOfReviews = trustpilotData.totalReviews
     }
 
     let comments: Array<Review> = []
-    if (selectedTab === Tabs.PRODUCT && reviewComments) {
+    if (selectedTab === TABS.PRODUCT && reviewComments) {
       comments = parseProductReviews(reviewComments.commentsByScore[selectedScore].latestComments)
-    } else if (selectedTab === Tabs.TRUSTPILOT && trustpilotData?.reviews) {
+    } else if (selectedTab === TABS.TRUSTPILOT && trustpilotData?.reviews) {
       comments = parseCompanyReviews(trustpilotData.reviews)
     }
 
     let reviewsDistribution: ReviewsDistribution = []
-    if (selectedTab === Tabs.PRODUCT && reviewComments) {
+    if (selectedTab === TABS.PRODUCT && reviewComments) {
       reviewsDistribution = getReviewsDistribution(reviewComments)
     }
 

--- a/apps/store/src/components/ProductReviews/ReviewTabs.tsx
+++ b/apps/store/src/components/ProductReviews/ReviewTabs.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'next-i18next'
+import { Button } from 'ui'
+import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
+import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
+import { useTrustpilotData } from '@/services/trustpilot/trustpilot'
+
+export const TABS = {
+  PRODUCT: 'product',
+  TRUSTPILOT: 'trustpilot',
+} as const
+
+export type Tab = (typeof TABS)[keyof typeof TABS]
+
+type Props = {
+  selectedTab: Tab
+  onTabChange: (tab: Tab) => void
+}
+
+export const ReviewTabs = (props: Props) => {
+  const { t } = useTranslation('common')
+  const { averageRating } = useProductPageContext()
+  const trustpilotData = useTrustpilotData()
+
+  const handleTabChange: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+    const tab = event.currentTarget.value as Tab
+    props.onTabChange(tab)
+  }
+
+  if (!averageRating || !trustpilotData) {
+    return null
+  }
+
+  return (
+    <SpaceFlex space={0.5}>
+      <Button
+        value={TABS.PRODUCT}
+        size="medium"
+        variant={props.selectedTab === TABS.PRODUCT ? 'primary-alt' : 'secondary'}
+        fullWidth={true}
+        onClick={handleTabChange}
+      >
+        {t('PRODUCT_REVIEWS_TAB_LABEL', { score: averageRating.score })}
+      </Button>
+      <Button
+        value={TABS.TRUSTPILOT}
+        size="medium"
+        variant={props.selectedTab === TABS.TRUSTPILOT ? 'primary-alt' : 'secondary'}
+        fullWidth={true}
+        onClick={handleTabChange}
+      >
+        {t('TRUSTPILOT_REVIEWS_TAB_LABEL', { score: trustpilotData.score })}
+      </Button>
+    </SpaceFlex>
+  )
+}


### PR DESCRIPTION
## Describe your changes

* Extract tabs into its own component: `ReviewTabs`. As we show it twice, for `ProductReviews` component and reviews dialog, it makes sense to reuse it.

<img width="507" alt="Screenshot 2024-01-02 at 10 11 42" src="https://github.com/HedvigInsurance/racoon/assets/19200662/a0b64534-2a58-4b25-9211-ad168d59ebc9">

<img width="585" alt="Screenshot 2024-01-02 at 10 11 50" src="https://github.com/HedvigInsurance/racoon/assets/19200662/820ffcc9-f7cf-4b2d-aa3c-673dce5dfb7d">

Can be tested [here](https://hedvig-dot-com-git-gen-1645-refactreview-tabs-hedvig.vercel.app/se/forsakringar/olycksfallsforsakring/av)

## Justify why they are needed

Avoid code duplication.