### PR TITLE
Refactor page.hideBreadcrumbs to work on CSS, without layout knowing about page info

### DIFF
--- a/apps/store/scripts/storyblok-analyze-stories.cjs
+++ b/apps/store/scripts/storyblok-analyze-stories.cjs
@@ -2,9 +2,9 @@
 const main = async () => {
   const stories = await readStoriesFromStdin()
   for (const story of stories) {
-    const { hideMenu, hideFooter } = story.content
-    if (hideMenu || hideFooter) {
-      console.log(story.full_slug, story.content.component, { hideMenu, hideFooter })
+    const { hideBreadcrumbs } = story.content
+    if (hideBreadcrumbs) {
+      console.log(story.full_slug, story.content.component, { hideBreadcrumbs })
     }
   }
 }

--- a/apps/store/src/app/[locale]/StoryblokLayout.tsx
+++ b/apps/store/src/app/[locale]/StoryblokLayout.tsx
@@ -38,6 +38,7 @@ export const StoryblokLayout = ({
 
   return (
     <div className={clsx(wrapper, darkBackground && dark)}>
+      {/* TODO: Make announcement part of page rendering, same as breadcrumbs */}
       {reusableBlock.map((referencedBlok) => (
         <StoryblokComponent key={referencedBlok._uid} blok={referencedBlok} />
       ))}
@@ -50,6 +51,7 @@ export const StoryblokLayout = ({
         />
       ))}
       {children}
+      {/* TODO: Add breadcumbs, should be RSC to avoid loading storyblok data from client */}
       {footerBlock.map((nestedBlock) => (
         <Fragment key={nestedBlock._uid}>
           <FooterBlock

--- a/apps/store/src/blocks/PageBlock.tsx
+++ b/apps/store/src/blocks/PageBlock.tsx
@@ -10,7 +10,11 @@ type PageBlockProps = SbBaseBlockProps<{
 export const PageBlock = ({ blok }: PageBlockProps) => {
   return (
     <>
-      <main className={main} {...storyblokEditable(blok)}>
+      <main
+        className={main}
+        {...storyblokEditable(blok)}
+        data-hide-breadcrumbs={!!blok.hideBreadcrumbs}
+      >
         {blok.body.map((nestedBlock) => (
           <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
         ))}

--- a/apps/store/src/components/LayoutWithMenu/Breadcumbs.css.ts
+++ b/apps/store/src/components/LayoutWithMenu/Breadcumbs.css.ts
@@ -8,12 +8,15 @@ export const breadcrumbsList = style({
   overflowX: 'auto',
   padding: theme.space.sm,
   backgroundColor: theme.colors.opaque2,
-  // Almost the same as justifyContent: 'center',
-  // but keeps left alignment when shrunk smaller than content
   selectors: {
+    // Almost the same as justifyContent: 'center',
+    // but keeps left alignment when shrunk smaller than content
     '&::before, &::after': {
       content: '""',
       margin: 'auto',
+    },
+    [`main[data-hide-breadcrumbs=true] ~ &`]: {
+      display: 'none',
     },
   },
 })

--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -47,7 +47,6 @@ export const LayoutWithMenu = (props: LayoutWithMenuProps) => {
   const showMenuOverlay = story?.content.overlayMenu ?? props.overlayMenu
   const darkBackground = story?.content.darkBackground
 
-  const showBreadcrumbList = !story?.content.hideBreadcrumbs && breadcrumbs?.length !== 0 && story
   const breadcrumbItems = [...(breadcrumbs ?? []), ...(story ? [{ label: story.name }] : [])]
 
   return (
@@ -69,7 +68,7 @@ export const LayoutWithMenu = (props: LayoutWithMenuProps) => {
         {!props.hideFooter &&
           footerBlock.map((nestedBlock) => (
             <Fragment key={nestedBlock._uid}>
-              {showBreadcrumbList && <BreadcrumbList items={breadcrumbItems} />}
+              <BreadcrumbList items={breadcrumbItems} />
 
               <FooterBlock
                 key={nestedBlock._uid}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Refactor breadcrumbs display to rely on main[data-hide-breadcrumbs] DOM attribute

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

This way we can make layout independent from story data.  Required for app router where we want to keep layout during navigation instead of rerendering it

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
