### PR TITLE
GEN-1692 / Go back to previous step to edit reg nr when clicking edit in warning dialog

### DIFF
--- a/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
@@ -86,6 +86,25 @@ export const PriceCalculator = (props: Props) => {
     },
   })
 
+  const goBackToPreviousSection = () => {
+    setActiveSectionId((currentSectionId) => {
+      const currentSectionIndex = form.sections.findIndex(({ id }) => id === currentSectionId)
+
+      const prevSection = form.sections[currentSectionIndex - 1]
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (prevSection) {
+        return prevSection.id
+      } else {
+        datadogLogs.logger.error('Failed to find previous section', {
+          currentSectionId,
+          templateName: priceTemplate.name,
+          priceIntentId: priceIntent.id,
+        })
+        return currentSectionId
+      }
+    })
+  }
+
   return (
     <>
       <PriceCalculatorAccordion
@@ -120,7 +139,12 @@ export const PriceCalculator = (props: Props) => {
         )}
       </PriceCalculatorAccordion>
 
-      {priceIntent.warning && <Warning priceIntentWarning={priceIntent.warning} />}
+      {priceIntent.warning && (
+        <Warning
+          priceIntentWarning={priceIntent.warning}
+          goBackToPreviousSection={goBackToPreviousSection}
+        />
+      )}
 
       <FetchInsuranceContainer priceIntent={priceIntent}>
         {({ externalInsurer, insurely }) => (

--- a/apps/store/src/components/PriceCalculator/Warning/Warning.tsx
+++ b/apps/store/src/components/PriceCalculator/Warning/Warning.tsx
@@ -7,22 +7,32 @@ import { WarningPrompt } from './WarningPrompt/WarningPrompt'
 
 type Props = {
   priceIntentWarning: PriceIntentWarning
+  goBackToPreviousSection: () => void
 }
 
-export const Warning = ({ priceIntentWarning }: Props) => {
+export const Warning = ({ priceIntentWarning, goBackToPreviousSection }: Props) => {
   const [open, setOpen] = useState(true)
 
   const handleClickConfirm = () => {
     setOpen(false)
   }
 
+  const handleEditPriceIntent = () => {
+    setOpen(false)
+    goBackToPreviousSection()
+  }
+
   if (!Features.enabled('PRICE_INTENT_WARNING')) return null
 
   return (
     <DialogRoot open={open}>
-      <DialogContent centerContent={true}>
+      <DialogContent centerContent={true} onClose={handleClickConfirm}>
         <DialogWindow>
-          <WarningPrompt {...priceIntentWarning} onClickConfirm={handleClickConfirm} />
+          <WarningPrompt
+            {...priceIntentWarning}
+            onClickConfirm={handleClickConfirm}
+            onClickEdit={handleEditPriceIntent}
+          />
         </DialogWindow>
       </DialogContent>
     </DialogRoot>

--- a/apps/store/src/components/PriceCalculator/Warning/WarningPrompt/WarningPrompt.tsx
+++ b/apps/store/src/components/PriceCalculator/Warning/WarningPrompt/WarningPrompt.tsx
@@ -6,9 +6,10 @@ import { PriceIntentWarning } from '@/services/graphql/generated'
 
 type Props = {
   onClickConfirm: () => void
+  onClickEdit: () => void
 } & PriceIntentWarning
 
-export const WarningPrompt = ({ header, message, onClickConfirm }: Props) => {
+export const WarningPrompt = ({ header, message, onClickConfirm, onClickEdit }: Props) => {
   const { t } = useTranslation('purchase-form')
 
   return (
@@ -26,7 +27,7 @@ export const WarningPrompt = ({ header, message, onClickConfirm }: Props) => {
 
         <Space y={0.25}>
           <Button onClick={onClickConfirm}>{t('PRICE_INTENT_WARNING_ACCEPT_BUTTON_LABEL')}</Button>
-          <Button onClick={onClickConfirm} variant="ghost">
+          <Button onClick={onClickEdit} variant="ghost">
             {t('PRICE_INTENT_WARNING_EDIT_BUTTON_LABEL')}
           </Button>
         </Space>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
When clicking "Edit" button, the logic is that you will go back to the previous step in the price form where you can edit reg number.

It made more sense to go back rather then block continuing to the next step since the happy path is smoother that way when you click "I understand".

https://github.com/HedvigInsurance/racoon/assets/6661511/e58b7f88-f70a-4f7b-bbdb-1197debc927d

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
User shoulkd be able to go back and edit reg number

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
