### PR TITLE
Forward OneTrust consent settings directly to GTM

### DIFF
--- a/apps/store/src/services/gtm.tsx
+++ b/apps/store/src/services/gtm.tsx
@@ -57,6 +57,8 @@ type DataLayerObject = {
   user_id?: string
 }
 
+type DataLayerArray = Array<unknown>
+
 export type EcommerceEvent = {
   event: TrackingEvent
   ecommerce: GTMEcommerceData
@@ -70,14 +72,23 @@ export type EcommerceEvent = {
 }
 
 // Needed in case event is sent before GTM is loaded, see https://github.com/HedvigInsurance/racoon/commit/38dbb73d552a590f652bbbe537d4d8ed4b0399f8
-export const pushToGTMDataLayer = (obj: DataLayerObject) => {
+export const pushToGTMDataLayer = (obj: DataLayerObject | DataLayerArray) => {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!window.dataLayer) window.dataLayer = []
   // Clear the previous ecommerce object
-  if (typeof obj.ecommerce !== 'undefined') {
+  if (!Array.isArray(obj) && typeof obj.ecommerce !== 'undefined') {
     window.dataLayer.push({ ecommerce: null })
   }
   window.dataLayer.push(obj)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function gtmGtag(...args: Array<any>) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!window.dataLayer) window.dataLayer = []
+  // We need to forward arguments directly for it to work
+  // eslint-disable-next-line prefer-rest-params
+  window.dataLayer.push(arguments)
 }
 
 export const GTMAppScript = () => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Send OneTrust consent settings to GTM via native API instead of relying on GTM tags and triggers to load consent settings

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Previous mechanism broke down when we started loading GTM after OneTrust.  Using this as a chance to simplify our setup

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
