### PR TITLE
Move app router global metadata to root layout

### DIFF
--- a/apps/store/src/app/[locale]/RootLayout.tsx
+++ b/apps/store/src/app/[locale]/RootLayout.tsx
@@ -2,7 +2,6 @@ import { Provider as JotaiProvider } from 'jotai'
 import { PropsWithChildren, Suspense } from 'react'
 import { NextAppDirEmotionCacheProvider } from 'tss-react/next/appDir'
 import globalCss from 'ui/src/global.css'
-import { theme } from 'ui/src/theme'
 import { ApolloWrapper } from '@/services/apollo/app-router/ApolloWrapper'
 import { contentFontClassName } from '@/utils/fonts'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
@@ -18,9 +17,6 @@ noop(globalCss)
 export const RootLayout = ({ locale, children }: PropsWithChildren<{ locale: RoutingLocale }>) => {
   return (
     <html lang={getLocaleOrFallback(locale).htmlLang}>
-      <head>
-        <meta name="theme-color" content={theme.colors.light} />
-      </head>
       <body className={contentFontClassName}>
         <NextAppDirEmotionCacheProvider options={{ key: 'css' }}>
           <Suspense>

--- a/apps/store/src/app/[locale]/layout.tsx
+++ b/apps/store/src/app/[locale]/layout.tsx
@@ -3,7 +3,6 @@
 /** @jsxImportSource react */
 
 import { ReactNode } from 'react'
-import { theme } from 'ui'
 import { fetchGlobalProductMetadata } from '@/components/LayoutWithMenu/fetchProductMetadata'
 import { getClient } from '@/services/apollo/app-router/rscClient'
 import { ShopSessionProvider } from '@/services/shopSession/ShopSessionContext'
@@ -14,7 +13,6 @@ import {
 } from '@/services/storyblok/storyblok.serverOnly'
 import { locales } from '@/utils/l10n/locales'
 import { RoutingLocale } from '@/utils/l10n/types'
-import { ORIGIN_URL } from '@/utils/PageLink'
 import { initTranslationsServerSide } from './i18n'
 import { ProductMetadataProvider } from './ProductMetadataProvider'
 import { RootLayout } from './RootLayout'
@@ -54,32 +52,6 @@ export const generateStaticParams = () => {
 export const dynamicParams = false
 
 export default Layout
-
-export const metadata = {
-  metadataBase: new URL(ORIGIN_URL),
-  twitter: { site: '@hedvigapp', card: 'summary_large_image' },
-  icons: [
-    { rel: 'apple-touch-icon', sizes: '76x76', url: '/apple-touch-icon.png' },
-    {
-      rel: 'icon',
-      type: 'image/png',
-      sizes: '32x32',
-      url: '/favicon-32x32.png',
-    },
-    {
-      rel: 'icon',
-      type: 'image/png',
-      sizes: '16x16',
-      url: '/favicon-16x16.png',
-    },
-    {
-      rel: 'mask-icon',
-      url: '/safari-pinned-tab.svg',
-      color: theme.colors.gray1000,
-    },
-  ],
-  manifest: '/site.webmanifest',
-}
 
 const initCacheVersionAndFetchGlobalStory = async (locale: RoutingLocale) => {
   // Not using the result, all we need is to put storyblok cache version into NextJs cache

--- a/apps/store/src/app/layout.tsx
+++ b/apps/store/src/app/layout.tsx
@@ -1,5 +1,41 @@
+import { Metadata, Viewport } from 'next'
 import { PropsWithChildren } from 'react'
+import { theme } from 'ui'
+import { ORIGIN_URL } from '@/utils/PageLink'
 
 // Everything interesting is in [locale]/layout, but we must provide root layout anyway
 const RootLayout = ({ children }: PropsWithChildren) => children
 export default RootLayout
+
+export const metadata: Metadata = {
+  metadataBase: new URL(ORIGIN_URL),
+  openGraph: {
+    type: 'website',
+  },
+  twitter: { site: '@hedvigapp', card: 'summary_large_image' },
+  icons: [
+    { rel: 'apple-touch-icon', sizes: '76x76', url: '/apple-touch-icon.png' },
+    {
+      rel: 'icon',
+      type: 'image/png',
+      sizes: '32x32',
+      url: '/favicon-32x32.png',
+    },
+    {
+      rel: 'icon',
+      type: 'image/png',
+      sizes: '16x16',
+      url: '/favicon-16x16.png',
+    },
+    {
+      rel: 'mask-icon',
+      url: '/safari-pinned-tab.svg',
+      color: theme.colors.gray1000,
+    },
+  ],
+  manifest: '/site.webmanifest',
+}
+
+export const viewport: Viewport = {
+  themeColor: theme.colors.light,
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Move site-global metadata to app/layouts
- Move viewport themeColor to static export from JSX

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Last step towards making app router stack mergeable

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
