### PR TITLE
Toggle cookie banner and GTM behind feature flag

### DIFF
--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -103,7 +103,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
       <Head>
         <meta key="viewport" name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
-      <CookieConsentLoader />
+      {Features.enabled('COOKIE_BANNER') && <CookieConsentLoader />}
       <GlobalLinkStyles />
       <OneTrustStyles />
       <PageTransitionProgressBar />

--- a/apps/store/src/utils/Features.ts
+++ b/apps/store/src/utils/Features.ts
@@ -7,6 +7,7 @@ export const Features = {
 }
 
 const config = {
+  COOKIE_BANNER: process.env.NEXT_PUBLIC_FEATURE_COOKIE_BANNER === 'true',
   INSURELY: process.env.NEXT_PUBLIC_FEATURE_INSURELY === 'true',
   MANYPETS_MIGRATION: process.env.NEXT_PUBLIC_FEATURE_MANYPETS_MIGRATION === 'true',
   MEMBER_AREA: process.env.NEXT_PUBLIC_FEATURE_MEMBER_AREA === 'true',


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Only load cookie banner and GTM when feature flag is enabled.  We're going to have it on in production and for debugging when needed and disabled otherwise.  Before it was controlled by GTM

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Do you love cookie banners when debugging?  I don't :)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
