### PR TITLE
fix(BankIdV6Dialog): added missing "fail to sign" copy

### DIFF
--- a/apps/store/public/locales/en/bankid.json
+++ b/apps/store/public/locales/en/bankid.json
@@ -18,5 +18,6 @@
   "NO_MOBILE_BANKID_TITLE": "Don't have Mobile BankID?",
   "QR_CODE_READ_SUBTITLE": "Follow the instructions in the BankID app",
   "QR_CODE_READ_TITLE": "Enter your security code",
-  "SIGN_BANKID": "Sign with BankID"
+  "SIGN_BANKID": "Sign with BankID",
+  "SIGN_BANKID_ERROR": "Failed to sign"
 }

--- a/apps/store/public/locales/sv-se/bankid.json
+++ b/apps/store/public/locales/sv-se/bankid.json
@@ -18,5 +18,6 @@
   "NO_MOBILE_BANKID_TITLE": "Har du inte Mobilt BankID?",
   "QR_CODE_READ_SUBTITLE": "Följ instruktionerna i BankID-appen",
   "QR_CODE_READ_TITLE": "Fyll i din säkerhetskod",
-  "SIGN_BANKID": "Signera med BankID"
+  "SIGN_BANKID": "Signera med BankID",
+  "SIGN_BANKID_ERROR": "Kunde inte sig"
 }

--- a/apps/store/src/components/BankIdV6Dialog/BankIdV6Dialog.tsx
+++ b/apps/store/src/components/BankIdV6Dialog/BankIdV6Dialog.tsx
@@ -198,7 +198,9 @@ export function BankIdV6Dialog() {
               </Text>
             ) : (
               <Text align="center" size="md">
-                {t('LOGIN_BANKID_ERROR')}
+                {currentOperation.type === 'login'
+                  ? t('LOGIN_BANKID_ERROR')
+                  : t('SIGN_BANKID_ERROR')}
               </Text>
             )}
 


### PR DESCRIPTION
## Describe your changes

- Added missing "fail to sign" copy

## Justify why they are needed

I forgot to add add and as I was showing "fail to login" for every case.
