### PR TITLE
Make sticky header DOM-driven instead of prop-driven

### DIFF
--- a/apps/store/src/app/[locale]/StoryblokLayout.tsx
+++ b/apps/store/src/app/[locale]/StoryblokLayout.tsx
@@ -5,7 +5,7 @@ import { Fragment } from 'react'
 import { FooterBlock } from '@/blocks/FooterBlock'
 import { HeaderBlock } from '@/blocks/HeaderBlock'
 import type { GlobalStory } from '@/services/storyblok/storyblok'
-import { filterByBlockType, isProductStory } from '@/services/storyblok/Storyblok.helpers'
+import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 import { wrapper } from './StoryblokLayout.css'
 
 // TODO: Render layout and page server-side
@@ -18,22 +18,13 @@ export const StoryblokLayout = ({
   globalStory: GlobalStory
   className?: string
 }) => {
-  // TODO: How should we pass story data here ?  For now, let's pretend it's non-story page
-  // Removed breadcrumbs from page router LayoutWithMenu, kept other flags in fixed state
-  const story: any = null
-
   const headerBlock = filterByBlockType(globalStory.content.header, HeaderBlock.blockName)
   const footerBlock = filterByBlockType(globalStory.content.footer, FooterBlock.blockName)
 
   return (
     <div className={clsx(wrapper, className)}>
       {headerBlock.map((nestedBlock) => (
-        // TODO: derive `static` from story DOM, similar to `data-hide-footer`, etc
-        <HeaderBlock
-          key={nestedBlock._uid}
-          blok={nestedBlock}
-          static={story && isProductStory(story)}
-        />
+        <HeaderBlock key={nestedBlock._uid} blok={nestedBlock} />
       ))}
       {children}
       {footerBlock.map((nestedBlock) => (

--- a/apps/store/src/blocks/PageBlock.tsx
+++ b/apps/store/src/blocks/PageBlock.tsx
@@ -16,6 +16,7 @@ export const PageBlock = ({ blok }: PageBlockProps) => {
         data-dark-background={!!blok.darkBackground}
         data-overlay-menu={!!blok.overlayMenu}
         data-hide-chat={!!blok.hideChat}
+        data-supports-sticky-header={true}
       >
         {blok.body.map((nestedBlock) => (
           <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />

--- a/apps/store/src/components/Header/Header.tsx
+++ b/apps/store/src/components/Header/Header.tsx
@@ -1,10 +1,10 @@
 'use client'
-
-import type { Transition } from 'framer-motion';
+import type { Transition } from 'framer-motion'
 import { motion } from 'framer-motion'
 import type { ReactNode } from 'react'
 import { bodyBgColor, headerBgTransparentColor } from 'ui/src/theme/vars.css'
 import { LogoHomeLink } from '@/components/LogoHomeLink'
+import { isBrowser } from '@/utils/env'
 import { useScrollState } from '@/utils/useScrollState'
 import { MENU_BAR_HEIGHT_PX } from './Header.constants'
 import { contentWrapper, ghostWrapper, logoWrapper, wrapper } from './Header.css'
@@ -34,21 +34,33 @@ type AnimationVariant = keyof typeof ANIMATION_VARIANTS | undefined
 type HeaderProps = {
   children: ReactNode
   opaque?: boolean
-  static?: boolean
 }
 
 export const Header = (props: HeaderProps) => {
-  const { children, opaque = false, static: staticPosition = false } = props
+  const { children, opaque = false } = props
   const scrollState = useScrollState({ threshold: MENU_BAR_HEIGHT_PX * 2 })
 
   const initialStyles = {
     backgroundColor: opaque ? bodyBgColor : headerBgTransparentColor,
   }
 
-  let animate: AnimationVariant = scrollState === 'SCROLL_UP' ? 'SLIDE_IN' : undefined
-  animate = scrollState === 'BELOW' ? 'HIDE' : animate
-  animate = scrollState === 'SCROLL_DOWN' ? 'SLIDE_OUT' : animate
-  animate = staticPosition ? undefined : animate
+  let animate: AnimationVariant = undefined
+  if (
+    isBrowser() &&
+    window.document.querySelector('main[data-supports-sticky-header=true]') != null
+  ) {
+    switch (scrollState) {
+      case 'SCROLL_UP':
+        animate = 'SLIDE_IN'
+        break
+      case 'SCROLL_DOWN':
+        animate = 'SLIDE_OUT'
+        break
+      case 'BELOW':
+        animate = 'HIDE'
+        break
+    }
+  }
 
   return (
     <div style={initialStyles} className={ghostWrapper}>

--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.tsx
@@ -3,8 +3,8 @@ import { Fragment, type ReactElement } from 'react'
 import { FooterBlock } from '@/blocks/FooterBlock'
 import { HeaderBlock } from '@/blocks/HeaderBlock'
 import { wrapper } from '@/components/LayoutWithMenu/LayoutWithMenu.css'
-import type { GlobalStory, PageStory } from '@/services/storyblok/storyblok'
-import { filterByBlockType, isProductStory } from '@/services/storyblok/Storyblok.helpers'
+import type { GlobalStory } from '@/services/storyblok/storyblok'
+import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
 import type { GlobalProductMetadata } from './fetchProductMetadata'
 import { GLOBAL_PRODUCT_METADATA_PROP_NAME } from './fetchProductMetadata'
 import { useHydrateProductMetadata } from './productMetadataHooks'
@@ -13,7 +13,6 @@ type LayoutWithMenuProps = {
   children: ReactElement<{
     className: string
     [GLOBAL_PRODUCT_METADATA_PROP_NAME]: GlobalProductMetadata
-    story: PageStory | undefined
     globalStory: GlobalStory | undefined
   }>
   hideFooter?: boolean
@@ -21,7 +20,7 @@ type LayoutWithMenuProps = {
 }
 
 export const LayoutWithMenu = (props: LayoutWithMenuProps) => {
-  const { story, globalStory, className } = props.children.props
+  const { globalStory, className } = props.children.props
 
   useHydrateProductMetadata(props.children.props[GLOBAL_PRODUCT_METADATA_PROP_NAME])
 
@@ -36,11 +35,7 @@ export const LayoutWithMenu = (props: LayoutWithMenuProps) => {
       <div className={clsx(wrapper, className)}>
         {!props.hideMenu &&
           headerBlock.map((nestedBlock) => (
-            <HeaderBlock
-              key={nestedBlock._uid}
-              blok={nestedBlock}
-              static={story && isProductStory(story)}
-            />
+            <HeaderBlock key={nestedBlock._uid} blok={nestedBlock} />
           ))}
         {props.children}
         {!props.hideFooter &&


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Make sticky header logic DOM-driven

Regular CMS pages now opt-in to sticky header with `data-supports-sticky-header=true` on `main` element. 
It felt safer to make it opt-in rather than opt-out

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

That was the last place where layout depended on page data

We don't want to use sticky header on product pages since we have multiple other sticky elements there.  All other pages normally have it

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
