### PR TITLE
Replace all remaining usages of next/router in CMS blocks. Car dealership blocks untouched since we don't use them in app router yet

### DIFF
--- a/apps/store/src/blocks/InsurelyBlock.tsx
+++ b/apps/store/src/blocks/InsurelyBlock.tsx
@@ -2,7 +2,7 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
-import { useRouter } from 'next/router'
+import { useSearchParams } from 'next/navigation'
 import { useEffect } from 'react'
 import { theme } from 'ui'
 import * as GridLayout from '@/components/GridLayout/GridLayout'
@@ -30,11 +30,10 @@ export const InsurelyBlock = (props: Props) => {
     align: props.blok.layout?.alignment,
   }
 
-  const router = useRouter()
+  const searchParams = useSearchParams()
+  const sessionId = searchParams?.get('sessionId')
   useEffect(() => {
-    if (!router.isReady) return
-
-    const sessionId = router.query.sessionId
+    if (!sessionId) return
     datadogLogs.setGlobalContextProperty('insurelySalesSupportToolSessionId', sessionId)
     setInsurelyConfig({
       showCloseButton: false,
@@ -42,7 +41,7 @@ export const InsurelyBlock = (props: Props) => {
       salesSupportToolSessionId: typeof sessionId === 'string' ? sessionId : undefined,
       multiCompanySelect: true,
     })
-  }, [router.isReady, router.query.sessionId])
+  }, [sessionId])
 
   return (
     <GridLayout.Root {...storyblokEditable}>

--- a/apps/store/src/blocks/QuickPurchaseBlock.tsx
+++ b/apps/store/src/blocks/QuickPurchaseBlock.tsx
@@ -2,15 +2,13 @@
 import { useApolloClient } from '@apollo/client'
 import { datadogLogs } from '@datadog/browser-logs'
 import styled from '@emotion/styled'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 import { useTranslation } from 'next-i18next'
 import { type FormEventHandler, useMemo, useState } from 'react'
 import { theme } from 'ui'
 import { useProductMetadata } from '@/components/LayoutWithMenu/productMetadataHooks'
 import { OPEN_PRICE_CALCULATOR_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam'
-import type {
-  FormError,
-  ProductOption} from '@/components/QuickPurchaseForm/QuickPurchaseForm';
+import type { FormError, ProductOption } from '@/components/QuickPurchaseForm/QuickPurchaseForm'
 import {
   PRODUCT_FIELDNAME,
   QuickPurchaseForm,

--- a/apps/store/src/features/blog/BlogArticleListBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleListBlock.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import styled from '@emotion/styled'
-import { useRouter } from 'next/router'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { useTranslation } from 'next-i18next'
 import { useMemo } from 'react'
 import { Space, theme } from 'ui'
@@ -14,7 +14,7 @@ import { ArticleTeaser } from './ArticleTeaser/ArticleTeaser'
 import { BLOG_ARTICLE_LIST_BLOCK } from './blog.constants'
 import { useBlogArticleTeasers } from './useBlog'
 
-const QUERY_PARAM = 'showAll'
+const SHOW_ALL_QUERY_PARAM = 'showAll'
 
 type Props = SbBaseBlockProps<{
   categories?: Array<string>
@@ -35,10 +35,13 @@ export const BlogArticleListBlock = (props: Props) => {
     })
   }, [teaserList, props.blok.categories])
 
-  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
   const initiallyVisibleCount = props.blok.initiallyVisibleCount ?? 12
   const showAll =
-    filteredTeaserList.length <= initiallyVisibleCount || router.query[QUERY_PARAM] === '1'
+    filteredTeaserList.length <= initiallyVisibleCount ||
+    searchParams?.has(SHOW_ALL_QUERY_PARAM, '1')
 
   const visibleTeaserList = showAll
     ? filteredTeaserList
@@ -70,7 +73,7 @@ export const BlogArticleListBlock = (props: Props) => {
           {!showAll && (
             <ButtonWrapper>
               <InlineButtonLink
-                href={{ query: { ...router.query, [QUERY_PARAM]: '1' } }}
+                href={`${pathname}?${SHOW_ALL_QUERY_PARAM}=1`}
                 shallow={true}
                 scroll={false}
               >


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Subj

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

App router compatibility. Any blocks except car dealership ones can be used in app router, therefore they should use `next/navigation` instead of `next/router`

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
