### PR TITLE
fix(TextWithLink): provide a better default for the case no link placeholder was given

### DIFF
--- a/apps/store/src/components/TextWithLink.tsx
+++ b/apps/store/src/components/TextWithLink.tsx
@@ -25,7 +25,12 @@ export const WithLink = (props: WithLinkProps) => {
   const [beforeLink, rest] = props.children.split('[[', 2)
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (rest === undefined) return <>props.children</>
+  if (rest === undefined) {
+    console.log(
+      'TextWithLink | no link placeholder found in text. Consider using a regular Text component instead.',
+    )
+    return <>{props.children}</>
+  }
 
   const [linkText, afterLink] = rest.split(']]', 2)
 


### PR DESCRIPTION
## Describe your changes

* Provide a better default for the case no link placeholder was given

## Justify why they are needed

Before we're rendering `<>props.children</>` on such cases and that's probably a mistake. What I think we want is to render `<>{props.children}</>` so `TextWithLink` is still able to render a some text that doesn't include a link placeholder ([[link placeholder]])). I'm also adding a log for such cases as using `Text` is better suitable for such cases.