### PR TITLE
Convert Breadcrumbs styles to vanilla-extract

### DIFF
--- a/apps/store/src/components/LayoutWithMenu/Breadcrumbs.tsx
+++ b/apps/store/src/components/LayoutWithMenu/Breadcrumbs.tsx
@@ -1,53 +1,33 @@
-import styled from '@emotion/styled'
+import { clsx } from 'clsx'
 import Link from 'next/link'
-import { Children, type ReactNode } from 'react'
-import { Text, theme } from 'ui'
-import { linkStyles } from '@/components/RichText/RichText.styles'
+import { Children, ComponentProps, type ReactNode } from 'react'
+import { Text } from 'ui'
+import {
+  breadcrumbItem,
+  breadcrumbsLink,
+  breadcrumbsList,
+} from '@/components/LayoutWithMenu/Breadcumbs.css'
 
 const BreadcrumbList = ({ children }: { children: ReactNode }) => {
   const count = Children.count(children)
 
   return (
     <>
-      <StyledBreadcrumbList>
+      <ul className={breadcrumbsList}>
         {Children.map(children, (child, index) => (
-          <BreadcumbItem>
+          <li className={breadcrumbItem}>
             {child}
             {index < count - 1 && <Text color="textSecondaryOnGray">&middot;</Text>}
-          </BreadcumbItem>
+          </li>
         ))}
-      </StyledBreadcrumbList>
+      </ul>
     </>
   )
 }
 
-const StyledBreadcrumbList = styled.ul({
-  display: 'flex',
-  flexFlow: 'row nowrap',
-  gap: theme.space.xxs,
-  overflowX: 'auto',
-
-  padding: theme.space.sm,
-  backgroundColor: theme.colors.opaque2,
-
-  '::before, ::after': {
-    content: '""',
-    margin: 'auto',
-  },
-})
-
-const BreadcumbItem = styled.li({
-  display: 'flex',
-  alignItems: 'center',
-  gap: theme.space.xxs,
-  flexShrink: 0,
-})
-
-const BreadcrumbLink = styled(Link)(linkStyles, {
-  fontSize: theme.fontSizes.sm,
-  color: theme.colors.textPrimary,
-  textDecorationColor: 'transparent',
-})
+const BreadcrumbLink = ({ className, ...forwardedProps }: ComponentProps<typeof Link>) => (
+  <Link className={clsx(breadcrumbsLink, className)} {...forwardedProps} />
+)
 
 export const Breadcrumbs = {
   Root: BreadcrumbList,

--- a/apps/store/src/components/LayoutWithMenu/Breadcumbs.css.ts
+++ b/apps/store/src/components/LayoutWithMenu/Breadcumbs.css.ts
@@ -1,0 +1,42 @@
+import { style } from '@vanilla-extract/css'
+import { theme } from 'ui/src/theme'
+
+export const breadcrumbsList = style({
+  display: 'flex',
+  flexFlow: 'row nowrap',
+  gap: theme.space.xxs,
+  overflowX: 'auto',
+  padding: theme.space.sm,
+  backgroundColor: theme.colors.opaque2,
+  // Almost the same as justifyContent: 'center',
+  // but keeps left alignment when shrunk smaller than content
+  selectors: {
+    '&::before, &::after': {
+      content: '""',
+      margin: 'auto',
+    },
+  },
+})
+
+export const breadcrumbItem = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.space.xxs,
+  flexShrink: 0,
+})
+
+export const breadcrumbsLink = style({
+  fontSize: theme.fontSizes.sm,
+  color: theme.colors.textPrimary,
+  textDecorationColor: 'transparent',
+  textDecorationLine: 'underline',
+  textDecorationThickness: 'clamp(1px, 0.07em, 2px);',
+  textUnderlineOffset: 5,
+  '@media': {
+    '(hover: hover)': {
+      ':hover': {
+        textDecorationColor: 'var(--random-hover-color)',
+      },
+    },
+  },
+})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Convert Breadcrumbs styling to vanilla-extract

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

In the next PR I plan to handle `hideBreadcrumbs` page property with pure CSS, which makes it compatible with app router

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
