### PR TITLE
GEN-2011 - feat(ProductReviewsBlock): enable review comments to be hidden via storyblok config 

### DIFF
--- a/apps/store/src/blocks/ProductReviewsBlock.tsx
+++ b/apps/store/src/blocks/ProductReviewsBlock.tsx
@@ -1,7 +1,13 @@
 'use client'
 
-import { ProductReviews } from '@/components/ProductReviews/ProductReviews'
+import {
+  ProductReviews,
+  type ProductReviewsProps,
+} from '@/components/ProductReviews/ProductReviews'
+import { type SbBaseBlockProps } from '@/services/storyblok/storyblok'
 
-export const ProductReviewsBlock = () => {
-  return <ProductReviews />
+type Props = SbBaseBlockProps<ProductReviewsProps>
+
+export const ProductReviewsBlock = (props: Props) => {
+  return <ProductReviews showReviewComments={props.blok.showReviewComments} />
 }

--- a/apps/store/src/components/ProductReviews/ProductReviews.tsx
+++ b/apps/store/src/components/ProductReviews/ProductReviews.tsx
@@ -15,7 +15,9 @@ import { ReviewsDialog } from './ReviewsDialog'
 import { ReviewsDiclaimer } from './ReviewsDisclaimer'
 import { ReviewsDistributionByScore } from './ReviewsDistributionByScore'
 
-export const ProductReviews = () => {
+export type ProductReviewsProps = { showReviewComments?: boolean }
+
+export const ProductReviews = ({ showReviewComments = true }: ProductReviewsProps) => {
   const { t } = useTranslation('reviews')
 
   const { name: productId, displayNameFull: productName, pillowImage } = useProductData()
@@ -46,22 +48,24 @@ export const ProductReviews = () => {
           ))}
         </div>
 
-        <ReviewsDialog
-          productIds={[productId]}
-          Header={
-            <PillowHeader
-              title={productName}
-              score={averageRating.score}
-              reviewsCount={averageRating.totalOfReviews}
-              pillow={pillowImage}
-            />
-          }
-          reviewsDistribution={reviewsDistribution}
-        >
-          <Button variant="primary-alt" size="medium">
-            {t('VIEW_REVIEWS_LABEL')}
-          </Button>
-        </ReviewsDialog>
+        {showReviewComments && (
+          <ReviewsDialog
+            productIds={[productId]}
+            Header={
+              <PillowHeader
+                title={productName}
+                score={averageRating.score}
+                reviewsCount={averageRating.totalOfReviews}
+                pillow={pillowImage}
+              />
+            }
+            reviewsDistribution={reviewsDistribution}
+          >
+            <Button variant="primary-alt" size="medium">
+              {t('VIEW_REVIEWS_LABEL')}
+            </Button>
+          </ReviewsDialog>
+        )}
       </Space>
     </div>
   )


### PR DESCRIPTION
## Describe your changes

* `ProductReviewsBlock`: Enable review comments to be hidden based on storyblok setting.

https://github.com/HedvigInsurance/racoon/assets/19200662/9e4b820a-b7a1-40b1-8c63-ee630d66acc1

## Justify why they are needed

Requested by Peter [here](https://www.notion.so/hedviginsurance/Hide-comments-in-product-reviews-0aa9a5ae162e4f07965461e0b193ebf9?pvs=4)