### PR TITLE
Require missing email for returning customers

### DIFF
--- a/apps/store/src/utils/customer.ts
+++ b/apps/store/src/utils/customer.ts
@@ -4,7 +4,8 @@ const isNewMember = (customer: ShopSessionCustomer) =>
   customer.authenticationStatus === ShopSessionAuthenticationStatus.None
 
 export const getShouldCollectEmail = (customer?: ShopSessionCustomer | null) => {
-  return !customer || customer.authenticationStatus === ShopSessionAuthenticationStatus.None
+  // Collect emails of new customers as well as returning customers with no email
+  return !customer?.email
 }
 
 export const getShouldCollectName = (customer: ShopSessionCustomer) => {


### PR DESCRIPTION
<!--
PR title: RND-525 / Fix / Require missing email for returning customers
-->

<!--
What changes are made?
Previously we only collected emails of new customers, we now collect it for returning customers with missing emails as well.
-->

## Justify why they are needed
It's required to have an email in order to make a transaction. Some old customers don't have an email, causing a backend service to crash when they return to make another purchase. This PR makes sure that we collect the missing emails during the purchase journey.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
