### PR TITLE
GEN-1835 - feat(ReviewsDialog): accept a Header section so it can be used in different contexts - ProductAverageRating and ProductReviews

### DIFF
--- a/apps/store/public/locales/en/reviews.json
+++ b/apps/store/public/locales/en/reviews.json
@@ -1,4 +1,7 @@
 {
+  "RATING_SCORE_LABEL": "{{score}} of {{maxScore}}",
+  "REVIEWS_COUNT_LABEL_one": "{{reviewsCount}} review",
+  "REVIEWS_COUNT_LABEL_other": "{{reviewsCount}} reviews",
   "REVIEWS_DISCLAIMER_one": "Shows the average of {{reviewsCount}} review from our customers. Anyone who has had an injury is invited to leave a review.",
   "REVIEWS_DISCLAIMER_other": "Shows the average of {{reviewsCount}} reviews from our customers. Anyone who has had an injury is invited to leave a review.",
   "VIEW_REVIEWS_LABEL": "View reviews"

--- a/apps/store/public/locales/sv-se/reviews.json
+++ b/apps/store/public/locales/sv-se/reviews.json
@@ -1,4 +1,7 @@
 {
+  "RATING_SCORE_LABEL": "{{score}} av {{maxScore}}",
+  "REVIEWS_COUNT_LABEL_one": "{{reviewsCount}} omdöme",
+  "REVIEWS_COUNT_LABEL_other": "{{reviewsCount}} omdömen",
   "REVIEWS_DISCLAIMER_one": "Visar genomsnittet av {{reviewsCount}} omdöme från våra kunder. Alla som haft en skada blir inbjuden till att lämna ett omdöme.",
   "REVIEWS_DISCLAIMER_other": "Visar genomsnittet av {{reviewsCount}} omdömen från våra kunder. Alla som haft en skada blir inbjuden till att lämna ett omdöme.",
   "VIEW_REVIEWS_LABEL": "Visa omdömen"

--- a/apps/store/src/components/ProductReviews/ProductAverageRatingV2.tsx
+++ b/apps/store/src/components/ProductReviews/ProductAverageRatingV2.tsx
@@ -13,6 +13,8 @@ import { MAX_SCORE } from '@/features/memberReviews/memberReviews.constants'
 import { useProuctReviewsDataContext } from '@/features/memberReviews/ProductReviewsDataProvider'
 import { sendDialogEvent } from '@/utils/dialogEvent'
 import { useFormatter } from '@/utils/useFormatter'
+import { AverageRatingV2 } from './AverageRatingV2'
+import { ReviewsDiclaimer } from './ReviewsDisclaimer'
 
 export const ProductAverageRatingV2 = () => {
   const { t } = useTranslation('common')
@@ -21,6 +23,7 @@ export const ProductAverageRatingV2 = () => {
   const productData = useProductData()
 
   const openDialog = () => {
+    // Notify that all playing media should be paused as a result of the dialog being opened
     sendDialogEvent('open')
   }
 
@@ -84,6 +87,7 @@ const Dialog = (props: DialogProps) => {
   const { rating, reviews, reviewsDistribution, selectedScore, setSelectedScore } = useReviewsV2()
 
   const closeDialog = () => {
+    // Notify that all media paused as a result of the dialog being opened should be resumed
     sendDialogEvent('close')
   }
 
@@ -91,7 +95,12 @@ const Dialog = (props: DialogProps) => {
 
   return (
     <ReviewsDialogV2
-      rating={rating}
+      Header={
+        <section>
+          <AverageRatingV2 size={{ _: 9, sm: 11 }} score={rating.score} maxScore={MAX_SCORE} />
+          <ReviewsDiclaimer size={{ _: 'xs', sm: 'md' }} reviewsCount={rating.totalOfReviews} />
+        </section>
+      }
       reviews={reviews}
       reviewsDistribution={reviewsDistribution}
       selectedScore={selectedScore}

--- a/apps/store/src/components/ProductReviews/ProductReviewsV2.css.ts
+++ b/apps/store/src/components/ProductReviews/ProductReviewsV2.css.ts
@@ -12,3 +12,11 @@ export const innerWrapper = style({
   flexDirection: 'column',
   alignItems: 'center',
 })
+
+export const dialogHeader = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: theme.space.md,
+  marginBottom: theme.space.xxxl,
+})

--- a/apps/store/src/components/ProductReviews/ProductReviewsV2.tsx
+++ b/apps/store/src/components/ProductReviews/ProductReviewsV2.tsx
@@ -1,8 +1,11 @@
 import { useTranslation } from 'next-i18next'
-import { Space, Button } from 'ui'
+import { Space, Text, Button } from 'ui'
+import { Pillow } from '@/components/Pillow/Pillow'
+import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { MAX_SCORE } from '@/features/memberReviews/memberReviews.constants'
+import { useFormatter } from '@/utils/useFormatter'
 import { AverageRatingV2 } from './AverageRatingV2'
-import { wrapper, innerWrapper } from './ProductReviewsV2.css'
+import { wrapper, innerWrapper, dialogHeader } from './ProductReviewsV2.css'
 import { ReviewsDialogV2 } from './ReviewsDialogV2'
 import { ReviewsDiclaimer } from './ReviewsDisclaimer'
 import { ReviewsDistributionByScore } from './ReviewsDistributionByScore'
@@ -10,7 +13,10 @@ import { useReviewsV2 } from './useReviewsV2'
 
 export const ProductReviewsV2 = () => {
   const { t } = useTranslation('reviews')
+
+  const { displayNameShort: productName, pillowImage } = useProductData()
   const { rating, reviews, reviewsDistribution, setSelectedScore, selectedScore } = useReviewsV2()
+  const { numberGrouping } = useFormatter()
 
   if (!rating) {
     console.warn('ProductReviews | No rating data available')
@@ -30,8 +36,24 @@ export const ProductReviewsV2 = () => {
         ))}
 
         <ReviewsDialogV2
+          Header={
+            <section className={dialogHeader}>
+              <Pillow size="xlarge" {...pillowImage} />
+
+              <div>
+                <Text align="center">{productName}</Text>
+                <Text align="center" color="textSecondary">
+                  {t('RATING_SCORE_LABEL', { score: rating.score, maxScore: MAX_SCORE })}
+                  {' · '}
+                  {t('REVIEWS_COUNT_LABEL', {
+                    count: rating.totalOfReviews,
+                    reviewsCount: numberGrouping(rating.totalOfReviews),
+                  })}
+                </Text>
+              </div>
+            </section>
+          }
           reviews={reviews}
-          rating={rating}
           reviewsDistribution={reviewsDistribution}
           selectedScore={selectedScore}
           onSelectedScoreChange={setSelectedScore}

--- a/apps/store/src/components/ProductReviews/ReviewsDialogV2.tsx
+++ b/apps/store/src/components/ProductReviews/ReviewsDialogV2.tsx
@@ -1,14 +1,8 @@
 import { useTranslation } from 'next-i18next'
-import { type ReactNode } from 'react'
+import { type ReactElement, type ReactNode } from 'react'
 import { Dialog, Text, Space, CrossIcon } from 'ui'
-import { MAX_SCORE } from '@/features/memberReviews/memberReviews.constants'
 import type { Score } from '@/features/memberReviews/memberReviews.types'
-import type {
-  Review,
-  Rating,
-  ReviewsDistribution,
-} from '@/features/memberReviews/memberReviews.types'
-import { AverageRatingV2 } from './AverageRatingV2'
+import type { Review, ReviewsDistribution } from '@/features/memberReviews/memberReviews.types'
 import { ReviewCommentV2 } from './ReviewCommentV2'
 import {
   closeBtn,
@@ -18,27 +12,26 @@ import {
   latestReviewsLabel,
   noReviewsLabel,
 } from './ReviewsDialogV2.css'
-import { ReviewsDiclaimer } from './ReviewsDisclaimer'
 import { ReviewsFilter } from './ReviewsFilter'
 
 type Props = {
   children: ReactNode
   reviews: Array<Review>
-  rating: Rating
   reviewsDistribution: ReviewsDistribution
-  onClose?: () => void
   selectedScore: Score
   onSelectedScoreChange: (score: Score) => void
+  Header?: ReactElement
+  onClose?: () => void
 }
 
 export const ReviewsDialogV2 = ({
   children,
   reviews,
-  rating,
   reviewsDistribution,
-  onClose,
   selectedScore,
   onSelectedScoreChange,
+  Header,
+  onClose,
 }: Props) => {
   const { t } = useTranslation('common')
 
@@ -52,11 +45,8 @@ export const ReviewsDialogV2 = ({
         </Dialog.Close>
 
         <Dialog.Window className={dialogWindow}>
-          <Space y={1.5}>
-            <section>
-              <AverageRatingV2 size={{ _: 9, sm: 11 }} score={rating.score} maxScore={MAX_SCORE} />
-              <ReviewsDiclaimer size={{ _: 'xs', sm: 'md' }} reviewsCount={rating.totalOfReviews} />
-            </section>
+          <Space y={2}>
+            {Header}
 
             <Space y={1}>
               <ReviewsFilter


### PR DESCRIPTION
## Describe your changes

* Update `ReviewsDialog` so it takes a `Header` section so it can be used in different contexts: When opening the Dialog through `ProductReviewsBlock` we should should the _pillow_ version; When opening it via `ProductAverageRating` we should shown the _average rating_ one.

<img width="514" alt="Screenshot 2024-02-19 at 14 28 30" src="https://github.com/HedvigInsurance/racoon/assets/19200662/e881aa43-546f-442e-89e4-ff14a9651d07">
<img width="512" alt="Screenshot 2024-02-19 at 14 27 05" src="https://github.com/HedvigInsurance/racoon/assets/19200662/1cb31a12-5166-4881-94e4-64e9d5b7b746">

## Justify why they are needed

Part of [_Product Reviews v2_](https://www.figma.com/file/PUA7SuN75sWH4Q1QxDaeCJ/Product-Reviews?type=design&node-id=1447-1775&mode=design&t=Sri79oZDuQ3Tbqo4-4)
