### PR TITLE
GEN-1930 - track(bankid-sign): add custom actions for better discoverability

### DIFF
--- a/apps/store/src/components/BankIdV6Dialog/BankIdV6Dialog.tsx
+++ b/apps/store/src/components/BankIdV6Dialog/BankIdV6Dialog.tsx
@@ -1,3 +1,4 @@
+import { datadogRum } from '@datadog/browser-rum'
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 import Link from 'next/link'
 import { useTranslation } from 'next-i18next'
@@ -237,6 +238,7 @@ const useTryAgainButtonProps = (bankIdOperation: BankIdOperation | null): Partia
       return {
         type: 'submit',
         form: SIGN_FORM_ID,
+        onClick: () => datadogRum.addAction('bankIdSign retry'),
       }
     case 'login':
       return {

--- a/apps/store/src/services/bankId/useBankIdCheckoutSign.ts
+++ b/apps/store/src/services/bankId/useBankIdCheckoutSign.ts
@@ -1,4 +1,5 @@
 import { type ApolloError } from '@apollo/client'
+import { datadogRum } from '@datadog/browser-rum'
 import { useTranslation } from 'next-i18next'
 import { useCallback, useRef } from 'react'
 import { Observable, Subscription } from 'zen-observable-ts'
@@ -37,12 +38,14 @@ export const useBankIdCheckoutSign = ({ dispatch }: Options) => {
         // Delay marking operation as success until handler resolves
         try {
           await onSuccess()
+          datadogRum.addAction('bankIdSign complete')
         } finally {
           dispatch({ type: 'success' })
         }
       }
 
       dispatch({ type: 'startCheckoutSign', ssn, customerAuthenticationStatus })
+      datadogRum.addAction('bankIdSign start')
 
       if (customerAuthenticationStatus === ShopSessionAuthenticationStatus.AuthenticationRequired) {
         bankIdLogger.info('Authentication required for returning member')


### PR DESCRIPTION
## Describe your changes

* Added custom actions for baknid sign flow

## Justify why they are needed

The idea is to keep an eye on signing sessions after bankid v6 changes get released.

More info [here](https://hedviginsurance.slack.com/archives/C06GPLWA8FM/p1710335651415919?thread_ts=1710270579.975809&cid=C06GPLWA8FM)