### PR TITLE
GEN-1871 - feat(bankid-sign): added UI form when qr code is scanned

### DIFF
--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -30,8 +30,10 @@ import {
 } from '@/services/graphql/generated'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { useTracking } from '@/services/Tracking/useTracking'
+import { Features } from '@/utils/Features'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
+import { SIGN_FORM_ID } from 'constants/sign.constants'
 import { FormElement, QueryParam } from './CheckoutPage.constants'
 import { CheckoutPageProps } from './CheckoutPage.types'
 import { PageDebugDialog } from './PageDebugDialog'
@@ -117,22 +119,24 @@ const CheckoutPage = (props: CheckoutPageProps) => {
         </Layout>
       </Space>
 
-      <FullscreenDialog.Root open={showSignError} onOpenChange={setShowSignError}>
-        <FullscreenDialog.Modal
-          center={true}
-          Footer={
-            <FullscreenDialog.Close asChild>
-              <Button type="button" variant="primary">
-                {t('ERROR_GENERAL_DIALOG_ACTION_TRY_AGAIN')}
-              </Button>
-            </FullscreenDialog.Close>
-          }
-        >
-          <ErrorPrompt size={{ _: 'md', lg: 'lg' }} align="center">
-            {t('ERROR_GENERAL_DIALOG_PROMPT')}
-          </ErrorPrompt>
-        </FullscreenDialog.Modal>
-      </FullscreenDialog.Root>
+      {!Features.enabled('BANKID_V6') && (
+        <FullscreenDialog.Root open={showSignError} onOpenChange={setShowSignError}>
+          <FullscreenDialog.Modal
+            center={true}
+            Footer={
+              <FullscreenDialog.Close asChild>
+                <Button type="button" variant="primary">
+                  {t('ERROR_GENERAL_DIALOG_ACTION_TRY_AGAIN')}
+                </Button>
+              </FullscreenDialog.Close>
+            }
+          >
+            <ErrorPrompt size={{ _: 'md', lg: 'lg' }} align="center">
+              {t('ERROR_GENERAL_DIALOG_PROMPT')}
+            </ErrorPrompt>
+          </FullscreenDialog.Modal>
+        </FullscreenDialog.Root>
+      )}
 
       <PageDebugDialog />
     </>
@@ -200,7 +204,7 @@ const CheckoutForm = ({
   const userErrorMessage = userError?.message
 
   return (
-    <form onSubmit={handleSubmitSign}>
+    <form id={SIGN_FORM_ID} onSubmit={handleSubmitSign}>
       <Space y={0.25}>
         <PersonalNumberField
           label={t('FIELD_PERSONAL_NUMBER_SE_LABEL')}

--- a/apps/store/src/constants/sign.constants.ts
+++ b/apps/store/src/constants/sign.constants.ts
@@ -1,0 +1,1 @@
+export const SIGN_FORM_ID = 'sign-form'

--- a/apps/store/src/features/widget/SignPage.tsx
+++ b/apps/store/src/features/widget/SignPage.tsx
@@ -30,8 +30,10 @@ import {
 } from '@/services/graphql/generated'
 import { type ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useTracking } from '@/services/Tracking/useTracking'
+import { Features } from '@/utils/Features'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
+import { SIGN_FORM_ID } from 'constants/sign.constants'
 import { Header } from './Header'
 import { ProductItemContainer } from './ProductItemContainer'
 
@@ -197,7 +199,7 @@ export const SignPage = (props: Props) => {
                   />
                 )}
 
-                <form onSubmit={handleSubmit}>
+                <form id={SIGN_FORM_ID} onSubmit={handleSubmit}>
                   <Space y={0.25}>
                     <PersonalNumberField
                       label={t('checkout:FIELD_PERSONAL_NUMBER_SE_LABEL')}
@@ -278,22 +280,24 @@ export const SignPage = (props: Props) => {
         </div>
       </Wrapper>
 
-      <FullscreenDialog.Root open={showSignError} onOpenChange={setShowSignError}>
-        <FullscreenDialog.Modal
-          center={true}
-          Footer={
-            <FullscreenDialog.Close asChild>
-              <Button type="button" variant="primary">
-                {t('checkout:ERROR_GENERAL_DIALOG_ACTION_TRY_AGAIN')}
-              </Button>
-            </FullscreenDialog.Close>
-          }
-        >
-          <ErrorPrompt size={{ _: 'md', lg: 'lg' }} align="center">
-            {t('checkout:ERROR_GENERAL_DIALOG_PROMPT')}
-          </ErrorPrompt>
-        </FullscreenDialog.Modal>
-      </FullscreenDialog.Root>
+      {!Features.enabled('BANKID_V6') && (
+        <FullscreenDialog.Root open={showSignError} onOpenChange={setShowSignError}>
+          <FullscreenDialog.Modal
+            center={true}
+            Footer={
+              <FullscreenDialog.Close asChild>
+                <Button type="button" variant="primary">
+                  {t('checkout:ERROR_GENERAL_DIALOG_ACTION_TRY_AGAIN')}
+                </Button>
+              </FullscreenDialog.Close>
+            }
+          >
+            <ErrorPrompt size={{ _: 'md', lg: 'lg' }} align="center">
+              {t('checkout:ERROR_GENERAL_DIALOG_PROMPT')}
+            </ErrorPrompt>
+          </FullscreenDialog.Modal>
+        </FullscreenDialog.Root>
+      )}
     </>
   )
 }

--- a/apps/store/src/graphql/ShopSessionSigningFragment.graphql
+++ b/apps/store/src/graphql/ShopSessionSigningFragment.graphql
@@ -1,9 +1,15 @@
 fragment ShopSessionSigning on ShopSessionSigning {
   id
   status
-  seBankidLiveQrCodeData
-  seBankidAutoStartToken
+  seBankidProperties {
+    autoStartToken
+    liveQrCodeData
+    bankidAppOpened
+  }
   completion {
     authorizationCode
+  }
+  userError {
+    message
   }
 }

--- a/apps/store/src/services/bankId/bankId.types.ts
+++ b/apps/store/src/services/bankId/bankId.types.ts
@@ -9,7 +9,7 @@ export enum BankIdState {
   Error = 'Error',
 }
 
-type BankIdLoginOperation = {
+export type BankIdLoginOperation = {
   type: 'login'
   ssn: string
   state: BankIdState
@@ -19,7 +19,7 @@ type BankIdLoginOperation = {
   bankidAppOpened?: boolean
 }
 
-type BankIdSignOperation = {
+export type BankIdSignOperation = {
   type: 'sign'
   ssn: string
   customerAuthenticationStatus: ShopSessionAuthenticationStatus

--- a/apps/store/tsconfig.json
+++ b/apps/store/tsconfig.json
@@ -5,42 +5,19 @@
     "outDir": "dist",
     "baseUrl": "src",
     "paths": {
-      "@/appComponents/*": [
-        "appComponents/*"
-      ],
-      "@/lib/*": [
-        "lib/*"
-      ],
-      "@/blocks/*": [
-        "blocks/*"
-      ],
-      "@/components/*": [
-        "components/*"
-      ],
-      "@/pages/*": [
-        "pages/*"
-      ],
-      "@/styles/*": [
-        "styles/*"
-      ],
-      "@/services/*": [
-        "services/*"
-      ],
-      "@/hooks/*": [
-        "hooks/*"
-      ],
-      "@/test/*": [
-        "test/*"
-      ],
-      "@/utils/*": [
-        "utils/*"
-      ],
-      "@/features/*": [
-        "features/*"
-      ],
-      "@/mocks/*": [
-        "mocks/*"
-      ]
+      "@/appComponents/*": ["appComponents/*"],
+      "@/lib/*": ["lib/*"],
+      "@/blocks/*": ["blocks/*"],
+      "@/components/*": ["components/*"],
+      "@/pages/*": ["pages/*"],
+      "@/styles/*": ["styles/*"],
+      "@/services/*": ["services/*"],
+      "@/hooks/*": ["hooks/*"],
+      "@/test/*": ["test/*"],
+      "@/utils/*": ["utils/*"],
+      "@/constants/*": ["constants/*"],
+      "@/features/*": ["features/*"],
+      "@/mocks/*": ["mocks/*"]
     },
     "incremental": true,
     "plugins": [
@@ -49,11 +26,7 @@
       }
     ],
     "target": "ESNext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "noEmit": true,
     "strict": true,
@@ -67,14 +40,6 @@
     "forceConsistentCasingInFileNames": true,
     "module": "esnext"
   },
-  "include": [
-    "src",
-    "*.d.ts",
-    ".next/types/**/*.ts",
-    "./codegen.ts",
-    "./jest-setup.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src", "*.d.ts", ".next/types/**/*.ts", "./codegen.ts", "./jest-setup.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Describe your changes

* Update _StartSigning_mutation / _Signing_ query so it users new API schema
* Update `startSign` function so it passes down `bankidAppOpened` information. That flag is gonna be used to provide UI feedback when QR were scanned during sign flow.
* `BankIdV6Dialog` update: Make sure _try again_ button works (shown in case of errors) works for both flows: _login_ and _sign_


https://github.com/HedvigInsurance/racoon/assets/19200662/1ca1e279-54dd-4fa4-91b9-32130e98d912

## Justify why they are needed

Part of UI changes requested for a better error handling during _sign_ flow.