### PR TITLE
Simplify locale usage with useRoutingLocale() hook

### DIFF
--- a/apps/store/src/blocks/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock.tsx
@@ -36,7 +36,7 @@ import {
   filterByBlockType,
   getLinkFieldURL,
 } from '@/services/storyblok/Storyblok.helpers'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { ButtonBlockProps } from './ButtonBlock'
 
@@ -112,7 +112,7 @@ type ProductNavContainerBlockProps = SbBaseBlockProps<{
 type ProductNavItem = { name: string; url: string; image?: string; label?: string }
 
 export const ProductNavContainerBlock = ({ blok }: ProductNavContainerBlockProps) => {
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const { t } = useTranslation()
   const productMetadata = useProductMetadata()
   const filteredNavItems = filterByBlockType(blok.navItems, NavItemBlock.blockName)
@@ -158,7 +158,7 @@ export const ProductNavContainerBlock = ({ blok }: ProductNavContainerBlockProps
           </ProductNavigationList>
         </NavigationMenuPrimitive.Sub>
         <ButtonNextLinkFullWidth
-          href={PageLink.store({ locale: routingLocale })}
+          href={PageLink.store({ locale })}
           variant="secondary"
           size="medium"
         >
@@ -176,9 +176,7 @@ export const ProductNavContainerBlock = ({ blok }: ProductNavContainerBlockProps
         <NavigationMenuPrimitiveItem value={blok.name} {...storyblokEditable(blok)}>
           <Space y={{ base: 1.5, lg: 0 }}>
             <DesktopOnly>
-              <NavigationTrigger href={PageLink.store({ locale: routingLocale })}>
-                {blok.name}
-              </NavigationTrigger>
+              <NavigationTrigger href={PageLink.store({ locale })}>{blok.name}</NavigationTrigger>
             </DesktopOnly>
             <NavigationMenuPrimitiveContent>{content}</NavigationMenuPrimitiveContent>
           </Space>

--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -19,7 +19,7 @@ import { TotalAmountContainer } from '@/components/ShopBreakdown/TotalAmountCont
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { useTracking } from '@/services/Tracking/useTracking'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { QueryParam } from './CartPage.constants'
 import { PageDebugDialog } from './PageDebugDialog'
@@ -159,7 +159,7 @@ type EmptyStateProps = { shopSession: ShopSession; children: ReactNode }
 
 const EmptyState = (props: EmptyStateProps) => {
   const { t } = useTranslation('cart')
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
 
   return (
     <PageWrapper>
@@ -175,7 +175,7 @@ const EmptyState = (props: EmptyStateProps) => {
                       {t('CART_EMPTY_SUMMARY')}
                     </Text>
                   </Space>
-                  <ButtonNextLink href={PageLink.store({ locale: routingLocale })}>
+                  <ButtonNextLink href={PageLink.store({ locale })}>
                     {t('GO_TO_STORE_BUTTON')}
                   </ButtonNextLink>
                 </Space>

--- a/apps/store/src/components/CartPage/PageDebugDialog.tsx
+++ b/apps/store/src/components/CartPage/PageDebugDialog.tsx
@@ -7,7 +7,7 @@ import { DebugDialog } from '@/components/DebugDialog/DebugDialog'
 import { DebugShopSessionSection } from '@/components/DebugDialog/DebugShopSessionSection'
 import { DebugTextKeys } from '@/components/DebugDialog/DebugTextKeys'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 
 export const PageDebugDialog = () => {
@@ -25,31 +25,31 @@ export const PageDebugDialog = () => {
 
 const LinkToCartSection = () => {
   const { shopSession } = useShopSession()
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const cartLink = useMemo(() => {
     if (!shopSession) return null
 
     return PageLink.session({
-      locale: routingLocale,
+      locale,
       shopSessionId: shopSession.id,
-      next: PageLink.cart({ locale: routingLocale }).pathname,
+      next: PageLink.cart({ locale }).pathname,
     }).toString()
-  }, [shopSession, routingLocale])
+  }, [shopSession, locale])
 
   return <CopyToClipboard label="Copy link to cart">{cartLink ?? ''}</CopyToClipboard>
 }
 
 const LinkToRetargetingSection = () => {
   const { shopSession } = useShopSession()
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const retargetingLink = useMemo(() => {
     if (!shopSession) return null
 
     return PageLink.retargeting({
-      locale: routingLocale,
+      locale,
       shopSessionId: shopSession.id,
     }).toString()
-  }, [shopSession, routingLocale])
+  }, [shopSession, locale])
 
   return <CopyToClipboard label="Copy re-targeting link">{retargetingLink ?? ''}</CopyToClipboard>
 }

--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -30,7 +30,7 @@ import {
 } from '@/services/graphql/generated'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { useTracking } from '@/services/Tracking/useTracking'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { FormElement, QueryParam } from './CheckoutPage.constants'
 import { CheckoutPageProps } from './CheckoutPage.types'
@@ -49,7 +49,7 @@ const CheckoutPage = (props: CheckoutPageProps) => {
   } = props
   const { t } = useTranslation('checkout')
 
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const [showSignError, setShowSignError] = useState(false)
   const { reset: resetShopSession } = useShopSession()
   const router = useRouter()
@@ -202,7 +202,7 @@ const CheckoutPage = (props: CheckoutPageProps) => {
                           size="xs"
                           align="center"
                           balance={true}
-                          href={PageLink.privacyPolicy({ locale: routingLocale })}
+                          href={PageLink.privacyPolicy({ locale })}
                           target="_blank"
                         >
                           {t('SIGN_DISCLAIMER')}

--- a/apps/store/src/components/ConfirmationPage/StaticContent.tsx
+++ b/apps/store/src/components/ConfirmationPage/StaticContent.tsx
@@ -9,7 +9,7 @@ import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { type ConfirmationStory } from '@/services/storyblok/storyblok'
 import { getImgSrc } from '@/services/storyblok/Storyblok.helpers'
 import { getAppStoreLink } from '@/utils/appStoreLinks'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { CheckList, CheckListItem } from './CheckList'
 import qrCodeImage from './download-app-qrcode.png'
 import { ImageSection } from './ImageSection'
@@ -89,12 +89,12 @@ const DownloadAppWrapper = styled.div({
 })
 
 const AppStoreButtons = () => {
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
 
   return (
     <ButtonWrapper>
       <Button
-        href={getAppStoreLink('apple', routingLocale).toString()}
+        href={getAppStoreLink('apple', locale).toString()}
         target="_blank"
         rel="noopener noreferrer"
         variant="secondary"
@@ -106,7 +106,7 @@ const AppStoreButtons = () => {
         </SpaceFlex>
       </Button>
       <Button
-        href={getAppStoreLink('google', routingLocale).toString()}
+        href={getAppStoreLink('google', locale).toString()}
         target="_blank"
         rel="noopener noreferrer"
         variant="secondary"

--- a/apps/store/src/components/ContactUs/ContactUs.tsx
+++ b/apps/store/src/components/ContactUs/ContactUs.tsx
@@ -3,20 +3,20 @@ import styled from '@emotion/styled'
 import * as Popover from '@radix-ui/react-popover'
 import Link from 'next/link'
 import { useTranslation } from 'next-i18next'
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import {
-  Text,
-  Space,
-  Heading,
-  Button,
-  HedvigSymbol,
-  MinusIcon,
   AndroidIcon,
   AppleIcon,
+  Button,
+  Heading,
+  HedvigSymbol,
+  MinusIcon,
+  Space,
+  Text,
   theme,
 } from 'ui'
 import { getAppStoreLink } from '@/utils/appStoreLinks'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { useBreakpoint } from '@/utils/useBreakpoint/useBreakpoint'
 import { zIndexes } from '@/utils/zIndex'
@@ -47,7 +47,7 @@ export const ContactUs = () => {
   const hasMounted = useHasMounted()
   const isDesktop = useBreakpoint('lg')
   const { t } = useTranslation('contact-us')
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const [open, setOpen] = useState(false)
 
   // There's no way to determine how this component should look on the server
@@ -85,7 +85,7 @@ export const ContactUs = () => {
               <AppButtons>
                 <Button
                   data-dd-action-name="Contact us | IOS App"
-                  href={getAppStoreLink('apple', routingLocale).toString()}
+                  href={getAppStoreLink('apple', locale).toString()}
                   target="_blank"
                   rel="noopener noreferrer"
                   variant="secondary"
@@ -97,7 +97,7 @@ export const ContactUs = () => {
 
                 <Button
                   data-dd-action-name="Contact us | Android App"
-                  href={getAppStoreLink('google', routingLocale).toString()}
+                  href={getAppStoreLink('google', locale).toString()}
                   target="_blank"
                   rel="noopener noreferrer"
                   variant="secondary"
@@ -117,7 +117,7 @@ export const ContactUs = () => {
                   <Space y={0.5}>
                     <LinkButton
                       data-dd-action-name="Contact us | faq"
-                      href={PageLink.faq({ locale: routingLocale }).pathname}
+                      href={PageLink.faq({ locale }).pathname}
                       target="_blank"
                     >
                       <span>{t('FAQ_OPTION_LABEL')}</span>
@@ -131,7 +131,7 @@ export const ContactUs = () => {
 
                     <LinkButton
                       data-dd-action-name="Contact us | phone"
-                      href={PageLink.help({ locale: routingLocale }).pathname}
+                      href={PageLink.help({ locale }).pathname}
                       target="_blank"
                     >
                       <span>{t('TELEPHONE_OPTION_LABEL')}</span>

--- a/apps/store/src/components/DebugDialog/DebugShopSessionSection.tsx
+++ b/apps/store/src/components/DebugDialog/DebugShopSessionSection.tsx
@@ -1,19 +1,19 @@
 import { useRouter } from 'next/router'
 import { Button, Space } from 'ui'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { CopyToClipboard } from './CopyToClipboard'
 import { DebugResumeSessionSection } from './DebugResumeSessionSection'
 
 export const DebugShopSessionSection = () => {
   const { shopSession } = useShopSession()
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const router = useRouter()
 
   if (!shopSession) return null
 
-  const nextUrl = `/${routingLocale}${router.asPath}`
+  const nextUrl = `/${locale}${router.asPath}`
 
   return (
     <Space y={0.25}>

--- a/apps/store/src/components/ForeverPage/ForeverPage.tsx
+++ b/apps/store/src/components/ForeverPage/ForeverPage.tsx
@@ -2,14 +2,14 @@ import styled from '@emotion/styled'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { FormEventHandler, useState } from 'react'
-import { Button, Space, mq, theme } from 'ui'
+import { Button, mq, Space, theme } from 'ui'
 import { useGlobalBanner } from '@/components/GlobalBanner/useGlobalBanner'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
-import { HEADER_HEIGHT_MOBILE, HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header'
+import { HEADER_HEIGHT_DESKTOP, HEADER_HEIGHT_MOBILE } from '@/components/Header/Header'
 import { TextField } from '@/components/TextField/TextField'
 import { TextWithLink } from '@/components/TextWithLink'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { useRedeemCampaign } from '@/utils/useCampaign'
 import { usePrintTextEffect } from './usePrintTextEffect'
@@ -24,9 +24,9 @@ export const ForeverPage = ({ code: initialCode }: Props) => {
   usePrintTextEffect({ value: initialCode, onValueChange: setCode })
 
   const { shopSession } = useShopSession()
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const { addBanner } = useGlobalBanner()
-  const redirectUrl = PageLink.store({ locale: routingLocale })
+  const redirectUrl = PageLink.store({ locale })
   const [addCampaign, { errorMessage, loading, called }] = useRedeemCampaign({
     shopSessionId: shopSession?.id ?? '',
     async onCompleted() {

--- a/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
+++ b/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
@@ -7,7 +7,7 @@ import { AndroidIcon, AppleIcon, Button, mq, theme } from 'ui'
 import { LogoHomeLink } from '@/components/LogoHomeLink'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { getAppStoreLink } from '@/utils/appStoreLinks'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { LogoWrapper } from '../Header'
 import {
   focusableStyles,
@@ -57,7 +57,7 @@ export const TopMenuMobile = (props: TopMenuMobileProps) => {
   const { children, isOpen, setIsOpen, defaultValue } = props
   const router = useRouter()
   const { t } = useTranslation('common')
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
 
   useEffect(() => {
     const closeDialog = () => setIsOpen(false)
@@ -83,7 +83,7 @@ export const TopMenuMobile = (props: TopMenuMobileProps) => {
                 <div>{children}</div>
                 <ButtonWrapper>
                   <Button
-                    href={getAppStoreLink('apple', routingLocale).toString()}
+                    href={getAppStoreLink('apple', locale).toString()}
                     target="_blank"
                     rel="noopener noreferrer"
                     variant="secondary"
@@ -95,7 +95,7 @@ export const TopMenuMobile = (props: TopMenuMobileProps) => {
                     </SpaceFlex>
                   </Button>
                   <Button
-                    href={getAppStoreLink('google', routingLocale).toString()}
+                    href={getAppStoreLink('google', locale).toString()}
                     target="_blank"
                     rel="noopener noreferrer"
                     variant="secondary"

--- a/apps/store/src/components/LayoutWithMenu/ProductMetadataContext.tsx
+++ b/apps/store/src/components/LayoutWithMenu/ProductMetadataContext.tsx
@@ -2,7 +2,7 @@ import { atom, useAtomValue } from 'jotai'
 import { atomFamily, useHydrateAtoms } from 'jotai/utils'
 import { globalStore } from '@/utils/globalStore'
 import { type RoutingLocale } from '@/utils/l10n/types'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { type GlobalProductMetadata } from './fetchProductMetadata'
 
 // We don't actually neeed _routineLocale for the atom creation. It will be used
@@ -13,13 +13,13 @@ const productsMetadataAtom = atomFamily((_routingLocale: RoutingLocale) =>
 )
 
 export const useProductMetadata = () => {
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
 
-  return useAtomValue(productsMetadataAtom(routingLocale), { store: globalStore })
+  return useAtomValue(productsMetadataAtom(locale), { store: globalStore })
 }
 
 export const useHydrateProductMetadata = (metadata: GlobalProductMetadata) => {
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
 
-  useHydrateAtoms([[productsMetadataAtom(routingLocale), metadata]], { store: globalStore })
+  useHydrateAtoms([[productsMetadataAtom(locale), metadata]], { store: globalStore })
 }

--- a/apps/store/src/components/PaymentConnectPage/IdleState.tsx
+++ b/apps/store/src/components/PaymentConnectPage/IdleState.tsx
@@ -10,7 +10,7 @@ import { exchangeAuthorizationCode } from '@/services/authApi/oauth'
 import { getAccessToken, saveAuthTokens } from '@/services/authApi/persist'
 import { createTrustlyUrl } from '@/services/trustly/createTrustlyUrl'
 import { trustlyIframeStyles } from '@/services/trustly/TrustlyIframe'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { Layout } from './Layout'
 
 type State = 'IDLE' | 'LOADING' | 'ERROR'
@@ -25,7 +25,7 @@ export const IdleState = (props: Props) => {
   const { t } = useTranslation(['common', 'checkout'])
   const router = useRouter()
   const apolloClient = useApolloClient()
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault()
@@ -41,7 +41,7 @@ export const IdleState = (props: Props) => {
     }
 
     try {
-      const trustlyUrl = await createTrustlyUrl({ apolloClient, locale: routingLocale })
+      const trustlyUrl = await createTrustlyUrl({ apolloClient, locale })
       props.onCompleted(trustlyUrl)
     } catch (error) {
       datadogLogs.logger.warn('Payment Connect failed to create trustly url', { error })

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorSection.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorSection.tsx
@@ -6,7 +6,7 @@ import { Button, Space, Text } from 'ui'
 import { linkStyles } from '@/components/RichText/RichText.styles'
 import { deserializeField } from '@/services/PriceCalculator/PriceCalculator.helpers'
 import { type FormSection, type JSONData } from '@/services/PriceCalculator/PriceCalculator.types'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { useTranslateFieldLabel } from './useTranslateFieldLabel'
 
@@ -19,7 +19,7 @@ type Props = {
 }
 
 export const PriceCalculatorSection = ({ section, loading, onSubmit, last, children }: Props) => {
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const { t } = useTranslation('purchase-form')
   const translateLabel = useTranslateFieldLabel()
 
@@ -51,7 +51,7 @@ export const PriceCalculatorSection = ({ section, loading, onSubmit, last, child
           </Button>
 
           {last && (
-            <Link href={PageLink.privacyPolicy({ locale: routingLocale })} target="_blank">
+            <Link href={PageLink.privacyPolicy({ locale })} target="_blank">
               <Text as="span" size="xs">
                 {t('GDPR_LINK_BEFORE_OFFER')}
               </Text>

--- a/apps/store/src/components/ProductPage/PageDebugDialog.tsx
+++ b/apps/store/src/components/ProductPage/PageDebugDialog.tsx
@@ -7,7 +7,7 @@ import { DebugDialog } from '@/components/DebugDialog/DebugDialog'
 import { DebugShopSessionSection } from '@/components/DebugDialog/DebugShopSessionSection'
 import { DebugTextKeys } from '@/components/DebugDialog/DebugTextKeys'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { usePriceIntent } from './PriceIntentContext'
 
@@ -24,7 +24,7 @@ export const PageDebugDialog = () => {
 }
 
 const LinkToOfferSection = () => {
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const { shopSession } = useShopSession()
   const [priceIntent] = usePriceIntent()
 
@@ -32,11 +32,11 @@ const LinkToOfferSection = () => {
     if (!(shopSession && priceIntent)) return null
 
     return PageLink.session({
-      locale: routingLocale,
+      locale,
       shopSessionId: shopSession.id,
       priceIntentId: priceIntent.id,
     }).toString()
-  }, [routingLocale, shopSession, priceIntent])
+  }, [locale, shopSession, priceIntent])
 
   return <CopyToClipboard label="Share link to offer">{link ?? ''}</CopyToClipboard>
 }

--- a/apps/store/src/components/ProductPage/PurchaseForm/DeductibleSelector.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/DeductibleSelector.tsx
@@ -7,7 +7,7 @@ import { Text } from 'ui'
 import * as TierLevelRadioGroup from '@/components/TierSelector/TierLevelRadioGroup'
 import * as TierSelector from '@/components/TierSelector/TierSelector'
 import { Money, ProductOfferFragment } from '@/services/graphql/generated'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { useFormatter } from '@/utils/useFormatter'
 
@@ -26,7 +26,7 @@ type Props = {
 
 export const DeductibleSelector = ({ offers, selectedOffer, onValueChange }: Props) => {
   const { t } = useTranslation('purchase-form')
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const formatter = useFormatter()
 
   const deductibleLevels = useMemo(() => {
@@ -70,11 +70,7 @@ export const DeductibleSelector = ({ offers, selectedOffer, onValueChange }: Pro
           ))}
         </TierLevelRadioGroup.Root>
         <TierSelector.Footer>
-          <Link
-            href={PageLink.deductibleHelp({ locale: routingLocale })}
-            target="_blank"
-            rel="noopener"
-          >
+          <Link href={PageLink.deductibleHelp({ locale })} target="_blank" rel="noopener">
             <Text as="span" size="xs">
               {t('DEDUCTIBLE_SELECTOR_FOOTER_LINK')}
             </Text>

--- a/apps/store/src/features/carDealership/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.tsx
@@ -1,8 +1,8 @@
 import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { useState, useMemo } from 'react'
-import { Space, Button, Text, BankIdIcon, CheckIcon, theme } from 'ui'
+import { useMemo, useState } from 'react'
+import { BankIdIcon, Button, CheckIcon, Space, Text, theme } from 'ui'
 import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
 import { TotalAmount } from '@/components/ShopBreakdown/TotalAmount'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
@@ -13,7 +13,7 @@ import {
   ShopSessionFragment,
 } from '@/services/graphql/generated'
 import { convertToDate } from '@/utils/date'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { useFormatter } from '@/utils/useFormatter'
 import { type TrialContract } from './carDealership.types'
@@ -37,7 +37,7 @@ export const TrialExtensionForm = ({
   requirePaymentConnection,
 }: Props) => {
   const { t } = useTranslation(['carDealership', 'checkout'])
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const formatter = useFormatter()
   const [acceptExtension, loading] = useAcceptExtension({
     shopSession: shopSession,
@@ -163,7 +163,7 @@ export const TrialExtensionForm = ({
             align="center"
             balance={true}
             color="textSecondary"
-            href={PageLink.privacyPolicy({ locale: routingLocale })}
+            href={PageLink.privacyPolicy({ locale })}
             target="_blank"
           >
             {t('checkout:SIGN_DISCLAIMER')}

--- a/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
+++ b/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
@@ -4,9 +4,8 @@ import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
-import { useRef } from 'react'
-import { FormEventHandler, ReactNode, useCallback, useEffect } from 'react'
-import { Space, Button, Heading, HedvigLogo, BankIdIcon, mq, theme } from 'ui'
+import { FormEventHandler, ReactNode, useCallback, useEffect, useRef } from 'react'
+import { BankIdIcon, Button, Heading, HedvigLogo, mq, Space, theme } from 'ui'
 import { CheckoutStep } from '@/components/CheckoutHeader/Breadcrumbs'
 import {
   fetchCheckoutSteps,
@@ -30,7 +29,7 @@ import {
 import { setupShopSessionServiceClientSide } from '@/services/shopSession/ShopSession.helpers'
 import { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { type ComparisonTableData } from '../manyPets.types'
 import { LatestAdoptionNote } from './LatestAdoptionNote'
@@ -62,7 +61,7 @@ export const ManyPetsMigrationPage = ({
   latestAdoptionDate,
   comparisonTableData,
 }: ManyPetsMigrationPageProps) => {
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const { t } = useTranslation('checkout')
 
   const migrationSessionQueryResult = useShopSessionQuery({
@@ -114,7 +113,7 @@ export const ManyPetsMigrationPage = ({
                   size={{ _: 'xs', md: 'sm' }}
                   align="center"
                   color="textSecondary"
-                  href={PageLink.privacyPolicy({ locale: routingLocale })}
+                  href={PageLink.privacyPolicy({ locale })}
                   target="_blank"
                 >
                   {t('SIGN_DISCLAIMER')}

--- a/apps/store/src/features/memberArea/PaymentsSection/PaymentConnection.tsx
+++ b/apps/store/src/features/memberArea/PaymentsSection/PaymentConnection.tsx
@@ -10,13 +10,13 @@ import {
   TRUSTLY_IFRAME_MAX_WIDTH,
   TrustlyIframe,
 } from '@/services/trustly/TrustlyIframe'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 
 type State = { type: 'IDLE' } | { type: 'READY'; trustlyUrl: string }
 
 export const PaymentConnection = ({ startButtonText }: { startButtonText: string }) => {
   const { showError } = useAppErrorHandleContext()
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const [createTrustlyUrl, result] = useTrustlyInitMutation({
     onError: showError,
     onCompleted(data) {
@@ -28,7 +28,7 @@ export const PaymentConnection = ({ startButtonText }: { startButtonText: string
 
   const handleClickStart = () => {
     datadogRum.addAction('Payment Config Start')
-    createTrustlyUrl({ variables: getTrustlyInitMutationVariables(routingLocale) })
+    createTrustlyUrl({ variables: getTrustlyInitMutationVariables(locale) })
   }
 
   const handleClose = () => {

--- a/apps/store/src/features/memberArea/components/Menu.tsx
+++ b/apps/store/src/features/memberArea/components/Menu.tsx
@@ -3,10 +3,10 @@ import styled from '@emotion/styled'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
-import { theme, mq, Text } from 'ui'
+import { mq, Text, theme } from 'ui'
 import { Skeleton } from '@/components/Skeleton'
 import { resetAuthTokens } from '@/services/authApi/persist'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { useFormatter } from '@/utils/useFormatter'
 import { useMemberAreaInfo } from '../useMemberAreaInfo'
@@ -14,7 +14,7 @@ import { useMemberAreaInfo } from '../useMemberAreaInfo'
 export const Menu = () => {
   const router = useRouter()
   const { firstName, lastName, ssn } = useMemberAreaInfo()
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const { t } = useTranslation('memberArea')
   const formatter = useFormatter()
 
@@ -59,7 +59,7 @@ export const Menu = () => {
           </NavigationLink>
         </NavgationItem>
         <NavgationItem>
-          <NavigationLink href={PageLink.faq({ locale: routingLocale })}>FAQ</NavigationLink>
+          <NavigationLink href={PageLink.faq({ locale })}>FAQ</NavigationLink>
         </NavgationItem>
         <LogoutButton />
       </NavigationList>

--- a/apps/store/src/features/retargeting/useApiRedirectEffect.ts
+++ b/apps/store/src/features/retargeting/useApiRedirectEffect.ts
@@ -3,18 +3,18 @@ import { datadogRum } from '@datadog/browser-rum'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo } from 'react'
 import { type RoutingLocale } from '@/utils/l10n/types'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { ORIGIN_URL, PageLink } from '@/utils/PageLink'
 import { QueryParam } from './retargeting.constants'
 
 export const useApiRedirectEffect = () => {
   const router = useRouter()
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
 
   const redirect = useMemo(() => {
     if (!router.isReady) return null
-    return getApiRedirect(router.asPath, routingLocale)
-  }, [routingLocale, router.asPath, router.isReady])
+    return getApiRedirect(router.asPath, locale)
+  }, [locale, router.asPath, router.isReady])
 
   useEffect(() => {
     if (!redirect) return
@@ -29,7 +29,7 @@ export const useApiRedirectEffect = () => {
 
     // Avoid `router.push` since it triggers middleware for API routes
     window.location.assign(redirect.url.toString())
-  }, [router, redirect, routingLocale])
+  }, [router, redirect, locale])
 }
 
 type Redirect = { type: 'api' | 'fallback'; url: URL }

--- a/apps/store/src/features/widget/SignPage.tsx
+++ b/apps/store/src/features/widget/SignPage.tsx
@@ -6,8 +6,8 @@ import { StoryblokComponent } from '@storyblok/react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
-import { useState, type PropsWithChildren, type MouseEvent, type FormEvent } from 'react'
-import { Heading, Text, Button, Space, BankIdIcon, CheckIcon, theme, mq } from 'ui'
+import { type FormEvent, type MouseEvent, type PropsWithChildren, useState } from 'react'
+import { BankIdIcon, Button, CheckIcon, Heading, mq, Space, Text, theme } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { FormElement } from '@/components/CheckoutPage/CheckoutPage.constants'
 import { useHandleSubmitCheckout } from '@/components/CheckoutPage/useHandleSubmitCheckout'
@@ -22,15 +22,15 @@ import { TotalAmountContainer } from '@/components/ShopBreakdown/TotalAmountCont
 import { TextField } from '@/components/TextField/TextField'
 import { TextWithLink } from '@/components/TextWithLink'
 import {
+  MemberPaymentConnectionStatus,
   type ProductOfferFragment,
   ShopSessionAuthenticationStatus,
   useCartEntryRemoveMutation,
   useCurrentMemberLazyQuery,
-  MemberPaymentConnectionStatus,
 } from '@/services/graphql/generated'
 import { type ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useTracking } from '@/services/Tracking/useTracking'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { Header } from './Header'
 import { ProductItemContainer } from './ProductItemContainer'
@@ -51,7 +51,7 @@ type Props = {
 
 export const SignPage = (props: Props) => {
   const { t } = useTranslation(['widget', 'checkout', 'cart'])
-  const { routingLocale: locale } = useCurrentLocale()
+  const locale = useRoutingLocale()
 
   const { offerRecommendation } = useProductRecommendations(props.shopSession.id)
 

--- a/apps/store/src/pages/payment/connect-legacy/error.tsx
+++ b/apps/store/src/pages/payment/connect-legacy/error.tsx
@@ -1,15 +1,15 @@
 import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
-import { Text, WarningTriangleIcon, theme } from 'ui'
+import { Text, theme, WarningTriangleIcon } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { Layout } from '@/components/PaymentConnectPage/Layout'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { useAdyenTranslations } from '@/services/adyen/useAdyenTranslations'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 
 const PaymentConnectLegacyErrorPage = () => {
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const { title, retry, error } = useAdyenTranslations()
 
   return (
@@ -27,7 +27,7 @@ const PaymentConnectLegacyErrorPage = () => {
           </div>
         </SpaceFlex>
         <ButtonNextLink
-          href={PageLink.paymentConnectLegacy({ locale: routingLocale })}
+          href={PageLink.paymentConnectLegacy({ locale })}
           size="medium"
           onClick={() => datadogRum.addAction('PaymentConnectLegacy Retry')}
         >

--- a/apps/store/src/pages/payment/connect-legacy/start.tsx
+++ b/apps/store/src/pages/payment/connect-legacy/start.tsx
@@ -3,7 +3,7 @@ import { Button } from 'ui'
 import { Layout } from '@/components/PaymentConnectPage/Layout'
 import { useAdyenTranslations } from '@/services/adyen/useAdyenTranslations'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 
 type Props = {
@@ -11,7 +11,7 @@ type Props = {
 }
 
 const Page = (props: Props) => {
-  const { routingLocale: locale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const { title, startButton } = useAdyenTranslations()
 
   const nextUrl = PageLink.paymentConnectLegacy({ locale }).pathname

--- a/apps/store/src/services/adyen/useTokenizePaymentDetails.ts
+++ b/apps/store/src/services/adyen/useTokenizePaymentDetails.ts
@@ -4,11 +4,11 @@ import {
   TokenizationChannel,
   useAdyenTokenizePaymentDetailsMutation,
 } from '@/services/graphql/generated'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 
 export const useTokenizePaymentDetails = () => {
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
   const [tokenizePaymentDetails] = useAdyenTokenizePaymentDetailsMutation()
 
   return useCallback(
@@ -19,7 +19,7 @@ export const useTokenizePaymentDetails = () => {
             browserInfo,
             paymentMethodDetails: JSON.stringify(paymentMethod),
             channel: TokenizationChannel.Web,
-            returnUrl: PageLink.apiAdyenCallback({ locale: routingLocale }).href,
+            returnUrl: PageLink.apiAdyenCallback({ locale }).href,
           },
         },
       })
@@ -32,6 +32,6 @@ export const useTokenizePaymentDetails = () => {
 
       return response
     },
-    [tokenizePaymentDetails, routingLocale],
+    [tokenizePaymentDetails, locale],
   )
 }

--- a/apps/store/src/services/trustly/TrustlyIframe.tsx
+++ b/apps/store/src/services/trustly/TrustlyIframe.tsx
@@ -1,8 +1,8 @@
 import { css, keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
-import { useEffect, type ReactEventHandler, useState } from 'react'
+import { type ReactEventHandler, useEffect, useState } from 'react'
 import { theme } from 'ui'
-import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 
 type Props = {
@@ -13,7 +13,7 @@ type Props = {
 }
 
 export const TrustlyIframe = ({ url, onSuccess, onFail, className }: Props) => {
-  const { routingLocale } = useCurrentLocale()
+  const locale = useRoutingLocale()
 
   useEffect(() => {
     const handler = (event: MessageEvent) => {
@@ -34,9 +34,9 @@ export const TrustlyIframe = ({ url, onSuccess, onFail, className }: Props) => {
   const handleLoad: ReactEventHandler<HTMLIFrameElement> = (event) => {
     try {
       const url = event.currentTarget.contentWindow?.location.href
-      if (url === PageLink.paymentSuccess({ locale: routingLocale }).href) {
+      if (url === PageLink.paymentSuccess({ locale }).href) {
         onSuccess()
-      } else if (url === PageLink.paymentFailure({ locale: routingLocale }).href) {
+      } else if (url === PageLink.paymentFailure({ locale }).href) {
         onFail()
       }
     } catch (error) {

--- a/apps/store/src/utils/l10n/useRoutingLocale.ts
+++ b/apps/store/src/utils/l10n/useRoutingLocale.ts
@@ -1,0 +1,5 @@
+import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
+
+export const useRoutingLocale = () => {
+  return useCurrentLocale().routingLocale
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Convert very common pattern of getting current routing locale into separate hook

```
- const { routingLocale: locale } = useCurrentLocale()
+ const locale = useRoutingLocale()
```

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Would simplify moving away from next routing i18n - we're going to need a lot more `useRoutingLocale()` calls

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
