### PR TITLE
RND-524 - fix(cookie-banner): make sure it doesn't get in the way of our dialogs

### DIFF
--- a/apps/store/src/components/GTMLoader.tsx
+++ b/apps/store/src/components/GTMLoader.tsx
@@ -1,39 +1,24 @@
-import Script from 'next/script'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { GTMAppScript, gtmGtag } from '@/services/gtm'
-
-const SCRIPT_ID = {
-  // Could be useful for testing changes on OneTrust side
-  TEST: '628f5fee-1891-418c-9ed2-f893b8a3998a-test',
-  PRODUCTION: '628f5fee-1891-418c-9ed2-f893b8a3998a',
-}
 
 type OneTrustApi = {
   OnConsentChanged: (callback: () => void) => void
   IsAlertBoxClosed: () => boolean
 }
 
-export function CookieConsentLoader() {
+export function GTMLoader() {
   // Optimization: start loading GTM after cookie consent has been given. Fixes negative effects of preloading GTM
   // - lots of GTM activity triggered immediately on consent, sync -> bad INP
   // - GTM resources taking network brandwidth on initial load when they have no chance to be useful yet
   const isConsentReady = useIsConsentReady()
-  return (
-    <>
-      <Script
-        id="onetrust-loader"
-        src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
-        data-document-language="true"
-        type="text/javascript"
-        data-domain-script={SCRIPT_ID.PRODUCTION}
-      />
-      {isConsentReady && <GTMAppScript />}
-    </>
-  )
+
+  if (!isConsentReady) return null
+
+  return <GTMAppScript />
 }
 
 // Potential optimization - don't load GTM if user only consented to required cookies
-const useIsConsentReady = () => {
+function useIsConsentReady() {
   const [isConsentReady, setIsConsentReady] = useState(false)
   const calledRef = useRef(false)
   const saveConsent = useCallback(() => {

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -12,15 +12,14 @@ import { AppErrorDialog } from '@/components/AppErrorDialog'
 import { BankIdDialogDynamic } from '@/components/BankIdDialogDynamic'
 import { BankIdV6DialogDynamic } from '@/components/BankIdV6Dialog/BankIdV6DialogDynamic'
 import { ContactUs } from '@/components/ContactUs/ContactUs'
-import { CookieConsentLoader } from '@/components/CookieConsentLoader'
 import { GlobalBannerDynamic } from '@/components/GlobalBanner/GlobalBannerDynamic'
+import { GTMLoader } from '@/components/GTMLoader'
 import { GlobalLinkStyles } from '@/components/RichText/RichText.styles'
 import { usePublishWidgetInitEvent } from '@/features/widget/usePublishWidgetInitEvent'
 import { useApollo } from '@/services/apollo/client'
 import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
 import { BankIdContextProvider } from '@/services/bankId/BankIdContext'
 import { CustomerFirstScript, hasHiddenChat } from '@/services/CustomerFirst'
-import { GTMAppScript } from '@/services/gtm'
 import { useInitDatadogAfterInteractive } from '@/services/logger/client'
 import { PageTransitionProgressBar } from '@/services/nprogress/pageTransition'
 import { OneTrustStyles } from '@/services/OneTrust'
@@ -134,10 +133,5 @@ const ShopSessionTrackingProvider = (props: { children: ReactNode }) => {
   const { shopSession } = useShopSession()
   return <TrackingProvider shopSession={shopSession}>{props.children}</TrackingProvider>
 }
-
-// When cookie consent is enabled we need to wait until consent value is available before loading GTM
-// See logic inside CookieConsentLoader
-const GTMLoader = () =>
-  Features.enabled('COOKIE_BANNER') ? <CookieConsentLoader /> : <GTMAppScript />
 
 export default appWithTranslation(MyApp)

--- a/apps/store/src/pages/_document.tsx
+++ b/apps/store/src/pages/_document.tsx
@@ -1,8 +1,16 @@
 import Document, { Head, Html, Main, NextScript } from 'next/document'
+import Script from 'next/script'
 import { GTMBodyScript } from '@/services/gtm'
+import { Features } from '@/utils/Features'
 import { contentFontClassName } from '@/utils/fonts'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
 import { UiLocale } from '@/utils/l10n/types'
+
+const COOKIE_CONSENT_SCRIPT_ID = {
+  // Could be useful for testing changes on OneTrust side
+  TEST: '628f5fee-1891-418c-9ed2-f893b8a3998a-test',
+  PRODUCTION: '628f5fee-1891-418c-9ed2-f893b8a3998a',
+}
 
 export default class MyDocument extends Document {
   lang() {
@@ -27,9 +35,21 @@ export default class MyDocument extends Document {
         </Head>
         {/* Fallback for pages that don't pass className down to DOM */}
         <body className={contentFontClassName}>
-          <GTMBodyScript />
           <Main />
           <NextScript />
+          <GTMBodyScript />
+          {/* Cookie consent script */}
+          {Features.enabled('COOKIE_BANNER') && (
+            <Script
+              id="onetrust-loader"
+              src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
+              data-document-language="true"
+              type="text/javascript"
+              data-domain-script={COOKIE_CONSENT_SCRIPT_ID.PRODUCTION}
+              // Load before any other script as recommended by Next (https://shorturl.at/hvO14)
+              strategy="beforeInteractive"
+            />
+          )}
         </body>
       </Html>
     )


### PR DESCRIPTION
# Describe your changes

* Make sure cookie banner consent doesn't get in into the way of our dialogs.

## Justify why they are needed

### The issue

Sometimes, cookie banner get's into the way of our dialogs which can be anoying:

https://github.com/HedvigInsurance/racoon/assets/19200662/9ad982bb-a2d2-420a-bb67-274a7f6ddd08

An easy way to reproduce this is load a product page with price calculator opened on mobile (`?openPriceCalculator=1`) while having disabled the cache.

### The reason

That happens for the cases our dialog gets added into the DOM before the cookie consent. Since both are positioned elements in the same stacking context, DOM order is used to determine should should be on top. In this case, cookie banner will be on top which can be annoying.

<img width="1220" alt="reason" src="https://github.com/HedvigInsurance/racoon/assets/19200662/09520b4c-80b0-4c08-9f22-3b3835b9b81b">


### The solution

[Nextjs recommends](https://shorturl.at/gkAQ8) to have cookie consent scripts loaded with `beforeInteractive` strategy.  If we follow that recommendation we can make sure our dialogs always get added after one trust into the DOM which then will make they override it without having to fight with `z-index` .

https://github.com/HedvigInsurance/racoon/assets/19200662/aef1f352-76db-42bf-9028-81138f8b36a4

As you can see in the video, cookie banner get's show first and then when our app scripts take in, our dialog is shown on top of it.

