### PR TITLE
fix: Validate debug session SSN server side

### DIFF
--- a/apps/store/src/app/debugger/actions.ts
+++ b/apps/store/src/app/debugger/actions.ts
@@ -21,7 +21,6 @@ import { PageLink } from '@/utils/PageLink'
 
 const DEFAULT_LOCALE: RoutingLocale = 'se-en'
 const DEFAULT_COUNTRY_CODE = CountryCode.Se
-const TEST_SSN = '199808302393'
 const productNames = ['SE_APARTMENT_RENT', 'SE_ACCIDENT'] as const
 
 const getRandomEmailAddress = () => {
@@ -29,12 +28,27 @@ const getRandomEmailAddress = () => {
   return `sven.svensson.${randomId}@hedvig.com`
 }
 
-export const createCustomerSession = async (formData: FormData) => {
-  try {
-    const ssn = formData.get('ssn') || TEST_SSN
+type CreateCustomerSessionFormState = null | {
+  errors?: {
+    fields?: Record<string, string>
+  }
+}
 
-    if (typeof ssn !== 'string') {
-      return
+export const createCustomerSession = async (
+  _: CreateCustomerSessionFormState,
+  formData: FormData,
+): Promise<CreateCustomerSessionFormState> => {
+  try {
+    const ssn = formData.get('ssn')
+
+    if (!ssn || typeof ssn !== 'string') {
+      return {
+        errors: {
+          fields: {
+            ssn: 'Valid SSN is required.',
+          },
+        },
+      }
     }
 
     const apolloClient = getApolloClient({ locale: DEFAULT_LOCALE })

--- a/apps/store/src/app/debugger/components/CreateSessionForm/CreateSessionForm.tsx
+++ b/apps/store/src/app/debugger/components/CreateSessionForm/CreateSessionForm.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { createCustomerSession } from 'app/debugger/actions'
 import { useEffect, useState } from 'react'
 import { useFormState } from 'react-dom'
 import { Space } from 'ui'
 import { SubmitButton } from '@/appComponents/SubmitButton'
 import { TextField } from '@/components/TextField/TextField'
+import { createCustomerSession } from 'app/debugger/actions'
 import { wrapper } from './CreateSessionForm.css'
 
 const HEDVIG_DEBUGGER_SSN = 'hedvig:debugger-ssn'

--- a/apps/store/src/app/debugger/components/CreateSessionForm/CreateSessionForm.tsx
+++ b/apps/store/src/app/debugger/components/CreateSessionForm/CreateSessionForm.tsx
@@ -1,33 +1,38 @@
 'use client'
 
+import { createCustomerSession } from 'app/debugger/actions'
 import { useEffect, useState } from 'react'
+import { useFormState } from 'react-dom'
 import { Space } from 'ui'
 import { SubmitButton } from '@/appComponents/SubmitButton'
 import { TextField } from '@/components/TextField/TextField'
-import { createCustomerSession } from 'app/debugger/actions'
 import { wrapper } from './CreateSessionForm.css'
 
 const HEDVIG_DEBUGGER_SSN = 'hedvig:debugger-ssn'
 
 export const CreateSessionForm = () => {
-  const [defaultSsn, setDefaultSsn] = useState<string | undefined>(undefined)
+  const [state, formAction] = useFormState(createCustomerSession, null)
+  const [defaultSSN, setDefaultSSN] = useState<string>()
 
   useEffect(() => {
     const ssn = window.localStorage.getItem(HEDVIG_DEBUGGER_SSN)
-    if (ssn) setDefaultSsn(ssn)
+    if (ssn) setDefaultSSN(ssn)
   }, [])
+
+  const SSNError = state?.errors?.fields?.ssn
 
   return (
     <div className={wrapper}>
-      <form action={createCustomerSession}>
+      <form action={formAction}>
         <Space y={0.25}>
           <TextField
             label="YYYYMMDDXXXX"
-            key={defaultSsn}
-            defaultValue={defaultSsn}
+            key={defaultSSN}
+            defaultValue={defaultSSN}
             autoFocus
-            required
             name="ssn"
+            warning={!!SSNError}
+            message={SSNError}
           />
           <SubmitButton>Create session</SubmitButton>
         </Space>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Remove the fallback test SSN and validate input on the server side.

<!--
What changes are made?
1. Remove native HTML validation
2. Remove the fallback test SSN
2. Validate and return error from server action
-->

## Justify why they are needed
We agreed to not fallback to a test SSN for this feature and handle missing input on the server.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
