### PR TITLE
fix: should collect email logic

### DIFF
--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -224,15 +224,14 @@ const CheckoutForm = ({
             />
           </>
         )}
-        {shouldCollectEmail && (
-          <TextField
-            type="email"
-            label={t('FORM_EMAIL_LABEL')}
-            name={FormElement.Email}
-            defaultValue={suggestedEmail}
-            required
-          />
-        )}
+        <TextField
+          type="email"
+          label={t('FORM_EMAIL_LABEL')}
+          name={FormElement.Email}
+          defaultValue={suggestedEmail}
+          required
+          hidden={!shouldCollectEmail}
+        />
         <Space y={0.5}>
           <SignButton
             loading={loading}

--- a/apps/store/src/components/TextField/TextField.tsx
+++ b/apps/store/src/components/TextField/TextField.tsx
@@ -76,6 +76,7 @@ export const TextField = (props: Props) => {
         data-active={!!inputValue || !!inputProps.placeholder}
         data-warning={warning}
         data-readonly={inputProps.readOnly ? '' : undefined}
+        data-hidden={inputProps.hidden ?? undefined}
         onClick={handleClickWrapper}
       >
         <Label htmlFor={identifier} data-disabled={inputProps.disabled} data-variant={variant}>
@@ -154,6 +155,10 @@ const BaseWrapper = styled.div({
   backgroundColor: theme.colors.translucent1,
   width: '100%',
   cursor: 'text',
+
+  '&[data-hidden=true]': {
+    display: 'none',
+  },
 
   '&[data-warning=true]': {
     animation: `${warningAnimation} 1.5s cubic-bezier(0.2, -2, 0.8, 2) 1`,

--- a/apps/store/src/features/widget/SignPage.tsx
+++ b/apps/store/src/features/widget/SignPage.tsx
@@ -223,15 +223,14 @@ export const SignPage = (props: Props) => {
                       </>
                     )}
 
-                    {props.shouldCollectEmail && (
-                      <TextField
-                        type="email"
-                        label={t('checkout:FORM_EMAIL_LABEL')}
-                        name={FormElement.Email}
-                        defaultValue={props.suggestedEmail}
-                        required
-                      />
-                    )}
+                    <TextField
+                      type="email"
+                      label={t('checkout:FORM_EMAIL_LABEL')}
+                      name={FormElement.Email}
+                      defaultValue={props.suggestedEmail}
+                      required
+                      hidden={!props.shouldCollectEmail}
+                    />
 
                     <Space y={1}>
                       <SignButton loading={loading} showBankIdIcon={true}>

--- a/apps/store/src/utils/customer.ts
+++ b/apps/store/src/utils/customer.ts
@@ -4,7 +4,8 @@ const isNewMember = (customer: ShopSessionCustomer) =>
   customer.authenticationStatus === ShopSessionAuthenticationStatus.None
 
 export const getShouldCollectEmail = (customer?: ShopSessionCustomer | null) => {
-  return !customer || customer.authenticationStatus === ShopSessionAuthenticationStatus.None
+  // Collect emails of new customers as well as returning customers with no email
+  return !customer?.email
 }
 
 export const getShouldCollectName = (customer: ShopSessionCustomer) => {


### PR DESCRIPTION
## Describe your changes

* Fix an issue where users with associated email couldn't proceed with signing flow. More info [here]([url](https://hedviginsurance.slack.com/archives/CPCUHMMJQ/p1709630294967369))

We simplified the logic used to collect email during signing flow [here](  // Collect emails of new customers as well as returning customers with no email
  return !customer?.email). Basically we want to collect email whenever we don't have that info at the moment one’s trying to sign. However the data used for signing comes from HTML `form`s so even when we don't need to collect email we still want to mount email form field in a hidden format.