### PR TITLE
GEN-1739 - chore(csp): allow linkedin (tracking) for sript-src

### DIFF
--- a/apps/store/next-csp.config.js
+++ b/apps/store/next-csp.config.js
@@ -11,6 +11,7 @@ const gtmInjectedOrigins = [
   'https://*.googleadservices.com',
   'https://*.google-analytics.com',
   'https://ion.hedvig.com',
+  'https://px.ads.linkedin.com',
 ]
 
 const adyenOrigins = [
@@ -95,8 +96,6 @@ const imgSrc = [
   'https://vercel.live',
   // Server-side Google Tag Manager
   'https://sgtm.hedvig.com',
-  // Linkedin
-  'https://px.ads.linkedin.com',
 
   ...adyenOrigins,
   ...gtmInjectedOrigins,


### PR DESCRIPTION
## Describe your changes

- Allow linkedin in our `script-src` CSP config

## Justify why they are needed

Cleanup [CSP violations](https://app.datadoghq.eu/dashboard/tft-qsw-5iu/vercel-hedvig-com?fullscreen_end_ts=1706696251347&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1706091451347&fullscreen_widget=1271882006666618&refresh_mode=sliding&view=spans&from_ts=1706694450075&to_ts=1706695350075&live=true)
