### PR TITLE
Prevent going to the next step in PriceCalculator when showing warning

### DIFF
--- a/apps/store/src/components/PriceCalculator/Warning/Warning.tsx
+++ b/apps/store/src/components/PriceCalculator/Warning/Warning.tsx
@@ -8,19 +8,19 @@ import { WarningPrompt } from './WarningPrompt/WarningPrompt'
 
 type Props = {
   priceIntentWarning: PriceIntentWarning
-  goBackToPreviousSection: () => void
+  onConfirm: () => void
 }
 
-export const Warning = ({ priceIntentWarning, goBackToPreviousSection }: Props) => {
+export const Warning = ({ priceIntentWarning, onConfirm }: Props) => {
   const [isOpen, setIsOpen] = useAtom(showPriceIntentWarningAtom)
 
   const handleClickConfirm = () => {
     setIsOpen(false)
+    onConfirm()
   }
 
   const handleEditPriceIntent = () => {
     setIsOpen(false)
-    goBackToPreviousSection()
   }
 
   if (!Features.enabled('PRICE_INTENT_WARNING')) return null


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Prevent going to the next form section when showing the warning dialog. Add a click handler for going to next section when clicking "I understand". This fixes the bug where you sometimes couldn't close the the dialog because we set autofocus on the on the next form section, as reported from the test session.

- Remove `goBackToPreviousSection` since we will default to not proceeding when showing the warning dialog
- Add `goToNextSection` and pass it to `Warning` 

### Before
https://github.com/HedvigInsurance/racoon/assets/6661511/e03adf4d-1483-47bf-883e-be2b9e226bf5

### After
https://github.com/HedvigInsurance/racoon/assets/6661511/a106f5a9-c09d-4be4-bce9-6d75b9de7f11


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Fix the bug reported from test session https://www.notion.so/hedviginsurance/On-mobile-when-getting-prompted-the-I-understand-I-can-t-click-I-understand-45e7989afa4344e09e0ecf0775b6249f

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
