### PR TITLE
GEN-1691 - chore(widget-tracking): added session data to tracking

### DIFF
--- a/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/[priceIntentId]/calculate-price.tsx
+++ b/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/[priceIntentId]/calculate-price.tsx
@@ -25,6 +25,7 @@ type Props = Pick<
 > & {
   priceIntentId: string
   shopSessionId: string
+  partner?: string
 }
 
 type Params = {
@@ -53,6 +54,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
     ])
 
     const compareInsurance = story.content.compareInsurance ?? false
+    const partner = story.content.partner
     const priceTemplate = getPriceTemplate(priceIntent.product.name, compareInsurance)
 
     console.info(`Widget | Calculate Price: ${priceIntent.product.name}/${priceTemplate.name}`)
@@ -62,6 +64,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
       props: {
         priceIntent,
         priceTemplate,
+        partner,
         ...hideChatOnPage(),
         ...translations,
         ...context.params,
@@ -74,16 +77,16 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
   }
 }
 
-const Page = (props: Props) => {
+const Page = ({ partner, ...rest }: Props) => {
   const { t } = useTranslation('widget')
 
   const shopSessionResult = useShopSessionQuery({
-    variables: { shopSessionId: props.shopSessionId },
+    variables: { shopSessionId: rest.shopSessionId },
   })
   const shopSession = shopSessionResult.data?.shopSession
 
   const priceIntentResult = useWidgetPriceIntentQuery({
-    variables: { priceIntentId: props.priceIntentId },
+    variables: { priceIntentId: rest.priceIntentId },
   })
   const priceIntent = priceIntentResult.data?.priceIntent
 
@@ -95,8 +98,8 @@ const Page = (props: Props) => {
       <Head>
         <title>{`Hedvig | ${t('CALCULATE_PRICE_PAGE_TITLE')}`}</title>
       </Head>
-      <TrackingProvider shopSession={shopSession} priceIntent={priceIntent}>
-        <CalculatePricePage {...props} shopSession={shopSession} priceIntent={priceIntent} />
+      <TrackingProvider shopSession={shopSession} priceIntent={priceIntent} partner={partner}>
+        <CalculatePricePage {...rest} shopSession={shopSession} priceIntent={priceIntent} />
       </TrackingProvider>
     </>
   )

--- a/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/select.tsx
+++ b/apps/store/src/pages/widget/run/[flow]/[shopSessionId]/select.tsx
@@ -19,7 +19,7 @@ import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { RoutingLocale } from '@/utils/l10n/types'
 import { PageLink } from '@/utils/PageLink'
 
-type Props = ComponentProps<typeof SelectProductPage>
+type Props = ComponentProps<typeof SelectProductPage> & { partner?: string }
 
 type Params = {
   flow: string
@@ -47,6 +47,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
 
   const searchParams = new URLSearchParams(stringify(context.query))
   const compareInsurance = story.content.compareInsurance ?? false
+  const partner = story.content.partner
 
   if (products.length === 1) {
     const productName = products[0].name
@@ -94,23 +95,24 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
       ...context.params,
       ...hideChatOnPage(),
       products,
+      partner,
       compareInsurance,
       showBackButton: story.content.showBackButton ?? false,
     },
   }
 }
 
-const NextPage = (props: Props) => {
+const NextPage = ({ partner, ...rest }: Props) => {
   const { t } = useTranslation('widget')
-  const { data } = useShopSessionQuery({ variables: { shopSessionId: props.shopSessionId } })
+  const { data } = useShopSessionQuery({ variables: { shopSessionId: rest.shopSessionId } })
 
   return (
     <>
       <Head>
         <title>{`Hedvig | ${t('SELECT_PAGE_TITLE')}`}</title>
       </Head>
-      <TrackingProvider shopSession={data?.shopSession}>
-        <SelectProductPage {...props} />
+      <TrackingProvider shopSession={data?.shopSession} partner={partner}>
+        <SelectProductPage {...rest} />
       </TrackingProvider>
     </>
   )

--- a/apps/store/src/services/Tracking/Tracking.ts
+++ b/apps/store/src/services/Tracking/Tracking.ts
@@ -58,6 +58,7 @@ type TrackingContext = Partial<{
   zipCode: string
   productId: string
   productDisplayName: string
+  partner: string
 }>
 
 // Simple version with 2 destinations (GTM and Datadog) implemented inline
@@ -127,6 +128,7 @@ export class Tracking {
       },
       userData,
       ...this.shopSessionData(),
+      ...this.sessionData(),
     }
     this.logger.log(event, eventData)
     pushToGTMDataLayer({ event, ...eventData })
@@ -242,8 +244,23 @@ export class Tracking {
     }
   }
 
+  static sessionData(context: TrackingContext) {
+    return {
+      sessionData: context.partner
+        ? {
+            channel: 'widget',
+            partner: context.partner,
+          }
+        : { channel: 'store' },
+    }
+  }
+
   private shopSessionData() {
     return Tracking.shopSessionData(this.context)
+  }
+
+  private sessionData() {
+    return Tracking.sessionData(this.context)
   }
 
   public reportInsurelyPrompted() {
@@ -309,6 +326,7 @@ const offerToEcommerceEvent = ({
       ],
     },
     ...Tracking.shopSessionData(context),
+    ...Tracking.sessionData(context),
     price_match: {
       exposure_matched: !!offer.priceMatch,
       price_matched: !!offer.priceMatch && offer.priceMatch.priceReduction.amount > 0,
@@ -336,6 +354,7 @@ const cartToEcommerceEvent = (
       })),
     },
     ...Tracking.shopSessionData(context),
+    ...Tracking.sessionData(context),
   } as const
 }
 
@@ -355,6 +374,7 @@ const productDataToEcommerceEvent = (
       ],
     },
     ...Tracking.shopSessionData(context),
+    ...Tracking.sessionData(context),
   } as const
 }
 

--- a/apps/store/src/services/Tracking/TrackingContext.tsx
+++ b/apps/store/src/services/Tracking/TrackingContext.tsx
@@ -12,6 +12,7 @@ type Props = {
   shopSession?: ShopSession
   priceIntent?: PriceIntent
   productData?: ProductData
+  partner?: string
 }
 
 export const TrackingProvider = (props: Props) => {
@@ -23,6 +24,7 @@ export const TrackingProvider = (props: Props) => {
       ...parseCustomerData(props.shopSession?.customer),
       ...parsePriceIntentData(props.priceIntent?.data ?? {}),
       ...(props.productData && parseProductData(props.productData)),
+      partner: props.partner,
       countryCode,
     }
   }, [
@@ -30,6 +32,7 @@ export const TrackingProvider = (props: Props) => {
     props.shopSession?.customer,
     props.priceIntent?.data,
     props.productData,
+    props.partner,
     countryCode,
   ])
 


### PR DESCRIPTION
## Describe your changes

- Added `sessionData` field which includes information about `channel` and `partner`

```
{ sessionData: { channel: 'store' } | { channel: 'widget', partner: string } }
```

## Justify why they are needed

Requested by Sonny.
