### PR TITLE
GEN-1893 - styles(QuickAddEditableView): avoid badge overflowing

### DIFF
--- a/apps/store/src/components/QuickAdd/QuickAddEditableView.css.ts
+++ b/apps/store/src/components/QuickAdd/QuickAddEditableView.css.ts
@@ -2,22 +2,32 @@ import { style } from '@vanilla-extract/css'
 import { theme, minWidth } from 'ui/src/theme'
 
 export const card = style({
-  padding: theme.space.md,
+  padding: '0.875rem',
   border: `1px solid ${theme.colors.borderTranslucent1}`,
   borderRadius: theme.radius.md,
   // TODO: replace this to theme.colors.signalbluefill when we update Uikit colors
   backgroundColor: 'hsl(201, 84%, 90%)',
 
   '@media': {
+    [minWidth.md]: {
+      padding: theme.space.md,
+    },
     [minWidth.lg]: {
       padding: theme.space.lg,
     },
   },
 })
 
-export const Wrapper = style({
-  width: '3rem',
-  aspectRatio: '1 / 1',
+export const cardHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.space.xs,
+
+  '@media': {
+    [minWidth.md]: {
+      gap: theme.space.md,
+    },
+  },
 })
 
 export const link = style({

--- a/apps/store/src/components/QuickAdd/QuickAddEditableView.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddEditableView.tsx
@@ -5,7 +5,6 @@ import { Space, Text, Badge, Button } from 'ui'
 import { InputDay } from '@/components/InputDay/InputDay'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { Price } from '@/components/Price'
-import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { StepperInput } from '@/components/StepperInput/StepperInput'
 import { type OfferRecommendationFragment } from '@/services/graphql/generated'
 import { getOfferPrice } from '@/utils/getOfferPrice'
@@ -14,6 +13,7 @@ import { DismissButton } from './DismissButton'
 import {
   alignedBadge,
   card,
+  cardHeader,
   link,
   formField,
   priceWrapper,
@@ -47,7 +47,7 @@ export function QuickAddEditableView(props: Props) {
   return (
     <div className={card}>
       <Space y={1}>
-        <SpaceFlex space={1} align="center">
+        <div className={cardHeader}>
           <Pillow size="small" {...props.pillow} />
 
           <div>
@@ -66,7 +66,7 @@ export function QuickAddEditableView(props: Props) {
               {props.badge}
             </Badge>
           )}
-        </SpaceFlex>
+        </div>
 
         {props.Body}
 


### PR DESCRIPTION
## Describe your changes

* Reduces inline padding and gap to avoid badge overflowing.

https://github.com/HedvigInsurance/racoon/assets/19200662/ef80a2ac-7f93-4ea0-9052-89439ada25fa

https://github.com/HedvigInsurance/racoon/assets/19200662/ee7086e0-e1c4-4684-a1e5-b30bf7270a41


