### PR TITLE
Wrap ui/Dialog.Root open/close change into startTransition (performance)

### DIFF
--- a/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
+++ b/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { motion, type Transition } from 'framer-motion'
-import React, { type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { CrossIcon, Dialog, mq, theme } from 'ui'
 
 type Props = {

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -1,6 +1,13 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { clsx } from 'clsx'
-import { forwardRef, PropsWithChildren, ReactNode } from 'react'
+import {
+  ComponentProps,
+  forwardRef,
+  PropsWithChildren,
+  ReactNode,
+  startTransition,
+  useCallback,
+} from 'react'
 import { contentWrapper, dialogWindow, overlay } from './Dialog.css'
 
 type ContentProps = {
@@ -41,7 +48,22 @@ const Overlay = forwardRef<HTMLDivElement, OverlayProps>(({ frosted }, ref) => {
 })
 Overlay.displayName = 'Overlay'
 
-export const Root = DialogPrimitive.Root
+export const Root = ({
+  onOpenChange,
+  ...forwardedProps
+}: ComponentProps<typeof DialogPrimitive.Root>) => {
+  // Optimization: dialogs can get quite large, so it's good idea to treat opening/closing as transition
+  const handleOpenChange = useCallback(
+    (newValue: boolean) => {
+      startTransition(() => {
+        onOpenChange?.(newValue)
+      })
+    },
+    [onOpenChange],
+  )
+  return <DialogPrimitive.Root {...forwardedProps} onOpenChange={handleOpenChange} />
+}
+
 export const Trigger = DialogPrimitive.Trigger
 export const Close = DialogPrimitive.Close
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Make Dialog open/close change a transition

This should improve responsiveness (INP) for most dialogs.  We still have 3 places where we use  '@radix-ui/react-dialog' directly, 1 already uses startTransition

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
