### PR TITLE
Show product review summary in loading state to avoid layout shift

### DIFF
--- a/apps/store/src/components/Animations/LottieAnimation.tsx
+++ b/apps/store/src/components/Animations/LottieAnimation.tsx
@@ -20,7 +20,7 @@ export const LottieAnimation = ({ importSrc, ...playerProps }: Props) => {
       import('@lottiefiles/react-lottie-player')
       importSrc().then(setSrc)
     }
-  }, [isInView])
+  }, [importSrc, isInView])
   const ready = isInView && src != null
   return (
     <div ref={wrapperRef} className={animationWrapper}>

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorDynamic.css.ts
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorDynamic.css.ts
@@ -1,12 +1,11 @@
 import { style } from '@vanilla-extract/css'
 import { theme } from 'ui/src/theme'
 
+export const skeletonWrapper = style({
+  paddingTop: '3rem', // first heading + padding
+})
+
 export const sectionSkeleton = style({
   height: theme.space.xxl,
   width: '100%',
-  selectors: {
-    '&:first-child': {
-      marginTop: theme.space.md,
-    },
-  },
 })

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorDynamic.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorDynamic.tsx
@@ -1,16 +1,19 @@
 import dynamic from 'next/dynamic'
 import { Skeleton } from '@/components/Skeleton'
 import { SpaceFlex } from '../SpaceFlex/SpaceFlex'
-import { sectionSkeleton } from './PriceCalculatorDynamic.css'
+import { sectionSkeleton, skeletonWrapper } from './PriceCalculatorDynamic.css'
 
 export const PriceCalculatorDynamic = dynamic({
   loader: async () => {
     const { PriceCalculator } = await import('./PriceCalculator')
+    await new Promise((resolve) => setTimeout(resolve, 500))
     return PriceCalculator
   },
   loading: () => (
-    <SpaceFlex direction="vertical" space={0.5}>
-      <Skeleton className={sectionSkeleton} />
+    // Element sizes hand-picked to match layout of the form
+    <SpaceFlex direction="vertical" space={0.25} className={skeletonWrapper}>
+      <Skeleton className={sectionSkeleton} style={{ height: '4.5rem' }} />
+      <Skeleton className={sectionSkeleton} style={{ height: '3.5rem' }} />
       <Skeleton className={sectionSkeleton} />
       <Skeleton className={sectionSkeleton} />
     </SpaceFlex>

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseFormErrorDialog.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseFormErrorDialog.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from 'next-i18next'
+import { Balancer } from 'react-wrap-balancer'
+import { Button, Text, theme, WarningTriangleIcon } from 'ui'
+import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
+import { GridLayout } from '@/components/GridLayout/GridLayout'
+import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
+
+type Props = {
+  errorMessage?: string
+  open: boolean
+  onOpenChange: () => void
+  onEditClick: () => void
+}
+export const PurchaseFormErrorDialog = (props: Props) => {
+  const { t } = useTranslation('purchase-form')
+  return (
+    <FullscreenDialog.Root open={props.open} onOpenChange={props.onOpenChange}>
+      <FullscreenDialog.Modal
+        center={true}
+        Footer={
+          <>
+            <Button type="button" onClick={props.onEditClick}>
+              {t('GENERAL_ERROR_DIALOG_PRIMARY_BUTTON')}
+            </Button>
+            <FullscreenDialog.Close asChild={true}>
+              <Button type="button" variant="ghost">
+                {t('DIALOG_BUTTON_CANCEL', { ns: 'common' })}
+              </Button>
+            </FullscreenDialog.Close>
+          </>
+        }
+      >
+        <GridLayout.Root>
+          <GridLayout.Content width="1/3" align="center">
+            <SpaceFlex direction="vertical" align="center" space={0}>
+              <Text size={{ _: 'lg', lg: 'xl' }}>
+                <SpaceFlex space={0.25} align="center">
+                  <WarningTriangleIcon size="1em" color={theme.colors.signalAmberElement} />
+                  {t('GENERAL_ERROR_DIALOG_TITLE', { ns: 'common' })}
+                </SpaceFlex>
+              </Text>
+              <Balancer ratio={0.5}>
+                <Text size={{ _: 'lg', lg: 'xl' }} align="center" color="textSecondary">
+                  {props.errorMessage ? props.errorMessage : t('GENERAL_ERROR_DIALOG_PROMPT')}
+                </Text>
+              </Balancer>
+            </SpaceFlex>
+          </GridLayout.Content>
+        </GridLayout.Root>
+      </FullscreenDialog.Modal>
+    </FullscreenDialog.Root>
+  )
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/GLY3tSM85RFBvAf6lFNA/fc16fe3c-82a6-429b-a192-1a594bcb8a2e.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/GLY3tSM85RFBvAf6lFNA/fc16fe3c-82a6-429b-a192-1a594bcb8a2e.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/fc16fe3c-82a6-429b-a192-1a594bcb8a2e.mov">Screen Recording 2024-03-01 at 11.16.24.mov</video>


Better UX:
- Show product review summary when purchase form is in loading state to avoid layout shift

Refactoring:
- Refactor purchase form render control flow to be more linear and readable
- Extract PurchaseFormErrorDialog into separate module

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
