### PR TITLE
Remove productData from ProductPageContext, use productDataAtom instead

### DIFF
--- a/apps/store/.storybook/decorators.tsx
+++ b/apps/store/.storybook/decorators.tsx
@@ -1,10 +1,11 @@
 import { type Decorator } from '@storybook/react'
 import { Global } from '@emotion/react'
+import { ApolloProvider } from '@apollo/client'
 import { ThemeProvider } from 'ui'
 import { storybookFontStyles } from 'ui/src/theme/storybookFontStyles'
 import { GridLayout } from '../src/components/GridLayout/GridLayout'
-import { ApolloProvider } from '@apollo/client'
 import { initializeApollo } from '../src/services/apollo/client'
+import { AppErrorProvider } from '../src/services/appErrors/AppErrorContext'
 
 export const themeDecorator: Decorator = (Story) => (
   <>
@@ -36,11 +37,13 @@ export const gridDecorator: Decorator = (Story, options) => {
   )
 }
 
-export const apolloDecorator: Decorator = (Story) => {
+export const appProvidersDecorator: Decorator = (Story) => {
   const apolloClient = initializeApollo()
   return (
     <ApolloProvider client={apolloClient}>
-      <Story />
+      <AppErrorProvider>
+        <Story />
+      </AppErrorProvider>
     </ApolloProvider>
   )
 }

--- a/apps/store/.storybook/preview.tsx
+++ b/apps/store/.storybook/preview.tsx
@@ -1,7 +1,7 @@
 import { MockedProvider } from '@apollo/client/testing'
 import './i18next'
 import { Preview } from '@storybook/react'
-import { apolloDecorator, gridDecorator, themeDecorator } from './decorators'
+import { appProvidersDecorator, gridDecorator, themeDecorator } from './decorators'
 import { theme } from 'ui'
 import globalCss from 'ui/src/global.css'
 
@@ -39,7 +39,7 @@ export const parameters = {
 }
 
 const preview: Preview = {
-  decorators: [themeDecorator, gridDecorator, apolloDecorator],
+  decorators: [themeDecorator, gridDecorator, appProvidersDecorator],
 }
 
 export default preview

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.stories.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryObj } from '@storybook/react'
-import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
 import { CurrencyCode, ExternalInsuranceCancellationOption } from '@/services/graphql/generated'
 import { ShopSessionOutcomeDocument } from '@/services/graphql/generated'
 import { ConfirmationStory } from '@/services/storyblok/storyblok'
