### PR TITLE
GEN-1696 - refact(ProductReviewsBlock): get default tab as a CMS setting

### DIFF
--- a/apps/store/src/blocks/ProductReviewsBlock.tsx
+++ b/apps/store/src/blocks/ProductReviewsBlock.tsx
@@ -1,12 +1,11 @@
+import { type ComponentProps } from 'react'
 import { ProductReviews } from '@/components/ProductReviews/ProductReviews'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
-type Props = SbBaseBlockProps<{
-  productAverageRatingThreshold?: number
-}>
+type Props = SbBaseBlockProps<ComponentProps<typeof ProductReviews>>
 
 export const ProductReviewsBlock = ({ blok }: Props) => {
-  return <ProductReviews productAverageRatingThreshold={blok.productAverageRatingThreshold} />
+  return <ProductReviews {...blok} />
 }
 
 ProductReviewsBlock.blockName = 'productReviews'

--- a/apps/store/src/components/ProductReviews/ProductReviews.tsx
+++ b/apps/store/src/components/ProductReviews/ProductReviews.tsx
@@ -2,23 +2,19 @@ import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { Button, Space, theme } from 'ui'
 import { MAX_SCORE } from '@/features/memberReviews/memberReviews.constants'
-import type { Rating } from '@/features/memberReviews/memberReviews.types'
-import { useProuctReviewsDataContext } from '@/features/memberReviews/ProductReviewsDataProvider'
 import { TrustpilotWidget } from '@/features/memberReviews/TruspilotWidget'
 import { AverageRating } from './AverageRating'
 import { ReviewsDialog } from './ReviewsDialog'
 import { ReviewsDistributionByScore } from './ReviewsDistributionByScore'
-import { ReviewTabs, TABS } from './ReviewTabs'
+import { ReviewTabs, TABS, type Tab } from './ReviewTabs'
 import { useReviews } from './useReviews'
 
 type Props = {
-  productAverageRatingThreshold?: number
+  defaultActiveTab?: Tab
 }
 
 export const ProductReviews = (props: Props) => {
   const { t } = useTranslation('common')
-
-  const productReviewsData = useProuctReviewsDataContext()
 
   const {
     rating,
@@ -28,9 +24,7 @@ export const ProductReviews = (props: Props) => {
     setSelectedTab,
     setSelectedScore,
     selectedScore,
-  } = useReviews(
-    getInitialSelectedTab(productReviewsData?.averageRating, props.productAverageRatingThreshold),
-  )
+  } = useReviews(getInitialSelectedTab(props.defaultActiveTab))
 
   if (!rating) {
     console.warn('ProductReviews | No rating data available')
@@ -106,12 +100,14 @@ const StyledTrustpilotWidget = styled(TrustpilotWidget)({
   borderRadius: theme.radius.md,
 })
 
-const getInitialSelectedTab = (averageRating?: Rating, threshold?: number) => {
-  const defaultTab = TABS.PRODUCT
+const getInitialSelectedTab = (defaultActiveTab?: Tab) => {
+  if (!defaultActiveTab) return TABS.PRODUCT
 
-  if (!averageRating || !threshold) {
-    return defaultTab
+  const isValidTab = Object.values(TABS).includes(defaultActiveTab)
+  if (isValidTab) {
+    return defaultActiveTab
   } else {
-    return averageRating.score >= threshold ? TABS.PRODUCT : TABS.TRUSTPILOT
+    console.warn(`ProductReviews | Invalid default tab ${defaultActiveTab}. Defaulting to product`)
+    return TABS.PRODUCT
   }
 }


### PR DESCRIPTION
## Describe your changes

* Added a _Default Active Tab_ setting for `ProductReviews`. Deprecated setting - _Product Average Rating Threshold_ - will be removed after this get's merged.

https://github.com/HedvigInsurance/racoon/assets/19200662/fe4402dd-b3ef-4170-9b78-8aaf2f5cc311

## Justify why they are needed

The idea is to replace the _Product Average Rating Threshold_ setting for a simpler one.