### PR TITLE
Add useResponsiveVariant as hydration-safe way to select desktop or mobile

### DIFF
--- a/apps/store/src/blocks/ComparisonTableBlock.tsx
+++ b/apps/store/src/blocks/ComparisonTableBlock.tsx
@@ -6,7 +6,7 @@ import { MobileComparisonTable } from '@/components/ComparisonTable/MobileCompar
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { ContentAlignment, ContentWidth } from '@/components/GridLayout/GridLayout.helper'
 import { type StoryblokTableField, type SbBaseBlockProps } from '@/services/storyblok/storyblok'
-import { useBreakpoint } from '@/utils/useBreakpoint/useBreakpoint'
+import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
 
 type Props = SbBaseBlockProps<{
   table: StoryblokTableField
@@ -17,7 +17,7 @@ type Props = SbBaseBlockProps<{
 }>
 
 export const ComparisonTableBlock = ({ blok }: Props) => {
-  const matchesMdAndUp = useBreakpoint('md')
+  const variant = useResponsiveVariant('md')
 
   const table = useMemo<Table>(
     () => ({
@@ -33,11 +33,10 @@ export const ComparisonTableBlock = ({ blok }: Props) => {
         width={blok.layout?.widths ?? { base: '1' }}
         align={blok.layout?.alignment ?? 'center'}
       >
-        {matchesMdAndUp ? (
+        {variant === 'desktop' && (
           <DesktopComparisonTable {...table} {...storyblokEditable(blok)} />
-        ) : (
-          <MobileComparisonTable {...table} {...storyblokEditable(blok)} />
         )}
+        {variant === 'mobile' && <MobileComparisonTable {...table} {...storyblokEditable(blok)} />}
       </GridLayout.Content>
     </GridLayout.Root>
   )

--- a/apps/store/src/blocks/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/services/storyblok/Storyblok.helpers'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
+import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
 import { ButtonBlockProps } from './ButtonBlock'
 
 type NavItemBlockProps = SbBaseBlockProps<{
@@ -244,10 +245,7 @@ export const HeaderBlock = ({ blok, ...headerProps }: HeaderBlockProps) => {
     [],
   )
 
-  const desktopMenu = useMemo(
-    () => <TopMenuDesktop>{blok.navMenuContainer.map(NestedNavigationBlock)}</TopMenuDesktop>,
-    [blok.navMenuContainer],
-  )
+  const variant = useResponsiveVariant('lg')
 
   const productNavItem = useMemo(
     () =>
@@ -262,10 +260,18 @@ export const HeaderBlock = ({ blok, ...headerProps }: HeaderBlockProps) => {
 
   return (
     <Header key={pathname} {...storyblokEditable(blok)} opaque={isOpen} {...headerProps}>
-      {desktopMenu}
-      <TopMenuMobile isOpen={isOpen} onOpenChange={handleOpenChange} defaultValue={productNavItem}>
-        {blok.navMenuContainer.map(NestedNavigationBlock)}
-      </TopMenuMobile>
+      {variant === 'desktop' && (
+        <TopMenuDesktop>{blok.navMenuContainer.map(NestedNavigationBlock)}</TopMenuDesktop>
+      )}
+      {variant === 'mobile' && (
+        <TopMenuMobile
+          isOpen={isOpen}
+          onOpenChange={handleOpenChange}
+          defaultValue={productNavItem}
+        >
+          {blok.navMenuContainer.map(NestedNavigationBlock)}
+        </TopMenuMobile>
+      )}
     </Header>
   )
 }

--- a/apps/store/src/components/ContactUs/ContactUs.tsx
+++ b/apps/store/src/components/ContactUs/ContactUs.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 import * as Popover from '@radix-ui/react-popover'
 import Link from 'next/link'
 import { useTranslation } from 'next-i18next'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import {
   AndroidIcon,
   AppleIcon,
@@ -18,7 +18,7 @@ import {
 import { getAppStoreLink } from '@/utils/appStoreLinks'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
-import { useBreakpoint } from '@/utils/useBreakpoint/useBreakpoint'
+import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
 import { zIndexes } from '@/utils/zIndex'
 
 const scaleIn = keyframes({
@@ -44,14 +44,12 @@ const scaleOut = keyframes({
 })
 
 export const ContactUs = () => {
-  const hasMounted = useHasMounted()
-  const isDesktop = useBreakpoint('lg')
+  const variant = useResponsiveVariant('lg')
   const { t } = useTranslation('contact-us')
   const locale = useRoutingLocale()
   const [open, setOpen] = useState(false)
 
-  // There's no way to determine how this component should look on the server
-  if (!hasMounted || !isDesktop) return null
+  if (variant !== 'desktop') return null
 
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
@@ -146,16 +144,6 @@ export const ContactUs = () => {
       </Popover.Portal>
     </Popover.Root>
   )
-}
-
-const useHasMounted = () => {
-  const [hasMounted, setHasMounted] = useState(false)
-
-  useEffect(() => {
-    setHasMounted(true)
-  }, [])
-
-  return hasMounted
 }
 
 const ContactUsButton = styled(Button)({

--- a/apps/store/src/components/Header/TopMenuDesktop/TopMenuDesktop.tsx
+++ b/apps/store/src/components/Header/TopMenuDesktop/TopMenuDesktop.tsx
@@ -1,7 +1,5 @@
-import styled from '@emotion/styled'
 import { usePathname } from 'next/navigation'
 import React, { useEffect } from 'react'
-import { mq } from 'ui'
 import { Navigation, NavigationPrimaryList } from '../HeaderStyles'
 
 export type TopMenuDesktopProps = {
@@ -16,18 +14,8 @@ export const TopMenuDesktop = ({ children }: TopMenuDesktopProps) => {
   }, [pathname])
 
   return (
-    <Wrapper>
-      <Navigation value={activeItem} onValueChange={setActiveItem}>
-        <NavigationPrimaryList>{children}</NavigationPrimaryList>
-      </Navigation>
-    </Wrapper>
+    <Navigation value={activeItem} onValueChange={setActiveItem}>
+      <NavigationPrimaryList>{children}</NavigationPrimaryList>
+    </Navigation>
   )
 }
-
-const Wrapper = styled.div({
-  display: 'none',
-
-  [mq.lg]: {
-    display: 'block',
-  },
-})

--- a/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
+++ b/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { useTranslation } from 'next-i18next'
-import { AndroidIcon, AppleIcon, Button, mq, theme } from 'ui'
+import { AndroidIcon, AppleIcon, Button, theme } from 'ui'
 import { LogoHomeLink } from '@/components/LogoHomeLink'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { getAppStoreLink } from '@/utils/appStoreLinks'
@@ -22,10 +22,6 @@ const triggerStyles = {
 
   ':active': {
     color: theme.colors.textSecondary,
-  },
-
-  [mq.lg]: {
-    display: 'none',
   },
 }
 

--- a/apps/store/src/components/ProductPage/PurchaseForm/ComparisonTableModal.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ComparisonTableModal.tsx
@@ -11,7 +11,7 @@ import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { ProductOfferFragment } from '@/services/graphql/generated'
 import { sendDialogEvent } from '@/utils/dialogEvent'
-import { useBreakpoint } from '@/utils/useBreakpoint/useBreakpoint'
+import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
 
 type Props = {
   tiers: Array<ProductOfferFragment>
@@ -20,7 +20,7 @@ type Props = {
 
 export const ComparisonTableModal = ({ tiers, selectedTierId }: Props) => {
   const { t } = useTranslation('purchase-form')
-  const matchesMdAndUp = useBreakpoint('md')
+  const variant = useResponsiveVariant('md')
   const { table, selectedTierDisplayName } = useTableData(tiers, selectedTierId)
 
   const handleOpenChange = (open: boolean) => {
@@ -53,10 +53,10 @@ export const ComparisonTableModal = ({ tiers, selectedTierId }: Props) => {
       >
         <Grid>
           <GridLayout.Content align="center" width={{ md: '2/3', xl: '1/2', xxl: '1/3' }}>
-            {!matchesMdAndUp && (
+            {variant === 'mobile' && (
               <MobileComparisonTable {...table} defaultSelectedColumn={selectedTierDisplayName} />
             )}
-            {matchesMdAndUp && (
+            {variant === 'desktop' && (
               <DesktopComparisonTable {...table} selectedColumn={selectedTierDisplayName} />
             )}
           </GridLayout.Content>

--- a/apps/store/src/services/CustomerFirst.tsx
+++ b/apps/store/src/services/CustomerFirst.tsx
@@ -3,7 +3,7 @@ import { atom, useAtom } from 'jotai'
 import Script from 'next/script'
 import { useCallback, useEffect } from 'react'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
-import { useBreakpoint } from '@/utils/useBreakpoint/useBreakpoint'
+import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
 
 const HIDE_CHAT_PAGE_PROP = '_hideChat'
 
@@ -13,13 +13,13 @@ export const hasHiddenChat = (props: Record<string, unknown>) => Boolean(props[H
 const OPEN_ATOM = atom(false)
 
 export const CustomerFirstScript = () => {
-  const isDesktop = useBreakpoint('lg')
+  const variant = useResponsiveVariant('lg')
   const { chatWidgetSrc } = useCurrentLocale()
   const { open } = useCustomerFirst()
 
   if (!chatWidgetSrc) return null
 
-  const showLauncher = isDesktop || open
+  const showLauncher = variant === 'desktop' || open
   return (
     <>
       <Global styles={{ '#chat-iframe': { display: showLauncher ? 'initial' : 'none' } }} />

--- a/apps/store/src/utils/useResponsiveVariant.ts
+++ b/apps/store/src/utils/useResponsiveVariant.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+import { type Level } from 'ui'
+import { useBreakpoint } from './useBreakpoint/useBreakpoint'
+
+// Lazy responsive rendering, we don't want hydration errors
+// and we don't want user-agent dependency for server side (mainly because it's not compatible with SSG)
+export const useResponsiveVariant = (breakpoint: Level) => {
+  const [variant, setVariant] = useState<'desktop' | 'mobile' | 'initial'>('initial')
+  const isDesktop = useBreakpoint(breakpoint)
+  useEffect(() => {
+    setVariant(isDesktop ? 'desktop' : 'mobile')
+  }, [isDesktop])
+  return variant
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Replace most usages of `useBreakpoint` with `useResponsiveVariant`

Main use case if hydration-compatible selection of mobile vs desktop variant

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Main driving goal was to make page header smaller - we don't want to keep desktop menu in DOM on mobile and we don't want to render it either

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
