### PR TITLE
Add widget loaded event

### DIFF
--- a/apps/store/src/features/widget/publishWidgetEvent.ts
+++ b/apps/store/src/features/widget/publishWidgetEvent.ts
@@ -1,4 +1,5 @@
 enum Status {
+  WidgetLoaded = 'widgetLoaded',
   Success = 'success',
   Signed = 'signed',
   Close = 'close',
@@ -9,6 +10,7 @@ enum Status {
  * WidgetEvent
  * Event sent from the widget to the parent window for partner integrations to listen to.
  *
+ * - `widgetLoaded` - Sent oncne the widget has first been render on widget landing page or first step of the flow page
  * - `signed` - The user has successfully signed the insurance
  * - `success` - The user has successfully signed the insurance and connected payment
  * - `close` - The user pressed one of our close buttons.
@@ -16,6 +18,7 @@ enum Status {
  */
 
 export type WidgetEvent =
+  | { status: Status.WidgetLoaded }
   | { status: Status.Success }
   | { status: Status.Signed }
   | { status: Status.Close }
@@ -33,6 +36,7 @@ const sendWidgetEvent = (event: WidgetEvent): void => {
 }
 
 export const publishWidgetEvent = {
+  widgetLoaded: () => sendWidgetEvent({ status: Status.WidgetLoaded }),
   success: () => sendWidgetEvent({ status: Status.Success }),
   signed: () => sendWidgetEvent({ status: Status.Signed }),
   close: () => sendWidgetEvent({ status: Status.Close }),

--- a/apps/store/src/features/widget/usePublishWidgetInitEvent.ts
+++ b/apps/store/src/features/widget/usePublishWidgetInitEvent.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { publishWidgetEvent } from './publishWidgetEvent'
 import { EXTERNAL_REQUEST_ID_QUERY_PARAM } from './widget.constants'
 
@@ -7,8 +7,16 @@ export const usePublishWidgetInitEvent = () => {
   const router = useRouter()
 
   const requestId = router.query[EXTERNAL_REQUEST_ID_QUERY_PARAM]
+  const widgetLoadedSent = useRef(false)
+
   useEffect(() => {
     if (!router.isReady) return
+
+    if (router.pathname.includes('widget') && !widgetLoadedSent.current) {
+      publishWidgetEvent.widgetLoaded()
+      widgetLoadedSent.current = true
+    }
+
     if (typeof requestId !== 'string') return
 
     publishWidgetEvent.event({ requestId })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Send an event when the widget has loaded.
Currently it will send it 2 times if the partner loads the initial widget page and then proceeds to the flow page. But it doesn't hurt I suppose. Or do you think we should make sure to only send it once? I'm thinking using an atom to check if it's been sent on a previous screen.

<img width="925" alt="Screenshot 2024-04-18 at 10 52 05" src="https://github.com/HedvigInsurance/racoon/assets/6661511/bbc4b37b-63d0-4782-b580-8374516de175">


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Request from partners to have an init event
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
