### PR TITLE
GEN-1893 - feat(QuickAddEditableView): added foundation for quick add editable card (cross sell)

### DIFF
--- a/apps/store/public/locales/en/cart.json
+++ b/apps/store/public/locales/en/cart.json
@@ -57,6 +57,10 @@
   "EDIT_CONFIRMATION_MODAL_PROMPT": "You need to calculate a new price when you edit your information.",
   "EXPOSURE_LABEL": "Valid for",
   "GO_TO_STORE_BUTTON": "Browse our insurances",
+  "NUMBER_COINSURED_INPUT_LABEL": "Insured people",
+  "NUMBER_COINSURED_OPTION_LABEL_one": "You + {{count}}",
+  "NUMBER_COINSURED_OPTION_LABEL_other": "You + {{count}}",
+  "NUMBER_COINSURED_OPTION_LABEL_zero": "You",
   "OFFER_PRICE_LABEL": "Your offer:",
   "QUICK_ADD_BADGE_LABEL": "Popular",
   "QUICK_ADD_BUTTON": "Add",
@@ -72,5 +76,7 @@
   "REMOVE_ENTRY_MODAL_CANCEL_BUTTON": "Cancel",
   "REMOVE_ENTRY_MODAL_CONFIRM_BUTTON": "Yes, remove",
   "REMOVE_ENTRY_MODAL_PROMPT": "Are you sure you want to remove {{name}}?",
+  "START_DATE_LABEL": "Start date",
+  "USP_NO_BINDING_TIME": "No binding time",
   "VIEW_ENTRY_DETAILS_BUTTON": "Details"
 }

--- a/apps/store/public/locales/sv-se/cart.json
+++ b/apps/store/public/locales/sv-se/cart.json
@@ -57,6 +57,10 @@
   "EDIT_CONFIRMATION_MODAL_PROMPT": "Du behöver göra en ny prisberäkning för att ändra dina uppgifter.",
   "EXPOSURE_LABEL": "Giltlig för",
   "GO_TO_STORE_BUTTON": "Se våra försäkringar",
+  "NUMBER_COINSURED_INPUT_LABEL": "Försäkrade personer",
+  "NUMBER_COINSURED_OPTION_LABEL_one": "Du + {{count}}",
+  "NUMBER_COINSURED_OPTION_LABEL_other": "Du + {{count}}",
+  "NUMBER_COINSURED_OPTION_LABEL_zero": "Du",
   "OFFER_PRICE_LABEL": "Ditt erbjudande:",
   "QUICK_ADD_BADGE_LABEL": "Populärt",
   "QUICK_ADD_BUTTON": "Lägg till",
@@ -72,5 +76,7 @@
   "REMOVE_ENTRY_MODAL_CANCEL_BUTTON": "Avbryt",
   "REMOVE_ENTRY_MODAL_CONFIRM_BUTTON": "Ja, ta bort",
   "REMOVE_ENTRY_MODAL_PROMPT": "Är du säker på att du vill ta bort {{name}}?",
+  "START_DATE_LABEL": "Startdatum",
+  "USP_NO_BINDING_TIME": "Ingen bindningstid",
   "VIEW_ENTRY_DETAILS_BUTTON": "Detaljer"
 }

