### PR TITLE
Use default jotai store for globalProduceMetadata

### DIFF
--- a/apps/store/src/components/LayoutWithMenu/ProductMetadataContext.tsx
+++ b/apps/store/src/components/LayoutWithMenu/ProductMetadataContext.tsx
@@ -1,6 +1,5 @@
 import { atom, useAtomValue } from 'jotai'
 import { atomFamily, useHydrateAtoms } from 'jotai/utils'
-import { globalStore } from '@/utils/globalStore'
 import { type RoutingLocale } from '@/utils/l10n/types'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { type GlobalProductMetadata } from './fetchProductMetadata'
@@ -14,12 +13,10 @@ const productsMetadataAtom = atomFamily((_routingLocale: RoutingLocale) =>
 
 export const useProductMetadata = () => {
   const locale = useRoutingLocale()
-
-  return useAtomValue(productsMetadataAtom(locale), { store: globalStore })
+  return useAtomValue(productsMetadataAtom(locale))
 }
 
 export const useHydrateProductMetadata = (metadata: GlobalProductMetadata) => {
   const locale = useRoutingLocale()
-
-  useHydrateAtoms([[productsMetadataAtom(locale), metadata]], { store: globalStore })
+  useHydrateAtoms([[productsMetadataAtom(locale), metadata]])
 }

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -32,7 +32,6 @@ import { TrackingProvider } from '@/services/Tracking/TrackingContext'
 import { trackPageViews } from '@/services/Tracking/trackPageViews'
 import { Features } from '@/utils/Features'
 import { contentFontClassName } from '@/utils/fonts'
-import { globalStore } from '@/utils/globalStore'
 import { getCountryByLocale } from '@/utils/l10n/countryUtils'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
 import { UiLocale } from '@/utils/l10n/types'
@@ -111,7 +110,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
         <GlobalLinkStyles />
         <OneTrustStyles />
         <PageTransitionProgressBar />
-        <JotaiProvider store={globalStore}>
+        <JotaiProvider>
           <ShopSessionProvider shopSessionId={pageProps[SHOP_SESSION_PROP_NAME]}>
             <ShopSessionTrackingProvider>
               <BankIdContextProvider>

--- a/apps/store/src/utils/globalStore.ts
+++ b/apps/store/src/utils/globalStore.ts
@@ -1,3 +1,0 @@
-import { createStore } from 'jotai'
-
-export const globalStore = createStore()


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Remove custom globalStore we were using for productMetadata atom - default one works just as well

This is a step towards correct usage of jotai with app router

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
