### PR TITLE
Load OneTrust before GTM

### DIFF
--- a/apps/store/public/mockServiceWorker.js
+++ b/apps/store/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (2.2.1).
+ * Mock Service Worker (2.2.2).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/apps/store/src/components/CookieConsentLoader.tsx
+++ b/apps/store/src/components/CookieConsentLoader.tsx
@@ -1,0 +1,52 @@
+import Script from 'next/script'
+import { useEffect, useState } from 'react'
+import { GTMAppScript } from '@/services/gtm'
+/* eslint-disable @next/next/no-sync-scripts */
+
+const SCRIPT_ID = {
+  // Could be useful for testing changes on OneTrust side
+  TEST: '628f5fee-1891-418c-9ed2-f893b8a3998a-test',
+  PRODUCTION: '628f5fee-1891-418c-9ed2-f893b8a3998a',
+}
+
+type OneTrustApi = {
+  OnConsentChanged: (callback: () => void) => void
+  IsAlertBoxClosed: () => boolean
+}
+
+export function CookieConsentLoader() {
+  // Optimization: start loading GTM after cookie consent has been given. Fixes negative effects of preloading GTM
+  // - lots of GTM activity triggered immediately on consent, sync -> bad INP
+  // - GTM resources taking network brandwidth on initial load when they have no chance to be useful yet
+  const isConsentReady = useIsConsentReady()
+  return (
+    <>
+      <Script
+        id="onetrust-loader"
+        src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
+        data-document-language="true"
+        type="text/javascript"
+        data-domain-script={SCRIPT_ID.PRODUCTION}
+      />
+      {isConsentReady && <GTMAppScript />}
+    </>
+  )
+}
+
+// Potential optimization - don't load GTM if user only consented to required cookies
+const useIsConsentReady = () => {
+  const [isConsentReady, setIsConsentReady] = useState(false)
+  useEffect(() => {
+    ;(window as any).OptanonWrapper = function () {
+      const OneTrust = (window as any).OneTrust as OneTrustApi
+      if (OneTrust.IsAlertBoxClosed()) {
+        setIsConsentReady(true)
+      } else {
+        OneTrust.OnConsentChanged(() => {
+          setIsConsentReady(true)
+        })
+      }
+    }
+  }, [])
+  return isConsentReady
+}

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -13,13 +13,13 @@ import { AppErrorDialog } from '@/components/AppErrorDialog'
 import { BankIdDialog } from '@/components/BankIdDialog'
 import { BankIdV6Dialog } from '@/components/BankIdV6Dialog/BankIdV6Dialog'
 import { ContactUs } from '@/components/ContactUs/ContactUs'
+import { CookieConsentLoader } from '@/components/CookieConsentLoader'
 import { GlobalLinkStyles } from '@/components/RichText/RichText.styles'
 import { usePublishWidgetInitEvent } from '@/features/widget/usePublishWidgetInitEvent'
 import { useApollo } from '@/services/apollo/client'
 import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
 import { BankIdContextProvider } from '@/services/bankId/BankIdContext'
 import { CustomerFirstScript, hasHiddenChat } from '@/services/CustomerFirst'
-import { GTMAppScript } from '@/services/gtm'
 import { initDatadog } from '@/services/logger/client'
 import { PageTransitionProgressBar } from '@/services/nprogress/pageTransition'
 import { OneTrustStyles } from '@/services/OneTrust'
@@ -103,13 +103,11 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
       <Head>
         <meta key="viewport" name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
-
-      <GTMAppScript />
-
+      <CookieConsentLoader />
+      <GlobalLinkStyles />
+      <OneTrustStyles />
+      <PageTransitionProgressBar />
       <ApolloProvider client={apolloClient}>
-        <GlobalLinkStyles />
-        <OneTrustStyles />
-        <PageTransitionProgressBar />
         <JotaiProvider>
           <ShopSessionProvider shopSessionId={pageProps[SHOP_SESSION_PROP_NAME]}>
             <ShopSessionTrackingProvider>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Load OneTrust (cookie banner) directly instead of relying on GTM to load it
- Load GTM after cookie consent has been given (or previous setting has been loaded)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Performance optimization, INP and initial load size

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
