### PR TITLE
GEN-1893 - styles(QuickAddEditableView): ensure form fields get white background

### DIFF
--- a/apps/store/src/components/QuickAdd/QuickAddEditableView.css.ts
+++ b/apps/store/src/components/QuickAdd/QuickAddEditableView.css.ts
@@ -32,12 +32,10 @@ export const alignedBadge = style({
   fontSize: theme.fontSizes.xs,
 })
 
-export const stepperInput = style({
-  backgroundColor: theme.colors.offWhite,
-})
-
-export const startDateInput = style({
-  backgroundColor: theme.colors.offWhite,
+// TODO: remove !important when we don't have issues with vanilla extract duplicated
+// styles anymore
+export const formField = style({
+  backgroundColor: `${theme.colors.offWhite} !important`,
 })
 
 export const priceWrapper = style({

--- a/apps/store/src/components/QuickAdd/QuickAddEditableView.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddEditableView.tsx
@@ -15,8 +15,7 @@ import {
   alignedBadge,
   card,
   link,
-  stepperInput,
-  startDateInput,
+  formField,
   priceWrapper,
   actionsWrapper,
 } from './QuickAddEditableView.css'
@@ -75,7 +74,7 @@ export function QuickAddEditableView(props: Props) {
           <form id={formId} onSubmit={handleSubmit}>
             <Space y={0.25}>
               <StepperInput
-                className={stepperInput}
+                className={formField}
                 label={t('NUMBER_COINSURED_INPUT_LABEL')}
                 min={0}
                 max={5}
@@ -84,7 +83,7 @@ export function QuickAddEditableView(props: Props) {
                 onChange={handleChangeNumberCoInsured}
               />
               <InputDay
-                className={startDateInput}
+                className={formField}
                 label={t('START_DATE_LABEL')}
                 fromDate={new Date()}
                 selected={state[Fields.START_DATE]}


### PR DESCRIPTION
## Describe your changes

* Make sure Accident Cross Sell form fields get white background color

## Justify why they are needed

In summary, it seems the issue is that `@vanilla-extract/next-plugin` is being shipped to the client as part of JS bundle. That package is a dependency of `@vanilla-extract/next-plugin`, which we use to integrate Nextjs with vanilla extract css.

![Screenshot 2024-04-19 at 14 22 51](https://github.com/HedvigInsurance/racoon/assets/19200662/db7195a4-4b3d-4d83-b154-bc53b8b4d585)

As a result styles are being applied twice. Once by classes defined inside CSS file and then for classes that came from a virtual css file:

![Screenshot 2024-04-19 at 14 24 02](https://github.com/HedvigInsurance/racoon/assets/19200662/79689682-3ff9-4ac5-a44f-b1a1a87f7d96)


![Screenshot 2024-04-19 at 14 49 34](https://github.com/HedvigInsurance/racoon/assets/19200662/51b75aa4-00cf-4b28-b600-2848d5fbfabd)

It's a hack to avoid an issue we're currently having with vanilla extract css.
More info [here](https://hedviginsurance.slack.com/archives/C041SD67G82/p1713531586956579)