### PR TITLE
GEN-1696 - styles(ReviewsDialog): added reviews disclaimers on different places

### DIFF
--- a/apps/store/public/locales/en/common.json
+++ b/apps/store/public/locales/en/common.json
@@ -30,6 +30,7 @@
   "LANGUAGE_LABEL_en": "English",
   "LANGUAGE_LABEL_no": "Norwegian",
   "LANGUAGE_LABEL_sv": "Swedish",
+  "LATEST_REVIEWS_TRUSTPILOT_LABEL": "Shows the latest reviews for all Hedvig's insurances on Trustpilot.",
   "LATEST_REVIEWS_WITH_COMMENTS_LABEL": "Shows latest reviews with comments",
   "LOGIN_BUTTON_TEXT": "Log in",
   "MONTHLY_PRICE": "{{displayAmount}}/mo.",

--- a/apps/store/public/locales/sv-se/common.json
+++ b/apps/store/public/locales/sv-se/common.json
@@ -27,6 +27,7 @@
   "HOME_PAGE_LINK_LABEL": "Hemsidan",
   "LANGUAGE_LABEL_en": "English",
   "LANGUAGE_LABEL_sv": "Svenska",
+  "LATEST_REVIEWS_TRUSTPILOT_LABEL": "Visar senaste recensioner för alla Hedvigs försäkringar på Trustpilot.",
   "LATEST_REVIEWS_WITH_COMMENTS_LABEL": "Visar senaste recensioner med kommentarer",
   "LOGIN_BUTTON_TEXT": "Logga in",
   "MONTHLY_PRICE": "{{displayAmount}}/mån",

--- a/apps/store/src/components/ProductReviews/ReviewsDialog.tsx
+++ b/apps/store/src/components/ProductReviews/ReviewsDialog.tsx
@@ -70,15 +70,29 @@ export const ReviewsDialog = ({
                 />
               )}
 
+              {selectedTab === TABS.TRUSTPILOT && (
+                <LatestReviewsTrustpilotLabel
+                  size="xs"
+                  color="textSecondary"
+                  align="center"
+                  balance={true}
+                >
+                  {t('LATEST_REVIEWS_TRUSTPILOT_LABEL')}
+                </LatestReviewsTrustpilotLabel>
+              )}
+
               {reviews.length > 0 ? (
-                <Reviews y={{ base: 0.5, md: 1 }}>
+                <Space y={{ base: 0.5, md: 1 }}>
                   {reviews.map((review) => (
                     <Review key={review.id} {...review} />
                   ))}
-                  <LatestReviewsWithCommentsLabel align="center" color="textSecondary">
-                    {t('LATEST_REVIEWS_WITH_COMMENTS_LABEL')}
-                  </LatestReviewsWithCommentsLabel>
-                </Reviews>
+
+                  {selectedTab === TABS.PRODUCT && (
+                    <LatestReviewsWithCommentsLabel size="xs" align="center" color="textSecondary">
+                      {t('LATEST_REVIEWS_WITH_COMMENTS_LABEL')}
+                    </LatestReviewsWithCommentsLabel>
+                  )}
+                </Space>
               ) : (
                 <NoReviewsLabel align="center" color="textSecondary">
                   {t('NO_REVIEWS_LABEL')}
@@ -168,31 +182,19 @@ const DialogContent = styled(Dialog.Content)({
   },
 })
 
-const Reviews = styled(Space)({
-  marginBottom: `-${theme.space.xxxl}`,
-})
-
 const Review = styled(ReviewComment)({
   width: '100%',
-
-  ':last-of-type': {
-    marginBottom: theme.space.md,
-  },
-
-  [mq.md]: {
-    ':last-of-type': {
-      marginBottom: theme.space.xxl,
-    },
-  },
 })
 
 const LatestReviewsWithCommentsLabel = styled(Text)({
-  marginBottom: theme.space.md,
-  padding: theme.space.md,
+  paddingTop: theme.space.md,
+  paddingInline: theme.space.md,
+})
 
-  [mq.md]: {
-    marginBottom: theme.space.xl,
-  },
+const LatestReviewsTrustpilotLabel = styled(Text)({
+  paddingTop: theme.space.lg,
+  paddingBottom: theme.space.sm,
+  paddingInline: theme.space.md,
 })
 
 const NoReviewsLabel = styled(Text)({


### PR DESCRIPTION
## Describe your changes

* Added a disclaimer copy about _Trustpilot_ reviews. It should be shown on top when _Trustpilot_ tab is active.
* Reduce font size of "Shows latest reviews with comments" text shown after last review - only when _Product_ tab is active.

**Trustpilot**

![Screenshot 2024-01-15 at 17 08 18](https://github.com/HedvigInsurance/racoon/assets/19200662/4af41d6d-1d18-4123-97e1-f9d20b26e9f1)

---

**Product**

![Screenshot 2024-01-15 at 17 08 32](https://github.com/HedvigInsurance/racoon/assets/19200662/c891d6d9-1daa-47c3-a1ab-926b50985f0f)

## Justify why they are needed

Design changes requested by Peter.