### PR TITLE
Move CMS announcement block inside content component

### DIFF
--- a/apps/store/src/app/[locale]/StoryblokLayout.css.ts
+++ b/apps/store/src/app/[locale]/StoryblokLayout.css.ts
@@ -10,6 +10,9 @@ import {
 export const wrapper = style({
   minHeight: '100vh',
   isolation: 'isolate',
+  // We're using flex to support `order` rule on announcement block inside
+  display: 'flex',
+  flexDirection: 'column',
   selectors: {
     '&:has(main[data-dark-background=true])': {
       vars: {

--- a/apps/store/src/app/[locale]/StoryblokLayout.tsx
+++ b/apps/store/src/app/[locale]/StoryblokLayout.tsx
@@ -1,11 +1,8 @@
 'use client'
-import { StoryblokComponent } from '@storyblok/react'
 import { clsx } from 'clsx'
-import type { ReactNode } from 'react';
-import { Fragment } from 'react'
+import type { ReactNode } from 'react'
 import { FooterBlock } from '@/blocks/FooterBlock'
 import { HeaderBlock } from '@/blocks/HeaderBlock'
-import { ReusableBlockReference } from '@/blocks/ReusableBlockReference'
 import type { GlobalStory } from '@/services/storyblok/storyblok'
 import { filterByBlockType, isProductStory } from '@/services/storyblok/Storyblok.helpers'
 import { wrapper } from './StoryblokLayout.css'
@@ -24,20 +21,11 @@ export const StoryblokLayout = ({
   // Removed breadcrumbs from page router LayoutWithMenu, kept other flags in fixed state
   const story: any = null
 
-  // Announcements are added as reusable blocks for Page and ProductPage content types
-  const reusableBlock = filterByBlockType(
-    story?.content.announcement,
-    ReusableBlockReference.blockName,
-  )
   const headerBlock = filterByBlockType(globalStory.content.header, HeaderBlock.blockName)
   const footerBlock = filterByBlockType(globalStory.content.footer, FooterBlock.blockName)
 
   return (
     <div className={clsx(wrapper, className)}>
-      {/* TODO: Make announcement part of page rendering, same as breadcrumbs */}
-      {reusableBlock.map((referencedBlok) => (
-        <StoryblokComponent key={referencedBlok._uid} blok={referencedBlok} />
-      ))}
       {headerBlock.map((nestedBlock) => (
         // TODO: derive `static` from story DOM, similar to `data-hide-footer`, etc
         <HeaderBlock
@@ -48,9 +36,7 @@ export const StoryblokLayout = ({
       ))}
       {children}
       {footerBlock.map((nestedBlock) => (
-        <Fragment key={nestedBlock._uid}>
-          <FooterBlock key={nestedBlock._uid} blok={nestedBlock} />
-        </Fragment>
+        <FooterBlock key={nestedBlock._uid} blok={nestedBlock} />
       ))}
     </div>
   )

--- a/apps/store/src/blocks/AnnouncementBlock.tsx
+++ b/apps/store/src/blocks/AnnouncementBlock.tsx
@@ -8,18 +8,21 @@ import { Banner } from '@/components/Banner/Banner'
 import type { BannerVariant } from '@/components/Banner/Banner.types'
 import type { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
-export type AnnouncementBlockProps = SbBaseBlockProps<{
+export type AnnouncementBlockParams = {
   id: string
   content: ISbRichtext
   variant?: BannerVariant
-}>
+}
+export type AnnouncementBlockProps = SbBaseBlockProps<AnnouncementBlockParams> & {
+  className?: string
+}
 
-export const AnnouncementBlock = ({ blok }: AnnouncementBlockProps) => {
-  const { announcements, addAnnouncement, dimissAnnouncement } = useAnnouncements()
+export const AnnouncementBlock = ({ blok, className }: AnnouncementBlockProps) => {
+  const { announcements, addAnnouncement, dismissAnnouncement } = useAnnouncements()
 
   const handleClose = useCallback(() => {
-    dimissAnnouncement(blok.id)
-  }, [blok.id, dimissAnnouncement])
+    dismissAnnouncement(blok.id)
+  }, [blok.id, dismissAnnouncement])
 
   useEffect(() => {
     addAnnouncement({
@@ -34,6 +37,7 @@ export const AnnouncementBlock = ({ blok }: AnnouncementBlockProps) => {
 
   return (
     <Banner
+      className={className}
       variant={matchedAnnouncement.variant}
       handleClose={handleClose}
       {...storyblokEditable(blok)}
@@ -95,7 +99,7 @@ const useAnnouncements = () => {
     [setAnnouncements],
   )
 
-  const dimissAnnouncement = useCallback(
+  const dismissAnnouncement = useCallback(
     (announcementId: string) => {
       setDismissedAnnouncementIds((prev) => [...prev, announcementId])
     },
@@ -105,6 +109,6 @@ const useAnnouncements = () => {
   return {
     announcements,
     addAnnouncement,
-    dimissAnnouncement,
+    dismissAnnouncement,
   }
 }

--- a/apps/store/src/blocks/PageBlock.css.ts
+++ b/apps/store/src/blocks/PageBlock.css.ts
@@ -3,3 +3,7 @@ import { style } from '@vanilla-extract/css'
 export const main = style({
   width: '100%',
 })
+
+export const announcementBanner = style({
+  order: -1,
+})

--- a/apps/store/src/blocks/PageBlock.tsx
+++ b/apps/store/src/blocks/PageBlock.tsx
@@ -2,15 +2,22 @@ import type { SbBlokData } from '@storyblok/react/rsc';
 import { storyblokEditable, StoryblokComponent } from '@storyblok/react/rsc'
 import { DiscountBannerTrigger } from '@/components/DiscountBannerTrigger'
 import type { SbBaseBlockProps } from '@/services/storyblok/storyblok'
-import { main } from './PageBlock.css'
+import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
+import { announcementBanner, main } from './PageBlock.css'
 
 type PageBlockProps = SbBaseBlockProps<{
   body: Array<SbBlokData>
+  announcement?: Array<any>
 }>
 
 export const PageBlock = ({ blok }: PageBlockProps) => {
+  // Announcements are added as reusable blocks for Page and ProductPage content types
+  const announcementBlocks = filterByBlockType(blok.announcement, 'reusableBlockReference')
   return (
     <>
+      {announcementBlocks.map((blok) => (
+        <StoryblokComponent key={blok._uid} blok={blok} className={announcementBanner} />
+      ))}
       <main
         className={main}
         {...storyblokEditable(blok)}

--- a/apps/store/src/blocks/ReusableBlockReference.tsx
+++ b/apps/store/src/blocks/ReusableBlockReference.tsx
@@ -5,13 +5,15 @@ import type { ReusableStory, SbBaseBlockProps } from '@/services/storyblok/story
 
 export type ReusableBlockReferenceProps = SbBaseBlockProps<{
   reference: Omit<ReusableStory, 'content'> & Partial<Pick<ReusableStory, 'content'>>
-}>
+}> & {
+  className?: string
+}
 
-export const ReusableBlockReference = ({ blok }: ReusableBlockReferenceProps) => {
+export const ReusableBlockReference = ({ blok, className }: ReusableBlockReferenceProps) => {
   return (
     <>
       {blok.reference.content?.body.map((nestedBlock) => (
-        <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+        <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} className={className} />
       ))}
     </>
   )

--- a/apps/store/src/components/Banner/Banner.css.ts
+++ b/apps/store/src/components/Banner/Banner.css.ts
@@ -1,0 +1,69 @@
+import { style, styleVariants } from '@vanilla-extract/css'
+import { colors, minWidth, theme } from 'ui/src/theme'
+
+const GridArea = {
+  Content: 'content',
+  CloseBtn: 'close-btn',
+}
+
+export const bannerRoot = styleVariants({
+  base: {
+    minHeight: '3rem',
+    display: 'grid',
+    // Using grid here to perfect center align banner's content, excluding close button
+    gridTemplateAreas: `
+    ". ${GridArea.Content} ${GridArea.CloseBtn}"
+  `,
+    gridTemplateColumns: '1fr auto 1fr',
+    alignItems: 'center',
+    paddingBlock: theme.space.sm,
+    paddingInline: theme.space.md,
+    fontSize: theme.fontSizes.xs,
+
+    borderBottom: `0.5px solid ${theme.colors.borderTranslucent1}`,
+
+    '@media': {
+      [minWidth.lg]: {
+        paddingInline: theme.space.xl,
+      },
+    },
+  },
+  info: {
+    color: theme.colors.blue800,
+    backgroundColor: theme.colors.blueFill1,
+  },
+  campaign: {
+    color: theme.colors.textGreen,
+    backgroundColor: theme.colors.signalGreenFill,
+  },
+  warning: {
+    color: theme.colors.textAmber,
+    backgroundColor: theme.colors.signalAmberFill,
+  },
+  error: {
+    color: theme.colors.textRed,
+    backgroundColor: theme.colors.signalRedFill,
+  },
+})
+
+export const bannerIcon = style({
+  alignSelf: 'start',
+  // Optical alignment
+  marginTop: 1,
+})
+
+export const bannerContent = style({
+  gridArea: GridArea.Content,
+  display: 'grid',
+  gridTemplateColumns: 'auto 1fr',
+  alignItems: 'center',
+  gap: theme.space.xs,
+})
+
+export const bannerCloseButton = style({
+  gridArea: GridArea.CloseBtn,
+  justifySelf: 'end',
+  color: colors.textPrimary,
+  paddingLeft: theme.space.xs,
+  cursor: 'pointer',
+})

--- a/apps/store/src/components/Banner/Banner.tsx
+++ b/apps/store/src/components/Banner/Banner.tsx
@@ -12,13 +12,14 @@ import type { BannerVariant } from './Banner.types'
 
 type Props = {
   children: ReactNode
+  className?: string
   handleClose: () => void
   variant?: BannerVariant
 }
 
-export const Banner = ({ children, handleClose, variant = 'info' }: Props) => {
+export const Banner = ({ children, handleClose, variant = 'info', className }: Props) => {
   return (
-    <div className={clsx(bannerRoot.base, bannerRoot[variant])}>
+    <div className={clsx(bannerRoot.base, bannerRoot[variant], className)}>
       <div className={bannerContent}>
         <Icon variant={variant} className={bannerIcon} />
         {children}

--- a/apps/store/src/components/Banner/Banner.tsx
+++ b/apps/store/src/components/Banner/Banner.tsx
@@ -1,13 +1,14 @@
-import styled from '@emotion/styled'
-import type { ComponentPropsWithoutRef} from 'react';
+import { clsx } from 'clsx'
+import type { ComponentPropsWithoutRef } from 'react'
 import { type ReactNode } from 'react'
-import { InfoIcon, CampaignIcon, WarningTriangleIcon, CrossIconSmall, mq, theme } from 'ui'
+import { InfoIcon, CampaignIcon, WarningTriangleIcon, CrossIconSmall, theme } from 'ui'
+import {
+  bannerCloseButton,
+  bannerContent,
+  bannerIcon,
+  bannerRoot,
+} from '@/components/Banner/Banner.css'
 import type { BannerVariant } from './Banner.types'
-
-const Area = {
-  Content: 'content',
-  CloseBtn: 'close-btn',
-}
 
 type Props = {
   children: ReactNode
@@ -17,15 +18,15 @@ type Props = {
 
 export const Banner = ({ children, handleClose, variant = 'info' }: Props) => {
   return (
-    <Wrapper variant={variant}>
-      <Content>
-        <StyledIcon variant={variant} />
+    <div className={clsx(bannerRoot.base, bannerRoot[variant])}>
+      <div className={bannerContent}>
+        <Icon variant={variant} className={bannerIcon} />
         {children}
-      </Content>
-      <CloseButton onClick={handleClose}>
+      </div>
+      <button className={bannerCloseButton} onClick={handleClose}>
         <CrossIconSmall size="1rem" />
-      </CloseButton>
-    </Wrapper>
+      </button>
+    </div>
   )
 }
 
@@ -53,74 +54,4 @@ const Icon = ({ variant, ...others }: IconProps) => {
   }
 
   return icon
-}
-
-const StyledIcon = styled(Icon)({
-  alignSelf: 'start',
-  // Optical alignment
-  marginTop: 1,
-})
-
-const Wrapper = styled.div<{ variant: BannerVariant }>(({ variant }) => ({
-  minHeight: '3rem',
-  display: 'grid',
-  // Using grid here to perfect center align banner's content, excluding close button
-  gridTemplateAreas: `
-    ". ${Area.Content} ${Area.CloseBtn}"
-  `,
-  gridTemplateColumns: '1fr auto 1fr',
-  alignItems: 'center',
-  paddingBlock: theme.space.sm,
-  paddingInline: theme.space.md,
-  fontSize: theme.fontSizes.xs,
-
-  borderBottom: `0.5px solid ${theme.colors.borderTranslucent1}`,
-  ...getVariantStyles(variant),
-
-  [mq.lg]: {
-    paddingInline: theme.space.xl,
-  },
-}))
-
-const Content = styled.div({
-  gridArea: Area.Content,
-  display: 'grid',
-  gridTemplateColumns: 'auto 1fr',
-  alignItems: 'center',
-  gap: theme.space.xs,
-})
-
-const CloseButton = styled.button({
-  gridArea: Area.CloseBtn,
-  justifySelf: 'end',
-  color: theme.colors.textPrimary,
-  paddingLeft: theme.space.xs,
-  cursor: 'pointer',
-})
-
-const getVariantStyles = (variant: BannerVariant) => {
-  switch (variant) {
-    case 'info':
-      return {
-        color: theme.colors.blue800,
-        backgroundColor: theme.colors.blueFill1,
-      }
-    case 'campaign':
-      return {
-        color: theme.colors.textGreen,
-        backgroundColor: theme.colors.signalGreenFill,
-      }
-    case 'warning':
-      return {
-        color: theme.colors.textAmber,
-        backgroundColor: theme.colors.signalAmberFill,
-      }
-    case 'error':
-      return {
-        color: theme.colors.textRed,
-        backgroundColor: theme.colors.signalRedFill,
-      }
-    default:
-      return {}
-  }
 }

--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.css.ts
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.css.ts
@@ -10,6 +10,9 @@ import {
 export const wrapper = style({
   minHeight: '100vh',
   isolation: 'isolate',
+  // We're using flex to support `order` rule on announcement block inside
+  display: 'flex',
+  flexDirection: 'column',
   selectors: {
     '&:has(main[data-dark-background=true])': {
       vars: {

--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -1,13 +1,11 @@
-import { StoryblokComponent } from '@storyblok/react'
 import { clsx } from 'clsx'
-import { Fragment, type ReactElement } from 'react'
+import { type ReactElement } from 'react'
 import { FooterBlock } from '@/blocks/FooterBlock'
 import { HeaderBlock } from '@/blocks/HeaderBlock'
-import { ReusableBlockReference } from '@/blocks/ReusableBlockReference'
 import { wrapper } from '@/components/LayoutWithMenu/LayoutWithMenu.css'
 import type { GlobalStory, PageStory } from '@/services/storyblok/storyblok'
 import { filterByBlockType, isProductStory } from '@/services/storyblok/Storyblok.helpers'
-import type { GlobalProductMetadata } from './fetchProductMetadata';
+import type { GlobalProductMetadata } from './fetchProductMetadata'
 import { GLOBAL_PRODUCT_METADATA_PROP_NAME } from './fetchProductMetadata'
 import { useHydrateProductMetadata } from './productMetadataHooks'
 
@@ -30,20 +28,12 @@ export const LayoutWithMenu = (props: LayoutWithMenuProps) => {
   // Happens for transitions from pages with layout to pages without layout
   if (!globalStory) return null
 
-  // Announcements are added as reusable blocks for Page and ProductPage content types
-  const announcementBlocks = filterByBlockType(
-    story?.content.announcement,
-    ReusableBlockReference.blockName,
-  )
   const headerBlock = filterByBlockType(globalStory.content.header, HeaderBlock.blockName)
   const footerBlock = filterByBlockType(globalStory.content.footer, FooterBlock.blockName)
 
   return (
     <>
       <div className={clsx(wrapper, className)}>
-        {announcementBlocks.map((referencedBlok) => (
-          <StoryblokComponent key={referencedBlok._uid} blok={referencedBlok} />
-        ))}
         {!props.hideMenu &&
           headerBlock.map((nestedBlock) => (
             <HeaderBlock


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Move announcement banner block inside page content

Align it visually above header with `order: -1` CSS rule

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Support for persistent layout in app router -> layout cannot know about page details, therefore announcement is moved out of it

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
