### PR TITLE
GEN-1970 - fix(ManyPets): unify error handling during signing

### DIFF
--- a/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
+++ b/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
@@ -4,7 +4,7 @@ import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
-import { FormEventHandler, ReactNode, useCallback, useEffect, useRef } from 'react'
+import { FormEventHandler, ReactNode, useCallback, useRef } from 'react'
 import { BankIdIcon, Button, Heading, HedvigLogo, mq, Space, theme } from 'ui'
 import { CheckoutStep } from '@/components/CheckoutHeader/Breadcrumbs'
 import {
@@ -298,13 +298,6 @@ const useSignMigration = (
     },
     [shopSession, startCheckoutSign, fillCart, offerIds, apolloClient, router, locale, showError],
   )
-
-  useEffect(() => {
-    if (currentOperation?.error) {
-      // Workaround for getting userError: {message: "Konflict."}} when trying to sign
-      showError(new Error('Signing failed'))
-    }
-  }, [currentOperation?.error, showError])
 
   let signLoading = false
   const { state: bankIdState } = currentOperation ?? {}


### PR DESCRIPTION
## Describe your changes

I noticed while checking a bunch of ManyPets [sessions](https://www.notion.so/hedviginsurance/90c3e914c86d4d09a000a015fdee61fc?v=c58a688827354418a90e74d4d16319ab) that we've been showing 2 error dialogs.
  
https://github.com/HedvigInsurance/racoon/assets/19200662/3234586e-7043-4269-9349-27b6faa2d28a

That's unnecessary single we're already handling errors during sign.

## Justify why they are needed

Better UX