### PR TITLE
fix: Set aspect ratio for video posters

### DIFF
--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -34,6 +34,7 @@ export const VideoBlock = ({ className, blok, nested = false }: VideoBlockProps)
     ? getImageProps({
         src: getImgSrc(posterImg),
         width: getMediaQueryBreakpoint('lg'),
+        height: getMediaQueryBreakpoint('lg'),
         alt: '',
       }).props.src
     : undefined


### PR DESCRIPTION
<!--
PR title: Fix / Set aspect ratio for video posters
-->

## Describe your changes
Make sure video poster images aspect ration is calculated

<!--
What changes are made?
Add a height while getting video poster props to calculate the aspect ratio
-->

## Justify why they are needed
It's required to have both width and height in order for `getImageProps` to work correctly

## Checklist before requesting a review

- [x] I have performed a self-review of my code
