### PR TITLE
Move breadcrumbs structured data from head to body (prevents duplication)

### DIFF
--- a/apps/store/src/components/PageBreadcrumbs/PageBreadcrumbs.tsx
+++ b/apps/store/src/components/PageBreadcrumbs/PageBreadcrumbs.tsx
@@ -1,5 +1,4 @@
 import { clsx } from 'clsx'
-import Head from 'next/head'
 import Link from 'next/link'
 import { Children, ComponentProps, type ReactNode } from 'react'
 import { Text } from 'ui'
@@ -40,13 +39,11 @@ export const PageBreadcrumbs = (props: Props) => {
         )}
       </List>
 
-      <Head>
-        <script
-          key="structured-data-breadcrumb-list"
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
-        />
-      </Head>
+      <script
+        key="structured-data-breadcrumb-list"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
     </>
   )
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix duplication of `structured-data-breadcrumb-list` element during navigation by moving it from `head` to `body`

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
