### PR TITLE
Use transition for opening mobile main menu (faster INP)

### DIFF
--- a/apps/store/src/blocks/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock.tsx
@@ -3,7 +3,7 @@ import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import { storyblokEditable } from '@storyblok/react'
 import { usePathname } from 'next/navigation'
 import { useTranslation } from 'next-i18next'
-import { useEffect, useMemo, useState } from 'react'
+import { startTransition, useCallback, useEffect, useMemo, useState } from 'react'
 import { mq, Space, theme } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { Header } from '@/components/Header/Header'
@@ -234,6 +234,10 @@ export const HeaderBlock = ({ blok, ...headerProps }: HeaderBlockProps) => {
   useEffect(() => {
     setIsOpen(false)
   }, [pathname])
+  const handleOpenChange = useCallback(
+    (newValue: boolean) => startTransition(() => setIsOpen(newValue)),
+    [],
+  )
 
   const productNavItem = useMemo(
     () =>
@@ -249,7 +253,7 @@ export const HeaderBlock = ({ blok, ...headerProps }: HeaderBlockProps) => {
   return (
     <Header key={pathname} {...storyblokEditable(blok)} opaque={isOpen} {...headerProps}>
       <TopMenuDesktop>{blok.navMenuContainer.map(NestedNavigationBlock)}</TopMenuDesktop>
-      <TopMenuMobile isOpen={isOpen} setIsOpen={setIsOpen} defaultValue={productNavItem}>
+      <TopMenuMobile isOpen={isOpen} onOpenChange={handleOpenChange} defaultValue={productNavItem}>
         {blok.navMenuContainer.map(NestedNavigationBlock)}
       </TopMenuMobile>
     </Header>

--- a/apps/store/src/components/Header/Header.stories.tsx
+++ b/apps/store/src/components/Header/Header.stories.tsx
@@ -92,7 +92,7 @@ const Template: StoryFn<TopMenuProps> = (props) => {
           <MockedNavItems />
         </TopMenuDesktop>
 
-        <TopMenuMobile isOpen={props.isOpen} setIsOpen={() => {}}>
+        <TopMenuMobile isOpen={props.isOpen} onOpenChange={() => {}}>
           <MockedNavItems />
         </TopMenuMobile>
 

--- a/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
+++ b/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
@@ -46,19 +46,19 @@ const ButtonWrapper = styled.div({
 
 export type TopMenuMobileProps = {
   isOpen: boolean
-  setIsOpen: (isOpen: boolean) => void
+  onOpenChange: (isOpen: boolean) => void
   defaultValue?: string
   children: React.ReactNode
 }
 
 export const TopMenuMobile = (props: TopMenuMobileProps) => {
-  const { children, isOpen, setIsOpen, defaultValue } = props
+  const { children, isOpen, onOpenChange, defaultValue } = props
   const { t } = useTranslation('common')
   const locale = useRoutingLocale()
 
   return (
     <>
-      <DialogPrimitive.Root open={isOpen} onOpenChange={setIsOpen}>
+      <DialogPrimitive.Root open={isOpen} onOpenChange={onOpenChange}>
         <DialogTrigger>{t('NAV_MENU_DIALOG_OPEN')}</DialogTrigger>
         <DialogContent>
           <Wrapper>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Use React's `startTransition` for opening mobile main menu

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

I've seen "Menu" button in list of elements responsible for long INP, this should fix it

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
