### PR TITLE
Add special case for normalizing gmail addresses

### DIFF
--- a/apps/store/src/services/Tracking/tracking.test.ts
+++ b/apps/store/src/services/Tracking/tracking.test.ts
@@ -1,11 +1,17 @@
 import { expect, test } from '@jest/globals'
-import { normalizeEmail, normalizeUserValue } from './Tracking'
+import { normalizeEmail, normalizeGmail, normalizeUserValue } from './Tracking'
 
 // See specification at https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters
 test('should normalize email', () => {
-  const email = ' John_Smith@gmail.com'
-  const expected = 'john_smith@gmail.com'
+  const email = ' John_Smith.Doe@hedvig.com'
+  const expected = 'john_smith.doe@hedvig.com'
   expect(normalizeEmail(email)).toEqual(expected)
+})
+
+test('should normalize gmail by removing dots before domain', () => {
+  const email = 'john.doe@gmail.com'
+  const expected = 'johndoe@gmail.com'
+  expect(normalizeGmail(email)).toEqual(expected)
 })
 
 test('should normalize user value', () => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add a conditional field to user data, `gem`, that passes a gmail address formatted according to Googles documentation https://developers.google.com/google-ads/api/docs/conversions/enhanced-conversions/web#python

> Remove all periods (.) that precede the domain name in gmail.com and googlemail.com email addresses

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Fix user data tracking

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
