### PR TITLE
Render Accordion trigger text as span

### DIFF
--- a/apps/store/src/blocks/AccordionItemBlock.tsx
+++ b/apps/store/src/blocks/AccordionItemBlock.tsx
@@ -19,7 +19,9 @@ export const AccordionItemBlock = ({ blok, openItem }: AccordionItemBlockProps) 
   return (
     <Accordion.Item value={value} {...storyblokEditable(blok)}>
       <Accordion.HeaderWithTrigger>
-        <Text size={{ _: 'md', md: 'lg' }}>{blok.title}</Text>
+        <Text as="span" size={{ _: 'md', md: 'lg' }}>
+          {blok.title}
+        </Text>
       </Accordion.HeaderWithTrigger>
       <Accordion.Content open={openItem === value} asChild={true}>
         <RichText>{content}</RichText>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Render Accordion trigger text as span instead of p
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Shouldn't nest a p tag inside a heading

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
