### PR TITLE
GEN-1893 - refact(useHighlightAnimation): use JS to get element's background color

### DIFF
--- a/apps/store/src/components/InputDate/InputDate.tsx
+++ b/apps/store/src/components/InputDate/InputDate.tsx
@@ -27,9 +27,7 @@ export const InputDate = (props: Props) => {
       ? theme.colors.backgroundFrostedGlass
       : theme.colors.translucent1
   const identifier = useId()
-  const { highlight, animationProps } = useHighlightAnimation<HTMLDivElement>({
-    defaultColor: backgroundColor,
-  })
+  const { highlight, animationProps } = useHighlightAnimation<HTMLDivElement>()
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     setInternalValue(event.target.value)

--- a/apps/store/src/components/InputDay/InputDay.tsx
+++ b/apps/store/src/components/InputDay/InputDay.tsx
@@ -55,9 +55,7 @@ export const InputDay = (props: Props) => {
       ? theme.colors.backgroundFrostedGlass
       : theme.colors.translucent1
 
-  const { highlight, animationProps } = useHighlightAnimation<HTMLButtonElement>({
-    defaultColor: backgroundColor,
-  })
+  const { highlight, animationProps } = useHighlightAnimation<HTMLButtonElement>()
 
   const handleSelect: SelectSingleEventHandler = (day) => {
     if (day) props.onSelect?.(day)

--- a/apps/store/src/components/InputSelect/InputSelect.tsx
+++ b/apps/store/src/components/InputSelect/InputSelect.tsx
@@ -35,9 +35,7 @@ export const InputSelect = ({
 }: InputSelectProps) => {
   const backgroundColor = _backgroundColor ? getColor(_backgroundColor) : undefined
 
-  const { highlight, animationProps } = useHighlightAnimation<HTMLSelectElement>({
-    ...(backgroundColor && { defaultColor: backgroundColor }),
-  })
+  const { highlight, animationProps } = useHighlightAnimation<HTMLSelectElement>()
 
   const handleChange: ChangeEventHandler<HTMLSelectElement> = (event) => {
     onChange?.(event)

--- a/apps/store/src/utils/useHighlightAnimation.ts
+++ b/apps/store/src/utils/useHighlightAnimation.ts
@@ -1,20 +1,22 @@
 'use client'
 
-import { type KeyboardEvent, useCallback, useRef } from 'react'
+import { type KeyboardEvent, useCallback, useRef, useState, useEffect } from 'react'
 import { theme } from 'ui'
 
 const SIGNAL_GREEN_FILL_HSLA = theme.colors.signalGreenFill
   .replace('hsl', 'hsla')
   .replace(')', ', 0.99)')
 
-type Params = {
-  defaultColor?: string
-}
-
-export const useHighlightAnimation = <Element extends HTMLElement>({
-  defaultColor = theme.colors.translucent1,
-}: Params = {}) => {
+export function useHighlightAnimation<Element extends HTMLElement>() {
   const ref = useRef<Element | null>(null)
+  const [backgroundColor, setBackgroundColor] = useState<string>(theme.colors.translucent1)
+
+  useEffect(() => {
+    if (!ref.current) return
+
+    const elementBackgroundColor = getComputedStyle(ref.current).backgroundColor
+    setBackgroundColor(elementBackgroundColor)
+  }, [])
 
   const highlight = useCallback(
     (event?: KeyboardEvent<Element>) => {
@@ -30,14 +32,14 @@ export const useHighlightAnimation = <Element extends HTMLElement>({
           {
             backgroundColor: SIGNAL_GREEN_FILL_HSLA,
           },
-          { backgroundColor: defaultColor, easing: 'ease-out' },
+          { backgroundColor, easing: 'ease-out' },
         ],
         {
           duration: 1200,
         },
       )
     },
-    [ref, defaultColor],
+    [ref, backgroundColor],
   )
 
   return { highlight, animationProps: { ref } } as const


### PR DESCRIPTION
## Describe your changes

* Update `useHightlightAnimation` implementation so it relies on JS to determine the background that should be used during the animation.

## Justify why they are needed

Gonna use that to easily implement that variant of `StepperInput`. With the new implementation of `useHightlightAnimation`, I can get that input animation working by just setting `StepperInput` `backgroud-color` via CSS, instead of making it accept a `backgroundColor` prop  just get it down into `useHIghtlightAnimation`

<img width="443" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/0fcd8874-8c44-411d-a321-a4275dbc48d8">
