### PR TITLE
GEN-1835 - feat(ReviewComment): added a tag for the review comment

### DIFF
--- a/apps/store/public/locales/en/reviews.json
+++ b/apps/store/public/locales/en/reviews.json
@@ -4,5 +4,14 @@
   "REVIEWS_COUNT_LABEL_other": "{{reviewsCount}} reviews",
   "REVIEWS_DISCLAIMER_one": "Shows the average of {{reviewsCount}} review from our customers. Anyone who has had an injury is invited to leave a review.",
   "REVIEWS_DISCLAIMER_other": "Shows the average of {{reviewsCount}} reviews from our customers. Anyone who has had an injury is invited to leave a review.",
+  "SE_ACCIDENT_REVIEW_COMMENT_TAG": "Accident",
+  "SE_APARTMENT_BRF_REVIEW_COMMENT_TAG": "Homeowner",
+  "SE_APARTMENT_RENT_REVIEW_COMMENT_TAG": "Rental",
+  "SE_APARTMENT_STUDENT_REVIEW_COMMENT_TAG": "Student",
+  "SE_CAR_REVIEW_COMMENT_TAG": "Car",
+  "SE_HOUSE_REVIEW_COMMENT_TAG": "House",
+  "SE_PET_CAT_REVIEW_COMMENT_TAG": "Cat",
+  "SE_PET_DOG_REVIEW_COMMENT_TAG": "Dog",
+  "VERIFIED_CUSTOMER_LABEL": "Verified customer",
   "VIEW_REVIEWS_LABEL": "View reviews"
 }

--- a/apps/store/public/locales/sv-se/reviews.json
+++ b/apps/store/public/locales/sv-se/reviews.json
@@ -4,5 +4,14 @@
   "REVIEWS_COUNT_LABEL_other": "{{reviewsCount}} omdömen",
   "REVIEWS_DISCLAIMER_one": "Visar genomsnittet av {{reviewsCount}} omdöme från våra kunder. Alla som haft en skada blir inbjuden till att lämna ett omdöme.",
   "REVIEWS_DISCLAIMER_other": "Visar genomsnittet av {{reviewsCount}} omdömen från våra kunder. Alla som haft en skada blir inbjuden till att lämna ett omdöme.",
+  "SE_ACCIDENT_REVIEW_COMMENT_TAG": "Olycksfall",
+  "SE_APARTMENT_BRF_REVIEW_COMMENT_TAG": "Bostadsrätt",
+  "SE_APARTMENT_RENT_REVIEW_COMMENT_TAG": "Hyresrätt",
+  "SE_APARTMENT_STUDENT_REVIEW_COMMENT_TAG": "Student",
+  "SE_CAR_REVIEW_COMMENT_TAG": "Bil",
+  "SE_HOUSE_REVIEW_COMMENT_TAG": "Villa",
+  "SE_PET_CAT_REVIEW_COMMENT_TAG": "Katt",
+  "SE_PET_DOG_REVIEW_COMMENT_TAG": "Hund",
+  "VERIFIED_CUSTOMER_LABEL": "Verifierad kund",
   "VIEW_REVIEWS_LABEL": "Visa omdömen"
 }

--- a/apps/store/src/components/ProductReviews/ReviewCommentV2.css.ts
+++ b/apps/store/src/components/ProductReviews/ReviewCommentV2.css.ts
@@ -19,13 +19,28 @@ export const wrapper = style({
   },
 })
 
+export const reviewHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: theme.space.xs,
+})
+
 export const reviewContent = style({
   whiteSpace: 'normal',
 })
 
-export const footer = style({
+export const reviewFooter = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
   color: theme.colors.textTranslucentSecondary,
+})
+
+export const reviewTag = style({
+  fontSize: theme.fontSizes.xs,
+  paddingBlock: theme.space.xxs,
+  paddingInline: theme.space.xs,
+  borderRadius: theme.radius.xs,
+  backgroundColor: theme.colors.backgroundStandard,
 })

--- a/apps/store/src/components/ProductReviews/ReviewCommentV2.tsx
+++ b/apps/store/src/components/ProductReviews/ReviewCommentV2.tsx
@@ -4,7 +4,13 @@ import { Text } from 'ui'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { Review } from '@/features/memberReviews/memberReviews.types'
 import { useFormatter } from '@/utils/useFormatter'
-import { wrapper, reviewContent, footer } from './ReviewCommentV2.css'
+import {
+  wrapper,
+  reviewHeader,
+  reviewTag,
+  reviewContent,
+  reviewFooter,
+} from './ReviewCommentV2.css'
 import { Stars } from './Stars'
 import { VerifiedIcon } from './VerifiedIcon'
 
@@ -12,17 +18,21 @@ type Props = Review & {
   className?: string
 }
 
-export const ReviewCommentV2 = ({ score, date, content, className }: Props) => {
-  const { t } = useTranslation('common')
+export const ReviewCommentV2 = ({ score, date, tag, content, className }: Props) => {
+  const { t } = useTranslation('reviews')
   const formatter = useFormatter()
 
   return (
     <div className={clsx(wrapper, className)}>
-      <Stars score={score} size="1rem" />
+      <div className={reviewHeader}>
+        <Stars score={score} size="1rem" />
+        {/* @ts-expect-error couldn't find a way to tell TS that tag string content belongs to 'reviews' namespace */}
+        {tag && <span className={reviewTag}>{t(tag)}</span>}
+      </div>
 
       <Text className={reviewContent}>{content}</Text>
 
-      <div className={footer}>
+      <div className={reviewFooter}>
         <SpaceFlex direction="horizontal" align="center" space={0.25}>
           <VerifiedIcon />
 

--- a/apps/store/src/features/memberReviews/memberReviews.types.ts
+++ b/apps/store/src/features/memberReviews/memberReviews.types.ts
@@ -11,6 +11,7 @@ export type Review = {
   score: number
   date: string
   content: string
+  tag?: string
 }
 
 export type ScoreDistributionTuple = [Score, number]

--- a/apps/store/src/features/memberReviews/productReviews.ts
+++ b/apps/store/src/features/memberReviews/productReviews.ts
@@ -120,6 +120,7 @@ const parseReviewsByScore = (
           date: comment.date,
           score: comment.score,
           content: comment.content,
+          tag: reviewComments.tag,
         })),
       },
     }),

--- a/apps/store/src/features/memberReviews/productReviews.utils.ts
+++ b/apps/store/src/features/memberReviews/productReviews.utils.ts
@@ -19,6 +19,7 @@ const commentsByScoreSchema = z.object({
 })
 
 export const reviewCommentsSchema = z.object({
+  tag: z.string(),
   commentsByScore: z.object({
     5: commentsByScoreSchema,
     4: commentsByScoreSchema,


### PR DESCRIPTION
## Describe your changes

* Added a _tag_ for review comments that identifies which product they're associated with. That's gonna be more relevant later.

<img width="510" alt="Screenshot 2024-02-20 at 10 11 40" src="https://github.com/HedvigInsurance/racoon/assets/19200662/185afd52-74d7-4663-a124-cbae6a896fc6">

## Justify why they are needed

Part of [_Product Reviews v2_](https://www.figma.com/file/PUA7SuN75sWH4Q1QxDaeCJ/Product-Reviews?type=design&node-id=1447-1775&mode=design&t=Sri79oZDuQ3Tbqo4-4)