### PR TITLE
GEN-1686 - refact(ProductAverageRating): make it availbe on purchase form

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -20,6 +20,7 @@ export type ProductPageBlockProps = SbBaseBlockProps<{
   overview: Array<SbBlokData>
   coverage: Array<SbBlokData>
   body: Array<SbBlokData>
+  showAverageRating: boolean
 }>
 
 export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
@@ -59,7 +60,7 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
       <Grid>
         <GridLayout.Content width="1/2" align="right">
           <PurchaseFormWrapper>
-            <PurchaseForm />
+            <PurchaseForm showAverageRating={blok.showAverageRating} />
           </PurchaseFormWrapper>
         </GridLayout.Content>
 

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { ReactNode, useCallback, useRef, useState } from 'react'
 import { Balancer } from 'react-wrap-balancer'
-import { Button, Heading, mq, Text, theme, WarningTriangleIcon } from 'ui'
+import { Button, Heading, Space, mq, Text, theme, WarningTriangleIcon } from 'ui'
 import { CartToast, CartToastAttributes } from '@/components/CartNotification/CartToast'
 import { ProductItemProps } from '@/components/CartNotification/ProductItem'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
@@ -21,6 +21,7 @@ import {
   useIsPriceCalculatorExpanded,
   useOpenPriceCalculatorQueryParam,
 } from '@/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam'
+import { ProductAverageRating } from '@/components/ProductReviews/ProductAverageRating'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { BankSigneringEvent } from '@/services/bankSignering'
 import {
@@ -43,7 +44,11 @@ import { ProductHero } from './ProductHero/ProductHero'
 import { usePurchaseFormState } from './usePurchaseFormState'
 import { useSelectedOffer } from './useSelectedOffer'
 
-export const PurchaseForm = () => {
+type Props = {
+  showAverageRating?: boolean
+}
+
+export const PurchaseForm = (props: Props) => {
   const { t } = useTranslation('purchase-form')
   const { priceTemplate } = useProductPageContext()
   const productData = useProductData()
@@ -239,7 +244,7 @@ export const PurchaseForm = () => {
           )
         }
 
-        return <IdleState onClick={handleOpen} />
+        return <IdleState onClick={handleOpen} showAverageRating={props.showAverageRating} />
       }}
     </Layout>
   )
@@ -289,9 +294,9 @@ const ProductHeroContainer = (props: ProductHeroContainerProps) => {
   )
 }
 
-type IdleStateProps = { onClick: () => void }
+type IdleStateProps = { onClick: () => void } & Pick<Props, 'showAverageRating'>
 
-const IdleState = ({ onClick }: IdleStateProps) => {
+const IdleState = ({ onClick, showAverageRating }: IdleStateProps) => {
   const ref = useRef<HTMLDivElement>(null)
   const { t } = useTranslation('purchase-form')
 
@@ -299,7 +304,10 @@ const IdleState = ({ onClick }: IdleStateProps) => {
     <>
       <div ref={ref}>
         <ProductHeroContainer size="large">
-          <Button onClick={onClick}>{t('OPEN_PRICE_CALCULATOR_BUTTON')}</Button>
+          <Space y={1}>
+            <Button onClick={onClick}>{t('OPEN_PRICE_CALCULATOR_BUTTON')}</Button>
+            {showAverageRating && <ProductAverageRating />}
+          </Space>
         </ProductHeroContainer>
       </div>
       <ScrollPast targetRef={ref}>

--- a/apps/store/src/components/ProductReviews/ProductAverageRating.tsx
+++ b/apps/store/src/components/ProductReviews/ProductAverageRating.tsx
@@ -12,9 +12,7 @@ import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { MAX_SCORE } from '@/features/memberReviews/memberReviews.constants'
 import { useProuctReviewsDataContext } from '@/features/memberReviews/ProductReviewsDataProvider'
 
-type AverageRating = NonNullable<ReturnType<typeof useProuctReviewsDataContext>>['averageRating']
-
-export const ProductAverageRatingBlock = () => {
+export const ProductAverageRating = () => {
   const { t } = useTranslation('common')
   const productReviewsData = useProuctReviewsDataContext()
   const productData = useProductData()
@@ -69,8 +67,6 @@ export const ProductAverageRatingBlock = () => {
     </>
   )
 }
-
-ProductAverageRatingBlock.blockName = 'productAverageRating'
 
 type DialogProps = {
   children: ReactNode
@@ -136,6 +132,8 @@ const Trigger = styled.button({
     },
   },
 })
+
+type AverageRating = NonNullable<ReturnType<typeof useProuctReviewsDataContext>>['averageRating']
 
 const getProductStructuredData = (product: ProductData, averageRating: AverageRating) => {
   return {

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -43,7 +43,6 @@ import { MediaListBlock } from '@/blocks/MediaListBlock'
 import { ModalBlock } from '@/blocks/ModalBlock'
 import { PageBlock } from '@/blocks/PageBlock'
 import { PerilsBlock } from '@/blocks/PerilsBlock'
-import { ProductAverageRatingBlock } from '@/blocks/ProductAverageRatingBlock'
 import { ProductCardBlock } from '@/blocks/ProductCardBlock'
 import { ProductDocumentsBlock } from '@/blocks/ProductDocumentsBlock'
 import { ProductGridBlock } from '@/blocks/ProductGridBlock'
@@ -195,6 +194,7 @@ export type ProductStory = ISbStoryData<
     body: Array<SbBlokData>
     globalStory: GlobalStory
     hideChat?: boolean
+    showAverageRating?: boolean
   } & SEOData
 >
 
@@ -255,7 +255,6 @@ export const initStoryblok = () => {
     AccordionBlock,
     AccordionItemBlock,
     AnnouncementBlock,
-    ProductAverageRatingBlock,
     BannerBlock,
     ButtonBlock,
     CheckListBlock,


### PR DESCRIPTION
## Describe your changes

* Transform `ProductAverageRatingBlock` into a component: `ProductAverageRating`. It's placement is defined by code so it doesn't need to be a block anymore.
* Add **showAverageRating** setting to `ProductPage`. When toggled on, we'll be showing `ProductAverageRating` bellow "Get your price button"

## Justify why they are needed

Requested by Peter