### PR TITLE
GEN-1860 - refac(ReviewsDialog): fetch reviews client side

### DIFF
--- a/apps/store/src/app/api/member-reviews/route.ts
+++ b/apps/store/src/app/api/member-reviews/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  fetchCompanyReviewsByScore,
+  fetchProductReviewsByScore,
+} from '@/features/memberReviews/memberReviews'
+import type { ReviewsByScore, Review, Score } from '@/features/memberReviews/memberReviews.types'
+
+export async function GET(req: NextRequest) {
+  try {
+    const searchParams = req.nextUrl.searchParams
+    const productIds = searchParams.getAll('productId')
+
+    let reviews: ReviewsByScore | null = null
+    if (productIds.length === 0) {
+      reviews = await fetchCompanyReviewsByScore()
+    } else {
+      reviews = await aggregateProductReviewsByScore(productIds)
+    }
+
+    if (reviews === null) {
+      return NextResponse.json(null, { status: 204 })
+    }
+
+    return NextResponse.json(reviews, { status: 200 })
+  } catch (error) {
+    console.error('Failed to fetch reviews', error)
+    return NextResponse.json(null, { status: 500 })
+  }
+}
+
+async function aggregateProductReviewsByScore(
+  productIds: Array<string>,
+): Promise<ReviewsByScore | null> {
+  const productReviewsByScoreList = await Promise.all(
+    productIds.map((id) => fetchProductReviewsByScore(id)),
+  )
+  const filteredProductReviewsByScoreList = productReviewsByScoreList.filter(
+    (review): review is ReviewsByScore => review !== null,
+  )
+
+  const maxReviewsPerScore = 10
+  const scores: Array<Score> = [5, 4, 3, 2, 1]
+  const result: ReviewsByScore = {
+    5: { total: 0, reviews: [] },
+    4: { total: 0, reviews: [] },
+    3: { total: 0, reviews: [] },
+    2: { total: 0, reviews: [] },
+    1: { total: 0, reviews: [] },
+  }
+  scores.forEach((score) => {
+    filteredProductReviewsByScoreList.forEach((reviewsByScore) => {
+      result[score].total += reviewsByScore[score].total
+      result[score].reviews.push(...reviewsByScore[score].reviews)
+    })
+
+    result[score].reviews.sort(sortReviewsByDate).splice(maxReviewsPerScore)
+  })
+
+  return result
+}
+
+function sortReviewsByDate(a: Review, b: Review) {
+  const dateA = new Date(a.date).getTime()
+  const dateB = new Date(b.date).getTime()
+
+  return dateB - dateA
+}

