### PR TITLE
GEN-1715 - fix(ProductCardBlock): hydration errors on landing page (se-en)

### DIFF
--- a/apps/store/src/components/LayoutWithMenu/ProductMetadataContext.tsx
+++ b/apps/store/src/components/LayoutWithMenu/ProductMetadataContext.tsx
@@ -1,14 +1,25 @@
 import { atom, useAtomValue } from 'jotai'
-import { useHydrateAtoms } from 'jotai/utils'
+import { atomFamily, useHydrateAtoms } from 'jotai/utils'
 import { globalStore } from '@/utils/globalStore'
-import { GlobalProductMetadata } from './fetchProductMetadata'
+import { type RoutingLocale } from '@/utils/l10n/types'
+import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { type GlobalProductMetadata } from './fetchProductMetadata'
 
-const productsAtom = atom<GlobalProductMetadata | null>(null)
+// We don't actually neeed _routineLocale for the atom creation. It will be used
+// to create a new atom for each locale by default.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const productsMetadataAtom = atomFamily((_routingLocale: RoutingLocale) =>
+  atom<GlobalProductMetadata | null>(null),
+)
 
 export const useProductMetadata = () => {
-  return useAtomValue(productsAtom, { store: globalStore })
+  const { routingLocale } = useCurrentLocale()
+
+  return useAtomValue(productsMetadataAtom(routingLocale), { store: globalStore })
 }
 
 export const useHydrateProductMetadata = (metadata: GlobalProductMetadata) => {
-  useHydrateAtoms([[productsAtom, metadata]], { store: globalStore })
+  const { routingLocale } = useCurrentLocale()
+
+  useHydrateAtoms([[productsMetadataAtom(routingLocale), metadata]], { store: globalStore })
 }


### PR DESCRIPTION
## Describe your changes

* Make sure we hydrate   _product metadata atom_ during build/SSR, avoiding wrong HTML being generated as a result of the wrong data being stored in _product metadata atom_.

## Justify why they are needed

**Context**

I've noticed some hydration errors involving `ProductCardBlock` and the English version of the landing page (`se-en`).

https://github.com/HedvigInsurance/racoon/assets/19200662/cbb9ebb9-016a-4c3d-9c1d-e21381aed5fc

The reason we get hydration errors here is because, on the server, we end up entering in an `if` statement that avoids rendering `ProductCardBlock` while linking into a story that doesn't belong to a product or a product category.

<img width="933" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/8906f5c6-c6fe-471c-b8e7-d9510533fe7f">

**The reason why that happens is because the `productMetada` used for `getLinkType` function holds the swedish product metadata, despite the fact we're loading the english version.** As a result, we get the wrong HTML:

<img width="760" alt="Screenshot 2024-01-22 at 17 36 44" src="https://github.com/HedvigInsurance/racoon/assets/19200662/4d3f34c3-c614-4ce8-a840-f692f1f01094">

What's interesting tho is that the correct data is being sent from the server to the client:

<img width="760" alt="Screenshot 2024-01-22 at 17 40 38" src="https://github.com/HedvigInsurance/racoon/assets/19200662/a32de452-dc0a-4cf4-ac86-337964bd1c65">

Which results in a different page while hydrating the app and then causes the warnings 😢 

We've added the `globalStore` [here](https://github.com/HedvigInsurance/racoon/pull/3687) as a fix for an issue where product metadata was not accessible on product pages. The side effect tho is that the same `globalStore` is used for all locales. By default, atoms are hydrated only once per store so if, during the building process, swedish pages are generated first, the swedish version of product metadata will be used while generating pages in english.

**The solution**

I could think on 2 solutions:

1. Having a global store per routing locale. This one is more explicit but evolves having a bunch stores. Doesn't look like future proof while thinking on adding new locales.
2. Hydrating product metadata atom more then once while on the server; Doesn't include multiple stores but it's more implicit.

What do you guys think?

