### PR TITLE
GEN-1950 - fix(ProductReviewsMetadataProvider): make sure we have one atom for product

### DIFF
--- a/apps/store/src/features/memberReviews/ProductReviewsMetadataProvider.tsx
+++ b/apps/store/src/features/memberReviews/ProductReviewsMetadataProvider.tsx
@@ -1,18 +1,24 @@
 'use client'
 import { atom, useAtomValue } from 'jotai'
-import { useHydrateAtoms } from 'jotai/utils'
+import { useHydrateAtoms, atomFamily } from 'jotai/utils'
 import { type PropsWithChildren } from 'react'
+import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import type { ReviewsMetadata } from './memberReviews.types'
 
-const productReviewsMetadataAtom = atom<ReviewsMetadata | null>(null)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const productReviewsMetadataAtomFamily = atomFamily((productName: string) =>
+  atom<ReviewsMetadata | null>(null),
+)
 
 type Props = PropsWithChildren<{ productReviewsMetadata: ReviewsMetadata | null }>
 
 export const ProductReviewsMetadataProvider = ({ children, productReviewsMetadata }: Props) => {
-  useHydrateAtoms([[productReviewsMetadataAtom, productReviewsMetadata]])
+  const productData = useProductData()
+  useHydrateAtoms([[productReviewsMetadataAtomFamily(productData.name), productReviewsMetadata]])
   return children
 }
 
 export const useProuctReviewsMetadata = () => {
-  return useAtomValue(productReviewsMetadataAtom)
+  const productData = useProductData()
+  return useAtomValue(productReviewsMetadataAtomFamily(productData.name))
 }


### PR DESCRIPTION
## Describe your changes

- Fix an issue where the same average rating data were being used for multiple products


https://github.com/HedvigInsurance/racoon/assets/19200662/3b7fbf87-7c38-4199-b6e9-ab4689e6f5eb

## Justify why they are needed

That happen becuase product reviews atom were being hydrated only once. We need to make sure we have a product reviews
atom per product.
