### PR TITLE
Use direct jotai writes in ProductData provider

### DIFF
--- a/apps/store/src/components/ProductData/ProductDataProvider.tsx
+++ b/apps/store/src/components/ProductData/ProductDataProvider.tsx
@@ -1,6 +1,6 @@
-import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { atomFamily, useHydrateAtoms } from 'jotai/utils'
-import { ReactNode, useEffect } from 'react'
+import { atom, useAtom, useAtomValue, useStore } from 'jotai'
+import { atomFamily } from 'jotai/utils'
+import { ReactNode } from 'react'
 import { RoutingLocale } from '@/utils/l10n/types'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import type { ProductData } from './ProductData.types'
@@ -35,21 +35,12 @@ type Props = {
 export const ProductDataProvider = (props: Props) => {
   const locale = useRoutingLocale()
   const key = productKey(props.productData.id, locale)
-  useHydrateAtoms([
-    [currentProductAtom, key],
-    [productDataAtomFamily(key), props.productData],
-    [selectedTypeOfContractAtom, props.selectedTypeOfContract],
-  ])
-  // Hydration only happens on very first render, effects below take care of navigation after that
-  const setCurrentProduct = useSetAtom(currentProductAtom)
-  useEffect(() => {
-    setCurrentProduct(key)
-  }, [key, setCurrentProduct])
-  const setSelectedTypeOfContract = useSetAtom(selectedTypeOfContractAtom)
-  useEffect(() => {
-    setSelectedTypeOfContract(props.selectedTypeOfContract)
-  }, [props.selectedTypeOfContract, setSelectedTypeOfContract])
-
+  // Writing on every render and relying on jotai skipping recalculations when value === prevValue
+  // This is faster that using effects to sync with current page during client-side navigation
+  const store = useStore()
+  store.set(currentProductAtom, key)
+  store.set(productDataAtomFamily(key), props.productData)
+  store.set(selectedTypeOfContractAtom, props.selectedTypeOfContract)
   return props.children
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Instead of hydrate + effects used to sync product data atoms with current page eventially simply set new value on every render

- It's stable (jotai skips update if values are equal, meaning atom dependencies will be updated only once)
- It's immediate, no lag between provider being rendered and atoms taking new value (unlike previous useEffect solution)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
