### PR TITLE
fix(revalidate): handles "unplubshed" action

### DIFF
--- a/apps/store/src/pages/api/revalidate.ts
+++ b/apps/store/src/pages/api/revalidate.ts
@@ -33,7 +33,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.json({ revalidated: true })
   } catch (error) {
     console.error('Error revalidating', error)
-    return res.status(500).json('Error revalidating')
+    const status = (error as { status?: number }).status ?? 500
+    return res.status(status).json('Error revalidating')
   }
 }
 

--- a/apps/store/src/pages/api/revalidate.ts
+++ b/apps/store/src/pages/api/revalidate.ts
@@ -19,10 +19,11 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(401).json({ message: 'Invalid token' })
   }
 
-  const { story_id } = req.body as Payload
+  const { story_id, action } = req.body as Payload
+  const version = action === 'unpublished' ? 'draft' : 'published'
 
   try {
-    const { data } = await getStoryblokApi().getStory(`${story_id}`, {})
+    const { data } = await getStoryblokApi().getStory(`${story_id}`, { version })
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const route = SLUG_TO_ROUTE_MAP[data.story.full_slug] ?? data.story.full_slug


### PR DESCRIPTION
## Describe your changes

- Update revalidate api router so it proper handle "unplubshed" actions
- Take `getStory()` error status into consideration while returning from api route

## Justify why they are needed

We've found some logs about missing record. It turned out they're happening as a side effect of unplubishing stories.
