### PR TITLE
Migrate Button component to vanilla-extract

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -55,6 +55,7 @@
     "@radix-ui/react-dialog": "1.0.5",
     "@vanilla-extract/css": "1.14.2",
     "@vanilla-extract/dynamic": "2.1.0",
+    "@vanilla-extract/recipes": "0.5.1",
     "@vanilla-extract/sprinkles": "1.6.1",
     "clsx": "2.1.0",
     "react": "18.2.0",

--- a/packages/ui/src/components/Button/Button.css.ts
+++ b/packages/ui/src/components/Button/Button.css.ts
@@ -1,0 +1,227 @@
+import { style, styleVariants } from '@vanilla-extract/css'
+import { minWidth, theme } from '../../theme'
+
+export const baseButton = style({
+  // opt out of double tap to zoom to immediately respond to taps
+  touchAction: 'manipulation',
+  borderRadius: theme.radius.sm,
+  whiteSpace: 'nowrap',
+  lineHeight: 1,
+  transition: `background-color ${theme.transitions.hover}, box-shadow 0.15s cubic-bezier(0.47, 0.03, 0.49, 1.38) 0s`,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+
+  cursor: 'pointer',
+  ':disabled': {
+    cursor: 'default',
+  },
+
+  ':focus-visible': {
+    boxShadow: theme.shadow.focus,
+  },
+})
+
+export const fullWidthStyles = style({
+  width: '100%',
+})
+
+const shadow = style({
+  boxShadow: theme.shadow.default,
+  backdropFilter: 'blur(30px)',
+})
+
+export const buttonVariant = styleVariants({
+  primary: [
+    baseButton,
+    {
+      backgroundColor: theme.colors.gray1000,
+      color: theme.colors.textNegative,
+
+      '@media (hover: hover)': {
+        '&:hover': {
+          backgroundColor: theme.colors.grayTranslucent900,
+        },
+      },
+
+      ':active': {
+        backgroundColor: theme.colors.grayTranslucent900,
+      },
+
+      ':focus-visible': {
+        boxShadow: theme.shadow.focusAlt,
+      },
+
+      selectors: {
+        '&:disabled:not([data-loading])': {
+          backgroundColor: theme.colors.gray200,
+          color: theme.colors.textDisabled,
+        },
+      },
+    },
+  ],
+
+  'primary-alt': [
+    baseButton,
+    shadow,
+    {
+      backgroundColor: theme.colors.green50,
+      color: theme.colors.textPrimary,
+
+      '@media (hover: hover)': {
+        '&:hover': {
+          backgroundColor: theme.colors.green100,
+        },
+      },
+
+      ':active': {
+        backgroundColor: theme.colors.green100,
+      },
+
+      selectors: {
+        '&:disabled:not([data-loading])': {
+          backgroundColor: theme.colors.gray200,
+          color: theme.colors.textDisabled,
+          boxShadow: 'none',
+          backdropFilter: 'none',
+        },
+      },
+    },
+  ],
+
+  secondary: [
+    baseButton,
+    shadow,
+    {
+      backgroundColor: theme.colors.translucent1,
+      color: theme.colors.textPrimary,
+
+      '@media (hover: hover)': {
+        '&:hover': {
+          backgroundColor: theme.colors.translucent2,
+        },
+      },
+
+      ':active': {
+        backgroundColor: theme.colors.translucent2,
+      },
+
+      selectors: {
+        '&:disabled:not([data-loading])': {
+          backgroundColor: theme.colors.gray200,
+          color: theme.colors.textDisabled,
+          boxShadow: 'none',
+          backdropFilter: 'none',
+        },
+      },
+    },
+  ],
+
+  'secondary-alt': [
+    baseButton,
+    shadow,
+    {
+      backgroundColor: theme.colors.offWhite,
+
+      '@media (hover: hover)': {
+        '&:hover': {
+          backgroundColor: theme.colors.grayTranslucentDark25,
+        },
+      },
+
+      ':active': {
+        backgroundColor: theme.colors.offWhite,
+      },
+    },
+  ],
+
+  ghost: [
+    baseButton,
+    {
+      backgroundColor: 'transparent',
+      color: theme.colors.textPrimary,
+
+      '@media (hover: hover)': {
+        '&:hover': {
+          backgroundColor: theme.colors.translucent1,
+        },
+      },
+
+      ':active': {
+        backgroundColor: theme.colors.gray100,
+      },
+
+      selectors: {
+        '&:disabled:not([data-loading])': {
+          color: theme.colors.textDisabled,
+          backgroundColor: 'transparent',
+        },
+      },
+    },
+  ],
+})
+
+const HEIGHT = {
+  small: '2rem',
+  medium: '2.5rem',
+  large: '3.5rem',
+}
+
+const SIZE_STYLES = {
+  small: {
+    height: HEIGHT.small,
+    paddingInline: theme.space.md,
+    fontSize: theme.fontSizes.xs,
+    borderRadius: theme.radius.xs,
+  },
+  medium: {
+    height: HEIGHT.medium,
+    paddingInline: theme.space.md,
+    fontSize: theme.fontSizes.md,
+    borderRadius: theme.radius.sm,
+  },
+  large: {
+    height: HEIGHT.large,
+    width: '100%',
+    paddingInline: theme.space.xl,
+    fontSize: theme.fontSizes.md,
+    textAlign: 'center',
+    borderRadius: theme.radius.md,
+  },
+} as const
+
+export const buttonSizeBase = styleVariants({
+  small: SIZE_STYLES.small,
+  medium: SIZE_STYLES.medium,
+  large: SIZE_STYLES.large,
+})
+
+export const buttonSizeLarge = styleVariants({
+  small: {
+    '@media': {
+      [minWidth.lg]: SIZE_STYLES.small,
+    },
+  },
+  medium: {
+    '@media': {
+      [minWidth.lg]: SIZE_STYLES.medium,
+    },
+  },
+  large: {
+    '@media': {
+      [minWidth.lg]: SIZE_STYLES.large,
+    },
+  },
+})
+
+export const childrenWrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.space.xs,
+})
+
+export const centered = style({
+  position: 'absolute',
+  display: 'flex',
+  justifyContent: 'center',
+})

