### PR TITLE
GEN-1871 - feat(bankid): added "open on the same device" link

### DIFF
--- a/apps/store/public/locales/en/bankid.json
+++ b/apps/store/public/locales/en/bankid.json
@@ -1,10 +1,10 @@
 {
+  "BANKID_CANCEL": "Cancel",
   "BANKID_MODAL_CANCEL": "Cancel",
   "BANKID_MODAL_SUCCESS_PROMPT": "Signing approved",
   "LOGIN_BANKID": "Log in with BankID",
   "LOGIN_BANKID_AUTHENTICATION_STEPS_DESKTOP": "Open the BankID app on your phone and tap Scan QR Code. Point the camera at the QR code to log in.",
   "LOGIN_BANKID_AUTHENTICATION_STEPS_MOBILE": "Open the BankID app on your phone and enter your security code.",
-  "LOGIN_BANKID_CANCEL": "Cancel login",
   "LOGIN_BANKID_ERROR": "Failed to log in",
   "LOGIN_BANKID_EXPLANATION": "If you have or had insurance with us, you can log in, and we will retrieve your data automatically.",
   "LOGIN_BANKID_FAIL_DESCRIPTION": "We could not log you in right now",
@@ -14,6 +14,8 @@
   "LOGIN_BANKID_SUCCESS": "Identified successfully",
   "LOGIN_BANKID_TRY_AGAIN": "Try again",
   "LOGIN_BANKID_WAITING": "Waiting for BankID...",
+  "NO_MOBILE_BANKID_LINK_LABEL": "Open BankID on this device",
+  "NO_MOBILE_BANKID_TITLE": "Don't have Mobile BankID?",
   "QR_CODE_READ_SUBTITLE": "Follow the instructions in the BankID app",
   "QR_CODE_READ_TITLE": "Enter your security code"
 }

--- a/apps/store/public/locales/sv-se/bankid.json
+++ b/apps/store/public/locales/sv-se/bankid.json
@@ -1,10 +1,10 @@
 {
+  "BANKID_CANCEL": "Avbryt",
   "BANKID_MODAL_CANCEL": "Avbryt",
   "BANKID_MODAL_SUCCESS_PROMPT": "Signering godkänd",
   "LOGIN_BANKID": "Logga in med BankID",
   "LOGIN_BANKID_AUTHENTICATION_STEPS_DESKTOP": "Öppna BankID-appen på din telefon och tryck på Skanna QR-kod. Rikta kameran mot QR-koden för att logga in.",
   "LOGIN_BANKID_AUTHENTICATION_STEPS_MOBILE": "Öppna BankID-appen på din telefon och fyll i din säkerhetskod.",
-  "LOGIN_BANKID_CANCEL": "Avbryt inloggning",
   "LOGIN_BANKID_ERROR": "Kunde inte logga in",
   "LOGIN_BANKID_EXPLANATION": "Om du har eller haft en försäkring hos oss kan du logga in, så hämtar vi dina uppgifter automatiskt.",
   "LOGIN_BANKID_FAIL_DESCRIPTION": "Vi kunde inte logga in dig just nu",
@@ -14,6 +14,8 @@
   "LOGIN_BANKID_SUCCESS": "Identifierad framgångsrikt",
   "LOGIN_BANKID_TRY_AGAIN": "Försök igen",
   "LOGIN_BANKID_WAITING": "Väntar på BankID...",
+  "NO_MOBILE_BANKID_LINK_LABEL": "Öppna BankID på den här enheten",
+  "NO_MOBILE_BANKID_TITLE": "Har du inte Mobilt BankID?",
   "QR_CODE_READ_SUBTITLE": "Följ instruktionerna i BankID-appen",
   "QR_CODE_READ_TITLE": "Fyll i din säkerhetskod"
 }

--- a/apps/store/src/components/BankIdV6Dialog/BankIdV6Dialog.css.ts
+++ b/apps/store/src/components/BankIdV6Dialog/BankIdV6Dialog.css.ts
@@ -30,3 +30,24 @@ export const contentWrapper = style({
     [contentWrapperMaxWidth]: '24rem',
   },
 })
+
+export const qrOnAnotherDeviceFooter = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+})
+
+export const qrOnAnotherDeviceLink = style({
+  fontSize: theme.fontSizes.md,
+  color: theme.colors.textSecondary,
+  textDecoration: 'underline',
+  textUnderlineOffset: 5,
+  textDecorationThickness: 1,
+  textDecorationColor: 'currentcolor',
+  ':hover': {
+    color: theme.colors.textPrimary,
+  },
+  ':focus-visible': {
+    outline: `2px solid ${theme.colors.gray900}`,
+  },
+})

--- a/apps/store/src/components/BankIdV6Dialog/BankIdV6Dialog.stories.tsx
+++ b/apps/store/src/components/BankIdV6Dialog/BankIdV6Dialog.stories.tsx
@@ -48,6 +48,7 @@ Pending.args = {
     ssn: '111122334455',
     qrCodeData:
       'bankid.67df3917-fa0d-44e5-b327-edcc928297f8.0.dc69358e712458a66a7525beef148ae8526b1c71610eff2c16cdffb4cdac9bf8',
+    autoStartToken: 'abc123',
   },
 }
 
