### PR TITLE
Add signed event to widget

### DIFF
--- a/apps/store/src/features/widget/SignPage.tsx
+++ b/apps/store/src/features/widget/SignPage.tsx
@@ -36,6 +36,7 @@ import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { Header } from './Header'
 import { ProductItemContainer } from './ProductItemContainer'
+import { publishWidgetEvent } from './publishWidgetEvent'
 
 type Props = {
   shopSession: ShopSession
@@ -67,6 +68,7 @@ export const SignPage = (props: Props) => {
     customerAuthenticationStatus: props.customerAuthenticationStatus,
     async onSuccess() {
       datadogLogs.logger.info('Widget Sign | Sign Success', { shopSessionId: props.shopSession.id })
+      publishWidgetEvent.signed()
 
       const { data } = await fetchCurrentMember()
       if (!data) throw new Error('Widget Sign | Missing current member')

--- a/apps/store/src/features/widget/publishWidgetEvent.ts
+++ b/apps/store/src/features/widget/publishWidgetEvent.ts
@@ -1,11 +1,23 @@
 enum Status {
   Success = 'success',
+  Signed = 'signed',
   Close = 'close',
   Event = 'event',
 }
 
+/**
+ * WidgetEvent
+ * Event sent from the widget to the parent window for partner integrations to listen to.
+ *
+ * - `signed` - The user has successfully signed the insurance
+ * - `success` - The user has successfully signed the insurance and connected payment
+ * - `close` - The user pressed one of our close buttons.
+ * - `event` - An unspecified event is sent to the partner including a second parameter “message” that includes the request ID
+ */
+
 export type WidgetEvent =
   | { status: Status.Success }
+  | { status: Status.Signed }
   | { status: Status.Close }
   | { status: Status.Event; message: { requestId: string } }
 
@@ -22,6 +34,7 @@ const sendWidgetEvent = (event: WidgetEvent): void => {
 
 export const publishWidgetEvent = {
   success: () => sendWidgetEvent({ status: Status.Success }),
+  signed: () => sendWidgetEvent({ status: Status.Signed }),
   close: () => sendWidgetEvent({ status: Status.Close }),
   event: (message: { requestId: string }) => sendWidgetEvent({ status: Status.Event, message }),
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
In the widget we currently have these events:

1. `success` - The user has successfully signed the insurance and connected payment.
2. `close` - The user pressed one of our close buttons. The partner should close e.g. the WebView upon receiving this event.
3. `event` - An unspecified event is sent to the partner including a second parameter “message” that includes the request ID (see below).

However, a few partners has asked about a signed event or was confused when the `success` event was sent, thinking it was sent at sign. 
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Improve widget events

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
