### PR TITLE
Prepare block components for app router: Replace Block.blockName with external keys

### DIFF
--- a/apps/store/src/blocks/AccordionBlock.tsx
+++ b/apps/store/src/blocks/AccordionBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { storyblokEditable, renderRichText } from '@storyblok/react'
 import Head from 'next/head'
@@ -91,7 +92,6 @@ export const AccordionBlock = ({ blok, nested }: Props) => {
     </>
   )
 }
-AccordionBlock.blockName = 'accordion'
 
 const AccodrionTitleDescription = ({ blok }: { blok: Props['blok'] }) => {
   return (

--- a/apps/store/src/blocks/AccordionItemBlock.tsx
+++ b/apps/store/src/blocks/AccordionItemBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { storyblokEditable, type ISbRichtext } from '@storyblok/react'
 import { useId, useMemo } from 'react'
 import { Text } from 'ui'

--- a/apps/store/src/blocks/AnnouncementBlock.tsx
+++ b/apps/store/src/blocks/AnnouncementBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { storyblokEditable, renderRichText, type ISbRichtext } from '@storyblok/react'
 import { atom, useAtom, useSetAtom } from 'jotai'
@@ -41,8 +42,6 @@ export const AnnouncementBlock = ({ blok }: AnnouncementBlockProps) => {
     </Banner>
   )
 }
-
-AnnouncementBlock.blockName = 'announcement'
 
 const Content = styled.span({
   a: {

--- a/apps/store/src/blocks/AverageRatingBannerBlock.tsx
+++ b/apps/store/src/blocks/AverageRatingBannerBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { useTranslation } from 'next-i18next'
 import { Button } from 'ui'
 import { AverageRating } from '@/components/ProductReviews/AverageRating'
@@ -12,7 +13,7 @@ import { wrapper, averageRatingLabel, disclaimerLabel, trigger } from './Average
 const HEDVIG_PILLOW_URL =
   'https://a.storyblok.com/f/165473/450x450/4b792f1052/hedvig-pillows-icon.png'
 
-export const AverageRatingBanner = () => {
+export const AverageRatingBannerBlock = () => {
   const { t } = useTranslation('reviews')
 
   const companyReviewsData = useCompanyReviewsDataContext()
@@ -58,5 +59,3 @@ export const AverageRatingBanner = () => {
     </div>
   )
 }
-
-AverageRatingBanner.blockName = 'averageRatingBanner'

--- a/apps/store/src/blocks/BannerBlock.tsx
+++ b/apps/store/src/blocks/BannerBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { Heading, Text, mq, theme } from 'ui'
@@ -45,7 +46,6 @@ export const BannerBlock = ({ blok }: BannerBlockProps) => {
     </Wrapper>
   )
 }
-BannerBlock.blockName = 'banner'
 
 const Wrapper = styled('div')<ImageSize>(({ aspectRatioLandscape, aspectRatioPortrait }) => ({
   position: 'relative',

--- a/apps/store/src/blocks/ButtonBlock.tsx
+++ b/apps/store/src/blocks/ButtonBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { useSearchParams } from 'next/navigation'

--- a/apps/store/src/blocks/CardLinkBlock.tsx
+++ b/apps/store/src/blocks/CardLinkBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { ArrowForwardIcon, theme, mq } from 'ui'
 import { SbBaseBlockProps, LinkField } from '@/services/storyblok/storyblok'
@@ -24,7 +25,6 @@ export const CardLinkBlock = ({ blok }: CardLinkBlockProps) => {
     </Card>
   )
 }
-CardLinkBlock.blockName = 'cardLink'
 
 const Card = styled.a({
   display: 'inline-flex',

--- a/apps/store/src/blocks/CardLinkListBlock.tsx
+++ b/apps/store/src/blocks/CardLinkListBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { theme, mq } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
@@ -19,7 +20,6 @@ export const CardLinkListBlock = ({ blok }: CardLinkListBlockProps) => {
     </Grid>
   )
 }
-CardLinkListBlock.blockName = 'cardLinkList'
 
 export const Grid = styled(GridLayout.Root)({
   gap: theme.space.xs,

--- a/apps/store/src/blocks/CheckListBlock.tsx
+++ b/apps/store/src/blocks/CheckListBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { SbBlokData, storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
@@ -26,7 +27,6 @@ export const CheckListBlock = ({ blok }: CheckListBlockProps) => {
     </Wrapper>
   )
 }
-CheckListBlock.blockName = 'checkList'
 
 const isTextBlock = (blok: SbBlokData): blok is TextBlockProps['blok'] => {
   return blok.component === TextBlock.blockName

--- a/apps/store/src/blocks/ComparisonTableBlock.tsx
+++ b/apps/store/src/blocks/ComparisonTableBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
 import { type Table } from '@/components/ComparisonTable/ComparisonTable.types'
@@ -41,5 +42,3 @@ export const ComparisonTableBlock = ({ blok }: Props) => {
     </GridLayout.Root>
   )
 }
-
-ComparisonTableBlock.blockName = 'comparisonTable'

--- a/apps/store/src/blocks/ConfirmationPageBlock.tsx
+++ b/apps/store/src/blocks/ConfirmationPageBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { storyblokEditable, StoryblokComponent, SbBlokData } from '@storyblok/react'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
@@ -15,5 +16,3 @@ export const ConfirmationPageBlock = ({ blok }: ConfirmationPageBlockProps) => {
     </div>
   )
 }
-
-ConfirmationPageBlock.blockName = 'confirmation'

--- a/apps/store/src/blocks/ContactSupportBlock.tsx
+++ b/apps/store/src/blocks/ContactSupportBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { storyblokEditable } from '@storyblok/react'
 import { ContactSupport, ContactSupportProps } from '@/components/ContactSupport/ContactSupport'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'

--- a/apps/store/src/blocks/ContentBlock.tsx
+++ b/apps/store/src/blocks/ContentBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { ISbRichtext, renderRichText, storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
@@ -25,7 +26,6 @@ export const ContentBlock = ({ blok }: Props) => {
     </Wrapper>
   )
 }
-ContentBlock.blockName = 'content'
 
 const Wrapper = styled(Space)({
   maxWidth: '37.5rem',

--- a/apps/store/src/blocks/CookieListBlock.tsx
+++ b/apps/store/src/blocks/CookieListBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { mq, theme } from 'ui'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
@@ -130,5 +131,3 @@ const OneTrustCookieInfo = styled.div`
     }
   }
 `
-
-CookieListBlock.blockName = 'cookieList'

--- a/apps/store/src/blocks/DownloadableContentItemBlock.tsx
+++ b/apps/store/src/blocks/DownloadableContentItemBlock.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+'use client'
 import { DownloadableContentItem } from '@/components/DownloadableContentItem/DownloadableContentItem'
 import { LinkField, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
 
@@ -10,5 +10,3 @@ export type DownloadableContentItemBlockProps = SbBaseBlockProps<{
 export const DownloadableContentItemBlock = ({ blok }: DownloadableContentItemBlockProps) => {
   return <DownloadableContentItem thumbnail={blok.thumbnail} url={blok.fileLink.url} />
 }
-
-DownloadableContentItemBlock.blockName = 'downloadableContentItem'

--- a/apps/store/src/blocks/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import Link from 'next/link'
@@ -23,7 +24,7 @@ type FooterLinkProps = SbBaseBlockProps<{
   linkText: string
 }>
 
-export const FooterLink = ({ blok }: FooterLinkProps) => {
+export const FooterLinkBlock = ({ blok }: FooterLinkProps) => {
   const Component = blok.link.linktype === 'url' ? StyledAnchor : StyledLink
 
   return (
@@ -37,15 +38,15 @@ export const FooterLink = ({ blok }: FooterLinkProps) => {
     </Component>
   )
 }
-FooterLink.blockName = 'footerLink' as const
+FooterLinkBlock.blockName = 'footerLink' as const
 
 type FooterSectionProps = SbBaseBlockProps<{
   footerLinks: ExpectedBlockType<FooterLinkProps>
   title: string
 }>
 
-export const FooterSection = ({ blok }: FooterSectionProps) => {
-  const filteredFooterLinks = filterByBlockType(blok.footerLinks, FooterLink.blockName)
+export const FooterSectionBlock = ({ blok }: FooterSectionProps) => {
+  const filteredFooterLinks = filterByBlockType(blok.footerLinks, FooterLinkBlock.blockName)
   return (
     <Space y={1.5} {...storyblokEditable(blok)}>
       <Text size="sm" color="textSecondary">
@@ -53,13 +54,13 @@ export const FooterSection = ({ blok }: FooterSectionProps) => {
       </Text>
       <Space y={0.5}>
         {filteredFooterLinks.map((nestedBlock) => (
-          <FooterLink key={nestedBlock._uid} blok={nestedBlock} />
+          <FooterLinkBlock key={nestedBlock._uid} blok={nestedBlock} />
         ))}
       </Space>
     </Space>
   )
 }
-FooterSection.blockName = 'footerSection' as const
+FooterSectionBlock.blockName = 'footerSection' as const
 
 export type FooterBlockProps = {
   onLocaleChange: (newLocale: IsoLocale) => void
@@ -85,13 +86,13 @@ export const FooterBlock = ({ blok, onLocaleChange }: FooterBlockProps) => {
     onLocaleChange(newLocale)
   }
 
-  const footerSections = filterByBlockType(blok.sections, FooterSection.blockName)
+  const footerSections = filterByBlockType(blok.sections, FooterSectionBlock.blockName)
   return (
     <div className={wrapperStyle}>
       <RootLayout>
         {footerSections.map((nestedBlok) => (
           <Column key={nestedBlok._uid}>
-            <FooterSection blok={nestedBlok} />
+            <FooterSectionBlock blok={nestedBlok} />
           </Column>
         ))}
 

--- a/apps/store/src/blocks/GridBlock.tsx
+++ b/apps/store/src/blocks/GridBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled, { CSSObject } from '@emotion/styled'
 import { StoryblokComponent, storyblokEditable } from '@storyblok/react'
 import { mq, theme } from 'ui'

--- a/apps/store/src/blocks/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import { storyblokEditable } from '@storyblok/react'

--- a/apps/store/src/blocks/HeadingBlock.tsx
+++ b/apps/store/src/blocks/HeadingBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { ConditionalWrapper, Heading, HeadingProps, PossibleHeadingVariant, theme } from 'ui'

--- a/apps/store/src/blocks/HeadingLabelBlock.tsx
+++ b/apps/store/src/blocks/HeadingLabelBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { ConditionalWrapper, Badge, BadgeProps, theme } from 'ui'
@@ -22,4 +23,3 @@ export const HeadingLabelBlock = ({ blok, nested }: HeadingLabelBlockProps) => {
     </ConditionalWrapper>
   )
 }
-HeadingLabelBlock.blockName = 'headingLabel'

--- a/apps/store/src/blocks/HeroBlock.tsx
+++ b/apps/store/src/blocks/HeroBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { SbBlokData, StoryblokComponent, storyblokEditable } from '@storyblok/react'
 import { ButtonBlock, ButtonBlockProps } from '@/blocks/ButtonBlock'
@@ -65,7 +67,6 @@ export const HeroBlock = ({ blok }: HeroBlockProps) => {
     </HeroSection>
   )
 }
-HeroBlock.blockName = 'hero'
 
 const HeroSection = styled.section(
   ({

--- a/apps/store/src/blocks/ImageBlock.tsx
+++ b/apps/store/src/blocks/ImageBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import isPropValid from '@emotion/is-prop-valid'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'

--- a/apps/store/src/blocks/ImageTextBlock.tsx
+++ b/apps/store/src/blocks/ImageTextBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { SbBlokData, StoryblokComponent } from '@storyblok/react'
 import { ConditionalWrapper, mq, theme } from 'ui'

--- a/apps/store/src/blocks/InlineSpaceBlock.tsx
+++ b/apps/store/src/blocks/InlineSpaceBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { theme } from 'ui'

--- a/apps/store/src/blocks/InsurableLimitsBlock.tsx
+++ b/apps/store/src/blocks/InsurableLimitsBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { storyblokEditable } from '@storyblok/react'
 import { InsurableLimits } from '@/components/InsurableLimits/InsurableLimits'
 import {

--- a/apps/store/src/blocks/InsurelyBlock.tsx
+++ b/apps/store/src/blocks/InsurelyBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'

--- a/apps/store/src/blocks/MediaListBlock.tsx
+++ b/apps/store/src/blocks/MediaListBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { StoryblokComponent, storyblokEditable } from '@storyblok/react'
 import { mq } from 'ui'
@@ -43,7 +44,6 @@ export const MediaListBlock = ({ blok }: MediaListBlockProps) => {
     </Slideshow>
   )
 }
-MediaListBlock.blockName = 'mediaList'
 
 const Wrapper = styled.div({
   paddingInline: 0,

--- a/apps/store/src/blocks/ModalBlock.tsx
+++ b/apps/store/src/blocks/ModalBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { SbBlokData, StoryblokComponent, storyblokEditable } from '@storyblok/react'
 import { ComponentProps, useState } from 'react'
@@ -33,8 +34,6 @@ export const ModalBlock = ({ blok }: ModalBlockProps) => {
     </Wrapper>
   )
 }
-
-ModalBlock.blockName = 'modal'
 
 const Wrapper = styled.div({
   display: 'flex',

--- a/apps/store/src/blocks/PageBlock.css.ts
+++ b/apps/store/src/blocks/PageBlock.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css'
+
+export const main = style({
+  width: '100%',
+})

--- a/apps/store/src/blocks/PageBlock.tsx
+++ b/apps/store/src/blocks/PageBlock.tsx
@@ -1,7 +1,7 @@
-import styled from '@emotion/styled'
-import { storyblokEditable, StoryblokComponent, SbBlokData } from '@storyblok/react'
-import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
-import { useDiscountBanner } from '@/utils/useDiscountBanner'
+import { storyblokEditable, StoryblokComponent, SbBlokData } from '@storyblok/react/rsc'
+import { DiscountBannerTrigger } from '@/components/DiscountBannerTrigger'
+import type { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { main } from './PageBlock.css'
 
 type PageBlockProps = SbBaseBlockProps<{
   body: Array<SbBlokData>
@@ -10,23 +10,13 @@ type PageBlockProps = SbBaseBlockProps<{
 export const PageBlock = ({ blok }: PageBlockProps) => {
   return (
     <>
-      <Main {...storyblokEditable(blok)}>
+      <main className={main} {...storyblokEditable(blok)}>
         {blok.body.map((nestedBlock) => (
           <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
         ))}
-      </Main>
+      </main>
       <DiscountBannerTrigger />
     </>
   )
 }
 PageBlock.blockName = 'page'
-
-// Optimization - this effect should run in component without children to avoid rerenders
-const DiscountBannerTrigger = () => {
-  useDiscountBanner()
-  return null
-}
-
-const Main = styled.main({
-  width: '100%',
-})

--- a/apps/store/src/blocks/PerilsBlock.tsx
+++ b/apps/store/src/blocks/PerilsBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
 import { Badge, Space } from 'ui'
@@ -47,5 +48,3 @@ export const PerilsBlock = ({ blok }: PerilsBlockProps) => {
     </GridLayout.Root>
   )
 }
-
-PerilsBlock.blockName = 'perils'

--- a/apps/store/src/blocks/ProductCardBlock.tsx
+++ b/apps/store/src/blocks/ProductCardBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { storyblokEditable } from '@storyblok/react'
 import { useProductMetadata } from '@/components/LayoutWithMenu/productMetadataHooks'
 import { type LinkType, ProductCard } from '@/components/ProductCard/ProductCard'
@@ -40,7 +41,6 @@ export const ProductCardBlock = ({ blok }: ProductCardBlockProps) => {
     />
   )
 }
-ProductCardBlock.blockName = 'productCard'
 
 // Make sure /se-en/products/home == se-en/products/home
 const isSameLink = (a: string, b: string) => {

--- a/apps/store/src/blocks/ProductDocumentsBlock.tsx
+++ b/apps/store/src/blocks/ProductDocumentsBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { storyblokEditable } from '@storyblok/react'
 import {
   useProductData,
@@ -31,5 +33,3 @@ export const ProductDocumentsBlock = ({ blok }: Props) => {
     />
   )
 }
-
-ProductDocumentsBlock.blockName = 'productDocuments'

--- a/apps/store/src/blocks/ProductGridBlock.tsx
+++ b/apps/store/src/blocks/ProductGridBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
@@ -24,7 +26,6 @@ export const ProductGridBlock = ({ blok }: ProductGridBlockProps) => {
     </Wrapper>
   )
 }
-ProductGridBlock.blockName = 'productGrid'
 
 const Wrapper = styled.div({
   paddingInline: theme.space.xs,

--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { storyblokEditable, StoryblokComponent, SbBlokData } from '@storyblok/react'
 import { motion, useInView, useScroll } from 'framer-motion'
@@ -87,7 +88,6 @@ export const ProductPageBlock = ({ blok }: ProductPageBlockProps) => {
     </main>
   )
 }
-ProductPageBlock.blockName = 'product'
 
 const StickyHeader = ({ children }: { children: ReactNode }) => {
   const { scrollY } = useScroll()

--- a/apps/store/src/blocks/ProductPillowsBlock/ProductPillowBlock.tsx
+++ b/apps/store/src/blocks/ProductPillowsBlock/ProductPillowBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { storyblokEditable } from '@storyblok/react'
 import { useProductMetadata } from '@/components/LayoutWithMenu/productMetadataHooks'
 import { ProductPillow } from '@/components/ProductPillow/ProductPillow'

--- a/apps/store/src/blocks/ProductPillowsBlock/ProductPillowsBlock.tsx
+++ b/apps/store/src/blocks/ProductPillowsBlock/ProductPillowsBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { mq, theme } from 'ui'
@@ -25,7 +26,6 @@ export const ProductPillowsBlock = ({ blok }: ProductPillowsBlockProps) => {
     </ProductPillowsWrapper>
   )
 }
-ProductPillowsBlock.blockName = 'productPillows'
 
 const PILLOW_HEIGHT = '10.75rem'
 

--- a/apps/store/src/blocks/ProductReviewsBlock.tsx
+++ b/apps/store/src/blocks/ProductReviewsBlock.tsx
@@ -1,7 +1,7 @@
+'use client'
+
 import { ProductReviews } from '@/components/ProductReviews/ProductReviews'
 
 export const ProductReviewsBlock = () => {
   return <ProductReviews />
 }
-
-ProductReviewsBlock.blockName = 'productReviews'

--- a/apps/store/src/blocks/ProductSlideshowBlock.tsx
+++ b/apps/store/src/blocks/ProductSlideshowBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { theme } from 'ui'
@@ -24,7 +26,6 @@ export const ProductSlideshowBlock = ({ blok }: ProductSlideshowBlockProps) => {
     </Wrapper>
   )
 }
-ProductSlideshowBlock.blockName = 'productSlideshow'
 
 const Wrapper = styled.div({
   paddingLeft: theme.space.sm,

--- a/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
+++ b/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { ConditionalWrapper, theme, mq } from 'ui'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
@@ -46,5 +48,3 @@ const StyledProductVariantSelector = styled(ProductVariantSelector)({
     backgroundColor: theme.colors.signalGreenHighlight,
   },
 })
-
-ProductVariantSelectorBlock.blockName = 'productVariantSelector'

--- a/apps/store/src/blocks/QuickPurchaseBlock.tsx
+++ b/apps/store/src/blocks/QuickPurchaseBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { useApolloClient } from '@apollo/client'
 import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
@@ -181,7 +182,6 @@ export const QuickPurchaseBlock = ({ blok, nested }: QuickPurchaseBlockProps) =>
     </Wrapper>
   )
 }
-QuickPurchaseBlock.blockName = 'quickPurchase'
 
 const Wrapper = styled.div({
   width: 'min(24rem, 100%)',

--- a/apps/store/src/blocks/ReusableBlockReference.tsx
+++ b/apps/store/src/blocks/ReusableBlockReference.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { StoryblokComponent } from '@storyblok/react'
 import { ReusableStory, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 

--- a/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
+++ b/apps/store/src/blocks/RichTextBlock/RichTextBlock.tsx
@@ -1,12 +1,9 @@
+'use client'
 import styled from '@emotion/styled'
 import { type ISbRichtext, storyblokEditable } from '@storyblok/react'
 import Link from 'next/link'
 import { useMemo, type ReactNode } from 'react'
-import {
-  render,
-  type RenderOptions,
-  MARK_LINK,
-} from 'storyblok-rich-text-react-renderer'
+import { render, type RenderOptions, MARK_LINK } from 'storyblok-rich-text-react-renderer'
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { RichText } from '@/components/RichText/RichText'
 import { type GridColumnsField, type SbBaseBlockProps } from '@/services/storyblok/storyblok'

--- a/apps/store/src/blocks/SelectInsuranceGridBlock.tsx
+++ b/apps/store/src/blocks/SelectInsuranceGridBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { mq } from 'ui'
@@ -46,5 +48,3 @@ const StyledSelectInsuranceGrid = styled(SelectInsuranceGrid)({
     },
   },
 })
-
-SelectInsuranceGridBlock.blockName = 'selectInsuranceGrid'

--- a/apps/store/src/blocks/SpacerBlock.tsx
+++ b/apps/store/src/blocks/SpacerBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { mq } from 'ui'

--- a/apps/store/src/blocks/TabsBlock.tsx
+++ b/apps/store/src/blocks/TabsBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import * as RadixTabs from '@radix-ui/react-tabs'
 import { SbBlokData, StoryblokComponent, storyblokEditable } from '@storyblok/react'
@@ -54,7 +56,6 @@ export const TabsBlock = ({ blok }: TabsBlockProps) => {
     </Wrapper>
   )
 }
-TabsBlock.blockName = 'tabs'
 
 const TabBlock = ({ blok }: TabBlockProps) => {
   return (

--- a/apps/store/src/blocks/TextBlock.tsx
+++ b/apps/store/src/blocks/TextBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { ISbRichtext, storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'

--- a/apps/store/src/blocks/TextContentBlock.tsx
+++ b/apps/store/src/blocks/TextContentBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { StoryblokComponent, storyblokEditable } from '@storyblok/react'
 import { theme } from 'ui'

--- a/apps/store/src/blocks/TickerBlock.tsx
+++ b/apps/store/src/blocks/TickerBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { theme } from 'ui'
 import { Ticker, TickerItem } from '@/components/Ticker/Ticker'
@@ -8,7 +10,7 @@ type Props = SbBaseBlockProps<{
   uspText?: string
 }>
 
-const TickerBlock = (props: Props) => {
+export const TickerBlock = (props: Props) => {
   const uspList = props.blok.uspText?.split('\n') ?? []
 
   return (
@@ -22,8 +24,5 @@ const TickerBlock = (props: Props) => {
     </>
   )
 }
-TickerBlock.blockName = 'ticker'
 
 const Spacer = styled.div({ height: theme.space.xs })
-
-export default TickerBlock

--- a/apps/store/src/blocks/TimelineBlock.tsx
+++ b/apps/store/src/blocks/TimelineBlock.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { TimelineItemBlock, TimelineItemBlockProps } from '@/blocks/TimelineItemBlock'
 import * as Timeline from '@/components//Timeline/Timeline'
 import { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
@@ -26,4 +27,3 @@ export const TimelineBlock = ({ blok }: Props) => {
     </Timeline.Root>
   )
 }
-TimelineBlock.blockName = 'timeline'

--- a/apps/store/src/blocks/TimelineItemBlock.tsx
+++ b/apps/store/src/blocks/TimelineItemBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { ISbRichtext, renderRichText } from '@storyblok/react'
 import { Heading, theme } from 'ui'

--- a/apps/store/src/blocks/TopPickCardBlock.tsx
+++ b/apps/store/src/blocks/TopPickCardBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import Link from 'next/link'

--- a/apps/store/src/blocks/USPBlock.tsx
+++ b/apps/store/src/blocks/USPBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { Badge, Text, theme, mq } from 'ui'

--- a/apps/store/src/blocks/VideoBlock.tsx
+++ b/apps/store/src/blocks/VideoBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import Head from 'next/head'
 import { getImageProps } from 'next/image'
@@ -64,7 +66,6 @@ export const VideoBlock = ({ className, blok, nested = false }: VideoBlockProps)
     </ConditionalWrapper>
   )
 }
-VideoBlock.blockName = 'videoBlock'
 
 const Wrapper = styled.div({
   paddingInline: theme.space.xs,

--- a/apps/store/src/blocks/WidgetFlowBlock.tsx
+++ b/apps/store/src/blocks/WidgetFlowBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { StoryblokComponent, storyblokEditable, type SbBlokData } from '@storyblok/react'
 import { Space } from 'ui'
@@ -26,7 +28,6 @@ export const WidgetFlowBlock = ({ blok }: Props) => {
     </GridLayout.Root>
   )
 }
-WidgetFlowBlock.blockName = 'widgetFlow'
 
 const RecommendationSkeleton = styled(Skeleton)({
   height: '16rem',

--- a/apps/store/src/components/DiscountBannerTrigger.tsx
+++ b/apps/store/src/components/DiscountBannerTrigger.tsx
@@ -1,0 +1,8 @@
+'use client'
+import { useDiscountBanner } from '@/utils/useDiscountBanner'
+
+// Optimization - this effect should run in component without children to avoid rerenders
+export const DiscountBannerTrigger = () => {
+  useDiscountBanner()
+  return null
+}

--- a/apps/store/src/features/blog/BlogArticleBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { StoryblokComponent, storyblokEditable } from '@storyblok/react'
 import Link from 'next/link'

--- a/apps/store/src/features/blog/BlogArticleCategoryBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleCategoryBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { type ComponentProps } from 'react'
 import { PageBlock } from '@/blocks/PageBlock'
 import { BLOG_ARTICLE_CATEGORY_CONTENT_TYPE } from './blog.constants'

--- a/apps/store/src/features/blog/BlogArticleCategoryListBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleCategoryListBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { GridLayout } from '@/components/GridLayout/GridLayout'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { makeAbsolute } from '@/services/storyblok/Storyblok.helpers'

--- a/apps/store/src/features/blog/BlogArticleListBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleListBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import styled from '@emotion/styled'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'

--- a/apps/store/src/features/blog/blogBlocks.ts
+++ b/apps/store/src/features/blog/blogBlocks.ts
@@ -1,11 +1,17 @@
+import {
+  BLOG_ARTICLE_CATEGORY_CONTENT_TYPE,
+  BLOG_ARTICLE_CATEGORY_LIST_BLOCK,
+  BLOG_ARTICLE_CONTENT_TYPE,
+  BLOG_ARTICLE_LIST_BLOCK,
+} from '@/features/blog/blog.constants'
 import { BlogArticleBlock } from './BlogArticleBlock'
 import { BlogArticleCategoryBlock } from './BlogArticleCategoryBlock'
 import { BlogArticleCategoryListBlock } from './BlogArticleCategoryListBlock'
 import { BlogArticleListBlock } from './BlogArticleListBlock'
 
-export const blogBlocks = [
-  BlogArticleBlock,
-  BlogArticleCategoryBlock,
-  BlogArticleCategoryListBlock,
-  BlogArticleListBlock,
-]
+export const blogBlocks = {
+  [BLOG_ARTICLE_CONTENT_TYPE]: BlogArticleBlock,
+  [BLOG_ARTICLE_CATEGORY_CONTENT_TYPE]: BlogArticleCategoryBlock,
+  [BLOG_ARTICLE_CATEGORY_LIST_BLOCK]: BlogArticleCategoryListBlock,
+  [BLOG_ARTICLE_LIST_BLOCK]: BlogArticleListBlock,
+}

--- a/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
+++ b/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { type QueryHookOptions } from '@apollo/client'
 import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
@@ -110,7 +112,6 @@ export const CarTrialExtensionBlock = (props: Props) => {
     </GridLayout.Root>
   )
 }
-CarTrialExtensionBlock.blockName = 'carTrialExtension'
 
 type UseCarTrialQueryParams = Pick<QueryHookOptions<NonNullable<CarTrialExtension>>, 'onCompleted'>
 

--- a/apps/store/src/features/carDealership/carDealershipBlocks.ts
+++ b/apps/store/src/features/carDealership/carDealershipBlocks.ts
@@ -1,3 +1,5 @@
 import { CarTrialExtensionBlock } from './CarTrialExtensionBlock'
 
-export const carDealershipBlocks = [CarTrialExtensionBlock]
+export const carDealershipBlocks = {
+  carTrialExtension: CarTrialExtensionBlock,
+}

--- a/apps/store/src/features/manyPets/ManyPetsMigrationPageBlock.tsx
+++ b/apps/store/src/features/manyPets/ManyPetsMigrationPageBlock.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { StoryblokComponent } from '@storyblok/react'
 import { CurrencyCode } from '@/services/graphql/generated'
 import { SbBaseBlockProps } from '@/services/storyblok/storyblok'
@@ -29,5 +31,3 @@ export const ManyPetsMigrationPageBlock = ({ blok }: Props) => {
     />
   )
 }
-
-ManyPetsMigrationPageBlock.blockName = 'ManypetsMigrationPage'

--- a/apps/store/src/features/manyPets/manyPetsBlocks.ts
+++ b/apps/store/src/features/manyPets/manyPetsBlocks.ts
@@ -1,3 +1,5 @@
 import { ManyPetsMigrationPageBlock } from './ManyPetsMigrationPageBlock'
 
-export const manyPetsBlocks = [ManyPetsMigrationPageBlock]
+export const manyPetsBlocks = {
+  ManypetsMigrationPage: ManyPetsMigrationPageBlock,
+}

--- a/apps/store/src/services/storyblok/storyblok.serverOnly.ts
+++ b/apps/store/src/services/storyblok/storyblok.serverOnly.ts
@@ -3,6 +3,7 @@ import { ISbStoryData } from '@storyblok/react'
 import { apiPlugin, getStoryblokApi, storyblokInit } from '@storyblok/react/rsc'
 import { BLOG_ARTICLE_CONTENT_TYPE } from '@/features/blog/blog.constants'
 import { StoryblokVersion, StoryOptions } from '@/services/storyblok/storyblok'
+import { storyblokComponents } from '@/services/storyblok/storyblokComponents'
 import { Language } from '@/utils/l10n/types'
 
 // Overall app router setup for Storyblok based on
@@ -13,6 +14,7 @@ const cvCacheTag = 'storyblok.cv'
 storyblokInit({
   accessToken: process.env.NEXT_PUBLIC_STORYBLOK_ACCESS_TOKEN,
   use: [apiPlugin],
+  components: storyblokComponents,
 })
 
 export const fetchStoryblokCacheVersion = async ({
@@ -25,6 +27,8 @@ export const fetchStoryblokCacheVersion = async ({
   return storyblokApi.cacheVersion()
 }
 
+const primeCache = () => fetchStoryblokCacheVersion({ cache: 'force-cache' })
+
 export type StoryblokFetchParams = {
   version?: StoryblokVersion
   language?: Language
@@ -36,6 +40,7 @@ export const getStoryBySlug = async <T extends ISbStoryData>(
   { version, locale }: StoryOptions,
 ): Promise<T> => {
   const storyblokApi = getStoryblokApi()
+  await primeCache()
   const { data } = await storyblokApi.getStory(`${locale}/${slug}`, {
     version,
     resolve_links: 'url',

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -8,81 +8,19 @@ import {
   StoryblokClient,
   storyblokInit,
 } from '@storyblok/react'
-import { AccordionBlock } from '@/blocks/AccordionBlock'
-import { AccordionItemBlock } from '@/blocks/AccordionItemBlock'
-import { AnnouncementBlock } from '@/blocks/AnnouncementBlock'
-import { AverageRatingBanner } from '@/blocks/AverageRatingBanner'
-import { BannerBlock } from '@/blocks/BannerBlock'
-import { ButtonBlock } from '@/blocks/ButtonBlock'
-import { CardLinkBlock } from '@/blocks/CardLinkBlock'
-import { CardLinkListBlock } from '@/blocks/CardLinkListBlock'
-import { CheckListBlock } from '@/blocks/CheckListBlock'
-import { ComparisonTableBlock } from '@/blocks/ComparisonTableBlock'
-import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
-import { ContactSupportBlock } from '@/blocks/ContactSupportBlock'
-import { ContentBlock } from '@/blocks/ContentBlock'
-import { CookieListBlock } from '@/blocks/CookieListBlock'
-import { DownloadableContentItemBlock } from '@/blocks/DownloadableContentItemBlock'
-import { FooterBlock, FooterBlockProps, FooterLink, FooterSection } from '@/blocks/FooterBlock'
-import { GridBlock } from '@/blocks/GridBlock'
-import {
-  HeaderBlock,
-  HeaderBlockProps,
-  NavItemBlock,
-  NestedNavContainerBlock,
-  ProductNavContainerBlock,
-} from '@/blocks/HeaderBlock'
-import { HeadingBlock } from '@/blocks/HeadingBlock'
-import { HeadingLabelBlock } from '@/blocks/HeadingLabelBlock'
-import { HeroBlock } from '@/blocks/HeroBlock'
-import { ImageBlock } from '@/blocks/ImageBlock'
-import { ImageTextBlock } from '@/blocks/ImageTextBlock'
-import { InlineSpaceBlock } from '@/blocks/InlineSpaceBlock'
-import { InsurableLimitsBlock } from '@/blocks/InsurableLimitsBlock'
-import { InsurelyBlock } from '@/blocks/InsurelyBlock'
-import { MediaListBlock } from '@/blocks/MediaListBlock'
-import { ModalBlock } from '@/blocks/ModalBlock'
-import { PageBlock } from '@/blocks/PageBlock'
-import { PerilsBlock } from '@/blocks/PerilsBlock'
-import { ProductCardBlock } from '@/blocks/ProductCardBlock'
-import { ProductDocumentsBlock } from '@/blocks/ProductDocumentsBlock'
-import { ProductGridBlock } from '@/blocks/ProductGridBlock'
-import { ProductPageBlock } from '@/blocks/ProductPageBlock'
-import { ProductPillowBlock } from '@/blocks/ProductPillowsBlock/ProductPillowBlock'
-import { ProductPillowsBlock } from '@/blocks/ProductPillowsBlock/ProductPillowsBlock'
-import { ProductReviewsBlock } from '@/blocks/ProductReviewsBlock'
-import { ProductSlideshowBlock } from '@/blocks/ProductSlideshowBlock'
-import { ProductVariantSelectorBlock } from '@/blocks/ProductVariantSelectorBlock'
-import { QuickPurchaseBlock } from '@/blocks/QuickPurchaseBlock'
-import {
-  ReusableBlockReference,
-  ReusableBlockReferenceProps,
-} from '@/blocks/ReusableBlockReference'
-import { RichTextBlock } from '@/blocks/RichTextBlock/RichTextBlock'
-import { SelectInsuranceGridBlock } from '@/blocks/SelectInsuranceGridBlock'
-import { SpacerBlock } from '@/blocks/SpacerBlock'
-import { TabsBlock } from '@/blocks/TabsBlock'
-import { TextBlock } from '@/blocks/TextBlock'
-import { TextContentBlock } from '@/blocks/TextContentBlock'
-import TickerBlock from '@/blocks/TickerBlock'
-import { TimelineBlock } from '@/blocks/TimelineBlock'
-import { TimelineItemBlock } from '@/blocks/TimelineItemBlock'
-import { TopPickCardBlock } from '@/blocks/TopPickCardBlock'
-import { USPBlock, USPBlockItem } from '@/blocks/USPBlock'
-import { VideoBlock } from '@/blocks/VideoBlock'
-import { WidgetFlowBlock } from '@/blocks/WidgetFlowBlock'
+import { FooterBlockProps } from '@/blocks/FooterBlock'
+import { HeaderBlockProps } from '@/blocks/HeaderBlock'
+import { ReusableBlockReferenceProps } from '@/blocks/ReusableBlockReference'
 import { type ContentAlignment, type ContentWidth } from '@/components/GridLayout/GridLayout.helper'
 import { BLOG_ARTICLE_CONTENT_TYPE } from '@/features/blog/blog.constants'
-import { blogBlocks } from '@/features/blog/blogBlocks'
 // TODO: get rid of this import, services should avoid feature-imports
-import { carDealershipBlocks } from '@/features/carDealership/carDealershipBlocks'
 import { STORYBLOK_MANYPETS_FOLDER_SLUG } from '@/features/manyPets/manyPets.constants'
-import { manyPetsBlocks } from '@/features/manyPets/manyPetsBlocks'
 import { STORYBLOK_WIDGET_FOLDER_SLUG } from '@/features/widget/widget.constants'
 import { isBrowser } from '@/utils/env'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { Language, RoutingLocale } from '@/utils/l10n/types'
 import { GLOBAL_STORY_PROP_NAME, STORY_PROP_NAME } from './Storyblok.constant'
+import { storyblokComponents } from './storyblokComponents'
 
 export type SbBaseBlockProps<T> = {
   blok: SbBlokData & T
@@ -245,85 +183,7 @@ type PageLink = {
   slugParts: Array<string>
 }
 
-type NamedBlock = {
-  blockName: string
-} & React.ElementType
-
 export const initStoryblok = () => {
-  const blockComponents: Array<NamedBlock> = [
-    AccordionBlock,
-    AccordionItemBlock,
-    AnnouncementBlock,
-    BannerBlock,
-    ButtonBlock,
-    CheckListBlock,
-    ContactSupportBlock,
-    ContentBlock,
-    ConfirmationPageBlock,
-    DownloadableContentItemBlock,
-    FooterBlock,
-    FooterLink,
-    FooterSection,
-    ReusableBlockReference,
-    // TODO: Header vs Heading is easy to confuse.  Discuss with team if we should rename one of these
-    GridBlock,
-    HeaderBlock,
-    HeadingBlock,
-    HeadingLabelBlock,
-    HeroBlock,
-    ImageBlock,
-    ImageTextBlock,
-    InlineSpaceBlock,
-    InsurableLimitsBlock,
-    CookieListBlock,
-    MediaListBlock,
-    ModalBlock,
-    NavItemBlock,
-    NestedNavContainerBlock,
-    PageBlock,
-    PerilsBlock,
-    ProductPageBlock,
-    ProductCardBlock,
-    ProductDocumentsBlock,
-    ProductGridBlock,
-    ProductPillowBlock,
-    ProductPillowsBlock,
-    ProductReviewsBlock,
-    ProductSlideshowBlock,
-    ProductVariantSelectorBlock,
-    RichTextBlock,
-    SpacerBlock,
-    TabsBlock,
-    TimelineBlock,
-    TimelineItemBlock,
-    TextBlock,
-    TextContentBlock,
-    TopPickCardBlock,
-    AverageRatingBanner,
-    VideoBlock,
-    WidgetFlowBlock,
-    ProductNavContainerBlock,
-    USPBlock,
-    USPBlockItem,
-    CardLinkBlock,
-    CardLinkListBlock,
-    SelectInsuranceGridBlock,
-    QuickPurchaseBlock,
-    ComparisonTableBlock,
-    InsurelyBlock,
-    TickerBlock,
-    ...blogBlocks,
-    ...manyPetsBlocks,
-    ...carDealershipBlocks,
-  ]
-  const blockAliases = { reusableBlock: PageBlock }
-  const components = {
-    ...Object.fromEntries(
-      blockComponents.map((blockComponent) => [blockComponent.blockName, blockComponent]),
-    ),
-    ...blockAliases,
-  }
-
   // https://github.com/storyblok/storyblok-react/issues/156#issuecomment-1197764828
   let shouldUseBridge = false
   if (isBrowser()) {
@@ -345,7 +205,7 @@ export const initStoryblok = () => {
     },
     use: [apiPlugin],
     bridge: shouldUseBridge,
-    components,
+    components: storyblokComponents,
   })
 }
 

--- a/apps/store/src/services/storyblok/storyblokComponents.ts
+++ b/apps/store/src/services/storyblok/storyblokComponents.ts
@@ -1,0 +1,132 @@
+import { AccordionBlock } from '@/blocks/AccordionBlock'
+import { AccordionItemBlock } from '@/blocks/AccordionItemBlock'
+import { AnnouncementBlock } from '@/blocks/AnnouncementBlock'
+import { AverageRatingBannerBlock } from '@/blocks/AverageRatingBannerBlock'
+import { BannerBlock } from '@/blocks/BannerBlock'
+import { ButtonBlock } from '@/blocks/ButtonBlock'
+import { CardLinkBlock } from '@/blocks/CardLinkBlock'
+import { CardLinkListBlock } from '@/blocks/CardLinkListBlock'
+import { CheckListBlock } from '@/blocks/CheckListBlock'
+import { ComparisonTableBlock } from '@/blocks/ComparisonTableBlock'
+import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
+import { ContactSupportBlock } from '@/blocks/ContactSupportBlock'
+import { ContentBlock } from '@/blocks/ContentBlock'
+import { CookieListBlock } from '@/blocks/CookieListBlock'
+import { DownloadableContentItemBlock } from '@/blocks/DownloadableContentItemBlock'
+import { FooterBlock, FooterLinkBlock, FooterSectionBlock } from '@/blocks/FooterBlock'
+import { GridBlock } from '@/blocks/GridBlock'
+import {
+  HeaderBlock,
+  NavItemBlock,
+  NestedNavContainerBlock,
+  ProductNavContainerBlock,
+} from '@/blocks/HeaderBlock'
+import { HeadingBlock } from '@/blocks/HeadingBlock'
+import { HeadingLabelBlock } from '@/blocks/HeadingLabelBlock'
+import { HeroBlock } from '@/blocks/HeroBlock'
+import { ImageBlock } from '@/blocks/ImageBlock'
+import { ImageTextBlock } from '@/blocks/ImageTextBlock'
+import { InlineSpaceBlock } from '@/blocks/InlineSpaceBlock'
+import { InsurableLimitsBlock } from '@/blocks/InsurableLimitsBlock'
+import { InsurelyBlock } from '@/blocks/InsurelyBlock'
+import { MediaListBlock } from '@/blocks/MediaListBlock'
+import { ModalBlock } from '@/blocks/ModalBlock'
+import { PageBlock } from '@/blocks/PageBlock'
+import { PerilsBlock } from '@/blocks/PerilsBlock'
+import { ProductCardBlock } from '@/blocks/ProductCardBlock'
+import { ProductDocumentsBlock } from '@/blocks/ProductDocumentsBlock'
+import { ProductGridBlock } from '@/blocks/ProductGridBlock'
+import { ProductPageBlock } from '@/blocks/ProductPageBlock'
+import { ProductPillowBlock } from '@/blocks/ProductPillowsBlock/ProductPillowBlock'
+import { ProductPillowsBlock } from '@/blocks/ProductPillowsBlock/ProductPillowsBlock'
+import { ProductReviewsBlock } from '@/blocks/ProductReviewsBlock'
+import { ProductSlideshowBlock } from '@/blocks/ProductSlideshowBlock'
+import { ProductVariantSelectorBlock } from '@/blocks/ProductVariantSelectorBlock'
+import { QuickPurchaseBlock } from '@/blocks/QuickPurchaseBlock'
+import { ReusableBlockReference } from '@/blocks/ReusableBlockReference'
+import { RichTextBlock } from '@/blocks/RichTextBlock/RichTextBlock'
+import { SelectInsuranceGridBlock } from '@/blocks/SelectInsuranceGridBlock'
+import { SpacerBlock } from '@/blocks/SpacerBlock'
+import { TabsBlock } from '@/blocks/TabsBlock'
+import { TextBlock } from '@/blocks/TextBlock'
+import { TextContentBlock } from '@/blocks/TextContentBlock'
+import { TickerBlock } from '@/blocks/TickerBlock'
+import { TimelineBlock } from '@/blocks/TimelineBlock'
+import { TimelineItemBlock } from '@/blocks/TimelineItemBlock'
+import { TopPickCardBlock } from '@/blocks/TopPickCardBlock'
+import { USPBlock, USPBlockItem } from '@/blocks/USPBlock'
+import { VideoBlock } from '@/blocks/VideoBlock'
+import { WidgetFlowBlock } from '@/blocks/WidgetFlowBlock'
+import { blogBlocks } from '@/features/blog/blogBlocks'
+import { carDealershipBlocks } from '@/features/carDealership/carDealershipBlocks'
+import { manyPetsBlocks } from '@/features/manyPets/manyPetsBlocks'
+
+const blockAliases = { reusableBlock: PageBlock }
+
+export const storyblokComponents = {
+  accordion: AccordionBlock,
+  accordionItem: AccordionItemBlock,
+  announcement: AnnouncementBlock,
+  averageRatingBanner: AverageRatingBannerBlock,
+  banner: BannerBlock,
+  button: ButtonBlock,
+  cardLink: CardLinkBlock,
+  cardLinkList: CardLinkListBlock,
+  checkList: CheckListBlock,
+  comparisonTable: ComparisonTableBlock,
+  confirmation: ConfirmationPageBlock,
+  contactSupport: ContactSupportBlock,
+  content: ContentBlock,
+  cookieList: CookieListBlock,
+  downloadableContentItem: DownloadableContentItemBlock,
+  footer: FooterBlock,
+  footerLink: FooterLinkBlock,
+  footerSection: FooterSectionBlock,
+  grid: GridBlock,
+  header: HeaderBlock,
+  heading: HeadingBlock,
+  headingLabel: HeadingLabelBlock,
+  hero: HeroBlock,
+  image: ImageBlock,
+  imageText: ImageTextBlock,
+  inlineSpace: InlineSpaceBlock,
+  insurely: InsurelyBlock,
+  insurableLimits: InsurableLimitsBlock,
+  mediaList: MediaListBlock,
+  modal: ModalBlock,
+  navItem: NavItemBlock,
+  nestedNavContainer: NestedNavContainerBlock,
+  page: PageBlock,
+  perils: PerilsBlock,
+  product: ProductPageBlock,
+  productCard: ProductCardBlock,
+  productDocuments: ProductDocumentsBlock,
+  productGrid: ProductGridBlock,
+  productNavContainer: ProductNavContainerBlock,
+  productPillow: ProductPillowBlock,
+  productPillows: ProductPillowsBlock,
+  productReviews: ProductReviewsBlock,
+  productSlideshow: ProductSlideshowBlock,
+  productVariantSelector: ProductVariantSelectorBlock,
+  quickPurchase: QuickPurchaseBlock,
+  reusableBlockReference: ReusableBlockReference,
+  richText: RichTextBlock,
+  selectInsuranceGrid: SelectInsuranceGridBlock,
+  spacer: SpacerBlock,
+  tabs: TabsBlock,
+  timeline: TimelineBlock,
+  timelineItem: TimelineItemBlock,
+  text: TextBlock,
+  textContent: TextContentBlock,
+  ticker: TickerBlock,
+  topPickCard: TopPickCardBlock,
+  usp: USPBlock,
+  uspItem: USPBlockItem,
+  videoBlock: VideoBlock,
+  widgetFlow: WidgetFlowBlock,
+
+  ...blogBlocks,
+  ...carDealershipBlocks,
+  ...manyPetsBlocks,
+  ...blockAliases,
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Replace SomeBlock.blockName static property with names assigned centrally

This is first step towards supporting rendering some Storyblok components in RSC.  Most important ones are probably top-level blocks like global layout and PageBlock

This breaks colocation principle, unfortunately.  With RSC we need to support "render block that has 'use client' on server side".  In this case you cannot access `.blockName` or any other property on client-side component

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