--- a/packages/ui/src/components/Button/Button.helpers.ts
+++ b/packages/ui/src/components/Button/Button.helpers.ts
@@ -1,54 +1,19 @@
-import { type CSSObject } from '@emotion/styled'
-import { type Level, mq, theme } from '../../theme'
-
-const HEIGHT = {
-  large: '3.5rem',
-  medium: '2.5rem',
-  small: '2rem',
-}
+import { buttonSizeBase, buttonSizeLarge } from './Button.css'
 
 type ButtonSizeVariant = 'small' | 'medium' | 'large'
+type ButtonLevels = 'base' | 'lg'
 
-export type ButtonSize = ButtonSizeVariant | Partial<Record<Level | 'base', ButtonSizeVariant>>
+export type ButtonSize = ButtonSizeVariant | Record<ButtonLevels, ButtonSizeVariant>
 
-export const getButtonSizeStyles = (size: ButtonSize) => {
-  if (typeof size !== 'object') {
-    return SIZE_STYLES[size]
+export const getButtonSizeStyles = (buttonSize: ButtonSize) => {
+  if (typeof buttonSize !== 'object') {
+    return buttonSizeBase[buttonSize]
   }
 
-  const styles = Object.entries(size).reduce((acc, [level, variant]) => {
-    if (level === 'base') return { ...acc, ...SIZE_STYLES[variant] }
+  const responsiveStyles = Object.entries(buttonSize).map(([level, size]) => {
+    if (level === 'base') return buttonSizeBase[size]
+    if (level === 'lg') return buttonSizeLarge[size]
+  })
 
-    return {
-      ...acc,
-      [mq[level as Level]]: {
-        ...SIZE_STYLES[variant],
-      },
-    }
-  }, {} as CSSObject)
-
-  return styles
+  return responsiveStyles
 }
-
-const SIZE_STYLES = {
-  small: {
-    height: HEIGHT.small,
-    paddingInline: theme.space.md,
-    fontSize: theme.fontSizes.xs,
-    borderRadius: theme.radius.xs,
-  },
-  medium: {
-    height: HEIGHT.medium,
-    paddingInline: theme.space.md,
-    fontSize: theme.fontSizes.md,
-    borderRadius: theme.radius.sm,
-  },
-  large: {
-    height: HEIGHT.large,
-    width: '100%',
-    paddingInline: theme.space.xl,
-    fontSize: theme.fontSizes.md,
-    textAlign: 'center',
-    borderRadius: theme.radius.md,
-  },
-} as const

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -84,6 +84,12 @@ Small.args = {
   size: 'small',
 }
 
+export const Responsive = Template.bind({})
+Responsive.args = {
+  children: 'Button label',
+  size: { base: 'small', lg: 'large' },
+}
+
 export const WithIcon = Template.bind({})
 WithIcon.args = {
   children: 'Button label',

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { css } from '@emotion/react'
-import styled from '@emotion/styled'
+import clsx from 'clsx'
 import { ButtonHTMLAttributes, forwardRef, type ReactNode } from 'react'
-import { theme } from '../../theme'
+import { buttonVariant, centered, childrenWrapper, fullWidthStyles } from './Button.css'
 import { ButtonSize, getButtonSizeStyles } from './Button.helpers'
 import { DotPulse } from './DotPulse'
 
@@ -24,17 +23,27 @@ type CustomButtonProps = {
 export type Props = ButtonHTMLAttributes<HTMLButtonElement> & CustomButtonProps
 
 export const Button = forwardRef<HTMLButtonElement, Props>((props, ref) => {
-  const { variant = 'primary', loading, children, target, title, rel, ...baseProps } = props
+  const {
+    variant = 'primary',
+    size = 'large',
+    fullWidth,
+    loading,
+    children,
+    target,
+    title,
+    rel,
+    ...baseProps
+  } = props
 
   const buttonChildren = (
     <>
-      <ChildrenWrapper style={{ opacity: loading ? 0 : 1 }}>
+      <span className={childrenWrapper} style={{ opacity: loading ? 0 : 1 }}>
         {props.Icon} {children}
-      </ChildrenWrapper>
+      </span>
       {loading && (
-        <Centered>
+        <span className={centered}>
           <DotPulse />
-        </Centered>
+        </span>
       )}
     </>
   )
@@ -50,180 +59,10 @@ export const Button = forwardRef<HTMLButtonElement, Props>((props, ref) => {
     ...(rel ? { rel: rel } : {}),
     ...(title ? { title: title } : {}),
   } as const
+  const sizeStyles = getButtonSizeStyles(size)
+  const classNames = clsx(buttonVariant[variant], sizeStyles, fullWidth && fullWidthStyles)
 
-  switch (variant) {
-    case 'primary':
-      return <PrimaryButton {...buttonProps} />
-    case 'primary-alt':
-      return <PrimaryAltButton {...buttonProps} />
-    case 'secondary':
-      return <SecondaryButton {...buttonProps} />
-    case 'secondary-alt':
-      return <SecondaryAltButton {...buttonProps} />
-    case 'ghost':
-      return <GhostButton {...buttonProps} />
-  }
+  return <button className={classNames} {...buttonProps} />
 })
 
 Button.displayName = 'Button'
-
-const Centered = styled.span({
-  position: 'absolute',
-  display: 'flex',
-  justifyContent: 'center',
-})
-
-const ChildrenWrapper = styled.span({
-  display: 'flex',
-  alignItems: 'center',
-  gap: theme.space.xs,
-})
-
-const StyledButton = styled.button<CustomButtonProps>(
-  {
-    // opt out of double tap to zoom to immediately respond to taps
-    touchAction: 'manipulation',
-
-    borderRadius: theme.radius.sm,
-
-    whiteSpace: 'nowrap',
-    lineHeight: 1,
-    transition: `background-color ${theme.transitions.hover}, box-shadow 0.15s cubic-bezier(0.47, 0.03, 0.49, 1.38) 0s`,
-
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-
-    cursor: 'pointer',
-    '&:disabled': {
-      cursor: 'default',
-    },
-
-    '&:focus-visible': {
-      boxShadow: theme.shadow.focus,
-    },
-  },
-  ({ size = 'large' }) => getButtonSizeStyles(size),
-  ({ fullWidth }) => fullWidth && { width: '100%' },
-)
-
-const PrimaryButton = styled(StyledButton)({
-  backgroundColor: theme.colors.gray1000,
-  color: theme.colors.textNegative,
-
-  '@media (hover: hover)': {
-    ':hover': {
-      backgroundColor: theme.colors.grayTranslucent900,
-    },
-  },
-
-  ':active': {
-    backgroundColor: theme.colors.grayTranslucent900,
-  },
-
-  '&:not([data-loading])': {
-    '&:disabled': {
-      backgroundColor: theme.colors.gray200,
-      color: theme.colors.textDisabled,
-    },
-  },
-
-  '&:focus-visible': {
-    boxShadow: theme.shadow.focusAlt,
-  },
-})
-
-const shadow = css({
-  boxShadow: theme.shadow.default,
-  backdropFilter: 'blur(30px)',
-})
-
-const PrimaryAltButton = styled(StyledButton)(
-  {
-    backgroundColor: theme.colors.green50,
-    color: theme.colors.textPrimary,
-
-    '@media (hover: hover)': {
-      ':hover': {
-        backgroundColor: theme.colors.green100,
-      },
-    },
-
-    ':active': {
-      backgroundColor: theme.colors.green100,
-    },
-
-    '&:not([data-loading])': {
-      '&:disabled': {
-        backgroundColor: theme.colors.gray200,
-        color: theme.colors.textDisabled,
-        boxShadow: 'none',
-        backdropFilter: 'none',
-      },
-    },
-  },
-  shadow,
-)
-
-const SecondaryButton = styled(StyledButton)(
-  {
-    backgroundColor: theme.colors.translucent1,
-    color: theme.colors.textPrimary,
-
-    '@media (hover: hover)': {
-      ':hover': {
-        backgroundColor: theme.colors.translucent2,
-      },
-    },
-
-    ':active': {
-      backgroundColor: theme.colors.translucent2,
-    },
-
-    '&:not([data-loading])': {
-      '&:disabled': {
-        backgroundColor: theme.colors.gray200,
-        color: theme.colors.textDisabled,
-        boxShadow: 'none',
-        backdropFilter: 'none',
-      },
-    },
-  },
-  shadow,
-)
-
-const SecondaryAltButton = styled(SecondaryButton)({
-  backgroundColor: theme.colors.offWhite,
-
-  '@media (hover: hover)': {
-    ':hover': {
-      backgroundColor: theme.colors.grayTranslucentDark25,
-    },
-  },
-
-  ':active': {
-    backgroundColor: theme.colors.offWhite,
-  },
-})
-
-const GhostButton = styled(StyledButton)({
-  backgroundColor: 'transparent',
-  color: theme.colors.textPrimary,
-
-  '@media (hover: hover)': {
-    '&:hover': {
-      backgroundColor: theme.colors.translucent1,
-    },
-  },
-
-  '&:active': {
-    backgroundColor: theme.colors.gray100,
-  },
-
-  '&:not([data-loading])': {
-    '&:disabled': {
-      color: theme.colors.textDisabled,
-      backgroundColor: 'transparent',
-    },
-  },
-})

--- a/yarn.lock
+++ b/yarn.lock
@@ -11479,6 +11479,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vanilla-extract/recipes@npm:0.5.1":
+  version: 0.5.1
+  resolution: "@vanilla-extract/recipes@npm:0.5.1"
+  peerDependencies:
+    "@vanilla-extract/css": ^1.0.0
+  checksum: 10c0/2d1a6ad3b421b91f005a0a8531050d98488e2e1dbcbda65d6fe21d239357cfe1e6b03ce9bf2a5eb5fbd065a373f0794eab121330a5f7e8d8fbb4cbbed67caf31
+  languageName: node
+  linkType: hard
+
 "@vanilla-extract/recipes@npm:0.5.2":
   version: 0.5.2
   resolution: "@vanilla-extract/recipes@npm:0.5.2"
@@ -26444,6 +26453,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:7.4.0"
     "@vanilla-extract/css": "npm:1.14.2"
     "@vanilla-extract/dynamic": "npm:2.1.0"
+    "@vanilla-extract/recipes": "npm:0.5.1"
     "@vanilla-extract/sprinkles": "npm:1.6.1"
     babel-jest: "npm:29.7.0"
     babel-loader: "npm:9.1.3"


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
### Migrate Button component to vanilla-extract
The goal is to keep the same API for button component as before:
```js
<Button variant="secondary" size={{ base: 'small', lg: 'medium' }} />
```

Did a lot of digging on different approaches. The main challenge is the responsive variants. 
With `sprinkles` it's easy to have single css rules responsive but that would be to verbose in this case. For creating multi variants you could use `recipes`, but they don't provide a way for creating responsive variants. 

So for creating the the responsive styles I looked at the use cases we have, and we only used breakpoint `lg` for responsive styles. So instead of creating styles for all breakpoints we can start with just supporting `base` and `lg`.

I found `recipes` to be a bit overkill for variants so I used [styleVariants](https://vanilla-extract.style/documentation/api/style-variants/) since we can simply map component props to styles `<button className={buttonVariant[variant]}>` and it also don't require a second package. 

This is a start but we can of course improve on this. The main thing for me is that we can find a way to support responsive variants in some way, especially for supporting the `Heading` component.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Migrate from emotion

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
