### PR TITLE
Only send UpdateConsent mutation on sign/connect payment button click

### DIFF
--- a/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
+++ b/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
@@ -87,7 +87,6 @@ export const CarTrialExtensionBlock = (props: Props) => {
                 requirePaymentConnection={props.blok.requirePaymentConnection ?? false}
                 {...(Features.enabled('MYMONEY') && {
                   collectConsent: data.carTrial.collectConsent,
-                  consentGiven: data.carTrial.consentGiven,
                   onConsentChange: handleMyMoneyConsent,
                 })}
               />
@@ -99,7 +98,6 @@ export const CarTrialExtensionBlock = (props: Props) => {
                 ssn={data.carTrial.shopSession.customer?.ssn ?? undefined}
                 {...(Features.enabled('MYMONEY') && {
                   collectConsent: data.carTrial.collectConsent,
-                  consentGiven: data.carTrial.consentGiven,
                   onConsentChange: handleMyMoneyConsent,
                 })}
               />

--- a/apps/store/src/features/carDealership/MyMoneyConsent/MyMoneyConsent.tsx
+++ b/apps/store/src/features/carDealership/MyMoneyConsent/MyMoneyConsent.tsx
@@ -1,25 +1,25 @@
 import * as Checkbox from '@radix-ui/react-checkbox'
+import { useAtom } from 'jotai'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 import { CheckIcon, Text } from 'ui'
 import { checkboxIndicator, checkboxRoot, consentBody, consentWrapper } from './MyMoneyConsent.css'
+import { concentAcceptedAtom } from './MyMoneyConsentAtom'
 
-type Props = {
-  consentGiven?: boolean
-  onConsentChange?: (consentGiven: boolean) => void
-}
-
-export const MyMoneyConsent = ({ consentGiven, onConsentChange }: Props) => {
+export const MyMoneyConsent = () => {
   const { t } = useTranslation('carDealership')
+  const [concentAccepted, setConsentAccepted] = useAtom(concentAcceptedAtom)
+
   const handleCheckedChange = (checked: boolean) => {
-    onConsentChange?.(checked)
+    setConsentAccepted(checked)
   }
+
   return (
     <div className={consentWrapper}>
       <Checkbox.Root
         className={checkboxRoot}
         id="myMoneyConsent"
-        defaultChecked={consentGiven}
+        checked={concentAccepted}
         onCheckedChange={handleCheckedChange}
       >
         <Checkbox.Indicator className={checkboxIndicator}>

--- a/apps/store/src/features/carDealership/MyMoneyConsent/MyMoneyConsentAtom.ts
+++ b/apps/store/src/features/carDealership/MyMoneyConsent/MyMoneyConsentAtom.ts
@@ -1,0 +1,3 @@
+import { atomWithStorage } from 'jotai/utils'
+
+export const concentAcceptedAtom = atomWithStorage('concentAccepted', false)

--- a/apps/store/src/features/carDealership/PayForTrial.tsx
+++ b/apps/store/src/features/carDealership/PayForTrial.tsx
@@ -1,4 +1,5 @@
 import { datadogRum } from '@datadog/browser-rum'
+import { useAtom } from 'jotai'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { Space } from 'ui'
@@ -13,6 +14,7 @@ import { type TrialContract } from './carDealership.types'
 import { ConfirmPayWithoutExtensionButton } from './ConfirmPayWithoutExtensionButton'
 import { ExtensionOfferToggle } from './ExtensionOfferToggle'
 import { MyMoneyConsent } from './MyMoneyConsent/MyMoneyConsent'
+import { concentAcceptedAtom } from './MyMoneyConsent/MyMoneyConsentAtom'
 import { PriceBreakdown } from './PriceBreakdown'
 import { ProductItemContractContainerCar } from './ProductItemContractContainer'
 import { type MyMoneyConsentProps } from './TrialExtensionForm'
@@ -30,7 +32,6 @@ export const PayForTrial = ({
   defaultOffer,
   ssn,
   collectConsent,
-  consentGiven,
   onConsentChange,
 }: Props) => {
   const router = useRouter()
@@ -39,12 +40,17 @@ export const PayForTrial = ({
   const locale = useRoutingLocale()
   const { dismissBanner } = useGlobalBanner()
   const { startLogin } = useBankIdContext()
+  const [concentAccepted] = useAtom(concentAcceptedAtom)
+
   const handleConfirmPay = () => {
     datadogRum.addAction('Car dealership | Decline extension offer')
 
     if (!ssn) {
       throw new Error('Must have customer ssn')
     }
+
+    // Send MyMoney consent state
+    onConsentChange?.(concentAccepted)
 
     startLogin({
       ssn,
@@ -92,9 +98,7 @@ export const PayForTrial = ({
         })}
       />
 
-      {collectConsent && (
-        <MyMoneyConsent consentGiven={consentGiven} onConsentChange={onConsentChange} />
-      )}
+      {collectConsent && <MyMoneyConsent />}
 
       <ConfirmPayWithoutExtensionButton onConfirm={handleConfirmPay} />
     </Space>

--- a/apps/store/src/features/carDealership/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.tsx
@@ -1,5 +1,6 @@
 import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
+import { useAtom } from 'jotai'
 import { useTranslation } from 'next-i18next'
 import { useMemo, useState } from 'react'
 import { BankIdIcon, Button, CheckIcon, Space, Text, theme } from 'ui'
@@ -20,13 +21,13 @@ import { type TrialContract } from './carDealership.types'
 import { EditActionButton } from './EditActionButton'
 import { ExtensionOfferToggle } from './ExtensionOfferToggle'
 import { MyMoneyConsent } from './MyMoneyConsent/MyMoneyConsent'
+import { concentAcceptedAtom } from './MyMoneyConsent/MyMoneyConsentAtom'
 import { PriceBreakdown } from './PriceBreakdown'
 import { ProductItemContractContainerCar } from './ProductItemContractContainer'
 import { useAcceptExtension } from './useAcceptExtension'
 
 export type MyMoneyConsentProps = {
   collectConsent?: boolean
-  consentGiven?: boolean
   onConsentChange?: (consentGiven: boolean) => void
 }
 
@@ -43,12 +44,12 @@ export const TrialExtensionForm = ({
   shopSession,
   requirePaymentConnection,
   collectConsent,
-  consentGiven,
   onConsentChange,
 }: Props) => {
   const { t } = useTranslation(['carDealership', 'checkout'])
   const locale = useRoutingLocale()
   const formatter = useFormatter()
+  const [concentAccepted] = useAtom(concentAcceptedAtom)
 
   const [acceptExtension, loading] = useAcceptExtension({
     shopSession: shopSession,
@@ -90,6 +91,8 @@ export const TrialExtensionForm = ({
   const handleClickSign = () => {
     datadogRum.addAction('Car dealership | Click Sign')
     acceptExtension(selectedOffer.id)
+    // Send MyMoney consent state
+    onConsentChange?.(concentAccepted)
   }
 
   return (
@@ -155,9 +158,7 @@ export const TrialExtensionForm = ({
           />
         )}
 
-        {collectConsent && (
-          <MyMoneyConsent consentGiven={consentGiven} onConsentChange={onConsentChange} />
-        )}
+        {collectConsent && <MyMoneyConsent />}
 
         <Space y={1}>
           <Button onClick={handleClickSign} loading={loading}>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
For compliance we can't update the user consent when a user ticks the checkbox. Instead we should send consent state once the user clicks either the sign or connect payment button.

Also persist the `checked` state in an atom if a user closes the browser or reloads the page

https://github.com/HedvigInsurance/racoon/assets/6661511/42fdb05f-bf3b-4277-a4a5-272adf9fc2a7

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
For compliance

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
