### PR TITLE
fix: Use current page host for default iframe debugger URL

### DIFF
--- a/apps/store/src/app/debugger/iframe/page.tsx
+++ b/apps/store/src/app/debugger/iframe/page.tsx
@@ -47,8 +47,13 @@ const getDebugURL = (url?: string) => {
   const headersList = headers()
 
   const referer = headersList.get('referer')
-  const refererURL = new URL(referer || '')
-  const { origin } = refererURL
+
+  let origin = 'http://localhost:8040'
+
+  if (typeof referer === 'string') {
+    const refererURL = new URL(referer)
+    origin = refererURL.origin
+  }
 
   const debugURL = url || `${origin}/se/widget/flows/avy-offer`
 

--- a/apps/store/src/app/debugger/iframe/page.tsx
+++ b/apps/store/src/app/debugger/iframe/page.tsx
@@ -1,3 +1,4 @@
+import { headers } from 'next/headers'
 import { Button, Space } from 'ui'
 import { TextField } from '@/components/TextField/TextField'
 import { MessageLogger } from './components/MessageLogger/MessageLogger'
@@ -41,9 +42,16 @@ function IFrameDebuggerPage({ searchParams }: Props) {
     </div>
   )
 }
-const DEFAULT_URL = 'http://localhost:8040/se/widget/flows/avy-offer'
 
-const getDebugURL = (url: string = DEFAULT_URL) => {
+const getDebugURL = (url?: string) => {
+  const headersList = headers()
+
+  const referer = headersList.get('referer')
+  const refererURL = new URL(referer || '')
+  const { origin } = refererURL
+
+  const debugURL = url || `${origin}/se/widget/flows/avy-offer`
+
   if (process.env.FEATURE_DEBUGGER !== 'true') {
     return {
       url: null,
@@ -51,7 +59,7 @@ const getDebugURL = (url: string = DEFAULT_URL) => {
   }
 
   return {
-    url,
+    url: debugURL,
   }
 }
 


### PR DESCRIPTION
<!--
PR title: Fix / Use current page host for default iframe debugger URL
-->

## Describe your changes
Use the current page `host` for the iframe debugger default URL instead of hardcoded localhost.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Set the iframe default URL dynamically so it works in all environments.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
