### PR TITLE
Prevent layout shift of cart item while loading desktop menu

### DIFF
--- a/apps/store/src/app/[locale]/StoryblokLayout.tsx
+++ b/apps/store/src/app/[locale]/StoryblokLayout.tsx
@@ -21,7 +21,6 @@ export const StoryblokLayout = ({
   // TODO: How should we pass story data here ?  For now, let's pretend it's non-story page
   // Removed breadcrumbs from page router LayoutWithMenu, kept other flags in fixed state
   const story: any = null
-  const hideFooter = Math.PI < 1 // always false, but does not trigger eslint static condition warning
   const overlayMenu = false
 
   const handleLocaleChange = useChangeLocale(story)
@@ -34,9 +33,7 @@ export const StoryblokLayout = ({
   const headerBlock = filterByBlockType(globalStory.content.header, HeaderBlock.blockName)
   const footerBlock = filterByBlockType(globalStory.content.footer, FooterBlock.blockName)
 
-  const showHeader = !story?.content.hideMenu
   const showMenuOverlay = story?.content.overlayMenu ?? overlayMenu
-  const showFooter = !hideFooter && !story?.content.hideFooter
   const darkBackground = story?.content.darkBackground
 
   return (
@@ -44,26 +41,24 @@ export const StoryblokLayout = ({
       {reusableBlock.map((referencedBlok) => (
         <StoryblokComponent key={referencedBlok._uid} blok={referencedBlok} />
       ))}
-      {showHeader &&
-        headerBlock.map((nestedBlock) => (
-          <HeaderBlock
+      {headerBlock.map((nestedBlock) => (
+        <HeaderBlock
+          key={nestedBlock._uid}
+          blok={nestedBlock}
+          overlay={showMenuOverlay}
+          static={story && isProductStory(story)}
+        />
+      ))}
+      {children}
+      {footerBlock.map((nestedBlock) => (
+        <Fragment key={nestedBlock._uid}>
+          <FooterBlock
             key={nestedBlock._uid}
             blok={nestedBlock}
-            overlay={showMenuOverlay}
-            static={story && isProductStory(story)}
+            onLocaleChange={handleLocaleChange}
           />
-        ))}
-      {children}
-      {showFooter &&
-        footerBlock.map((nestedBlock) => (
-          <Fragment key={nestedBlock._uid}>
-            <FooterBlock
-              key={nestedBlock._uid}
-              blok={nestedBlock}
-              onLocaleChange={handleLocaleChange}
-            />
-          </Fragment>
-        ))}
+        </Fragment>
+      ))}
     </div>
   )
 }

--- a/apps/store/src/components/Header/Header.css.ts
+++ b/apps/store/src/components/Header/Header.css.ts
@@ -92,12 +92,6 @@ export const contentWrapper = style({
   alignItems: 'center',
   flex: 1,
   gap: theme.space.xs,
-
-  '@media': {
-    [minWidth.lg]: {
-      justifyContent: 'space-between',
-    },
-  },
 })
 
 export const navigation = style({
@@ -110,6 +104,14 @@ export const navigation = style({
     },
   },
 })
+
+export const topMenuDesktop = style([
+  navigation,
+  {
+    // Ensure menu is left-aligned while cart item is right-aligned
+    flexGrow: 1,
+  },
+])
 
 export const navigationItem = style({
   selectors: {

--- a/apps/store/src/components/Header/TopMenuDesktop/TopMenuDesktop.tsx
+++ b/apps/store/src/components/Header/TopMenuDesktop/TopMenuDesktop.tsx
@@ -1,7 +1,7 @@
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import { usePathname } from 'next/navigation'
 import React, { useEffect } from 'react'
-import { navigation, navigationPrimaryList } from '../Header.css'
+import { navigationPrimaryList, topMenuDesktop } from '../Header.css'
 
 export type TopMenuDesktopProps = {
   children: React.ReactNode
@@ -16,7 +16,7 @@ export const TopMenuDesktop = ({ children }: TopMenuDesktopProps) => {
 
   return (
     <NavigationMenuPrimitive.Root
-      className={navigation}
+      className={topMenuDesktop}
       value={activeItem}
       onValueChange={setActiveItem}
     >

--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -23,6 +23,7 @@ type LayoutWithMenuProps = {
   }>
   overlayMenu?: boolean
   hideFooter?: boolean
+  hideMenu?: boolean
 }
 
 export const LayoutWithMenu = (props: LayoutWithMenuProps) => {
@@ -36,16 +37,14 @@ export const LayoutWithMenu = (props: LayoutWithMenuProps) => {
   if (!globalStory) return null
 
   // Announcements are added as reusable blocks for Page and ProductPage content types
-  const reusableBlock = filterByBlockType(
+  const announcementBlocks = filterByBlockType(
     story?.content.announcement,
     ReusableBlockReference.blockName,
   )
   const headerBlock = filterByBlockType(globalStory.content.header, HeaderBlock.blockName)
   const footerBlock = filterByBlockType(globalStory.content.footer, FooterBlock.blockName)
 
-  const showHeader = !story?.content.hideMenu
   const showMenuOverlay = story?.content.overlayMenu ?? props.overlayMenu
-  const showFooter = !props.hideFooter && !story?.content.hideFooter
   const darkBackground = story?.content.darkBackground
 
   const showBreadcrumbList = !story?.content.hideBreadcrumbs && breadcrumbs?.length !== 0 && story
@@ -54,10 +53,10 @@ export const LayoutWithMenu = (props: LayoutWithMenuProps) => {
   return (
     <>
       <div className={clsx(wrapper, className, darkBackground && dark)}>
-        {reusableBlock.map((referencedBlok) => (
+        {announcementBlocks.map((referencedBlok) => (
           <StoryblokComponent key={referencedBlok._uid} blok={referencedBlok} />
         ))}
-        {showHeader &&
+        {!props.hideMenu &&
           headerBlock.map((nestedBlock) => (
             <HeaderBlock
               key={nestedBlock._uid}
@@ -67,7 +66,7 @@ export const LayoutWithMenu = (props: LayoutWithMenuProps) => {
             />
           ))}
         {props.children}
-        {showFooter &&
+        {!props.hideFooter &&
           footerBlock.map((nestedBlock) => (
             <Fragment key={nestedBlock._uid}>
               {showBreadcrumbList && <BreadcrumbList items={breadcrumbItems} />}

--- a/apps/store/src/components/StoryblokPage.tsx
+++ b/apps/store/src/components/StoryblokPage.tsx
@@ -1,0 +1,33 @@
+import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
+import { DefaultDebugDialog } from '@/components/DebugDialog/DefaultDebugDialog'
+import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
+import { BlogContext, parseBlogContext } from '@/features/blog/useBlog'
+import { CompanyReviewsMetadataProvider } from '@/features/memberReviews/CompanyReviewsMetadataProvider'
+import type { ReviewsMetadata } from '@/features/memberReviews/memberReviews.types'
+import { StoryblokPageProps } from '@/services/storyblok/storyblok'
+
+type Props = StoryblokPageProps & {
+  companyReviewsMetadata?: ReviewsMetadata | null
+}
+export const StoryblokPage = (props: Props) => {
+  const story = useStoryblokState(props.story)
+  if (!story) return null
+  const abTestOriginStory = story.content.abTestOrigin
+  // Always use robots value from the source page in A/B test cases
+  const robots = story.content.robots
+
+  return (
+    <BlogContext.Provider value={parseBlogContext(props)}>
+      <CompanyReviewsMetadataProvider companyReviewsMetadata={props.companyReviewsMetadata ?? null}>
+        <HeadSeoInfo
+          // Gotcha:  Sometimes Storyblok returns "" for PageStory pages that doesn't get 'abTestOrigin' configured
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          story={abTestOriginStory || story}
+          robots={robots}
+        />
+        <StoryblokComponent blok={story.content} />
+        <DefaultDebugDialog />
+      </CompanyReviewsMetadataProvider>
+    </BlogContext.Provider>
+  )
+}

--- a/apps/store/src/features/carDealership/CarBuyerCmsPage.tsx
+++ b/apps/store/src/features/carDealership/CarBuyerCmsPage.tsx
@@ -1,0 +1,14 @@
+import { NextPageWithLayout } from 'next'
+import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
+import { StoryblokPage } from '@/components/StoryblokPage'
+import { StoryblokPageProps } from '@/services/storyblok/storyblok'
+
+export const CarBuyerCmsPage: NextPageWithLayout<StoryblokPageProps> = (props) => (
+  <StoryblokPage {...props} />
+)
+
+CarBuyerCmsPage.getLayout = (children) => (
+  <LayoutWithMenu hideFooter={true} hideMenu={true}>
+    {children}
+  </LayoutWithMenu>
+)

--- a/apps/store/src/pages/[locale]/[[...slug]].tsx
+++ b/apps/store/src/pages/[locale]/[[...slug]].tsx
@@ -1,16 +1,13 @@
-import { StoryblokComponent, useStoryblokState } from '@storyblok/react'
+import { useStoryblokState } from '@storyblok/react'
 import { type GetStaticPaths, type GetStaticProps, type NextPageWithLayout } from 'next'
-import { DefaultDebugDialog } from '@/components/DebugDialog/DefaultDebugDialog'
 import { HeadSeoInfo } from '@/components/HeadSeoInfo/HeadSeoInfo'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
 import { fetchProductData } from '@/components/ProductData/fetchProductData'
 import { ProductPage } from '@/components/ProductPage/ProductPage'
 import { type ProductPageProps } from '@/components/ProductPage/ProductPage.types'
+import { StoryblokPage } from '@/components/StoryblokPage'
 import { fetchBlogPageProps } from '@/features/blog/fetchBlogPageProps'
-import { BlogContext, parseBlogContext } from '@/features/blog/useBlog'
-import { CompanyReviewsMetadataProvider } from '@/features/memberReviews/CompanyReviewsMetadataProvider'
 import { fetchProductReviewsMetadata } from '@/features/memberReviews/memberReviews'
-import type { ReviewsMetadata } from '@/features/memberReviews/memberReviews.types'
 import { initializeApollo } from '@/services/apollo/client'
 import { getPriceTemplate } from '@/services/PriceCalculator/PriceCalculator.helpers'
 import { getStoryblokPageProps } from '@/services/storyblok/getStoryblokPageProps'
@@ -25,40 +22,13 @@ import { isProductStory } from '@/services/storyblok/Storyblok.helpers'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { patchNextI18nContext } from '@/utils/patchNextI18nContext'
 
-type NextContentPageProps = StoryblokPageProps & {
-  type: 'content'
-  companyReviewsMetadata: ReviewsMetadata | null
-}
 type NextProductPageProps = ProductPageProps & { type: 'product' }
-
+type NextContentPageProps = StoryblokPageProps & { type: 'content' }
 type PageProps = NextContentPageProps | NextProductPageProps
 
 const NextCmsPage: NextPageWithLayout<PageProps> = (props) => {
   if (props.type === 'product') return <NextProductPage {...props} />
-  return <NextStoryblokPage {...props} />
-}
-
-const NextStoryblokPage = (props: NextContentPageProps) => {
-  const story = useStoryblokState(props.story)
-  if (!story) return null
-  const abTestOriginStory = story.content.abTestOrigin
-  // Always use robots value from the source page in A/B test cases
-  const robots = story.content.robots
-
-  return (
-    <BlogContext.Provider value={parseBlogContext(props)}>
-      <CompanyReviewsMetadataProvider companyReviewsMetadata={props.companyReviewsMetadata}>
-        <HeadSeoInfo
-          // Gotcha:  Sometimes Storyblok returns "" for PageStory pages that doesn't get 'abTestOrigin' configured
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          story={abTestOriginStory || story}
-          robots={robots}
-        />
-        <StoryblokComponent blok={story.content} />
-        <DefaultDebugDialog />
-      </CompanyReviewsMetadataProvider>
-    </BlogContext.Provider>
-  )
+  return <StoryblokPage {...props} />
 }
 
 const NextProductPage = (props: ProductPageProps) => {

--- a/apps/store/src/pages/[locale]/car-buyer/[contractId]/index.tsx
+++ b/apps/store/src/pages/[locale]/car-buyer/[contractId]/index.tsx
@@ -1,5 +1,5 @@
 import { type GetServerSideProps } from 'next'
-import NextCmsPage from '@/pages/[locale]/[[...slug]]'
+import { CarBuyerCmsPage } from '@/features/carDealership/CarBuyerCmsPage'
 import { getStoryblokPageProps } from '@/services/storyblok/getStoryblokPageProps'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { patchNextI18nContext } from '@/utils/patchNextI18nContext'
@@ -30,4 +30,4 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
   }
 }
 
-export default NextCmsPage
+export default CarBuyerCmsPage

--- a/apps/store/src/pages/[locale]/car-buyer/extension/[[...contractId]].tsx
+++ b/apps/store/src/pages/[locale]/car-buyer/extension/[[...contractId]].tsx
@@ -1,5 +1,5 @@
 import { type GetServerSideProps } from 'next'
-import NextCmsPage from '@/pages/[locale]/[[...slug]]'
+import { CarBuyerCmsPage } from '@/features/carDealership/CarBuyerCmsPage'
 import { getStoryblokPageProps } from '@/services/storyblok/getStoryblokPageProps'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { patchNextI18nContext } from '@/utils/patchNextI18nContext'
@@ -30,4 +30,4 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
   }
 }
 
-export default NextCmsPage
+export default CarBuyerCmsPage

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -110,10 +110,8 @@ export type PageStory = ISbStoryData<
   {
     announcement?: ExpectedBlockType<ReusableBlockReferenceProps>
     body: Array<SbBlokData>
-    hideMenu?: boolean
     overlayMenu?: boolean
     darkBackground?: boolean
-    hideFooter?: boolean
     hideBreadcrumbs?: boolean
     hideChat?: boolean
   } & SEOData


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Prevent cart menu item from jumping on desktop when page loads

It was aligned centrally before this PR and jumped to the right when desktop menu variant appeared

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
