### PR TITLE
Prevent full page rerender after initial shopSessionCustomerUpdate

### DIFF
--- a/apps/store/src/blocks/PageBlock.tsx
+++ b/apps/store/src/blocks/PageBlock.tsx
@@ -8,17 +8,24 @@ type PageBlockProps = SbBaseBlockProps<{
 }>
 
 export const PageBlock = ({ blok }: PageBlockProps) => {
-  useDiscountBanner()
   return (
-    <Main {...storyblokEditable(blok)}>
-      {blok.body.map((nestedBlock) => (
-        <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
-      ))}
-    </Main>
+    <>
+      <Main {...storyblokEditable(blok)}>
+        {blok.body.map((nestedBlock) => (
+          <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+        ))}
+      </Main>
+      <DiscountBannerTrigger />
+    </>
   )
 }
-
 PageBlock.blockName = 'page'
+
+// Optimization - this effect should run in component without children to avoid rerenders
+const DiscountBannerTrigger = () => {
+  useDiscountBanner()
+  return null
+}
 
 const Main = styled.main({
   width: '100%',


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Price calculator was particularly slow after SSN section submit

I tracked root cause to the way we subscribed to session change for tracking and discount banner display

We've run `useEffect` on top level of `ProductPageBlock` which led to full rerender every time customer or session changed even if it had nothing to do with direct children on a block.  I've isolated those effects into childless components.  Rerender after updating customer is not ~3x cheaper

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Optimize slow interaction

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
