### PR TITLE
Optimize product pillow image size

### DIFF
--- a/apps/store/src/components/Pillow/Pillow.tsx
+++ b/apps/store/src/components/Pillow/Pillow.tsx
@@ -21,6 +21,7 @@ export const Pillow = ({ alt, src, priority, ...props }: PillowProps) => {
       height={208}
       decoding="sync"
       priority={priority}
+      quality={70}
     />
   )
 }

--- a/apps/store/src/components/ProductPage/PurchaseForm/ProductHero/ProductHero.css.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ProductHero/ProductHero.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css'
+
+export const pillow = style({
+  marginInline: 'auto',
+})

--- a/apps/store/src/components/ProductPage/PurchaseForm/ProductHero/ProductHero.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ProductHero/ProductHero.tsx
@@ -1,7 +1,7 @@
-import styled from '@emotion/styled'
 import { Heading, Space, Text } from 'ui'
-import { Pillow as BasePillow } from '@/components/Pillow/Pillow'
+import { Pillow } from '@/components/Pillow/Pillow'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
+import { pillow } from './ProductHero.css'
 
 type Props = {
   name: string
@@ -13,7 +13,12 @@ type Props = {
 export const ProductHero = (props: Props) => {
   return (
     <SpaceFlex space={1} direction="vertical" align="center">
-      <CenteredPillow size={props.size === 'small' ? 'large' : 'xxlarge'} {...props.pillow} />
+      <Pillow
+        className={pillow}
+        size={props.size === 'small' ? 'large' : 'xxlarge'}
+        {...props.pillow}
+        priority={true}
+      />
 
       <Space y={0.75}>
         <Heading as="h1" variant="standard.24" align="center">
@@ -26,5 +31,3 @@ export const ProductHero = (props: Props) => {
     </SpaceFlex>
   )
 }
-
-const CenteredPillow = styled(BasePillow)({ marginInline: 'auto' })

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -18,4 +18,4 @@ export * from './theme'
 
 // Overriding default of 75 to flush old image cache.  Do not change it back to 75 or 74
 // unless you're ready to manually change every single storyblok image or solve it some other way
-export const DEFAULT_IMAGE_QUALITY = 73
+export const DEFAULT_IMAGE_QUALITY = 70


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Make ProductHero image a priority
- Reduce pillow image quality 73 -> 50
- Reduce default image block quality 73 -> 70

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Optimize LCP metric for product pages

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
