### PR TITLE
GEN-1703 / Update what tags we render for text elements

### DIFF
--- a/apps/store/src/blocks/USPBlock.tsx
+++ b/apps/store/src/blocks/USPBlock.tsx
@@ -46,7 +46,7 @@ type USPItemBlockProps = SbBaseBlockProps<{
 export const USPBlockItem = ({ blok, numberOfItems }: USPItemBlockProps) => {
   return (
     <ListItem numberOfItems={numberOfItems}>
-      <Badge>{blok.title}</Badge>
+      <Badge as="h3">{blok.title}</Badge>
       <Text size={{ _: 'xl' }}>{blok.content}</Text>
     </ListItem>
   )

--- a/apps/store/src/components/ProductPage/ProductDocuments.tsx
+++ b/apps/store/src/components/ProductPage/ProductDocuments.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { mq, Space, Text, theme } from 'ui'
+import { Heading, mq, Space, Text, theme } from 'ui'
 import { GridLayout, TEXT_CONTENT_MAX_WIDTH } from '@/components/GridLayout/GridLayout'
 import { InsuranceDocumentLink } from '@/components/InsuranceDocumentLink'
 import { InsuranceDocumentFragment } from '@/services/graphql/generated'
@@ -15,7 +15,9 @@ export const ProductDocuments = ({ heading, description, docs }: Props) => {
     <Layout>
       <GridLayout.Content width="1/2" align="left">
         <Content>
-          <Text size={{ _: 'xl', lg: 'xxl' }}>{heading}</Text>
+          <Heading as="h2" variant={{ _: 'standard.24', lg: 'standard.32' }}>
+            {heading}
+          </Heading>
           <Text size={{ _: 'xl', lg: 'xxl' }} color="textSecondary">
             {description}
           </Text>

--- a/packages/ui/src/components/Text/Text.tsx
+++ b/packages/ui/src/components/Text/Text.tsx
@@ -56,7 +56,7 @@ export const TextBase = styled(
   ...(strikethrough && { textDecorationLine: 'line-through' }),
 }))
 
-export const Text = ({ as, balance, children, className, ...rest }: TextProps) => (
+export const Text = ({ as = 'p', balance, children, className, ...rest }: TextProps) => (
   <TextBase as={as} className={className} {...rest}>
     {!balance ? children : <Balancer>{children}</Balancer>}
   </TextBase>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Set `<p>` as default element to render for `Text` component (default was a div before)
- Update some heading levels in different blocks
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Request by Peter, improve markup semantics
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