@@ -16,11 +15,7 @@ export default meta
 type Story = StoryObj<typeof ConfirmationPage>
 
 const Template: Story = {
-  render: (args) => (
-    <AppErrorProvider>
-      <ConfirmationPage {...args} />
-    </AppErrorProvider>
-  ),
+  render: (args) => <ConfirmationPage {...args} />,
 }
 
 const storyblokStory = {

--- a/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection.stories.tsx
+++ b/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
-import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
 import {
   ContractExternalInsuranceCancellationStatus,
   ShopSessionOutcomeDocument,
@@ -19,13 +18,11 @@ type Story = StoryObj<typeof SwitchingAssistantSection>
 
 const Template: Story = {
   render: (args) => (
-    <AppErrorProvider>
-      <GridLayout.Root>
-        <GridLayout.Content width="1/3" align="center">
-          <SwitchingAssistantSection {...args} />
-        </GridLayout.Content>
-      </GridLayout.Root>
-    </AppErrorProvider>
+    <GridLayout.Root>
+      <GridLayout.Content width="1/3" align="center">
+        <SwitchingAssistantSection {...args} />
+      </GridLayout.Content>
+    </GridLayout.Root>
   ),
 }
 

--- a/apps/store/src/components/ProductPage/ProductPageContext.tsx
+++ b/apps/store/src/components/ProductPage/ProductPageContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, PropsWithChildren, useContext, useMemo } from 'react'
+import { useProductData } from '../ProductData/ProductDataProvider'
 import { ProductPageProps } from './ProductPage.types'
 
 type ProductPageContextData = Pick<ProductPageProps, 'priceTemplate'> & {
@@ -13,14 +14,10 @@ type ProductPageContextData = Pick<ProductPageProps, 'priceTemplate'> & {
 
 const ProductPageContext = createContext<ProductPageContextData | null>(null)
 
-type Props = PropsWithChildren<Pick<ProductPageProps, 'priceTemplate' | 'story' | 'productData'>>
+type Props = PropsWithChildren<Pick<ProductPageProps, 'priceTemplate' | 'story'>>
 
-export const ProductPageContextProvider = ({
-  children,
-  story,
-  productData,
-  priceTemplate,
-}: Props) => {
+export const ProductPageContextProvider = ({ children, story, priceTemplate }: Props) => {
+  const productData = useProductData()
   const contextValue = useMemo(
     () => ({
       priceTemplate,

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.stories.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react'
+import { ProductDataProvider } from '@/components/ProductData/ProductDataProvider'
 import { productData } from '@/mocks/productData'
-import { globalStory, productStoryBRF } from '@/mocks/storyblok'
+import { productStoryBRF } from '@/mocks/storyblok'
 import { BankIdContextProvider } from '@/services/bankId/BankIdContext'
 import { PriceIntentCreateDocument, ShopSessionCreateDocument } from '@/services/graphql/generated'
 import { SE_APARTMENT_BRF } from '@/services/PriceCalculator/data/SE_APARTMENT_BRF'
@@ -19,26 +20,27 @@ type Story = StoryObj<typeof PurchaseForm>
 const Template: Story = {
   render: () => (
     <ShopSessionProvider shopSessionId="1e517b18-fd77-4384-aee1-17481da3781a">
-      <ProductPageContextProvider {...props} story={productStoryBRF}>
-        <PriceIntentContextProvider>
-          <BankIdContextProvider>
-            <PurchaseForm />
-          </BankIdContextProvider>
-        </PriceIntentContextProvider>
-      </ProductPageContextProvider>
+      <ProductDataProvider productData={props.productData}>
+        <ProductPageContextProvider priceTemplate={props.priceTemplate} story={productStoryBRF}>
+          <PriceIntentContextProvider>
+            <BankIdContextProvider>
+              <PurchaseForm />
+            </BankIdContextProvider>
+          </PriceIntentContextProvider>
+        </ProductPageContextProvider>
+      </ProductDataProvider>
     </ShopSessionProvider>
   ),
 }
 
 const props = {
   priceTemplate: SE_APARTMENT_BRF,
-  productData: productData,
+  productData,
   averageRating: {
     score: 5,
     reviewCount: 1000,
   },
   reviewComments: null,
-  globalStory: globalStory,
   trustpilot: null,
 }
 

--- a/apps/store/src/features/carDealership/TrialExtensionForm.stories.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryObj } from '@storybook/react'
-import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
 import { BankIdContextProvider } from '@/services/bankId/BankIdContext'
 import { ShopSessionProvider } from '@/services/shopSession/ShopSessionContext'
 import { CAR_TRIAL_DATA_QUERY } from './carDealershipFixtures'
@@ -18,13 +17,11 @@ const meta: Meta<typeof TrialExtensionForm> = {
 const Template: Story = {
   render(args) {
     return (
-      <AppErrorProvider>
-        <BankIdContextProvider>
-          <ShopSessionProvider>
-            <TrialExtensionForm {...args} />
-          </ShopSessionProvider>
-        </BankIdContextProvider>
-      </AppErrorProvider>
+      <BankIdContextProvider>
+        <ShopSessionProvider>
+          <TrialExtensionForm {...args} />
+        </ShopSessionProvider>
+      </BankIdContextProvider>
     )
   },
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Another simplification of `ProductPageContext` - rely on `productData` from outer context instead of re-providing it
-  Update usage in Storyblok, fix some broken stories, move default providers around

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
