### PR TITLE
GEN-1696 - styles(ReviewsDialog): remove frosted overlay

### DIFF
--- a/apps/store/src/components/ProductReviews/ReviewsDialog.tsx
+++ b/apps/store/src/components/ProductReviews/ReviewsDialog.tsx
@@ -43,7 +43,7 @@ export const ReviewsDialog = ({
     <Dialog.Root>
       <Dialog.Trigger asChild={true}>{children}</Dialog.Trigger>
 
-      <DialogContent centerContent={true} frostedOverlay={true}>
+      <DialogContent centerContent={true}>
         <Dialog.Close asChild={true}>
           <CloseButton>
             <CrossIcon size={'1rem'} />
@@ -154,7 +154,7 @@ const DialogContent = styled(Dialog.Content)({
   alignSelf: 'center',
   display: 'flex',
   flexDirection: 'column',
-  width: `min(35.5rem, calc(100% - ${theme.space.md} * 2))`,
+  width: `min(35.5rem, calc(100% - ${theme.space.xs} * 2))`,
   maxHeight: `calc(100% - ${theme.space.md} * 2)`,
   border: `1px solid ${theme.colors.borderTranslucent1}`,
   borderRadius: theme.radius.lg,


### PR DESCRIPTION
## Describe your changes

* Updated `Dialog` overlay `background` color so it looks more like into its frosted counterpart.
* Minor style changes on `ReviewsDialog`

![Screenshot 2024-01-15 at 15 15 48](https://github.com/HedvigInsurance/racoon/assets/19200662/a33d76e9-63f4-4388-8c8a-f0df6a24722c)

## Justify why they are needed

Frosted overlay was causing issues with `Dialog`, at least when used in `ReviewsDialog`. I could find some mentions about [performance issues](https://github.com/tailwindlabs/headlessui/issues/690) involving `backdrop-filter: blur`. Removing frosted overlay from `ReviewsDialog` made it work smoothly so we decide to move forward without it.
