### PR TITLE
chore(bankId): include shop session id on sign logs

### DIFF
--- a/apps/store/src/components/BankIdV6Dialog/BankIdV6Dialog.tsx
+++ b/apps/store/src/components/BankIdV6Dialog/BankIdV6Dialog.tsx
@@ -23,6 +23,7 @@ import { BankIdOperation, BankIdState } from '@/services/bankId/bankId.types'
 import { bankIdLogger } from '@/services/bankId/bankId.utils'
 import { useBankIdContext } from '@/services/bankId/BankIdContext'
 import { ShopSessionAuthenticationStatus } from '@/services/graphql/generated'
+import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { wait } from '@/utils/wait'
 import {
   qrCode,
@@ -36,6 +37,7 @@ import {
 
 export function BankIdV6Dialog() {
   const { t } = useTranslation('bankid')
+  const { shopSession } = useShopSession()
   const { startLogin, cancelLogin, cancelCheckoutSign, currentOperation } = useBankIdContext()
 
   useTriggerBankIdOnSameDevice(currentOperation)
@@ -59,7 +61,8 @@ export function BankIdV6Dialog() {
       cancelCurrentOperation()
 
       const logPrefix = currentOperation.type === 'login' ? 'Login' : 'Sign'
-      bankIdLogger.info(`${logPrefix} | Operation cancelled`)
+      const logMessageContext = shopSession ? { shopSessionId: shopSession.id } : undefined
+      bankIdLogger.info(`${logPrefix} | Operation cancelled`, logMessageContext)
     }
   }
 

--- a/apps/store/src/services/bankId/useBankIdCheckoutSign.ts
+++ b/apps/store/src/services/bankId/useBankIdCheckoutSign.ts
@@ -96,6 +96,8 @@ const useBankIdCheckoutSignApi = ({ dispatch }: Options) => {
         bankidAppOpened: BankIdSignOperation['bankidAppOpened']
       }>((subscriber) => {
         const startPolling = (shopSessionSigningId: string) => {
+          bankIdLogger.setContextProperty('shopSessionId', shopSessionId)
+
           fetchSigning({
             variables: { shopSessionSigningId },
             pollInterval: 1000,


### PR DESCRIPTION
## Describe your changes

- Add `shop session id` on sign with bankid logs

## Justify why they are needed

Better debugging experience in Datadog
