### PR TITLE
fix(storybook): make sure global styles (vanilla extract) are included

### DIFF
--- a/apps/store/.storybook/preview.tsx
+++ b/apps/store/.storybook/preview.tsx
@@ -3,6 +3,16 @@ import './i18next'
 import { Preview } from '@storybook/react'
 import { gridDecorator, themeDecorator } from './decorators'
 import { theme } from 'ui'
+import globalCss from 'ui/src/global.css'
+
+// GOTCHA: Here we need to trick compiler into thinking we need global.css import
+// for anything other than side effects
+// Would've been easier if we just imported module without using it, but this leads to
+// styles never appearing in resulting HTML. I guess tree shaking or similar optimization
+// is the reason
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const noop = (val: any) => {}
+noop(globalCss)
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },


### PR DESCRIPTION
## Describe your changes

* Added `vanilla-extract-css` global styles to `storybook`

## Justify why they are needed

Without it storybook stories look a little bit off as it would be missing some style definitions.