--- a/apps/store/src/components/ProductReviews/ProductAverageRating.tsx
+++ b/apps/store/src/components/ProductReviews/ProductAverageRating.tsx
@@ -53,6 +53,7 @@ export const ProductAverageRating = () => {
         <CertifiedIcon className={certifiedIcon} size="1.15rem" />
 
         <ReviewsDialog
+          productIds={[productData.name]}
           Header={
             <section>
               <AverageRating

--- a/apps/store/src/components/ProductReviews/ProductReviews.tsx
+++ b/apps/store/src/components/ProductReviews/ProductReviews.tsx
@@ -18,7 +18,7 @@ import { ReviewsDistributionByScore } from './ReviewsDistributionByScore'
 export const ProductReviews = () => {
   const { t } = useTranslation('reviews')
 
-  const { displayNameFull: productName, pillowImage } = useProductData()
+  const { name: productId, displayNameFull: productName, pillowImage } = useProductData()
   const productReviewsMetadata = useProuctReviewsMetadata()
 
   if (!productReviewsMetadata) {
@@ -47,6 +47,7 @@ export const ProductReviews = () => {
         </div>
 
         <ReviewsDialog
+          productIds={[productId]}
           Header={
             <PillowHeader
               title={productName}

--- a/apps/store/src/components/ProductReviews/ReviewsDialog.tsx
+++ b/apps/store/src/components/ProductReviews/ReviewsDialog.tsx
@@ -1,8 +1,10 @@
 import { useTranslation } from 'next-i18next'
-import { useState, type ReactElement, type ReactNode } from 'react'
+import { useReducer, useCallback, type ReactElement, type ReactNode } from 'react'
 import { Dialog, Text, Space, CrossIcon } from 'ui'
-import type { Score } from '@/features/memberReviews/memberReviews.types'
-import type { Review, ReviewsDistribution } from '@/features/memberReviews/memberReviews.types'
+import { Skeleton } from '@/components/Skeleton'
+import type { Review, Score } from '@/features/memberReviews/memberReviews.types'
+import type { ReviewsDistribution } from '@/features/memberReviews/memberReviews.types'
+import type { ReviewsByScore } from '@/features/memberReviews/memberReviews.types'
 import { ReviewComment } from './ReviewComment'
 import {
   closeBtn,
@@ -17,78 +19,229 @@ import { ReviewsFilter } from './ReviewsFilter'
 type Props = {
   children: ReactNode
   reviewsDistribution: ReviewsDistribution
+  productIds?: Array<string>
   Header?: ReactElement
   onClose?: () => void
 }
 
-export const ReviewsDialog = ({ children, reviewsDistribution, Header, onClose }: Props) => {
-  const { t } = useTranslation('reviews')
-
-  const { reviews, selectedScore, setSelectedScore } = useReviewsDialog()
+export function ReviewsDialog({
+  reviewsDistribution,
+  children,
+  productIds = [],
+  Header,
+  onClose,
+}: Props) {
+  const { state, fetchReviews, setSelectedScore } = useReviewsDialog()
 
   return (
-    <Dialog.Root>
+    <Dialog.Root
+      onOpenChange={(isOpen) => {
+        if (isOpen) {
+          fetchReviews(productIds)
+        }
+      }}
+    >
       <Dialog.Trigger asChild={true}>{children}</Dialog.Trigger>
 
-      <Dialog.Content className={dialogContent} centerContent={true} onClose={onClose}>
-        <Dialog.Close className={closeBtn} onClick={onClose}>
-          <CrossIcon size={'1rem'} />
-        </Dialog.Close>
+      {state.status !== 'initial' && (
+        <Dialog.Content className={dialogContent} centerContent={true} onClose={onClose}>
+          <Dialog.Close className={closeBtn} onClick={onClose}>
+            <CrossIcon size={'1rem'} />
+          </Dialog.Close>
 
-        <Dialog.Window className={dialogWindow}>
-          <Space y={2}>
-            {Header}
-
+          <Dialog.Window className={dialogWindow}>
             <Space y={2}>
-              <ReviewsFilter
-                reviewsDistribution={reviewsDistribution}
-                selectedScore={selectedScore}
-                onSelectedScoreChange={setSelectedScore}
-              />
+              {Header}
 
-              {reviews.length > 0 ? (
-                <>
-                  <Text
-                    className={latestReviewsLabel}
-                    size={{ _: 'xs', sm: 'md' }}
-                    align="center"
-                    color="textSecondary"
-                  >
-                    {t('LATEST_REVIEWS_WITH_COMMENTS_LABEL')}
-                  </Text>
+              {state.status === 'loading' && <LoadingStateUI />}
 
-                  <Space y={{ base: 0.5, md: 1 }}>
-                    {reviews.map((review) => (
-                      <ReviewComment key={review.id} className={reviewComment} {...review} />
-                    ))}
-                  </Space>
-                </>
-              ) : (
-                <Text
-                  className={noReviewsLabel}
-                  size={{ _: 'xs', sm: 'md' }}
-                  align="center"
-                  color="textSecondary"
-                >
-                  {t('NO_REVIEWS_LABEL')}
-                </Text>
+              {state.status === 'success' && (
+                <SuccessStateUI
+                  reviews={state.reviews}
+                  reviewsDistribution={reviewsDistribution}
+                  selectedScore={state.selectedScore}
+                  setSelectedScore={setSelectedScore}
+                />
               )}
             </Space>
-          </Space>
-        </Dialog.Window>
-      </Dialog.Content>
+          </Dialog.Window>
+        </Dialog.Content>
+      )}
     </Dialog.Root>
   )
 }
 
-// TODO: Implement client side reviews fetching and additional state management
+function LoadingStateUI() {
+  return (
+    <Space y={2}>
+      <Space y={0.25}>
+        <Skeleton style={{ height: '3.5rem' }} />
+        <Skeleton style={{ height: '3.5rem' }} />
+        <Skeleton style={{ height: '3.5rem' }} />
+        <Skeleton style={{ height: '3.5rem' }} />
+        <Skeleton style={{ height: '3.5rem' }} />
+      </Space>
+      <Skeleton style={{ height: '12rem' }} />
+    </Space>
+  )
+}
+
+function SuccessStateUI({
+  reviews,
+  reviewsDistribution,
+  selectedScore,
+  setSelectedScore,
+}: {
+  reviews: Array<Review>
+  reviewsDistribution: ReviewsDistribution
+  selectedScore: Score
+  setSelectedScore: (score: Score) => void
+}) {
+  const { t } = useTranslation('reviews')
+
+  return (
+    <Space y={2}>
+      <ReviewsFilter
+        reviewsDistribution={reviewsDistribution}
+        selectedScore={selectedScore}
+        onSelectedScoreChange={setSelectedScore}
+      />
+
+      {reviews.length > 0 && (
+        <>
+          <Text
+            className={latestReviewsLabel}
+            size={{ _: 'xs', sm: 'md' }}
+            align="center"
+            color="textSecondary"
+          >
+            {t('LATEST_REVIEWS_WITH_COMMENTS_LABEL')}
+          </Text>
+
+          <Space y={{ base: 0.5, md: 1 }}>
+            {reviews.map((review) => (
+              <ReviewComment key={review.id} className={reviewComment} {...review} />
+            ))}
+          </Space>
+        </>
+      )}
+
+      {reviews.length === 0 && (
+        <Text
+          className={noReviewsLabel}
+          size={{ _: 'xs', sm: 'md' }}
+          align="center"
+          color="textSecondary"
+        >
+          {t('NO_REVIEWS_LABEL')}
+        </Text>
+      )}
+    </Space>
+  )
+}
+
+type State =
+  | { status: 'initial' }
+  | { status: 'loading' }
+  | {
+      status: 'success'
+      selectedScore: Score
+      reviews: Array<Review>
+      reviewsByScore: ReviewsByScore
+    }
+  | { status: 'error'; errorMsg?: string }
+
+type Action =
+  | { type: 'LOAD_REVIEWS' }
+  | {
+      type: 'SUCCESS'
+      payload: { selectedScore: Score; reviews: Array<Review>; reviewsByScore: ReviewsByScore }
+    }
+  | { type: 'ERROR'; payload: { errorMsg?: string } }
+  | { type: 'SELECT_SCORE'; payload: { score: Score } }
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'LOAD_REVIEWS':
+      return { status: 'loading' }
+    case 'SUCCESS':
+      return {
+        status: 'success',
+        selectedScore: action.payload.selectedScore,
+        reviews: action.payload.reviews,
+        reviewsByScore: action.payload.reviewsByScore,
+      }
+    case 'ERROR':
+      return { status: 'error', errorMsg: action.payload.errorMsg }
+    case 'SELECT_SCORE':
+      if (state.status !== 'success') return state
+      return {
+        ...state,
+        selectedScore: action.payload.score,
+        reviews: state.reviewsByScore[action.payload.score].reviews,
+      }
+    default:
+      return state
+  }
+}
+
 const useReviewsDialog = () => {
-  const [selectedScore, setSelectedScore] = useState<Score>(5)
-  const [reviews] = useState<Array<Review>>([])
+  const [state, dispatch] = useReducer(reducer, { status: 'initial' })
+
+  const fetchReviews = useCallback(
+    async (productIds: Array<string>) => {
+      try {
+        // Avoid refetching reviews when it's alreay cached
+        if (state.status === 'success') return
+
+        dispatch({ type: 'LOAD_REVIEWS' })
+
+        const urlSearchParams = new URLSearchParams()
+        productIds.forEach((id) => urlSearchParams.append('productId', id))
+
+        const searchParams = urlSearchParams.toString() ? `?${urlSearchParams.toString()}` : ''
+        const response = await fetch(`/api/member-reviews${searchParams}`)
+        if (response.ok) {
+          const reviewsByScore = (await response.json()) as ReviewsByScore
+          const initialSelectedScore = getInitialSelectedScore(reviewsByScore)
+
+          dispatch({
+            type: 'SUCCESS',
+            payload: {
+              selectedScore: initialSelectedScore,
+              reviews: reviewsByScore[initialSelectedScore].reviews,
+              reviewsByScore,
+            },
+          })
+        } else {
+          dispatch({ type: 'ERROR', payload: { errorMsg: 'Failed to fetch reviews.' } })
+        }
+      } catch (error) {
+        console.log(error)
+        dispatch({ type: 'ERROR', payload: { errorMsg: 'Failed to fetch reviews.' } })
+      }
+    },
+    [state.status],
+  )
+
+  const setSelectedScore = useCallback((score: Score) => {
+    dispatch({ type: 'SELECT_SCORE', payload: { score } })
+  }, [])
 
   return {
-    reviews,
-    selectedScore,
+    state,
+    fetchReviews,
     setSelectedScore,
   }
+}
+
+const getInitialSelectedScore = (reviewsByScore: ReviewsByScore | null): Score => {
+  const defaultScore: Score = 5
+
+  const scores: Array<Score> = [5, 4, 3, 2, 1]
+  const initialSelectedScore = reviewsByScore
+    ? scores.find((score) => reviewsByScore[score].reviews.length)
+    : undefined
+
+  return initialSelectedScore ?? defaultScore
 }

--- a/apps/store/src/features/memberReviews/memberReviews.types.ts
+++ b/apps/store/src/features/memberReviews/memberReviews.types.ts
@@ -10,9 +10,9 @@ export type Rating = {
 
 export type Review = z.infer<typeof reviewSchema>
 
-export type ScoreDistributionTuple = [Score, number]
-
 export type ReviewsByScore = Record<Score, { total: number; reviews: Array<Review> }>
+
+export type ScoreDistributionTuple = [Score, number]
 
 export type ReviewsDistribution = Array<ScoreDistributionTuple>
 


### PR DESCRIPTION
## Describe your changes

* `features/member-reviews`: Added `fetchReviewsByScore` function which will be used to get reviews information - _reviews by score_ - given `productId`(s). When no `productId` is provided it will get it for all the products.
* `api/member-reviews/index.tsx`: Small _api route_ to make `fetchReviewsByScore` accessible client side. We're gonna be able to remove this step when we migrate to RSC.
* `ReviewsDialog`: It now fetches reviews client side, which will reduce the payload we send to our users. Consumers of `ReviewsDialog` can now give the `productId`(s) which should be used while fetching reviews.

## Justify why they are needed

This is a series of PRs that's gonna be used as the foundation for getting the following request done by the usage of RSC:

* Being able to render `AverageRatingBanner` block with data about all the reviews (as we're already doing today) **or** a subset of it configured in _Storyblok_. That would allow Peter to use that block for category pages like _Pet Insurance_ as well, by showing average rating, reviews distribution and reviews of _Dog_ and _Cat_ insurance only. That data should also be used for structured data so it's important to have it done during build time.

<img width="1082" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/bd443d04-214f-4122-8a19-d14b4d57c671">

