### PR TITLE
GEN-1696 - styles: custom styles for scrollbar. Make appear roughly the same on all browsers.

### DIFF
--- a/apps/store/src/components/ProductReviews/ReviewsDialog.tsx
+++ b/apps/store/src/components/ProductReviews/ReviewsDialog.tsx
@@ -116,13 +116,32 @@ const CloseButton = styled.button({
 })
 
 const DialogWindow = styled(Dialog.Window)({
+  '--scrollbar-thumb-color': theme.colors.gray500,
+  '--scrollbar-thumb-color-hover': theme.colors.gray600,
+  '--scrollbar-track-width': '8px',
+
   paddingInline: theme.space.md,
   paddingBlock: theme.space.xxxl,
   overflowY: 'auto',
-  // Hide scrollbar in Dialog
-  scrollbarWidth: 'none',
-  '&::-webkit-scrollbar': {
-    display: 'none',
+
+  // Scrollbar styles
+  [mq.sm]: {
+    // Firefox
+    scrollbarColor: 'var(--scrollbar-thumb-color)',
+    scrollbarWidth: 'thin',
+
+    // Webkit based browsers
+    '::-webkit-scrollbar': {
+      width: 'var(--scrollbar-track-width)',
+      height: 'var(--scrollbar-track-width)',
+    },
+    '::-webkit-scrollbar-thumb': {
+      borderRadius: '1000px',
+      backgroundColor: 'var(--scrollbar-thumb-color)',
+    },
+    '::-webkit-scrollbar-thumb:hover': {
+      backgroundColor: 'var(--scrollbar-thumb-color-hover)',
+    },
   },
 
   [mq.md]: {


### PR DESCRIPTION
## Describe your changes

Customise scrollbar so they appear roughly the same in all browsers.
Note: CSS specification includes two properties that can be used for that purpose: `scrollbar-width` and `scrollbar-color` but at the time only _Firefox_ implements it. That's why we need declarations for `-webkit` based browsers like _Chrome_ and _Safari_. 

**Chrome**
https://github.com/HedvigInsurance/racoon/assets/19200662/24e4df7e-42ed-4e70-8afe-6b1e5d73c14e

**Safari**
https://github.com/HedvigInsurance/racoon/assets/19200662/69ca0cc0-9cbd-4e24-9d3b-d473668faab4

**Firefox**
https://github.com/HedvigInsurance/racoon/assets/19200662/fd7b75ec-4948-4877-ae9d-2ce42e04ade9

Please, give it a try :)

## Justify why they are needed

We wanted to move away from how PC scrollbar looks like, while customising into something that blends in more naturally in our app.
