### PR TITLE
fix: Use `button` props for `Button` by default

### DIFF
--- a/apps/store/src/components/ConfirmationPage/StaticContent.tsx
+++ b/apps/store/src/components/ConfirmationPage/StaticContent.tsx
@@ -94,6 +94,7 @@ const AppStoreButtons = () => {
   return (
     <ButtonWrapper>
       <Button
+        as="a"
         href={getAppStoreLink('apple', locale).toString()}
         target="_blank"
         rel="noopener noreferrer"
@@ -106,6 +107,7 @@ const AppStoreButtons = () => {
         </SpaceFlex>
       </Button>
       <Button
+        as="a"
         href={getAppStoreLink('google', locale).toString()}
         target="_blank"
         rel="noopener noreferrer"

--- a/apps/store/src/components/ContactUs/ContactUs.tsx
+++ b/apps/store/src/components/ContactUs/ContactUs.tsx
@@ -82,6 +82,7 @@ export const ContactUs = () => {
 
               <AppButtons>
                 <Button
+                  as="a"
                   data-dd-action-name="Contact us | IOS App"
                   href={getAppStoreLink('apple', locale).toString()}
                   target="_blank"
@@ -94,6 +95,7 @@ export const ContactUs = () => {
                 </Button>
 
                 <Button
+                  as="a"
                   data-dd-action-name="Contact us | Android App"
                   href={getAppStoreLink('google', locale).toString()}
                   target="_blank"

--- a/apps/store/src/components/DebugDialog/DebugShopSessionSection.tsx
+++ b/apps/store/src/components/DebugDialog/DebugShopSessionSection.tsx
@@ -15,7 +15,7 @@ export const DebugShopSessionSection = () => {
     <Space y={0.25}>
       <CopyToClipboard label="Shop Session">{shopSession.id}</CopyToClipboard>
 
-      <Button variant="secondary" href={PageLink.apiSessionReset({ next: pathname }).href}>
+      <Button as="a" variant="secondary" href={PageLink.apiSessionReset({ next: pathname }).href}>
         Reset Shop Session
       </Button>
 

--- a/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
+++ b/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
@@ -66,6 +66,7 @@ export const TopMenuMobile = (props: TopMenuMobileProps) => {
                 <div>{children}</div>
                 <ButtonWrapper>
                   <Button
+                    as="a"
                     href={getAppStoreLink('apple', locale).toString()}
                     target="_blank"
                     rel="noopener noreferrer"
@@ -78,6 +79,7 @@ export const TopMenuMobile = (props: TopMenuMobileProps) => {
                     </SpaceFlex>
                   </Button>
                   <Button
+                    as="a"
                     href={getAppStoreLink('google', locale).toString()}
                     target="_blank"
                     rel="noopener noreferrer"

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx'
 import { forwardRef, type ReactNode } from 'react'
 import type { PolymorphicComponentPropsWithRef, PolymorphicRef } from '../TypeUtils'
 import { buttonVariant, centered, childrenWrapper, fullWidthStyles } from './Button.css'
-import type { ButtonSize} from './Button.helpers';
+import type { ButtonSize } from './Button.helpers'
 import { getButtonSizeStyles } from './Button.helpers'
 import { DotPulse } from './DotPulse'
 
@@ -18,7 +18,9 @@ type BaseProps = {
 
 export type Props<C extends React.ElementType> = PolymorphicComponentPropsWithRef<C, BaseProps>
 
-type PolymorphicComponent = <C extends React.ElementType>(props: Props<C>) => ReactNode | null
+type PolymorphicComponent = <C extends React.ElementType = 'button'>(
+  props: Props<C>,
+) => ReactNode | null
 
 export const Button: PolymorphicComponent = forwardRef(function Button<
   C extends React.ElementType = 'button',


### PR DESCRIPTION
<!--
PR title: Feature / Use `button` props for `Button` by default
-->

## Describe your changes
- Set the default element type for the `Button` component to `button`
- Update anchor buttons to use the `a` element.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Fix broken anchor buttons and provide better TS support.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
