### PR TITLE
tech: [RND-531] Preload and move video poster image to vercel 

### DIFF
--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled'
+import Head from 'next/head'
+import { getImageProps } from 'next/image'
 import { ConditionalWrapper, getMediaQueryBreakpoint, mq, theme } from 'ui'
 import { Video, VideoProps } from '@/components/Video/Video'
 import { SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
-import { getImgSrc, getOptimizedImageUrl } from '@/services/storyblok/Storyblok.helpers'
+import { getImgSrc } from '@/services/storyblok/Storyblok.helpers'
 
 export type VideoBlockProps = SbBaseBlockProps<
   {
@@ -29,15 +31,21 @@ export const VideoBlock = ({ className, blok, nested = false }: VideoBlockProps)
   ]
   const posterImg = blok.poster?.filename
   const posterUrl = posterImg
-    ? getOptimizedImageUrl(getImgSrc(posterImg), {
-        maxWidth: getMediaQueryBreakpoint('lg'),
-      })
+    ? getImageProps({
+        src: getImgSrc(posterImg),
+        width: getMediaQueryBreakpoint('lg'),
+        alt: '',
+      }).props.src
     : undefined
   return (
     <ConditionalWrapper
       condition={!(blok.fullBleed || nested)}
       wrapWith={(children) => <Wrapper className={className}>{children}</Wrapper>}
     >
+      <Head>
+        <link rel="preload" href={posterUrl} as="image" />
+      </Head>
+
       <Video
         sources={videoSources}
         poster={posterUrl}

--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -42,9 +42,11 @@ export const VideoBlock = ({ className, blok, nested = false }: VideoBlockProps)
       condition={!(blok.fullBleed || nested)}
       wrapWith={(children) => <Wrapper className={className}>{children}</Wrapper>}
     >
-      <Head>
-        <link rel="preload" href={posterUrl} as="image" />
-      </Head>
+      {blok.autoPlay && (
+        <Head>
+          <link rel="preload" href={posterUrl} as="image" />
+        </Head>
+      )}
 
       <Video
         sources={videoSources}

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -68,21 +68,6 @@ export const getStoryblokImageSize = (filename: string) => {
   return { width: Number(width), height: Number(height) }
 }
 
-type ImageOptimizationOptions = {
-  maxHeight?: number
-  maxWidth?: number
-}
-export const getOptimizedImageUrl = (
-  originalUrl: string,
-  options: ImageOptimizationOptions = {},
-) => {
-  let optimizationRules = ''
-  if (options.maxHeight || options.maxWidth) {
-    optimizationRules = `fit-in/${options.maxWidth ?? 0}x${options.maxHeight ?? 0}`
-  }
-  return `${originalUrl}/m/${optimizationRules}`
-}
-
 // Replace domain for Storyblok assets
 export const getImgSrc = (src: string) => {
   if (!Features.enabled('CUSTOM_ASSET_DOMAIN')) {


### PR DESCRIPTION
<!--
PR title: RND-531 / Fix / Preload and 
-->

## Describe your changes
Preload and load video poster images from next instead of Storyblok.

<!--
What changes are made?
1. Replace `getOptimizedImageUrl` with Next's `getImageProps`
2. Preload the poster image
-->

## Justify why they are needed
A step to improve the LCP core web vital. By using `getImageProps` the images are now served from next server which reduces the TTFB and load delay of poster images.

To further improve LCP, we preload the images to improve load times.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
