### PR TITLE
GEN-1686 - feat(ProductReviews): set default tab based on product average rating threshold

### DIFF
--- a/apps/store/src/blocks/ProductReviewsBlock.tsx
+++ b/apps/store/src/blocks/ProductReviewsBlock.tsx
@@ -1,7 +1,12 @@
 import { ProductReviews } from '@/components/ProductReviews/ProductReviews'
+import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
-export const ProductReviewsBlock = () => {
-  return <ProductReviews />
+type Props = SbBaseBlockProps<{
+  productAverageRatingThreshold?: number
+}>
+
+export const ProductReviewsBlock = ({ blok }: Props) => {
+  return <ProductReviews productAverageRatingThreshold={blok.productAverageRatingThreshold} />
 }
 
 ProductReviewsBlock.blockName = 'productReviews'

--- a/apps/store/src/components/ProductReviews/ProductReviews.tsx
+++ b/apps/store/src/components/ProductReviews/ProductReviews.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { Button, Space, theme } from 'ui'
 import { MAX_SCORE } from '@/features/memberReviews/memberReviews.constants'
+import type { Rating } from '@/features/memberReviews/memberReviews.types'
+import { useProuctReviewsDataContext } from '@/features/memberReviews/ProductReviewsDataProvider'
 import { TrustpilotWidget } from '@/features/memberReviews/TruspilotWidget'
 import { AverageRating } from './AverageRating'
 import { ReviewsDialog } from './ReviewsDialog'
@@ -9,8 +11,15 @@ import { ReviewsDistributionByScore } from './ReviewsDistributionByScore'
 import { ReviewTabs, TABS } from './ReviewTabs'
 import { useReviews } from './useReviews'
 
-export const ProductReviews = () => {
+type Props = {
+  productAverageRatingThreshold?: number
+}
+
+export const ProductReviews = (props: Props) => {
   const { t } = useTranslation('common')
+
+  const productReviewsData = useProuctReviewsDataContext()
+
   const {
     rating,
     reviews,
@@ -19,7 +28,9 @@ export const ProductReviews = () => {
     setSelectedTab,
     setSelectedScore,
     selectedScore,
-  } = useReviews()
+  } = useReviews(
+    getInitialSelectedTab(productReviewsData?.averageRating, props.productAverageRatingThreshold),
+  )
 
   if (!rating) {
     console.warn('ProductReviews | No rating data available')
@@ -87,3 +98,13 @@ const StyledTrustpilotWidget = styled(TrustpilotWidget)({
   backgroundColor: theme.colors.opaque1,
   borderRadius: theme.radius.md,
 })
+
+const getInitialSelectedTab = (averageRating?: Rating, threshold?: number) => {
+  const defaultTab = TABS.PRODUCT
+
+  if (!averageRating || !threshold) {
+    return defaultTab
+  } else {
+    return averageRating.score >= threshold ? TABS.PRODUCT : TABS.TRUSTPILOT
+  }
+}

--- a/apps/store/src/components/ProductReviews/useReviews.ts
+++ b/apps/store/src/components/ProductReviews/useReviews.ts
@@ -16,16 +16,12 @@ export const useReviews = (initialSelectedTab: Tab = TABS.PRODUCT) => {
   const [selectedScore, setSelectedScore] = useState<Score>(() => {
     const defaultScore: Score = 5
 
-    if (productReviewsData?.reviewsByScore) {
-      const scores: Array<Score> = [5, 4, 3, 2, 1]
-      const initialSelectedScore: Score | undefined = scores.find(
-        (score) => productReviewsData.reviewsByScore[score].reviews.length > 0,
-      )
+    const scores: Array<Score> = [5, 4, 3, 2, 1]
+    const initialSelectedScore = productReviewsData
+      ? scores.find((score) => productReviewsData.reviewsByScore[score].reviews.length)
+      : undefined
 
-      return initialSelectedScore ?? defaultScore
-    }
-
-    return defaultScore
+    return initialSelectedScore ?? defaultScore
   })
   const [selectedTab, setSelectedTab] = useState<Tab>(initialSelectedTab)
 


### PR DESCRIPTION
## Describe your changes

* `useReviews`: refact _initial selected score_ logic. It's simpler now.
* `ProductReviewsBlock`: adds a `productAverageRatingThreshold` setting that's being used for setting initial selected tab.

## Justify why they are needed

Requested by Peter.
