### PR TITLE
GEN-1835 - feat: added AverageRatingBanner which will replace TrustpilotBlock

### DIFF
--- a/apps/store/src/blocks/AverageRatingBanner.css.ts
+++ b/apps/store/src/blocks/AverageRatingBanner.css.ts
@@ -1,0 +1,37 @@
+import { style } from '@vanilla-extract/css'
+import { theme, minWidth } from 'ui/src/theme'
+
+export const wrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: theme.space.xxl,
+  aspectRatio: '4 / 5',
+  maxWidth: '100%',
+  background: `linear-gradient(
+    to bottom,
+    transparent 0%,
+    hsl(84, 96%, 90%) 30%,
+    hsl(84, 98%, 90%) 50%,
+    hsl(85, 100%, 90%) 70%,
+    transparent 100%
+  )`,
+  paddingBlock: theme.space[10],
+  paddingInline: theme.space.md,
+
+  '@media': {
+    [minWidth.lg]: {
+      aspectRatio: '16 / 9',
+    },
+  },
+})
+
+export const averageRatingLabel = style({
+  fontSize: 'clamp(5.5rem, 20vw + 1.2rem, 13rem)',
+})
+
+export const disclaimerLabel = style({
+  maxWidth: '32rem',
+  marginInline: 'auto',
+})

--- a/apps/store/src/blocks/AverageRatingBanner.tsx
+++ b/apps/store/src/blocks/AverageRatingBanner.tsx
@@ -1,0 +1,32 @@
+import { useTranslation } from 'next-i18next'
+import { Button } from 'ui'
+import { AverageRatingV2 } from '@/components/ProductReviews/AverageRatingV2'
+import { ReviewsDiclaimer } from '@/components/ProductReviews/ReviewsDisclaimer'
+import { MAX_SCORE } from '@/features/memberReviews/memberReviews.constants'
+import { wrapper, averageRatingLabel, disclaimerLabel } from './AverageRatingBanner.css'
+
+export const AverageRatingBanner = () => {
+  const { t } = useTranslation('reviews')
+
+  return (
+    <div className={wrapper}>
+      <div>
+        {/* TODO: get average rating from vercel kv */}
+        <AverageRatingV2 className={averageRatingLabel} score={4.1} maxScore={MAX_SCORE} />
+        {/* TODO: get reviews count from vercel kv */}
+        <ReviewsDiclaimer
+          className={disclaimerLabel}
+          size={{ _: 'xs', sm: 'md' }}
+          reviewsCount={4748}
+        />
+      </div>
+
+      {/* TODO: get latest reviews from vercel kv and display ReviewsDialogV2 */}
+      <Button variant="primary" size="medium">
+        {t('VIEW_REVIEWS_LABEL')}
+      </Button>
+    </div>
+  )
+}
+
+AverageRatingBanner.blockName = 'averageRatingBanner'

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -11,6 +11,7 @@ import {
 import { AccordionBlock } from '@/blocks/AccordionBlock'
 import { AccordionItemBlock } from '@/blocks/AccordionItemBlock'
 import { AnnouncementBlock } from '@/blocks/AnnouncementBlock'
+import { AverageRatingBanner } from '@/blocks/AverageRatingBanner'
 import { BannerBlock } from '@/blocks/BannerBlock'
 import { ButtonBlock } from '@/blocks/ButtonBlock'
 import { CardLinkBlock } from '@/blocks/CardLinkBlock'
@@ -301,6 +302,7 @@ export const initStoryblok = () => {
     TextContentBlock,
     TopPickCardBlock,
     TrustpilotBlock,
+    AverageRatingBanner,
     TrustpilotReviewsBlock,
     VideoBlock,
     WidgetFlowBlock,


### PR DESCRIPTION
## Describe your changes

* Added `AverageRatingBanner` which will be used to replace `TrustpilotBlock`

Next step is use actual data from `productReviews` service (next PR).

![Screenshot 2024-02-21 at 10.49.02.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/3c847c7f-2530-4eb6-b88c-d77b01e7c094.png)

## Justify why they are needed

Part of [_Product Reviews v2_](https://www.figma.com/file/PUA7SuN75sWH4Q1QxDaeCJ/Product-Reviews?type=design&node-id=1447-1775&mode=design&t=Sri79oZDuQ3Tbqo4-4)