### PR TITLE
GEN-1690 / Add WarningPromt to be used inside PurchaseForm

### DIFF
--- a/apps/store/src/components/PriceCalculator/WarningPrompt/WarningPrompt.stories.tsx
+++ b/apps/store/src/components/PriceCalculator/WarningPrompt/WarningPrompt.stories.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled'
+import type { Meta, StoryObj } from '@storybook/react'
+import { theme } from 'ui'
+import { WarningPrompt } from './WarningPrompt'
+
+const meta: Meta<typeof WarningPrompt> = {
+  title: 'Purchase Form / WarningPrompt',
+  component: WarningPrompt,
+}
+
+export default meta
+type Story = StoryObj<typeof WarningPrompt>
+
+export const Default: Story = {
+  args: {
+    heading: 'Du står inte som ägare',
+    message:
+      'För att kunna teckna en försäkring för ABH234 behöver du stå som registrerad ägare för bilen inom 8 dagar',
+  },
+  render: (args) => (
+    <DialogWindow>
+      <WarningPrompt {...args} />
+    </DialogWindow>
+  ),
+}
+
+const DialogWindow = styled.div({
+  width: '100%',
+  maxWidth: '24rem',
+  borderRadius: theme.radius.sm,
+  boxShadow: '0 0 0.5rem rgba(0, 0, 0, 0.25)',
+  backgroundColor: theme.colors.white,
+})

--- a/apps/store/src/components/PriceCalculator/WarningPrompt/WarningPrompt.tsx
+++ b/apps/store/src/components/PriceCalculator/WarningPrompt/WarningPrompt.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
+import { Button, InfoIcon, Space, Text, theme } from 'ui'
+import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
+
+type Props = {
+  heading?: string
+  message?: string
+}
+
+export const WarningPrompt = ({ heading, message }: Props) => {
+  const { t } = useTranslation('purchase-form')
+
+  return (
+    <Wrapper>
+      <Space y={1.5}>
+        <SpaceFlex space={1} direction="vertical" align="center">
+          <InfoIcon size="1.5rem" color={theme.colors.signalBlueElement} />
+          <div>
+            <Text>{heading}</Text>
+            <Text color="textSecondary">{message}</Text>
+          </div>
+        </SpaceFlex>
+
+        <Space y={0.25}>
+          <Button>{t('PRICE_INTENT_WARNING_ACCEPT_BUTTON_LABEL')}</Button>
+          <Button variant="ghost">{t('PRICE_INTENT_WARNING_EDIT_BUTTON_LABEL')}</Button>
+        </Space>
+      </Space>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div({
+  paddingBlock: `${theme.space.xl} ${theme.space.md}`,
+  paddingInline: theme.space.md,
+  textAlign: 'center',
+})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Add new WarningPrompt that we can use in PurchaseForm to display warnings from a PriceIntent

<img width="806" alt="Screenshot 2024-01-16 at 15 46 47" src="https://github.com/HedvigInsurance/racoon/assets/6661511/7cbcbed8-e487-4ea7-a910-f6a5dc0f5258">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
To be able to display decomisioned/not owner of car warning 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
