### PR TITLE
Add MyMoney consent to car trial extension

### DIFF
--- a/apps/store/src/features/carDealership/CarTrialExtension.graphql
+++ b/apps/store/src/features/carDealership/CarTrialExtension.graphql
@@ -1,6 +1,8 @@
 query CarTrialExtension($contractId: UUID!) {
   carTrial(contractId: $contractId) {
     id
+    collectConsent
+    consentGiven
     priceIntent {
       ...PriceIntentCarTrialExtension
     }

--- a/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
+++ b/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
@@ -10,6 +10,7 @@ import { useGlobalBanner } from '@/components/GlobalBanner/useGlobalBanner'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { useCarTrialExtensionQuery } from '@/services/graphql/generated'
 import { type SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { Features } from '@/utils/Features'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { useFormatter } from '@/utils/useFormatter'
@@ -61,6 +62,10 @@ export const CarTrialExtensionBlock = (props: Props) => {
                 priceIntent={data.carTrial.priceIntent}
                 shopSession={data.carTrial.shopSession}
                 requirePaymentConnection={props.blok.requirePaymentConnection ?? false}
+                {...(Features.enabled('MYMONEY') && {
+                  collectConsent: data.carTrial.collectConsent,
+                  consentGiven: data.carTrial.consentGiven,
+                })}
               />
             ) : (
               <PayForTrial
@@ -68,6 +73,10 @@ export const CarTrialExtensionBlock = (props: Props) => {
                 shopSessionId={data.carTrial.shopSession.id}
                 defaultOffer={data.carTrial.priceIntent.defaultOffer ?? undefined}
                 ssn={data.carTrial.shopSession.customer?.ssn ?? undefined}
+                {...(Features.enabled('MYMONEY') && {
+                  collectConsent: data.carTrial.collectConsent,
+                  consentGiven: data.carTrial.consentGiven,
+                })}
               />
             )}
           </Space>

--- a/apps/store/src/features/carDealership/PayForTrial.tsx
+++ b/apps/store/src/features/carDealership/PayForTrial.tsx
@@ -12,17 +12,25 @@ import { useFormatter } from '@/utils/useFormatter'
 import { type TrialContract } from './carDealership.types'
 import { ConfirmPayWithoutExtensionButton } from './ConfirmPayWithoutExtensionButton'
 import { ExtensionOfferToggle } from './ExtensionOfferToggle'
+import { MyMoneyConsent } from './MyMoneyConsent/MyMoneyConsent'
 import { PriceBreakdown } from './PriceBreakdown'
 import { ProductItemContractContainerCar } from './ProductItemContractContainer'
+import { type MyMoneyConsentProps } from './TrialExtensionForm'
 
 type Props = {
   trialContract: TrialContract
   shopSessionId: string
   defaultOffer?: ProductOfferFragment
   ssn?: string
-}
+} & MyMoneyConsentProps
 
-export const PayForTrial = ({ trialContract, shopSessionId, defaultOffer, ssn }: Props) => {
+export const PayForTrial = ({
+  collectConsent,
+  trialContract,
+  shopSessionId,
+  defaultOffer,
+  ssn,
+}: Props) => {
   const router = useRouter()
   const { t } = useTranslation('carDealership')
   const formatter = useFormatter()
@@ -81,6 +89,8 @@ export const PayForTrial = ({ trialContract, shopSessionId, defaultOffer, ssn }:
           }),
         })}
       />
+
+      {collectConsent && <MyMoneyConsent />}
 
       <ConfirmPayWithoutExtensionButton onConfirm={handleConfirmPay} />
     </Space>

--- a/apps/store/src/features/carDealership/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.tsx
@@ -19,26 +19,34 @@ import { useFormatter } from '@/utils/useFormatter'
 import { type TrialContract } from './carDealership.types'
 import { EditActionButton } from './EditActionButton'
 import { ExtensionOfferToggle } from './ExtensionOfferToggle'
+import { MyMoneyConsent } from './MyMoneyConsent/MyMoneyConsent'
 import { PriceBreakdown } from './PriceBreakdown'
 import { ProductItemContractContainerCar } from './ProductItemContractContainer'
 import { useAcceptExtension } from './useAcceptExtension'
+
+export type MyMoneyConsentProps = {
+  collectConsent?: boolean
+  consentGiven?: boolean
+}
 
 type Props = {
   trialContract: TrialContract
   priceIntent: PriceIntentCarTrialExtensionFragment
   shopSession: ShopSessionFragment
   requirePaymentConnection: boolean
-}
+} & MyMoneyConsentProps
 
 export const TrialExtensionForm = ({
   trialContract,
   priceIntent,
   shopSession,
   requirePaymentConnection,
+  collectConsent,
 }: Props) => {
   const { t } = useTranslation(['carDealership', 'checkout'])
   const locale = useRoutingLocale()
   const formatter = useFormatter()
+
   const [acceptExtension, loading] = useAcceptExtension({
     shopSession: shopSession,
     trialContractId: trialContract.id,
@@ -143,6 +151,8 @@ export const TrialExtensionForm = ({
             currencyCode={selectedOffer.cost.net.currencyCode}
           />
         )}
+
+        {collectConsent && <MyMoneyConsent />}
 
         <Space y={1}>
           <Button onClick={handleClickSign} loading={loading}>

--- a/apps/store/src/utils/Features.ts
+++ b/apps/store/src/utils/Features.ts
@@ -21,6 +21,7 @@ const config = {
   WIDGET_SWITCH: process.env.NEXT_PUBLIC_FEATURE_WIDGET_SWITCH === 'true',
   PRICE_INTENT_WARNING: process.env.NEXT_PUBLIC_FEATURE_PRICE_INTENT_WARNING === 'true',
   BANKID_V6: process.env.NEXT_PUBLIC_FEATURE_BANKID_V6 === 'true',
+  MYMONEY: process.env.NEXT_PUBLIC_FEATURE_MYMONEY === 'true',
 } as const
 
 export type FeatureFlag = keyof typeof config


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add MyMoney consent component to `TrialExtensionForm` och `PayForTrial` since we want to make it possible to accept or change consent at any point.

Next PR: add update consent mutation

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
MyMoney project

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