--- a/apps/store/src/components/InputDay/InputDay.tsx
+++ b/apps/store/src/components/InputDay/InputDay.tsx
@@ -33,7 +33,6 @@ type Props = {
   fromDate?: Date
   toDate?: Date
   disabled?: boolean
-  backgroundColor?: 'default' | 'light'
   required?: boolean
   autoFocus?: boolean
   loading?: boolean
@@ -58,11 +57,6 @@ export const InputDay = (props: Props) => {
   const autoIdentifier = useId()
   const inputId = props.id ?? autoIdentifier
 
-  const backgroundColor =
-    props.backgroundColor === 'light'
-      ? theme.colors.backgroundFrostedGlass
-      : theme.colors.translucent1
-
   const { highlight, animationProps } = useHighlightAnimation<HTMLButtonElement>()
 
   const handleSelect: SelectSingleEventHandler = (day) => {
@@ -85,7 +79,6 @@ export const InputDay = (props: Props) => {
       <Popover.Trigger
         {...animationProps}
         className={clsx(trigger, props.className)}
-        style={{ backgroundColor }}
         disabled={props.disabled}
       >
         <label className={label} htmlFor={inputId} data-disabled={props.disabled}>

--- a/apps/store/src/components/QuickAdd/AddToCartButton.tsx
+++ b/apps/store/src/components/QuickAdd/AddToCartButton.tsx
@@ -1,25 +1,28 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
-import { type ReactNode } from 'react'
-import { Button } from 'ui'
+import { Button, type ButtonProps } from 'ui'
 import { type OfferRecommendationFragment } from '@/services/graphql/generated'
 import { useTracking } from '@/services/Tracking/useTracking'
 import { useAddToCart } from '@/utils/useAddToCart'
 
-type Props = {
+export type AddToCartButtonProps = {
   shopSessionId: string
   offer: OfferRecommendationFragment
   productName: string
-  children: ReactNode
-}
+} & Omit<ButtonProps<'button'>, 'onClick' | 'loading'>
 
-export const AddToCartButton = (props: Props) => {
+export const AddToCartButton = ({
+  shopSessionId,
+  offer,
+  productName,
+  ...buttonProps
+}: AddToCartButtonProps) => {
   const [addToCart, loading] = useAddToCart({
-    shopSessionId: props.shopSessionId,
+    shopSessionId: shopSessionId,
     onSuccess() {
       datadogLogs.logger.info('Quick Add | Added offer to cart', {
-        productOfferId: props.offer.id,
-        product: props.productName,
+        productOfferId: offer.id,
+        product: productName,
       })
       window.scrollTo({ top: 0 })
     },
@@ -29,16 +32,12 @@ export const AddToCartButton = (props: Props) => {
   const handleAdd = () => {
     datadogRum.addAction('Quick Add To Cart', {
       type: 'complete',
-      productOfferId: props.offer.id,
-      product: props.productName,
+      productOfferId: offer.id,
+      product: productName,
     })
-    tracking.reportAddToCart(props.offer, 'recommendations')
-    addToCart(props.offer.id)
+    tracking.reportAddToCart(offer, 'recommendations')
+    addToCart(offer.id)
   }
 
-  return (
-    <Button size="medium" fullWidth={true} loading={loading} onClick={handleAdd}>
-      {props.children}
-    </Button>
-  )
+  return <Button size="medium" {...buttonProps} onClick={handleAdd} loading={loading} />
 }

--- a/apps/store/src/components/QuickAdd/DismissButton.tsx
+++ b/apps/store/src/components/QuickAdd/DismissButton.tsx
@@ -1,9 +1,11 @@
 import { datadogRum } from '@datadog/browser-rum'
 import { useTranslation } from 'next-i18next'
-import { Button } from 'ui'
+import { Button, type ButtonProps } from 'ui'
 import { useShowQuickAdd } from './useShowQuickAdd'
 
-export const DismissButton = () => {
+type Props = Omit<ButtonProps<'button'>, 'onClick' | 'children'>
+
+export function DismissButton(props: Props) {
   const { t } = useTranslation('cart')
   const [, setShow] = useShowQuickAdd()
 
@@ -14,7 +16,7 @@ export const DismissButton = () => {
   }
 
   return (
-    <Button size="medium" variant="ghost" fullWidth={true} onClick={handleDismiss}>
+    <Button size="medium" {...props} onClick={handleDismiss}>
       {t('QUICK_ADD_DISMISS')}
     </Button>
   )

--- a/apps/store/src/components/QuickAdd/ProductUsp.css.ts
+++ b/apps/store/src/components/QuickAdd/ProductUsp.css.ts
@@ -1,0 +1,20 @@
+import { style } from '@vanilla-extract/css'
+import { theme } from 'ui/src/theme'
+
+export const productUsp = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  columnGap: theme.space.xs,
+  paddingBlock: theme.space.md,
+
+  selectors: {
+    '&:not(:last-of-type)': {
+      borderBottom: `1px solid ${theme.colors.borderTranslucent1}`,
+    },
+  },
+})
+
+export const checkicon = style({
+  flexShrink: 0,
+})

--- a/apps/store/src/components/QuickAdd/ProductUsp.tsx
+++ b/apps/store/src/components/QuickAdd/ProductUsp.tsx
@@ -1,0 +1,12 @@
+import { type PropsWithChildren } from 'react'
+import { Text, CheckIcon } from 'ui'
+import { productUsp, checkicon } from './ProductUsp.css'
+
+export function ProductUsp({ children }: PropsWithChildren) {
+  return (
+    <li className={productUsp}>
+      <Text color="textTranslucentSecondary">{children}</Text>
+      <CheckIcon className={checkicon} size="1rem" role="presentation" />
+    </li>
+  )
+}

--- a/apps/store/src/components/QuickAdd/QuickAddBundleView.stories.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddBundleView.stories.tsx
@@ -3,9 +3,9 @@ import { Button, Heading, Text, theme } from 'ui'
 import { Perils } from '@/components/Perils/Perils'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { Price } from '@/components/Price'
-import type { PerilFragment } from '@/services/graphql/generated';
-import { CurrencyCode } from '@/services/graphql/generated'
-import { ProductUsp, QuickAddBundleView } from './QuickAddBundleView'
+import { CurrencyCode, type PerilFragment } from '@/services/graphql/generated'
+import { ProductUsp } from './ProductUsp'
+import { QuickAddBundleView } from './QuickAddBundleView'
 import { QuickAddInfoDialog } from './QuickAddInfoDialog'
 
 const meta: Meta<typeof QuickAddBundleView> = {

--- a/apps/store/src/components/QuickAdd/QuickAddBundleView.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddBundleView.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { useTranslation } from 'next-i18next'
-import { type ReactNode, type ComponentProps, type PropsWithChildren } from 'react'
-import { Badge, CheckIcon, Space, Text } from 'ui'
+import { type ReactNode, type ComponentProps } from 'react'
+import { Badge, Space, Text } from 'ui'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { Price } from '@/components/Price'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
@@ -14,8 +14,6 @@ import {
   pillow,
   pillowWrapper,
   priceWrapper,
-  productDetail,
-  productUsp,
 } from './QuickAddBundleView.css'
 
 type Props = {
@@ -84,36 +82,5 @@ export function QuickAddBundleView(props: Props) {
         </div>
       </Space>
     </div>
-  )
-}
-
-type ProductDetailProps = {
-  children: string | ReactNode
-  value: string
-}
-
-export function ProductDetail(props: ProductDetailProps) {
-  return (
-    <li className={productDetail}>
-      {typeof props.children === 'string' ? (
-        <Text as="p" color="textSecondary">
-          {props.children}
-        </Text>
-      ) : (
-        props.children
-      )}
-      <Text as="p" color="textSecondary">
-        {props.value}
-      </Text>
-    </li>
-  )
-}
-
-export function ProductUsp({ children }: PropsWithChildren) {
-  return (
-    <li className={productUsp}>
-      <Text color="textTranslucentSecondary">{children}</Text>
-      <CheckIcon size="1rem" aria-label="Covered" />
-    </li>
   )
 }

--- a/apps/store/src/components/QuickAdd/QuickAddEditableView.css.ts
+++ b/apps/store/src/components/QuickAdd/QuickAddEditableView.css.ts
@@ -1,0 +1,54 @@
+import { style } from '@vanilla-extract/css'
+import { theme, minWidth } from 'ui/src/theme'
+
+export const card = style({
+  padding: theme.space.md,
+  border: `1px solid ${theme.colors.borderTranslucent1}`,
+  borderRadius: theme.radius.md,
+  backgroundColor: theme.colors.blueFill1,
+
+  '@media': {
+    [minWidth.lg]: {
+      padding: theme.space.lg,
+    },
+  },
+})
+
+export const Wrapper = style({
+  width: '3rem',
+  aspectRatio: '1 / 1',
+})
+
+export const link = style({
+  ':hover': {
+    textDecoration: 'underline',
+  },
+})
+
+export const alignedBadge = style({
+  alignSelf: 'flex-start',
+  marginLeft: 'auto',
+  fontSize: theme.fontSizes.xs,
+})
+
+export const stepperInput = style({
+  backgroundColor: theme.colors.offWhite,
+})
+
+export const startDateInput = style({
+  backgroundColor: theme.colors.offWhite,
+})
+
+export const priceWrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: theme.space.sm,
+})
+
+export const actionsWrapper = style({
+  display: 'grid',
+  gridAutoFlow: 'column',
+  gridAutoColumns: '1fr',
+  gap: theme.space.xs,
+})

--- a/apps/store/src/components/QuickAdd/QuickAddEditableView.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddEditableView.tsx
@@ -1,3 +1,106 @@
-export function QuickAddEditableView() {
-  return null
+import Link from 'next/link'
+import { useTranslation } from 'next-i18next'
+import { type ComponentProps, type ReactNode } from 'react'
+import { Space, Text, Badge } from 'ui'
+import { InputDay } from '@/components/InputDay/InputDay'
+import { Pillow } from '@/components/Pillow/Pillow'
+import { Price } from '@/components/Price'
+import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
+import { StepperInput } from '@/components/StepperInput/StepperInput'
+import { AddToCartButton, type AddToCartButtonProps } from './AddToCartButton'
+import { DismissButton } from './DismissButton'
+import {
+  alignedBadge,
+  card,
+  link,
+  stepperInput,
+  startDateInput,
+  priceWrapper,
+  actionsWrapper,
+} from './QuickAddEditableView.css'
+
+type Props = {
+  title: string
+  subtitle: string
+  pillow: ComponentProps<typeof Pillow>
+  price: ComponentProps<typeof Price>
+  productPageLink: string
+  badge?: string
+  Body?: ReactNode
+} & Pick<AddToCartButtonProps, 'shopSessionId' | 'offer' | 'productName'>
+
+export function QuickAddEditableView(props: Props) {
+  const { t } = useTranslation('cart')
+
+  return (
+    <div className={card}>
+      <Space y={1}>
+        <SpaceFlex space={1} align="center">
+          <Pillow size="small" {...props.pillow} />
+
+          <div>
+            <Link className={link} href={props.productPageLink}>
+              <Text as="span" color="textTranslucentPrimary">
+                {props.title}
+              </Text>
+            </Link>
+            <Text as="p" color="textTranslucentSecondary">
+              {props.subtitle}
+            </Text>
+          </div>
+
+          {props.badge && (
+            <Badge className={alignedBadge} color="pinkFill1">
+              {props.badge}
+            </Badge>
+          )}
+        </SpaceFlex>
+
+        {props.Body}
+
+        <Space y={1}>
+          <Space y={0.25}>
+            <StepperInput
+              className={stepperInput}
+              name="numberCoInsured"
+              label={t('NUMBER_COINSURED_INPUT_LABEL')}
+              min={0}
+              max={5}
+              defaultValue={0}
+              optionLabel={(count) => t('NUMBER_COINSURED_OPTION_LABEL', { count })}
+            />
+            <InputDay
+              className={startDateInput}
+              name="startDate"
+              label={t('START_DATE_LABEL')}
+              fromDate={new Date()}
+              defaultSelected={new Date()}
+            />
+          </Space>
+
+          <div className={priceWrapper}>
+            <Text as="p" color="textTranslucentPrimary">
+              {t('OFFER_PRICE_LABEL')}
+            </Text>
+            <Price
+              {...props.price}
+              color="textTranslucentPrimary"
+              secondaryColor="textTranslucentSecondary"
+            />
+          </div>
+
+          <div className={actionsWrapper}>
+            <DismissButton variant="secondary" />
+            <AddToCartButton
+              shopSessionId={props.shopSessionId}
+              offer={props.offer}
+              productName={props.productName}
+            >
+              {t('QUICK_ADD_BUTTON')}
+            </AddToCartButton>
+          </div>
+        </Space>
+      </Space>
+    </div>
+  )
 }

--- a/apps/store/src/components/QuickAdd/QuickAddOfferContainer.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddOfferContainer.tsx
@@ -12,7 +12,8 @@ import { Features } from '@/utils/Features'
 import { getOfferPrice } from '@/utils/getOfferPrice'
 import { AddToCartButton } from './AddToCartButton'
 import { DismissButton } from './DismissButton'
-import { ProductUsp, QuickAddBundleView } from './QuickAddBundleView'
+import { ProductUsp } from './ProductUsp'
+import { QuickAddBundleView } from './QuickAddBundleView'
 import { QuickAddEditableView } from './QuickAddEditableView'
 import { QuickAddInfoDialog } from './QuickAddInfoDialog'
 import { useShowQuickAdd } from './useShowQuickAdd'
@@ -48,7 +49,26 @@ export function QuickAddOfferContainer(props: Props) {
   const homeInsuranceInCart =
     props.cart.entries.find((entry) => HOME_INSURANCES.includes(entry.product.name)) ?? null
   if (!homeInsuranceInCart && Features.enabled('CROSS_SELL_CARD_V2')) {
-    return <QuickAddEditableView />
+    return (
+      <QuickAddEditableView
+        shopSessionId={props.shopSessionId}
+        offer={props.offer}
+        productName={props.product.name}
+        pillow={props.product.pillowImage}
+        title={props.product.displayNameFull}
+        subtitle={t('USP_NO_BINDING_TIME')}
+        productPageLink={props.product.pageLink}
+        price={getOfferPrice(props.offer.cost)}
+        badge={t('QUICK_ADD_BADGE_LABEL')}
+        Body={
+          <ul>
+            <ProductUsp>{t('ACCIDENT_OFFER_USP_1')}</ProductUsp>
+            <ProductUsp>{t('ACCIDENT_OFFER_USP_2')}</ProductUsp>
+            <ProductUsp>{t('ACCIDENT_OFFER_USP_3')}</ProductUsp>
+          </ul>
+        }
+      />
+    )
   }
 
   const householdSize = parseInt(props.offer.priceIntentData[CO_INSURED_DATA_KEY] || 0, 10) + 1
@@ -72,7 +92,6 @@ export function QuickAddOfferContainer(props: Props) {
       price={price}
       badge={{ children: t('QUICK_ADD_BADGE_LABEL') }}
       Body={
-        // Assume Accident insurance
         <>
           <Text as="p" color="textTranslucentSecondary">
             {t('ACCIDENT_OFFER_DESCRIPTION_BUNDLE')}
@@ -103,10 +122,11 @@ export function QuickAddOfferContainer(props: Props) {
             shopSessionId={props.shopSessionId}
             productName={props.product.name}
             offer={props.offer}
+            fullWidth={true}
           >
             {t('QUICK_ADD_BUTTON_BUNDLE')}
           </AddToCartButton>
-          <DismissButton />
+          <DismissButton variant="ghost" fullWidth={true} />
         </Space>
       }
     />

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -7,7 +7,7 @@ import { getBadgeSize } from './Badge.helper'
 
 type BadgeColors = Pick<
   UIColors,
-  'blueFill1' | 'blueFill2' | 'blueFill3' | 'green50' | 'signalAmberHighlight'
+  'blueFill1' | 'blueFill2' | 'blueFill3' | 'green50' | 'signalAmberHighlight' | 'pinkFill1'
 >
 
 export type BadgeProps = Margins & {


### PR DESCRIPTION
## Describe your changes

* Implement the UI for the new _Accident Cross Sell Card_. At the moment one can _decline_ and _add_ the form. Editing it will be added next, the changes that will make for _start date_ and _number of insured people_ will not be considered when adding the offer to the cart.

<img width="508" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/d8ae0d90-cc1a-4b21-b82a-8c588e71a6e9">

It's not exactly the same as described [in figma](https://www.figma.com/file/8SfzuQEJ4LJ6uKL0l7WKoE/Hedvig.com?type=design&node-id=11183-2675&mode=dev). Card blue color is off but we have some changes on UI kit planned that's going to enable the new hue.

## Justify why they are needed

Accident cross sell new card.
