### PR TITLE
fix(bankid): avoid showing an unexpected loading state while the dialog gets lazy loaded

### DIFF
--- a/apps/store/src/components/BankIdDialogDynamic.tsx
+++ b/apps/store/src/components/BankIdDialogDynamic.tsx
@@ -1,21 +1,12 @@
 import dynamic from 'next/dynamic'
-import { Space } from 'ui'
-import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
-import { Skeleton } from '@/components/Skeleton'
 
+// By the time it gets used, BankIdDialog will probably be loaded/cached already so
+// no reason to add a 'loading' component here. At the end of the day it's also hard to
+// add a loading component as this dialog is not opened directly by the user
+// but as a consequence of having a BankId operation in progress.
 export const BankIdDialogDynamic = dynamic({
   loader: async () => {
     const { BankIdDialog } = await import('./BankIdDialog')
     return BankIdDialog
   },
-  loading: () => (
-    <FullscreenDialog.Root open={true}>
-      <FullscreenDialog.Modal center={true}>
-        <Space y={0.5}>
-          <Skeleton style={{ height: 22, width: 180 }} />
-          <Skeleton style={{ height: 22, width: 200 }} />
-        </Space>
-      </FullscreenDialog.Modal>
-    </FullscreenDialog.Root>
-  ),
 })

--- a/apps/store/src/components/BankIdV6Dialog/BankIdV6DialogDynamic.tsx
+++ b/apps/store/src/components/BankIdV6Dialog/BankIdV6DialogDynamic.tsx
@@ -1,29 +1,13 @@
 import dynamic from 'next/dynamic'
-import { Space } from 'ui'
-import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
-import { Skeleton } from '@/components/Skeleton'
-import { contentWrapper } from './BankIdV6Dialog.css'
 
+// By the time it gets used, BankIdV6Dialog will probably be loaded/cached already so
+// no reason to add a 'loading' component here. At the end of the day it's also hard to
+// add a loading component as this dialog is not opened directly by the user
+// but as a consequence of having a BankId operation in progress.
 export const BankIdV6DialogDynamic = dynamic({
   loader: async () => {
     const { BankIdV6Dialog } = await import('./BankIdV6Dialog')
     return BankIdV6Dialog
   },
-  loading: () => (
-    <FullscreenDialog.Root open={true}>
-      <FullscreenDialog.Modal center={true}>
-        <Space className={contentWrapper} y={2}>
-          <Skeleton style={{ height: 64, width: 64 }} />
-
-          <Skeleton style={{ height: 200, width: 200 }} />
-
-          <Space y={0.5}>
-            <Skeleton style={{ height: 22, width: 384 }} />
-            <Skeleton style={{ height: 68, width: 384 }} />
-          </Space>
-        </Space>
-      </FullscreenDialog.Modal>
-    </FullscreenDialog.Root>
-  ),
   ssr: false,
 })


### PR DESCRIPTION
## Describe your changes

I've noticed an unexpected loading dialog while loading home page. I've accidentally added that..

https://github.com/HedvigInsurance/racoon/assets/19200662/366988b9-f7f5-4a32-86b3-cfcb81a47401

What I was trying to do is having a loading state for bankid dialog in case it gets used before being loaded (it's been lazy loaded right now). The issue tho is that those dialogs doesn't get opened directly by a user interaction so it's hard to load it only when it's needed. So I removed the loading state as I think it will probably be always loaded/cached by the time it gets used so no issues here. Worst case scenario is some delay between clicking on login/sign and getting that dialog opened but I think that's gonna be rare as we trigger the loading of those dialogs code right after any page get's loaded.
