### PR TITLE
GEN.1569 - refact: calculate product reviews distribution once during build time

### DIFF
--- a/apps/store/src/components/ProductData/ProductData.types.ts
+++ b/apps/store/src/components/ProductData/ProductData.types.ts
@@ -1,7 +1,9 @@
+import type { ReviewsDistribution } from '@/components/ProductReviews/ProductReviews.types'
 import { ProductDataQuery } from '@/services/graphql/generated'
 import type { AverageRating, ReviewComments } from '@/services/productReviews/productReviews.types'
 
 export type ProductData = NonNullable<ProductDataQuery['product']> & {
   averageRating: AverageRating | null
   reviewComments: ReviewComments | null
+  reviewsDistribution: ReviewsDistribution | null
 }

--- a/apps/store/src/components/ProductData/fetchProductData.ts
+++ b/apps/store/src/components/ProductData/fetchProductData.ts
@@ -4,6 +4,7 @@ import {
   type ProductDataQuery,
   type ProductDataQueryVariables,
 } from '@/services/graphql/generated'
+import { getReviewsDistribution } from '@/services/productReviews/getReviewsDistribution'
 import {
   getProductAverageRating,
   getProductReviewComments,
@@ -29,10 +30,12 @@ export const fetchProductData = async ({
 
   const averageRating = await getProductAverageRating(variables.productName)
   const reviewComments = await getProductReviewComments(variables.productName)
+  const reviewsDistribution = reviewComments ? getReviewsDistribution(reviewComments) : null
 
   return {
     ...data.product,
     averageRating,
     reviewComments,
+    reviewsDistribution,
   }
 }

--- a/apps/store/src/components/ProductReviews/ProductReviews.tsx
+++ b/apps/store/src/components/ProductReviews/ProductReviews.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled'
 import React, { useState } from 'react'
 import { Space, theme } from 'ui'
-import { getReviewsDistribution } from '@/services/productReviews/getReviewsDistribution'
 import { MAX_SCORE } from '@/services/productReviews/productReviews.constants'
 import type { Review as ProductReview } from '@/services/productReviews/productReviews.types'
 import { TrustpilotWidget } from '@/services/trustpilot/TruspilotWidget'
@@ -29,7 +28,7 @@ export const ProductReviews = (props: Props) => {
     console.warn('[ProductReviews]: No review data available. Skip rendering.')
     return null
   }
-  const { rating, reviewsDistribution, reviews } = reviewsData
+  const { rating, reviews, reviewsDistribution } = reviewsData
 
   return (
     <Wrapper y={3.5}>
@@ -70,7 +69,11 @@ export const ProductReviews = (props: Props) => {
 }
 
 const useGetReviewsData = () => {
-  const { averageRating, reviewComments } = useProductData()
+  const {
+    averageRating,
+    reviewComments,
+    reviewsDistribution: productReviewsDistribution,
+  } = useProductData()
   const trustpilotData = useTrustpilotData()
 
   const getReviewsData = (selectedTab: Tab, selectedScore: Score) => {
@@ -95,8 +98,8 @@ const useGetReviewsData = () => {
     }
 
     let reviewsDistribution: ReviewsDistribution = []
-    if (selectedTab === TABS.PRODUCT && reviewComments) {
-      reviewsDistribution = getReviewsDistribution(reviewComments)
+    if (selectedTab === TABS.PRODUCT && productReviewsDistribution) {
+      reviewsDistribution = productReviewsDistribution
     }
 
     return {

--- a/apps/store/src/mocks/productData.ts
+++ b/apps/store/src/mocks/productData.ts
@@ -296,4 +296,5 @@ export const productData: ProductData = {
   ],
   averageRating: null,
   reviewComments: null,
+  reviewsDistribution: null,
 }


### PR DESCRIPTION
## Describe your changes

Calculates product reviews distribution (by score) once (per product), during build time, and make it available via `ProductData` context.

## Justify why they are needed

It's a expensive computation that doesn't need to be done frequently.
