### PR TITLE
GEN-1696 - feat(ProductAverageRating): support average rating source

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -5,7 +5,10 @@ import { useState, useEffect, useRef, ReactNode } from 'react'
 import { theme, mq } from 'ui'
 import { GridLayout, MAX_WIDTH } from '@/components/GridLayout/GridLayout'
 import { HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header'
-import { PurchaseForm } from '@/components/ProductPage/PurchaseForm/PurchaseForm'
+import {
+  PurchaseForm,
+  type PurchaseFormProps,
+} from '@/components/ProductPage/PurchaseForm/PurchaseForm'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { zIndexes } from '@/utils/zIndex'
 
@@ -14,14 +17,15 @@ const SCROLL_PERCENTAGE_THRESHOLD = 10 // 10%
 
 export type PageSection = 'overview' | 'coverage'
 
-export type ProductPageBlockProps = SbBaseBlockProps<{
-  overviewLabel: string
-  coverageLabel: string
-  overview: Array<SbBlokData>
-  coverage: Array<SbBlokData>
-  body: Array<SbBlokData>
-  showAverageRating: boolean
-}>
+export type ProductPageBlockProps = SbBaseBlockProps<
+  {
+    overviewLabel: string
+    coverageLabel: string
+    overview: Array<SbBlokData>
+    coverage: Array<SbBlokData>
+    body: Array<SbBlokData>
+  } & Pick<PurchaseFormProps, 'showAverageRating' | 'averageRatingSource'>
+>
 
 export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
   const [activeSection, setActiveSection] = useState<PageSection>('overview')
@@ -60,7 +64,10 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
       <Grid>
         <GridLayout.Content width="1/2" align="right">
           <PurchaseFormWrapper>
-            <PurchaseForm showAverageRating={blok.showAverageRating} />
+            <PurchaseForm
+              showAverageRating={blok.showAverageRating}
+              averageRatingSource={blok.averageRatingSource}
+            />
           </PurchaseFormWrapper>
         </GridLayout.Content>
 

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -21,7 +21,10 @@ import {
   useIsPriceCalculatorExpanded,
   useOpenPriceCalculatorQueryParam,
 } from '@/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam'
-import { ProductAverageRating } from '@/components/ProductReviews/ProductAverageRating'
+import {
+  ProductAverageRating,
+  type AverageRatingSource,
+} from '@/components/ProductReviews/ProductAverageRating'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { BankSigneringEvent } from '@/services/bankSignering'
 import {
@@ -44,11 +47,12 @@ import { ProductHero } from './ProductHero/ProductHero'
 import { usePurchaseFormState } from './usePurchaseFormState'
 import { useSelectedOffer } from './useSelectedOffer'
 
-type Props = {
+export type PurchaseFormProps = {
   showAverageRating?: boolean
+  averageRatingSource?: AverageRatingSource
 }
 
-export const PurchaseForm = (props: Props) => {
+export const PurchaseForm = (props: PurchaseFormProps) => {
   const { t } = useTranslation('purchase-form')
   const { priceTemplate } = useProductPageContext()
   const productData = useProductData()
@@ -244,7 +248,13 @@ export const PurchaseForm = (props: Props) => {
           )
         }
 
-        return <IdleState onClick={handleOpen} showAverageRating={props.showAverageRating} />
+        return (
+          <IdleState
+            onClick={handleOpen}
+            showAverageRating={props.showAverageRating}
+            averageRatingSource={props.averageRatingSource}
+          />
+        )
       }}
     </Layout>
   )
@@ -294,9 +304,12 @@ const ProductHeroContainer = (props: ProductHeroContainerProps) => {
   )
 }
 
-type IdleStateProps = { onClick: () => void } & Pick<Props, 'showAverageRating'>
+type IdleStateProps = { onClick: () => void } & Pick<
+  PurchaseFormProps,
+  'showAverageRating' | 'averageRatingSource'
+>
 
-const IdleState = ({ onClick, showAverageRating }: IdleStateProps) => {
+const IdleState = ({ onClick, showAverageRating, averageRatingSource }: IdleStateProps) => {
   const ref = useRef<HTMLDivElement>(null)
   const { t } = useTranslation('purchase-form')
 
@@ -306,7 +319,9 @@ const IdleState = ({ onClick, showAverageRating }: IdleStateProps) => {
         <ProductHeroContainer size="large">
           <Space y={1}>
             <Button onClick={onClick}>{t('OPEN_PRICE_CALCULATOR_BUTTON')}</Button>
-            {showAverageRating && <ProductAverageRating />}
+            {showAverageRating && (
+              <ProductAverageRating averageRatingSource={averageRatingSource} />
+            )}
           </Space>
         </ProductHeroContainer>
       </div>


### PR DESCRIPTION
## Describe your changes

* Update `ProductPage` block so it supports different sources for the average rating to be shown: product or trustpilot.

https://github.com/HedvigInsurance/racoon/assets/19200662/bfa480d1-a35c-4829-b10d-0dd80e7a555e

## Justify why they are needed

Peter want to be able to configure which average rate - product or trustpilot - that should be render. Despite of that, we always generate structured data about product average rating.