### PR TITLE
Lazy render coverage block on Product Page (30% smaller DOM)

### DIFF
--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { storyblokEditable, StoryblokComponent, SbBlokData } from '@storyblok/react'
-import { motion, useScroll } from 'framer-motion'
+import { motion, useInView, useScroll } from 'framer-motion'
 import { useState, useEffect, useRef, ReactNode } from 'react'
 import { theme, mq } from 'ui'
 import { GridLayout, MAX_WIDTH } from '@/components/GridLayout/GridLayout'
@@ -77,11 +77,7 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
         </OverviewGridArea>
 
         <GridLayout.Content width="1" align="center">
-          <section id="coverage">
-            {blok.coverage.map((nestedBlock) => (
-              <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
-            ))}
-          </section>
+          <CoverageSection blocks={blok.coverage} />
         </GridLayout.Content>
       </Grid>
 
@@ -257,4 +253,19 @@ const useActiveSectionChangeListener = (
 
     return () => observer.disconnect()
   }, [sectionsId, callback])
+}
+
+// Optimization:
+// Perils list could be hundreds of DOM elements (400+ for Apartment rent) and if we lazy-render it, page load time of product pages improves
+const CoverageSection = (props: { blocks: Array<SbBlokData> }) => {
+  const ref = useRef(null)
+  const cameIntoView = useInView(ref, { once: true })
+  return (
+    <section id="coverage" ref={ref}>
+      {cameIntoView &&
+        props.blocks.map((nestedBlock) => (
+          <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+        ))}
+    </section>
+  )
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Render coverage block of product page after it first comes into view

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Optimization: smaller DOM and faster page load
- 30% less DOM elements
- ~15% smaller document size
- ~10% faster hydration

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
