### PR TITLE
GEN-1696 - styles(ProductReviews): fix tab content height (avoiding layout shift between tabs)

### DIFF
--- a/apps/store/src/components/ProductReviews/ProductReviews.tsx
+++ b/apps/store/src/components/ProductReviews/ProductReviews.tsx
@@ -55,11 +55,11 @@ export const ProductReviews = (props: Props) => {
         <ReviewTabs selectedTab={selectedTab} onTabChange={setSelectedTab} />
 
         {selectedTab === TABS.PRODUCT && (
-          <div>
+          <DistributionByScoreWrapper>
             {reviewsDistribution.map(([score, percentage]) => (
               <ReviewsDistributionByScore key={score} score={score} percentage={percentage} />
             ))}
-          </div>
+          </DistributionByScoreWrapper>
         )}
         {selectedTab === TABS.TRUSTPILOT && (
           <StyledTrustpilotWidget variant="mini" data-style-height="112px" />
@@ -82,16 +82,23 @@ export const ProductReviews = (props: Props) => {
   )
 }
 
+const TAB_CONTENT_HEIGHT = '17.18rem' // 275px
+
 const Wrapper = styled(Space)({
   width: 'min(30.5rem, 100%)',
   marginInline: 'auto',
   paddingInline: theme.space.md,
 })
 
+const DistributionByScoreWrapper = styled.div({
+  height: TAB_CONTENT_HEIGHT,
+})
+
 const StyledTrustpilotWidget = styled(TrustpilotWidget)({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
+  height: TAB_CONTENT_HEIGHT,
   padding: theme.space.lg,
   // Optical alignment so widget gets horizontally centered
   paddingLeft: '2.5rem',


### PR DESCRIPTION
## Describe your changes

* Set hight for `ProductReviews` tab content.
 
https://github.com/HedvigInsurance/racoon/assets/19200662/5bbec2b8-4454-4a81-a0e1-da6ed36f205f

## Justify why they are needed

The idea behind it is to avoid layout shifts between tabs. Observe "View Reviews" button.
