### PR TITLE
refactor: [RND-542] Implement customer session debugging logic in server actions

### DIFF
--- a/apps/store/src/app/debugger/actions.ts
+++ b/apps/store/src/app/debugger/actions.ts
@@ -1,22 +1,69 @@
 'use server'
 
-import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
+import { addProduct, updateCustomer } from '@/pages/api/session/create'
+import { getApolloClient } from '@/services/apollo/app-router/rscClient'
+import { CountryCode } from '@/services/graphql/graphql'
+import { setupPriceIntentService } from '@/services/priceIntent/app-router/PriceIntentService.utils'
+import { setupShopSession } from '@/services/shopSession/app-router/ShopSession.utils'
+import { RoutingLocale } from '@/utils/l10n/types'
 import { PageLink } from '@/utils/PageLink'
 
-export const create = async (formData: FormData) => {
-  const ssn = formData.get('ssn')
+const DEFAULT_LOCALE: RoutingLocale = 'se-en'
+const DEFAULT_COUNTRY_CODE = CountryCode.Se
+const TEST_SSN = '199808302393'
+const productNames = ['SE_APARTMENT_RENT', 'SE_ACCIDENT'] as const
 
-  if (typeof ssn !== 'string') {
-    return
+const getRandomEmailAddress = () => {
+  const randomId = Math.random().toString(36).substring(2, 5)
+  return `sven.svensson.${randomId}@hedvig.com`
+}
+
+export const createCustomerSession = async (formData: FormData) => {
+  try {
+    const ssn = formData.get('ssn') || TEST_SSN
+
+    if (typeof ssn !== 'string') {
+      return
+    }
+
+    const apolloClient = getApolloClient({ locale: DEFAULT_LOCALE })
+
+    const shopSessionService = setupShopSession(apolloClient)
+    const shopSession = await shopSessionService.create({ countryCode: DEFAULT_COUNTRY_CODE })
+    console.log(`Created new ShopSession: ${shopSession.id}`)
+
+    const maskedSsn = ssn.replace(/(\d{4})$/, '****')
+    const emailAddress = getRandomEmailAddress()
+    console.log(`Using SSN: ${maskedSsn} and email: ${emailAddress}`)
+
+    await updateCustomer({
+      apolloClient,
+      shopSessionId: shopSession.id,
+      ssn,
+      emailAddress,
+    })
+
+    const priceIntentService = setupPriceIntentService(apolloClient)
+
+    await Promise.all(
+      productNames.map((productName) =>
+        addProduct({
+          apolloClient,
+          priceIntentService,
+          productName,
+          shopSessionId: shopSession.id,
+        }),
+      ),
+    )
+
+    shopSessionService.saveId(shopSession.id)
+  } catch (error) {
+    throw new Error('Unable to create ShopSession with products', { cause: error })
   }
 
-  const response = await fetch(PageLink.apiSessionCreate(ssn))
-  // TODO: Handle error
-  if (!response.ok) {
-    throw new Error("Couldn't create session")
-  }
+  const destination = PageLink.cart({ locale: DEFAULT_LOCALE }).href
+  console.log(`Re-directing to destination: ${destination}`)
 
-  cookies().set('hedvig_debugger_ssn', ssn)
-  redirect(PageLink.cart({ locale: 'se-en' }).toString())
+  redirect(destination)
 }

--- a/apps/store/src/app/debugger/components/CreateSessionForm/CreateSessionForm.tsx
+++ b/apps/store/src/app/debugger/components/CreateSessionForm/CreateSessionForm.tsx
@@ -1,10 +1,10 @@
 'use client'
 
+import { createCustomerSession } from 'app/debugger/actions'
 import { useEffect, useState } from 'react'
 import { Space } from 'ui'
 import { SubmitButton } from '@/appComponents/SubmitButton'
 import { TextField } from '@/components/TextField/TextField'
-import { create } from '../../actions'
 import { wrapper } from './CreateSessionForm.css'
 
 const HEDVIG_DEBUGGER_SSN = 'hedvig:debugger-ssn'
@@ -19,7 +19,7 @@ export const CreateSessionForm = () => {
 
   return (
     <div className={wrapper}>
-      <form action={create}>
+      <form action={createCustomerSession}>
         <Space y={0.25}>
           <TextField
             label="YYYYMMDDXXXX"

--- a/apps/store/src/app/debugger/components/CreateSessionForm/CreateSessionForm.tsx
+++ b/apps/store/src/app/debugger/components/CreateSessionForm/CreateSessionForm.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { createCustomerSession } from 'app/debugger/actions'
 import { useEffect, useState } from 'react'
 import { Space } from 'ui'
 import { SubmitButton } from '@/appComponents/SubmitButton'
 import { TextField } from '@/components/TextField/TextField'
+import { createCustomerSession } from 'app/debugger/actions'
 import { wrapper } from './CreateSessionForm.css'
 
 const HEDVIG_DEBUGGER_SSN = 'hedvig:debugger-ssn'

--- a/apps/store/src/pages/api/session/create.ts
+++ b/apps/store/src/pages/api/session/create.ts
@@ -84,7 +84,7 @@ type AddProductParams = {
   apolloClient: ApolloClient<unknown>
 }
 
-const addProduct = async ({
+export const addProduct = async ({
   productName,
   priceIntentService,
   shopSessionId,
@@ -136,7 +136,7 @@ type UpdateCustomerParams = {
   apolloClient: ApolloClient<unknown>
 }
 
-const updateCustomer = async ({
+export const updateCustomer = async ({
   apolloClient,
   shopSessionId,
   ssn,

--- a/apps/store/src/services/persister/Persister.types.ts
+++ b/apps/store/src/services/persister/Persister.types.ts
@@ -1,4 +1,5 @@
 import { OptionsType, TmpCookiesObj } from 'cookies-next/lib/types'
+import { RequestCookie } from 'next/dist/compiled/@edge-runtime/cookies'
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface SimplePersister {
@@ -8,5 +9,5 @@ export interface SimplePersister {
 
   reset(key?: string): void
 
-  getAll(): TmpCookiesObj
+  getAll(): TmpCookiesObj | Array<RequestCookie>
 }

--- a/apps/store/src/services/persister/app-router/AppRouterCookiePersister.ts
+++ b/apps/store/src/services/persister/app-router/AppRouterCookiePersister.ts
@@ -1,0 +1,23 @@
+import { cookies } from 'next/headers'
+
+export class AppRouterCookiePersister {
+  constructor(private readonly cookieKey: string) {}
+
+  public save(value: string, cookieKey = this.cookieKey) {
+    cookies().set(cookieKey, value)
+  }
+
+  public fetch(cookieKey = this.cookieKey) {
+    const cookieValue = cookies().get(cookieKey)
+    if (typeof cookieValue === 'string') return cookieValue
+    return null
+  }
+
+  public reset(cookieKey = this.cookieKey) {
+    cookies().delete(cookieKey)
+  }
+
+  public getAll() {
+    return cookies().getAll()
+  }
+}

--- a/apps/store/src/services/priceIntent/app-router/PriceIntentService.utils.ts
+++ b/apps/store/src/services/priceIntent/app-router/PriceIntentService.utils.ts
@@ -1,0 +1,7 @@
+import { ApolloClient } from '@apollo/client'
+import { AppRouterCookiePersister } from '@/services/persister/app-router/AppRouterCookiePersister'
+import { PriceIntentService } from '../PriceIntentService'
+
+export const setupPriceIntentService = (apolloClient: ApolloClient<unknown>) => {
+  return new PriceIntentService(new AppRouterCookiePersister('UNUSED_DEFAULT_KEY'), apolloClient)
+}

--- a/apps/store/src/services/shopSession/app-router/ShopSession.utils.ts
+++ b/apps/store/src/services/shopSession/app-router/ShopSession.utils.ts
@@ -1,5 +1,12 @@
+import { ApolloClient } from '@apollo/client'
 import { cookies } from 'next/headers'
+import { AppRouterCookiePersister } from '@/services/persister/app-router/AppRouterCookiePersister'
 import { COOKIE_KEY_SHOP_SESSION } from '../ShopSession.constants'
+import { ShopSessionService } from '../ShopSessionService'
+
+export const setupShopSession = (apolloClient: ApolloClient<unknown>) => {
+  return new ShopSessionService(new AppRouterCookiePersister(COOKIE_KEY_SHOP_SESSION), apolloClient)
+}
 
 export const getShopSessionId = () => {
   const cookieStore = cookies()


### PR DESCRIPTION
<!--
PR title: RND-542 / refactor / Implement customer session debugging logic in server actions
-->

## Describe your changes
Implement the session debugging logic in a server action.

<!--
What changes are made?
1. Create an app router cookie persister
2. Create a shop session and price intent service setup util using the app router cookie persister
3. Copy the logic from `api/session/create` to the server action.
-->

## Justify why they are needed
Used services relied on the `req` and `res` objects to handle cookies, which isn't working in app router. The app router cookie persister is created in order to reuse the same services but with the `cookies` util from next.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