@@ -61,6 +62,7 @@ QrCodeRead.args = {
     bankidAppOpened: true,
     qrCodeData:
       'bankid.67df3917-fa0d-44e5-b327-edcc928297f8.0.dc69358e712458a66a7525beef148ae8526b1c71610eff2c16cdffb4cdac9bf8',
+    autoStartToken: 'abc123',
   },
 }
 

--- a/apps/store/src/components/BankIdV6Dialog/BankIdV6Dialog.tsx
+++ b/apps/store/src/components/BankIdV6Dialog/BankIdV6Dialog.tsx
@@ -1,4 +1,5 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic'
+import Link from 'next/link'
 import { useTranslation } from 'next-i18next'
 import { QRCodeSVG } from 'qrcode.react'
 import { useEffect, useRef, type ReactNode } from 'react'
@@ -27,6 +28,8 @@ import {
   iconWithText,
   contentWrapper,
   contentWrapperMaxWidth,
+  qrOnAnotherDeviceFooter,
+  qrOnAnotherDeviceLink,
 } from './BankIdV6Dialog.css'
 
 export const BankIdV6Dialog = () => {
@@ -114,36 +117,50 @@ export const BankIdV6Dialog = () => {
               <Skeleton className={qrCodeSkeleton} />
             )}
 
-            <div>
-              {currentOperation.bankidAppOpened ? (
-                <>
-                  <Text color="textPrimary" align="center">
-                    {t('QR_CODE_READ_TITLE')}
-                  </Text>
-                  <Text color="textSecondary" align="center">
-                    {t('QR_CODE_READ_SUBTITLE')}
-                  </Text>
-                </>
-              ) : (
-                <>
-                  <Text color="textPrimary" align="center">
-                    {t('LOGIN_BANKID')}
-                  </Text>
-                  <Text color="textSecondary" align="center">
-                    {isMobile
-                      ? t('LOGIN_BANKID_AUTHENTICATION_STEPS_MOBILE')
-                      : t('LOGIN_BANKID_AUTHENTICATION_STEPS_DESKTOP')}
-                  </Text>
-                </>
-              )}
-            </div>
+            <Space y={1.5}>
+              <div>
+                {currentOperation.bankidAppOpened ? (
+                  <>
+                    <Text color="textPrimary" align="center">
+                      {t('QR_CODE_READ_TITLE')}
+                    </Text>
+                    <Text color="textSecondary" align="center">
+                      {t('QR_CODE_READ_SUBTITLE')}
+                    </Text>
+                  </>
+                ) : (
+                  <>
+                    <Text color="textPrimary" align="center">
+                      {t('LOGIN_BANKID')}
+                    </Text>
+                    <Text color="textSecondary" align="center">
+                      {isMobile
+                        ? t('LOGIN_BANKID_AUTHENTICATION_STEPS_MOBILE')
+                        : t('LOGIN_BANKID_AUTHENTICATION_STEPS_DESKTOP')}
+                    </Text>
+                  </>
+                )}
+              </div>
+
+              <FullscreenDialog.Close asChild>
+                <Button variant="ghost">{t('BANKID_CANCEL')}</Button>
+              </FullscreenDialog.Close>
+            </Space>
           </Space>
         )
-        Footer = (
-          <FullscreenDialog.Close asChild>
-            <Button variant="ghost">{t('LOGIN_BANKID_CANCEL')}</Button>
-          </FullscreenDialog.Close>
-        )
+        Footer =
+          !isMobile && currentOperation.autoStartToken ? (
+            <div className={qrOnAnotherDeviceFooter}>
+              <Text>{t('NO_MOBILE_BANKID_TITLE')}</Text>
+              <Link
+                className={qrOnAnotherDeviceLink}
+                href={getBankIdUrl(currentOperation.autoStartToken)}
+                target="_self"
+              >
+                {t('NO_MOBILE_BANKID_LINK_LABEL')}
+              </Link>
+            </div>
+          ) : null
         break
       }
 
@@ -182,7 +199,7 @@ export const BankIdV6Dialog = () => {
         )
         Footer = (
           <FullscreenDialog.Close asChild>
-            <Button variant="ghost">{t('LOGIN_BANKID_CANCEL')}</Button>
+            <Button variant="ghost">{t('BANKID_CANCEL')}</Button>
           </FullscreenDialog.Close>
         )
         break


### PR DESCRIPTION
## Describe your changes

* Added a "open BankId App on the same device" link. It's going to be rendered only on desktop and it can be used to trigger BankdId app.

<img width="1161" alt="Screenshot 2024-03-05 at 14 44 43" src="https://github.com/HedvigInsurance/racoon/assets/19200662/0ae31c29-11f8-4453-9c23-b57d66c34bcc">

## Justify why they are needed

As requested by design.
