### PR TITLE
Fix loading Storyblok redirects

### DIFF
--- a/apps/store/next-csp.config.mjs
+++ b/apps/store/next-csp.config.mjs
@@ -141,9 +141,6 @@ const connectSrc = [
   ...adyenOrigins,
   ...gtmInjectedOrigins,
 
-  // OLD market web
-  'https://api.storyblok.com',
-
   // Affiliate tracking
   'https://addrevenue.io',
 

--- a/apps/store/next.config.mjs
+++ b/apps/store/next.config.mjs
@@ -127,6 +127,7 @@ const config = {
     let storyblokRedirects = []
     if (process.env.NEXT_PUBLIC_FEATURE_STORYBLOK_REDIRECTS === 'true') {
       storyblokRedirects = await getStoryblokRedirects()
+      console.log(`Loaded ${storyblokRedirects.length} redirects from storyblok`)
     }
 
     return [
@@ -187,16 +188,11 @@ const getStoryblokRedirects = async () => {
 
   if (!storyblokApi) throw new Error('Storyblok API not initialized')
 
-  const cacheVersion = process.env.STORYBLOK_CACHE_VERSION
-    ? parseInt(process.env.STORYBLOK_CACHE_VERSION)
-    : NaN
-  const isCacheVersionValid = !isNaN(cacheVersion)
-  const cv = isCacheVersionValid ? cacheVersion : undefined
-
+  const cacheVersion = parseInt(process.env.STORYBLOK_CACHE_VERSION, 10)
   try {
     const repsonse = await storyblokApi.getAll('cdn/datasource_entries', {
       datasource: 'permanent-redirects',
-      cv,
+      ...(!isNaN(cacheVersion) ? { cv: cacheVersion } : {}),
     })
 
     const redirects = repsonse.map((entry) => ({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

We used to pass `cv: undefined` to storyblok API when loading redirects unless env variable with cache version was defined

Storyblok returned some old data for that case, while not passing `cv` correctly fetched latest data

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
