### PR TITLE
fix(PillowHeader): disclaimer text

### DIFF
--- a/apps/store/src/components/ProductReviews/PillowHeader.tsx
+++ b/apps/store/src/components/ProductReviews/PillowHeader.tsx
@@ -3,10 +3,7 @@ import { useTranslation } from 'next-i18next'
 import { type ComponentProps } from 'react'
 import { Text, Space } from 'ui'
 import { Pillow } from '@/components/Pillow/Pillow'
-import { TextWithLink } from '@/components/TextWithLink'
 import { MAX_SCORE } from '@/features/memberReviews/memberReviews.constants'
-import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
-import { PageLink } from '@/utils/PageLink'
 import { useFormatter } from '@/utils/useFormatter'
 import { wrapper, disclaimerText } from './PillowHeader.css'
 
@@ -21,7 +18,6 @@ type Props = {
 export const PillowHeader = ({ title, score, reviewsCount, pillow, className }: Props) => {
   const { numberGrouping } = useFormatter()
   const { t } = useTranslation('reviews')
-  const locale = useRoutingLocale()
 
   return (
     <div className={clsx(wrapper, className)}>
@@ -41,15 +37,14 @@ export const PillowHeader = ({ title, score, reviewsCount, pillow, className }: 
             })}
           </Text>
         </div>
-        <TextWithLink
+        <Text
           className={disclaimerText}
-          href={PageLink.reviews({ locale })}
           size={{ _: 'xs', sm: 'md' }}
           align="center"
           color="textSecondary"
         >
           {t('PILLOW_HEADER_REVIEWS_DISCLAIMER')}
-        </TextWithLink>
+        </Text>
       </Space>
     </div>
   )


### PR DESCRIPTION

## Describe your changes

* Fix an issue with "pillow header" disclaimer text.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/b71a6ff3-e80b-4e29-bbf2-6e3252f7442b.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/eecde547-8c77-4e78-b90f-9f052c2faf48.png)


## Justify why they are needed

That translation key held a link placeholder before but not it doesn't so instead of render with `TextWithLink` component we should use regular `Text` component.