### PR TITLE
GEN-1764 - fix(renderRichText): avoid hydration errors for rich text's text style markers

### DIFF
--- a/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
+++ b/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
@@ -2,7 +2,12 @@ import styled from '@emotion/styled'
 import { type ISbRichtext, storyblokEditable } from '@storyblok/react'
 import Link from 'next/link'
 import { useMemo, type ReactNode } from 'react'
-import { render, type RenderOptions, MARK_LINK } from 'storyblok-rich-text-react-renderer'
+import {
+  render,
+  type RenderOptions,
+  MARK_LINK,
+  MARK_TEXT_STYLE,
+} from 'storyblok-rich-text-react-renderer'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { RichText } from '@/components/RichText/RichText'
 import { type GridColumnsField, type SbBaseBlockProps } from '@/services/storyblok/storyblok'
@@ -77,6 +82,12 @@ const RENDER_OPTIONS: RenderOptions = {
 
       // Internal links
       return <Link {...linkProps} />
+    },
+    [MARK_TEXT_STYLE]: (children, { color }) => {
+      // Avoids hydration errors when 'color' is not valid: nullish or empty string
+      const props = color ? { style: { color } } : {}
+
+      return <span {...props}>{children}</span>
     },
   },
 }


### PR DESCRIPTION
## Describe your changes

* Update `renderRichText` function setting so it avoids hydration errors while rendering rich text's text style markers.

## Justify why they are needed

More info on this slack [thread](https://hedviginsurance.slack.com/archives/C041SD67G82/p1706628411035529?thread_ts=1706619155.314889&cid=C041SD67G82)
