### PR TITLE
GEN-1860 - refact(ReviewComment): move tag logic to component level

### DIFF
--- a/apps/store/src/components/ProductReviews/ReviewComment.tsx
+++ b/apps/store/src/components/ProductReviews/ReviewComment.tsx
@@ -12,16 +12,16 @@ type Props = Review & {
   className?: string
 }
 
-export const ReviewComment = ({ score, date, tag, content, className }: Props) => {
+export function ReviewComment({ score, date, content, attributedTo, className }: Props) {
   const { t } = useTranslation('reviews')
+  const tag = useTag(attributedTo)
   const formatter = useFormatter()
 
   return (
     <div className={clsx(wrapper, className)}>
       <div className={reviewHeader}>
         <Stars score={score} size="1rem" />
-        {/* @ts-expect-error couldn't find a way to tell TS that tag string content belongs to 'reviews' namespace */}
-        {tag && <span className={reviewTag}>{t(tag)}</span>}
+        {<span className={reviewTag}>{tag}</span>}
       </div>
 
       <Text className={reviewContent} size="md">
@@ -43,4 +43,29 @@ export const ReviewComment = ({ score, date, tag, content, className }: Props) =
       </div>
     </div>
   )
+}
+
+function useTag(attributedTo: string) {
+  const { t } = useTranslation('reviews')
+
+  switch (attributedTo) {
+    case 'SE_PET_DOG':
+      return t('SE_PET_DOG_REVIEW_COMMENT_TAG')
+    case 'SE_PET_CAT':
+      return t('SE_PET_CAT_REVIEW_COMMENT_TAG')
+    case 'SE_HOUSE':
+      return t('SE_HOUSE_REVIEW_COMMENT_TAG')
+    case 'SE_APARTMENT_STUDENT':
+      return t('SE_APARTMENT_STUDENT_REVIEW_COMMENT_TAG')
+    case 'SE_ACCIDENT':
+      return t('SE_ACCIDENT_REVIEW_COMMENT_TAG')
+    case 'SE_CAR':
+      return t('SE_CAR_REVIEW_COMMENT_TAG')
+    case 'SE_APARTMENT_BRF':
+      return t('SE_APARTMENT_BRF_REVIEW_COMMENT_TAG')
+    case 'SE_APARTMENT_RENT':
+      return t('SE_APARTMENT_RENT_REVIEW_COMMENT_TAG')
+    default:
+      return attributedTo
+  }
 }

--- a/apps/store/src/features/memberReviews/memberReviews.utils.ts
+++ b/apps/store/src/features/memberReviews/memberReviews.utils.ts
@@ -11,7 +11,7 @@ export const reviewSchema = z.object({
   score: z.number(),
   content: z.string(),
   author: z.string(),
-  tag: z.string().optional(),
+  attributedTo: z.string(),
 })
 
 const commentByScoreValueSchema = z.object({


### PR DESCRIPTION
## Describe your changes

* Update the way _review tags_ are obtained. There is a translation key for each product type that follows the patter: `[productId]__REVIEW_COMMENT_TAG`. E.g: `SE_CAT_REVIEW_COMMENT_TAG`. Before I was storing this for each comment on _redis_ which it seems wrong. Now I have a `attributedTo` field for each comment which indicates which product it's connected to. I then build that translation key at the UI level inside `ReviewComment` comment.

<img width="462" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/9bc9fb52-f5c3-4c78-9780-437d72f8fa34">

## Justify why they are needed

It feels better this way.

**Not to myself**: Remember to remove `tag` deprecated field from comments stored on _redis_.

