### PR TITLE
chore(storyblok-rich-text-react-renderer): bump version to 2.9.2

### DIFF
--- a/apps/store/package.json
+++ b/apps/store/package.json
@@ -78,7 +78,7 @@
     "react-i18next": "14.0.5",
     "react-wrap-balancer": "1.1.0",
     "server-only": "0.0.1",
-    "storyblok-rich-text-react-renderer": "2.9.1",
+    "storyblok-rich-text-react-renderer": "2.9.2",
     "tss-react": "4.9.4",
     "ui": "workspace:",
     "uuid": "9.0.1",

--- a/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
+++ b/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
@@ -6,7 +6,6 @@ import {
   render,
   type RenderOptions,
   MARK_LINK,
-  MARK_TEXT_STYLE,
 } from 'storyblok-rich-text-react-renderer'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { RichText } from '@/components/RichText/RichText'
@@ -82,12 +81,6 @@ const RENDER_OPTIONS: RenderOptions = {
 
       // Internal links
       return <Link {...linkProps} />
-    },
-    [MARK_TEXT_STYLE]: (children, { color }) => {
-      // Avoids hydration errors when 'color' is not valid: nullish or empty string
-      const props = color ? { style: { color } } : {}
-
-      return <span {...props}>{children}</span>
     },
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25252,7 +25252,7 @@ __metadata:
     react-i18next: "npm:14.0.5"
     react-wrap-balancer: "npm:1.1.0"
     server-only: "npm:0.0.1"
-    storyblok-rich-text-react-renderer: "npm:2.9.1"
+    storyblok-rich-text-react-renderer: "npm:2.9.2"
     storybook: "npm:7.6.17"
     storybook-addon-apollo-client: "npm:5.0.0"
     subscriptions-transport-ws: "npm:0.11.0"
@@ -25275,12 +25275,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"storyblok-rich-text-react-renderer@npm:2.9.1":
-  version: 2.9.1
-  resolution: "storyblok-rich-text-react-renderer@npm:2.9.1"
+"storyblok-rich-text-react-renderer@npm:2.9.2":
+  version: 2.9.2
+  resolution: "storyblok-rich-text-react-renderer@npm:2.9.2"
   peerDependencies:
     react: ">=16.0.0"
-  checksum: 10c0/b73ae39d28cf081db92bee3f23ae40b7b65ea416494665149489dbf01751254a1fb91d7b4f95c9c639be12b8ec2bc2be404c70cf1d604bd0a2dab5791ced5ad6
+  checksum: 10c0/48ffdf31b7885ee3c5c0bd9402133915791a066c7e5170137bd1674ac4272bce2a510104532c0007e8e1c9e756169743796ff6ec58594bfa7a9fd4571f81dc34
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes

* Bumps `storyblok-rich-text-react-renderer@2.9.2` and removed unecessary sanitization

## Justify why they are needed

I've added some sanitiazation code to avoid hydration errors #3881 as a workaround while a fix was not included in the library itself. The fix is merged and available on version 2.9.2 (more info [here](https://github.com/claus/storyblok-rich-text-react-renderer/pull/46)) so I'm bumping the package and removing my workaround.
