### PR TITLE
Fix links in blog category

### DIFF
--- a/apps/store/src/features/blog/ArticleTeaser/ArticleTeaser.tsx
+++ b/apps/store/src/features/blog/ArticleTeaser/ArticleTeaser.tsx
@@ -3,6 +3,7 @@ import NextImage, { type ImageProps } from 'next/image'
 import Link from 'next/link'
 import { type ReactNode } from 'react'
 import { Heading, Space, Text, theme } from 'ui'
+import { makeAbsolute } from '@/services/storyblok/Storyblok.helpers'
 
 type Props = {
   children: ReactNode
@@ -26,7 +27,7 @@ const Root = (props: Props) => {
       <ContentWrapper>
         <ClampedText>
           <Space y={0.25}>
-            <ExtendedLink href={props.href} style={{ display: 'block' }}>
+            <ExtendedLink href={makeAbsolute(props.href)} style={{ display: 'block' }}>
               <Heading as="h3" variant="standard.20">
                 {props.title}
               </Heading>

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -1,4 +1,4 @@
-import { type SbBlokData, type ISbStoryData } from '@storyblok/react'
+import { type ISbStoryData, type SbBlokData } from '@storyblok/react'
 import { Features } from '@/utils/Features'
 import { LinkField, ProductStory, WidgetFlowStory } from './storyblok'
 
@@ -43,7 +43,7 @@ export const getLinkFieldURL = (link: LinkField, linkText?: string) => {
   return makeAbsolute(appendAnchor(link.cached_url, link.anchor))
 }
 
-const makeAbsolute = (url: string) => {
+export const makeAbsolute = (url: string) => {
   if (/^(\/|https?:\/\/|\/\/)/.test(url)) {
     return url
   }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix links to blog articles

We were passing `href='se/blogg/...'` to link where absolute path or full URL object were expected

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
