### PR TITLE
GEN-1835 - styles(ProductAverageRating): product reviews v2 UI changes

### DIFF
--- a/apps/store/src/components/ProductReviews/ProductAverageRatingV2.css.ts
+++ b/apps/store/src/components/ProductReviews/ProductAverageRatingV2.css.ts
@@ -1,0 +1,28 @@
+import { style } from '@vanilla-extract/css'
+import { theme } from 'ui/src/theme'
+
+export const wrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: theme.space.xxs,
+})
+
+export const trigger = style({
+  color: theme.colors.textSecondary,
+  fontSize: theme.fontSizes.xs,
+  textDecoration: 'underline',
+  cursor: 'pointer',
+
+  ':focus-visible': {
+    boxShadow: theme.shadow.focus,
+  },
+
+  '@media': {
+    '(hover: hover)': {
+      ':hover': {
+        color: theme.colors.textPrimary,
+      },
+    },
+  },
+})

--- a/apps/store/src/components/ProductReviews/ProductAverageRatingV2.tsx
+++ b/apps/store/src/components/ProductReviews/ProductAverageRatingV2.tsx
@@ -1,19 +1,17 @@
-import styled from '@emotion/styled'
 import Head from 'next/head'
 import { useTranslation } from 'next-i18next'
 import { type ReactNode } from 'react'
-import { Text, StarIcon, theme } from 'ui'
-import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { InfoIcon } from 'ui'
 import { ProductData } from '@/components/ProductData/ProductData.types'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { ReviewsDialogV2 } from '@/components/ProductReviews/ReviewsDialogV2'
 import { useReviewsV2 } from '@/components/ProductReviews/useReviewsV2'
-import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { MAX_SCORE } from '@/features/memberReviews/memberReviews.constants'
 import { useProuctReviewsDataContext } from '@/features/memberReviews/ProductReviewsDataProvider'
 import { sendDialogEvent } from '@/utils/dialogEvent'
 import { useFormatter } from '@/utils/useFormatter'
 import { AverageRatingV2 } from './AverageRatingV2'
+import { wrapper, trigger } from './ProductAverageRatingV2.css'
 import { ReviewsDiclaimer } from './ReviewsDisclaimer'
 
 export const ProductAverageRatingV2 = () => {
@@ -23,7 +21,7 @@ export const ProductAverageRatingV2 = () => {
   const productData = useProductData()
 
   const openDialog = () => {
-    // Notify that all playing media should be paused as a result of the dialog being opened
+    // Notify that playing media should be paused as a result of the dialog being opened
     sendDialogEvent('open')
   }
 
@@ -45,36 +43,18 @@ export const ProductAverageRatingV2 = () => {
         />
       </Head>
 
-      <GridLayout.Root>
-        <GridLayout.Content
-          width={{
-            base: '1',
-          }}
-        >
-          <Wrapper>
-            <StarIcon size="1rem" />
+      <div className={wrapper}>
+        <InfoIcon size="1rem" />
 
-            <SpaceFlex direction="horizontal" space={0.2} align="center">
-              <Text as="span" color="textSecondary" size={{ _: 'xs' }}>
-                {t('RATING_SCORE_LABEL', { score: averageRating.score, maxScore: MAX_SCORE })}
-              </Text>
-
-              <Text as="span" color="textSecondary" size={{ _: 'xs' }}>
-                ·
-              </Text>
-
-              <Dialog>
-                <Trigger onClick={openDialog}>
-                  {t('REVIEWS_COUNT_LABEL', {
-                    count: averageRating.totalOfReviews,
-                    reviewsCount: numberGrouping(averageRating.totalOfReviews),
-                  })}
-                </Trigger>
-              </Dialog>
-            </SpaceFlex>
-          </Wrapper>
-        </GridLayout.Content>
-      </GridLayout.Root>
+        <Dialog>
+          <button className={trigger} onClick={openDialog}>
+            {t('REVIEWS_COUNT_LABEL', {
+              count: averageRating.totalOfReviews,
+              reviewsCount: numberGrouping(averageRating.totalOfReviews),
+            })}
+          </button>
+        </Dialog>
+      </div>
     </>
   )
 }
@@ -111,31 +91,6 @@ const Dialog = (props: DialogProps) => {
     </ReviewsDialogV2>
   )
 }
-
-const Wrapper = styled.div({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  gap: theme.space.xxs,
-  flexWrap: 'wrap',
-})
-
-const Trigger = styled.button({
-  color: theme.colors.textSecondary,
-  fontSize: theme.fontSizes.xs,
-  textDecoration: 'underline',
-  cursor: 'pointer',
-
-  ':focus-visible': {
-    boxShadow: theme.shadow.focus,
-  },
-
-  '@media (hover: hover)': {
-    ':hover': {
-      color: theme.colors.textPrimary,
-    },
-  },
-})
 
 type AverageRating = NonNullable<ReturnType<typeof useProuctReviewsDataContext>>['averageRating']
 


### PR DESCRIPTION
## Describe your changes

* `ProductAverageRating ` UI changes.
* Migrate to `@vanilla-extract/css`

<img width="447" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/08918f16-7f94-4c30-adff-2707c2389411">

## Justify why they are needed

Part of [_Product Reviews v2_](https://www.figma.com/file/PUA7SuN75sWH4Q1QxDaeCJ/Product-Reviews?type=design&node-id=1447-1775&mode=design&t=Sri79oZDuQ3Tbqo4-4)