### PR TITLE
Make sure Button renders <a> tag when href is passed

### DIFF
--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,7 +1,13 @@
 'use client'
 
 import clsx from 'clsx'
-import { ButtonHTMLAttributes, forwardRef, type ReactNode } from 'react'
+import {
+  ButtonHTMLAttributes,
+  forwardRef,
+  type ForwardedRef,
+  type LegacyRef,
+  type ReactNode,
+} from 'react'
 import { buttonVariant, centered, childrenWrapper, fullWidthStyles } from './Button.css'
 import { ButtonSize, getButtonSizeStyles } from './Button.helpers'
 import { DotPulse } from './DotPulse'
@@ -20,15 +26,17 @@ type CustomButtonProps = {
   Icon?: ReactNode
 } & LinkProps
 
-export type Props = ButtonHTMLAttributes<HTMLButtonElement> & CustomButtonProps
+export type Props = ButtonHTMLAttributes<HTMLButtonElement | HTMLAnchorElement> & CustomButtonProps
+type Ref = HTMLButtonElement | HTMLAnchorElement
 
-export const Button = forwardRef<HTMLButtonElement, Props>((props, ref) => {
+export const Button = forwardRef<Ref, Props>((props, ref) => {
   const {
     className,
     variant = 'primary',
     size = 'large',
     fullWidth,
     loading,
+    href,
     children,
     target,
     title,
@@ -52,8 +60,6 @@ export const Button = forwardRef<HTMLButtonElement, Props>((props, ref) => {
   const buttonProps = {
     ...baseProps,
     children: buttonChildren,
-    as: props.href ? 'a' : 'button',
-    ref,
     disabled: props.disabled || loading,
     ...(loading && { 'data-loading': true }),
     ...(target === '_blank' && { target: '_blank', rel: 'noopener' }),
@@ -68,7 +74,20 @@ export const Button = forwardRef<HTMLButtonElement, Props>((props, ref) => {
     className,
   )
 
-  return <button className={classNames} {...buttonProps} />
+  if (href) {
+    return (
+      <a
+        className={classNames}
+        href={href}
+        ref={ref as LegacyRef<HTMLAnchorElement>}
+        {...buttonProps}
+      />
+    )
+  }
+
+  return (
+    <button className={classNames} ref={ref as ForwardedRef<HTMLButtonElement>} {...buttonProps} />
+  )
 })
 
 Button.displayName = 'Button'


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
When a ui button component is wrapped in a link (as in `ButtonNextLink` component), we should output an a tag instead of a button tag as specified in [Next docs ](https://nextjs.org/docs/pages/api-reference/components/link#if-the-child-is-a-functional-component)

Before when we used emotion we could use the as prop to let emotion either render and `<a>` or a `<button>` and the typing was not actually not matching the behaviour, but it didn't complain. But now we need to check if a href is provided and either render an `<a>` or a `<button>`

### The problem
~~I can't find the right way to type this, since forwardRef could either be the an `HTMLAnchorElement` passed from `ButtonNextLink` or a `HTMLButtonElement` passed from a component where we need to pass a ref to a button (see [ManyPetsMigrationPage](https://github.com/HedvigInsurance/racoon/blob/main/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx#L107))~~

Use type assertion for now

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
We need to output a link (<a> tag) when a href is passed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
