### PR TITLE
Move bold style from GlobalBanner (emotion) to Banner (vanilla)

### DIFF
--- a/apps/store/src/components/Banner/Banner.css.ts
+++ b/apps/store/src/components/Banner/Banner.css.ts
@@ -1,4 +1,4 @@
-import { style, styleVariants } from '@vanilla-extract/css'
+import { globalStyle, style, styleVariants } from '@vanilla-extract/css'
 import { colors, minWidth, theme } from 'ui/src/theme'
 
 const GridArea = {
@@ -58,6 +58,10 @@ export const bannerContent = style({
   gridTemplateColumns: 'auto 1fr',
   alignItems: 'center',
   gap: theme.space.xs,
+})
+
+globalStyle(`${bannerContent} b`, {
+  color: theme.colors.textPrimary,
 })
 
 export const bannerCloseButton = style({

--- a/apps/store/src/components/Banner/Banner.stories.tsx
+++ b/apps/store/src/components/Banner/Banner.stories.tsx
@@ -57,8 +57,10 @@ export const Error: Story = {
 export const LongText: Story = {
   render: () => (
     <Banner onClose={noopHandleClose}>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eget nunc cursus, laoreet leo
-      ut, mollis odio. Nunc egestas, nisi ac lobortis bibendum, libero
+      <span>
+        Lorem ipsum <b>dolor sit amet</b>, consectetur adipiscing elit. Mauris eget nunc cursus,
+        laoreet leo ut, mollis odio. Nunc egestas, nisi ac lobortis bibendum, libero
+      </span>
     </Banner>
   ),
 }

--- a/apps/store/src/components/GlobalBanner/GlobalBanner.tsx
+++ b/apps/store/src/components/GlobalBanner/GlobalBanner.tsx
@@ -1,7 +1,5 @@
 'use client'
-import styled from '@emotion/styled'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { theme } from 'ui'
 import { Banner } from '@/components/Banner/Banner'
 import {
   dismissedBannerIdAtom,
@@ -20,18 +18,8 @@ const GlobalBanner = () => {
 
   return (
     <Banner variant={globalBanner.variant} onClose={() => setDismissedBannerId(globalBanner.id)}>
-      <Content dangerouslySetInnerHTML={{ __html: globalBanner.content }} />
+      <span dangerouslySetInnerHTML={{ __html: globalBanner.content }} />
     </Banner>
   )
 }
-
-// TODO: Move to default banner styles
-const Content = styled.span({
-  // GlobalBanner receives a HTML formatted string.
-  // This is meant to style important text wrapped into <b> tags
-  '& > b': {
-    color: theme.colors.textPrimary,
-  },
-})
-
 export default GlobalBanner


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Move styles for bold text from `Globalbanner` to generic `Banner`

It's useful presentation logic, no reason for it to live in component that's primarily responsible for state management

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
