### PR TITLE
Add loading skeleton for price calculator

### DIFF
--- a/apps/store/src/components/PriceCalculator/PriceCalculatorDynamic.css.ts
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorDynamic.css.ts
@@ -1,0 +1,12 @@
+import { style } from '@vanilla-extract/css'
+import { theme } from 'ui/src/theme'
+
+export const sectionSkeleton = style({
+  height: theme.space.xxl,
+  width: '100%',
+  selectors: {
+    '&:first-child': {
+      marginTop: theme.space.md,
+    },
+  },
+})

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorDynamic.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorDynamic.tsx
@@ -1,5 +1,18 @@
 import dynamic from 'next/dynamic'
+import { Skeleton } from '@/components/Skeleton'
+import { SpaceFlex } from '../SpaceFlex/SpaceFlex'
+import { sectionSkeleton } from './PriceCalculatorDynamic.css'
 
-export const PriceCalculatorDynamic = dynamic(() =>
-  import('./PriceCalculator').then((mod) => mod.PriceCalculator),
-)
+export const PriceCalculatorDynamic = dynamic({
+  loader: async () => {
+    const { PriceCalculator } = await import('./PriceCalculator')
+    return PriceCalculator
+  },
+  loading: () => (
+    <SpaceFlex direction="vertical" space={0.5}>
+      <Skeleton className={sectionSkeleton} />
+      <Skeleton className={sectionSkeleton} />
+      <Skeleton className={sectionSkeleton} />
+    </SpaceFlex>
+  ),
+})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Added loading indicator for PriceCalculator.  See attached video (loading speed artifically slowed down)

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/GLY3tSM85RFBvAf6lFNA/a3107499-4988-4e60-b340-874725ba6250.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/GLY3tSM85RFBvAf6lFNA/a3107499-4988-4e60-b340-874725ba6250.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/a3107499-4988-4e60-b340-874725ba6250.mov">Screen Recording 2024-02-29 at 15.01.38.mov</video>


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
