### PR TITLE
Fix resetting purchase form after adding item to cart

### DIFF
--- a/apps/store/src/services/priceIntent/PriceIntentService.ts
+++ b/apps/store/src/services/priceIntent/PriceIntentService.ts
@@ -138,6 +138,7 @@ export class PriceIntentService {
   }
 
   public clear(templateName: string, shopSessionId: string) {
+    this.createParams = null
     this.persister.reset(this.getPriceIntentKey(templateName, shopSessionId))
   }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix resetting priceIntent after adding to cart.  Allows to buy to 2+ cat/dog/car items in the same session

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Not clear when it broke, but the fix is trivial - reset cached priceIntent creation promise when resetting corresponding cookie

## Checklist before requesting a review

- [ ] I have performed a self-review of my code

![Screenshot 2024-03-04 at 09.38.23.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/ac79f83b-2dcc-4795-bc60-9ed7e7abab68.png)

