### PR TITLE
GEN-1673 - refact(trustpilot): provider Trustpilot data from a context provider

### DIFF
--- a/apps/store/src/blocks/TrustpilotBlock.tsx
+++ b/apps/store/src/blocks/TrustpilotBlock.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { Text, InfoIcon, theme, mq } from 'ui'
 import { Tooltip } from '@/components/Tooltip/Tooltip'
 import { TrustpilotLogo } from '@/components/TrustpilotLogo/TrustpilotLogo'
-import { useTrustpilotData } from '@/features/memberReviews/trustpilot'
+import { useTrustpilotData } from '@/features/memberReviews/TrustpilotDataProvider'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { LinkField } from '@/services/storyblok/storyblok'
 import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
@@ -17,9 +17,9 @@ type Props = SbBaseBlockProps<{
 export const TrustpilotBlock = ({ blok }: Props) => {
   const { t } = useTranslation('common')
   const { numberGrouping } = useFormatter()
-  const data = useTrustpilotData()
+  const trustpilotData = useTrustpilotData()
 
-  if (!data) {
+  if (!trustpilotData) {
     console.warn('[TrustpilotBlock]: No Trustpilot data found. Skip rendering.')
     return null
   }
@@ -33,12 +33,12 @@ export const TrustpilotBlock = ({ blok }: Props) => {
     <Wrapper {...storyblokEditable(blok)}>
       <StyledTrustpilotLogo />
 
-      <ScoreText as="span">{t('TRUSTPILOT_SCORE', { score: data.score })}</ScoreText>
+      <ScoreText as="span">{t('TRUSTPILOT_SCORE', { score: trustpilotData.score })}</ScoreText>
 
       <ReviewText as="span" size="md" color="textSecondaryOnGray">
         <a href={getLinkFieldURL(blok.link)} target={isInternalLink ? '_self' : '_blank'} rel={rel}>
           {t('TRUSTPILOT_REVIEWS_COUNT', {
-            numberOfReviews: numberGrouping(data.totalReviews),
+            numberOfReviews: numberGrouping(trustpilotData.totalReviews),
           })}
         </a>
 

--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -6,7 +6,7 @@ import { theme } from 'ui'
 import { FooterBlock } from '@/blocks/FooterBlock'
 import { HeaderBlock } from '@/blocks/HeaderBlock'
 import { ReusableBlockReference } from '@/blocks/ReusableBlockReference'
-import { GlobalStory, PageStory, StoryblokPageProps } from '@/services/storyblok/storyblok'
+import { GlobalStory, PageStory } from '@/services/storyblok/storyblok'
 import { filterByBlockType, isProductStory } from '@/services/storyblok/Storyblok.helpers'
 import { useChangeLocale } from '@/utils/l10n/useChangeLocale'
 import { BreadcrumbList, BreadcrumbListItem } from './BreadcrumbList'
@@ -19,15 +19,13 @@ const Wrapper = styled.div({
 })
 
 type LayoutWithMenuProps = {
-  children: ReactElement<
-    Pick<StoryblokPageProps, 'trustpilot'> & {
-      className: string
-      [GLOBAL_PRODUCT_METADATA_PROP_NAME]: GlobalProductMetadata
-      story: PageStory | undefined
-      globalStory: GlobalStory | undefined
-      breadcrumbs?: Array<BreadcrumbListItem>
-    }
-  >
+  children: ReactElement<{
+    className: string
+    [GLOBAL_PRODUCT_METADATA_PROP_NAME]: GlobalProductMetadata
+    story: PageStory | undefined
+    globalStory: GlobalStory | undefined
+    breadcrumbs?: Array<BreadcrumbListItem>
+  }>
   overlayMenu?: boolean
   hideFooter?: boolean
 }

--- a/apps/store/src/components/ProductPage/ProductPage.tsx
+++ b/apps/store/src/components/ProductPage/ProductPage.tsx
@@ -6,6 +6,7 @@ import {
   PriceIntentContextProvider,
   usePriceIntent,
 } from '@/components/ProductPage/PriceIntentContext'
+import { TrustpilotDataProvider } from '@/features/memberReviews/TrustpilotDataProvider'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
 import { useTracking } from '@/services/Tracking/useTracking'
@@ -33,8 +34,10 @@ export const ProductPage = ({ story, ...props }: ProductPageProps) => {
       <ProductPageContextProvider {...props} story={story}>
         <PriceIntentContextProvider>
           <ProductPageTrackingProvider>
-            <StoryblokComponent blok={story.content} />
-            <PageDebugDialog />
+            <TrustpilotDataProvider trustpilotData={props.trustpilotData}>
+              <StoryblokComponent blok={story.content} />
+              <PageDebugDialog />
+            </TrustpilotDataProvider>
           </ProductPageTrackingProvider>
         </PriceIntentContextProvider>
       </ProductPageContextProvider>

--- a/apps/store/src/components/ProductPage/ProductPage.types.ts
+++ b/apps/store/src/components/ProductPage/ProductPage.types.ts
@@ -1,5 +1,5 @@
 import type { ProductData } from '@/components/ProductData/ProductData.types'
-import { type TrustpilotData } from '@/features/memberReviews/trustpilot.types'
+import type { TrustpilotData } from '@/features/memberReviews/trustpilot.types'
 import { Template } from '@/services/PriceCalculator/PriceCalculator.types'
 import type { AverageRating, ReviewComments } from '@/services/productReviews/productReviews.types'
 import { ProductStory, StoryblokPageProps } from '@/services/storyblok/storyblok'
@@ -9,7 +9,7 @@ export type ProductPageProps = StoryblokPageProps & {
   priceTemplate: Template
   productData: ProductData
   initialSelectedTypeOfContract?: string
-  trustpilot: TrustpilotData | null
   averageRating: AverageRating | null
   reviewComments: ReviewComments | null
+  trustpilotData: TrustpilotData | null
 }

--- a/apps/store/src/components/ProductPage/ProductPageContext.tsx
+++ b/apps/store/src/components/ProductPage/ProductPageContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, PropsWithChildren, useContext, useMemo } from 'react'
 import { ProductPageProps } from './ProductPage.types'
 
-type ProductPageContextData = Omit<ProductPageProps, 'productData'> & {
+type ProductPageContextData = Omit<ProductPageProps, 'productData' | 'trustpilotData'> & {
   content: {
     product: {
       name: string
@@ -13,7 +13,7 @@ type ProductPageContextData = Omit<ProductPageProps, 'productData'> & {
 
 const ProductPageContext = createContext<ProductPageContextData | null>(null)
 
-type Props = PropsWithChildren<ProductPageProps>
+type Props = PropsWithChildren<Omit<ProductPageProps, 'trustpilotData'>>
 
 export const ProductPageContextProvider = ({ children, ...rest }: Props) => {
   const contextValue = useMemo(

--- a/apps/store/src/components/ProductReviews/ProductReviews.tsx
+++ b/apps/store/src/components/ProductReviews/ProductReviews.tsx
@@ -2,8 +2,8 @@ import styled from '@emotion/styled'
 import React, { useState } from 'react'
 import { Space, theme } from 'ui'
 import { TrustpilotWidget } from '@/features/memberReviews/TruspilotWidget'
-import { useTrustpilotData } from '@/features/memberReviews/trustpilot'
 import { type Review as CompanyReview } from '@/features/memberReviews/trustpilot.types'
+import { useTrustpilotData } from '@/features/memberReviews/TrustpilotDataProvider'
 import { getReviewsDistribution } from '@/services/productReviews/getReviewsDistribution'
 import { MAX_SCORE } from '@/services/productReviews/productReviews.constants'
 import type { Review as ProductReview } from '@/services/productReviews/productReviews.types'
@@ -90,7 +90,7 @@ const useGetReviewsData = () => {
     let reviews: Array<Review> = []
     if (selectedTab === TABS.PRODUCT && reviewComments) {
       reviews = parseProductReviews(reviewComments.commentsByScore[selectedScore].latestComments)
-    } else if (selectedTab === TABS.TRUSTPILOT && trustpilotData?.reviews) {
+    } else if (selectedTab === TABS.TRUSTPILOT && trustpilotData) {
       reviews = parseCompanyReviews(trustpilotData.reviews)
     }
 

--- a/apps/store/src/components/ProductReviews/ReviewTabs.tsx
+++ b/apps/store/src/components/ProductReviews/ReviewTabs.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'next-i18next'
 import { Button } from 'ui'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
-import { useTrustpilotData } from '@/features/memberReviews/trustpilot'
+import { useTrustpilotData } from '@/features/memberReviews/TrustpilotDataProvider'
 
 export const TABS = {
   PRODUCT: 'product',

--- a/apps/store/src/features/memberReviews/TrustpilotDataProvider.tsx
+++ b/apps/store/src/features/memberReviews/TrustpilotDataProvider.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext, type PropsWithChildren } from 'react'
+import type { TrustpilotData } from './trustpilot.types'
+
+const TrustpilotDataContext = createContext<TrustpilotData | null>(null)
+
+type Props = PropsWithChildren<{ trustpilotData: TrustpilotData | null }>
+
+export const TrustpilotDataProvider = ({ children, trustpilotData }: Props) => {
+  return (
+    <TrustpilotDataContext.Provider value={trustpilotData}>
+      {children}
+    </TrustpilotDataContext.Provider>
+  )
+}
+
+export const useTrustpilotData = () => {
+  const context = useContext(TrustpilotDataContext)
+
+  return context
+}

--- a/apps/store/src/features/memberReviews/trustpilot.tsx
+++ b/apps/store/src/features/memberReviews/trustpilot.tsx
@@ -1,9 +1,5 @@
-import { atom, useAtomValue } from 'jotai'
-import { useHydrateAtoms } from 'jotai/utils'
-import { globalStore } from '@/utils/globalStore'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
 import { type RoutingLocale, Language } from '@/utils/l10n/types'
-import type { TrustpilotData } from './trustpilot.types'
 
 type AverageRatingJSONResponse = {
   score: {
@@ -24,29 +20,17 @@ type ReviewsJSONResponse = {
   }>
 }
 
-const trustpilotAtom = atom<TrustpilotData | null>(null)
-
-export const useTrustpilotData = () => {
-  return useAtomValue(trustpilotAtom, { store: globalStore })
-}
-
-export const useHydrateTrustpilotData = (data: TrustpilotData | null) => {
-  useHydrateAtoms([[trustpilotAtom, data]], { store: globalStore })
-}
-
 export const fetchTrustpilotData = async (locale: RoutingLocale) => {
   try {
     const hedvigBusinessUnitId = process.env.NEXT_PUBLIC_TRUSTPILOT_HEDVIG_BUSINESS_UNIT_ID
     if (!hedvigBusinessUnitId) {
-      logMissingSetting(
-        'NEXT_PUBLIC_TRUSTPILOT_HEDVIG_BUSINESS_UNIT_ID is not configured, skipping Trustpilot data',
-      )
+      logMissingSetting('NEXT_PUBLIC_TRUSTPILOT_HEDVIG_BUSINESS_UNIT_ID is not configured')
       return null
     }
 
     const trustpilotApiKey = process.env.TRUSTPILOT_API_KEY
     if (!trustpilotApiKey) {
-      logMissingSetting('TRUSTPILOT_API_KEY is not configured, skipping Trustpilot data')
+      logMissingSetting('TRUSTPILOT_API_KEY is not configured')
       return null
     }
 
@@ -59,7 +43,7 @@ export const fetchTrustpilotData = async (locale: RoutingLocale) => {
 
     return { ...averageRating, reviews }
   } catch (error) {
-    console.error(error)
+    console.error(`Could not get Trustpilot data: ${error}`)
     return null
   }
 }

--- a/apps/store/src/pages/widget/[[...slug]].tsx
+++ b/apps/store/src/pages/widget/[[...slug]].tsx
@@ -4,7 +4,9 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { HedvigLogo } from 'ui'
 import { DefaultDebugDialog } from '@/components/DebugDialog/DefaultDebugDialog'
 import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
-import { fetchTrustpilotData, useHydrateTrustpilotData } from '@/features/memberReviews/trustpilot'
+import { fetchTrustpilotData } from '@/features/memberReviews/trustpilot'
+import type { TrustpilotData } from '@/features/memberReviews/trustpilot.types'
+import { TrustpilotDataProvider } from '@/features/memberReviews/TrustpilotDataProvider'
 import { HeaderFrame, LogoArea } from '@/features/widget/Header'
 import { STORYBLOK_WIDGET_FOLDER_SLUG } from '@/features/widget/widget.constants'
 import { hideChatOnPage } from '@/services/CustomerFirst'
@@ -19,10 +21,9 @@ import {
 import { STORY_PROP_NAME } from '@/services/storyblok/Storyblok.constant'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
-type PageProps = Pick<StoryblokPageProps, 'story' | 'trustpilot'>
+type PageProps = Pick<StoryblokPageProps, 'story'> & { trustpilotData: TrustpilotData | null }
 
 const NextPage: NextPageWithLayout<PageProps> = (props) => {
-  useHydrateTrustpilotData(props.trustpilot)
   const story = useStoryblokState(props.story)
 
   if (!story) return null
@@ -40,7 +41,9 @@ const NextPage: NextPageWithLayout<PageProps> = (props) => {
           <HedvigLogo />
         </LogoArea>
       </HeaderFrame>
-      <StoryblokComponent blok={story.content} />
+      <TrustpilotDataProvider trustpilotData={props.trustpilotData}>
+        <StoryblokComponent blok={story.content} />
+      </TrustpilotDataProvider>
       <DefaultDebugDialog />
     </>
   )
@@ -69,7 +72,7 @@ export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = a
       ...(await serverSideTranslations(context.locale)),
       ...hideChatOnPage(story.content.hideChat ?? false),
       [STORY_PROP_NAME]: story,
-      trustpilot: await fetchTrustpilotData(context.locale),
+      trustpilotData: await fetchTrustpilotData(context.locale),
     },
     revalidate: getRevalidate(),
   }

--- a/apps/store/src/pages/widget/preview/[[...slug]].tsx
+++ b/apps/store/src/pages/widget/preview/[[...slug]].tsx
@@ -4,6 +4,9 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { fetchProductData } from '@/components/ProductData/fetchProductData'
 import type { ProductData } from '@/components/ProductData/ProductData.types'
 import { ProductDataProvider } from '@/components/ProductData/ProductDataProvider'
+import { fetchTrustpilotData } from '@/features/memberReviews/trustpilot'
+import type { TrustpilotData } from '@/features/memberReviews/trustpilot.types'
+import { TrustpilotDataProvider } from '@/features/memberReviews/TrustpilotDataProvider'
 import { STORYBLOK_WIDGET_FOLDER_SLUG } from '@/features/widget/widget.constants'
 import { initializeApollo } from '@/services/apollo/client'
 import {
@@ -20,6 +23,7 @@ const EXAMPLE_PRODUCT_NAME = 'SE_APARTMENT_RENT'
 type PageProps = {
   story: WidgetFlowStory
   productData: ProductData
+  trustpilotData: TrustpilotData | null
 }
 
 const WidgetCmsPage = (props: PageProps) => {
@@ -29,7 +33,9 @@ const WidgetCmsPage = (props: PageProps) => {
 
   return (
     <ProductDataProvider productData={props.productData}>
-      <StoryblokComponent blok={story.content} />
+      <TrustpilotDataProvider trustpilotData={props.trustpilotData}>
+        <StoryblokComponent blok={story.content} />
+      </TrustpilotDataProvider>
     </ProductDataProvider>
   )
 }
@@ -43,19 +49,20 @@ export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = a
   const slug = `${STORYBLOK_WIDGET_FOLDER_SLUG}/flows/${params.slug.join('/')}`
   const version = draftMode ? 'draft' : undefined
 
-  const [story, translations, productData] = await Promise.all([
+  const [story, translations, productData, trustpilotData] = await Promise.all([
     getStoryBySlug(slug, { version, locale }),
     serverSideTranslations(locale),
     fetchProductData({
       apolloClient: initializeApollo({ locale }),
       productName: EXAMPLE_PRODUCT_NAME,
     }),
+    fetchTrustpilotData(locale),
   ])
 
   if (!isWidgetFlowStory(story)) throw new Error(`Invalid story type: ${story.slug}.`)
 
   return {
-    props: { ...translations, story, productData },
+    props: { ...translations, story, productData, trustpilotData },
     revalidate: getRevalidate(),
   }
 }

--- a/apps/store/src/services/storyblok/getStoryblokPageProps.ts
+++ b/apps/store/src/services/storyblok/getStoryblokPageProps.ts
@@ -27,7 +27,7 @@ export const getStoryblokPageProps = async ({
 
   const timerName = `Get Storyblok page props for ${locale}/${slug} ${draftMode ? '(draft)' : ''}`
   console.time(timerName)
-  const [layoutWithMenuProps, breadcrumbs, trustpilot] = await Promise.all([
+  const [layoutWithMenuProps, breadcrumbs, trustpilotData] = await Promise.all([
     getLayoutWithMenuProps(context, apolloClient),
     fetchBreadcrumbs(slug, { version, locale }),
     fetchTrustpilotData(locale),
@@ -49,6 +49,6 @@ export const getStoryblokPageProps = async ({
     ...hideChatOnPage(story.content.hideChat ?? false),
     [STORY_PROP_NAME]: story,
     breadcrumbs,
-    trustpilot,
+    trustpilotData,
   }
 }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -80,7 +80,6 @@ import { blogBlocks } from '@/features/blog/blogBlocks'
 import { carDealershipBlocks } from '@/features/carDealership/carDealershipBlocks'
 import { STORYBLOK_MANYPETS_FOLDER_SLUG } from '@/features/manyPets/manyPets.constants'
 import { manyPetsBlocks } from '@/features/manyPets/manyPetsBlocks'
-import { TrustpilotData } from '@/features/memberReviews/trustpilot.types'
 import { STORYBLOK_WIDGET_FOLDER_SLUG } from '@/features/widget/widget.constants'
 import { isBrowser } from '@/utils/env'
 import { Features } from '@/utils/Features'
@@ -105,7 +104,6 @@ export type StoryblokQueryParams = {
 export type StoryblokPageProps = {
   [STORY_PROP_NAME]: PageStory
   [GLOBAL_STORY_PROP_NAME]: GlobalStory
-  trustpilot: TrustpilotData | null
 }
 
 export type StoryblokVersion = 'draft' | 'published'


### PR DESCRIPTION
## Describe your changes

* 🙅🏻 Stop using _Jotai_ for storing Trustpilot data (I was having an issue with multiple stores). _Trustpilot_ data is now served via its own _React Context_

## Justify why they are needed

Easier to work with. In order to make _Trustpilot_ data available one just need to call `fetchTrustpilotData` (`memberReviews/trustpilot.ts` file) server side and pass the result to `TrustpilotDataProvider`.
