### PR TITLE
Stop using shopSession.customer.authenticationStatus

### DIFF
--- a/apps/store/src/components/BankIdDialog/BankIdDialog.tsx
+++ b/apps/store/src/components/BankIdDialog/BankIdDialog.tsx
@@ -23,7 +23,6 @@ import type { BankIdOperation } from '@/services/bankId/bankId.types'
 import { BankIdState } from '@/services/bankId/bankId.types'
 import { bankIdLogger } from '@/services/bankId/bankId.utils'
 import { useBankIdContext } from '@/services/bankId/BankIdContext'
-import { ShopSessionAuthenticationStatus } from '@/services/graphql/generated'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { wait } from '@/utils/wait'
 import {
@@ -44,16 +43,7 @@ export function BankIdDialog() {
   useTriggerBankIdOnSameDevice(currentOperation)
   const tryAgainButtonProps = useTryAgainButtonProps(currentOperation)
 
-  let isOpen = !!currentOperation
-  if (currentOperation?.type === 'sign') {
-    // In some cases we show progress on signing page, not in dialog
-    const isSigningAuthenticatedMember =
-      currentOperation.customerAuthenticationStatus ===
-      ShopSessionAuthenticationStatus.Authenticated
-    if (isSigningAuthenticatedMember) {
-      isOpen = false
-    }
-  }
+  const isOpen = !!currentOperation
 
   const handleOpenChange = (open: boolean) => {
     if (!open && currentOperation) {

--- a/apps/store/src/components/CheckoutPage/CheckoutPage.types.ts
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.types.ts
@@ -1,10 +1,8 @@
 import type { CheckoutStep } from '@/components/CheckoutHeader/Breadcrumbs'
-import type { ShopSessionAuthenticationStatus } from '@/services/graphql/generated'
 import type { ShopSession } from '@/services/shopSession/ShopSession.types'
 
 export type CheckoutPageProps = {
   shopSessionId: string
-  customerAuthenticationStatus: ShopSessionAuthenticationStatus
   shopSessionSigningId: string | null
   ssn: string
   shouldCollectEmail: boolean

--- a/apps/store/src/components/CheckoutPage/useHandleSubmitCheckout.ts
+++ b/apps/store/src/components/CheckoutPage/useHandleSubmitCheckout.ts
@@ -1,40 +1,38 @@
-import { datadogLogs } from '@datadog/browser-logs'
 import { useTranslation } from 'next-i18next'
 import type { FormEventHandler } from 'react'
 import { BankIdState } from '@/services/bankId/bankId.types'
 import { useBankIdContext } from '@/services/bankId/BankIdContext'
-import { ShopSessionAuthenticationStatus } from '@/services/graphql/generated'
+import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { useUpdateCustomer } from './useUpdateCustomer'
 
 type Options = {
   shopSessionId: string
   ssn: string
-  customerAuthenticationStatus: ShopSessionAuthenticationStatus
   onError: () => void
   onSuccess: () => void
 }
 
 export const useHandleSubmitCheckout = (options: Options) => {
   const { t } = useTranslation('common')
-  const { customerAuthenticationStatus, shopSessionId, ssn, onSuccess, onError } = options
+  const { shopSessionId, ssn, onSuccess, onError } = options
   const [updateCustomer, updateCustomerResult] = useUpdateCustomer({ shopSessionId })
-
   const { currentOperation, startCheckoutSign } = useBankIdContext()
+  const { shopSession } = useShopSession()
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault()
-    if (customerAuthenticationStatus === ShopSessionAuthenticationStatus.None) {
-      datadogLogs.logger.debug('New member, updating customer data')
+
+    if ((shopSession?.customer?.missingFields ?? []).length > 0) {
       const formData = new FormData(event.currentTarget)
       await updateCustomer(formData)
     }
-    startCheckoutSign({ customerAuthenticationStatus, shopSessionId, ssn, onSuccess, onError })
+
+    startCheckoutSign({ shopSessionId, ssn, onSuccess, onError })
   }
 
   let userError = updateCustomerResult.userError
   if (!userError && currentOperation?.error) {
-    // TODO: Expose userError from API
-    userError = { message: t('UNKNOWN_ERROR_MESSAGE') }
+    userError = t('UNKNOWN_ERROR_MESSAGE')
   }
 
   let signLoading = false

--- a/apps/store/src/components/CheckoutPage/useUpdateCustomer.ts
+++ b/apps/store/src/components/CheckoutPage/useUpdateCustomer.ts
@@ -1,21 +1,14 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { useShopSessionCustomerUpdateMutation } from '@/services/graphql/generated'
-import { useGetMutationError } from '@/utils/useGetMutationError'
+import { useErrorMessage } from '@/utils/useErrorMessage'
 import { FormElement } from './CheckoutPage.constants'
 
 type Params = {
   shopSessionId: string
-  onSuccess?: () => void
 }
 
-export const useUpdateCustomer = ({ shopSessionId, onSuccess }: Params) => {
-  const getMutationError = useGetMutationError()
+export const useUpdateCustomer = ({ shopSessionId }: Params) => {
   const [updateCustomer, result] = useShopSessionCustomerUpdateMutation({
-    onCompleted(data) {
-      if (!data.shopSessionCustomerUpdate.userError) {
-        onSuccess?.()
-      }
-    },
     onError(error) {
       datadogLogs.logger.warn('Failed to update contact details', { error })
     },
@@ -35,7 +28,7 @@ export const useUpdateCustomer = ({ shopSessionId, onSuccess }: Params) => {
     handleSubmit,
     {
       loading: result.loading,
-      userError: getMutationError(result, result.data?.shopSessionCustomerUpdate),
+      userError: useErrorMessage(result.error),
     },
   ] as const
 }

--- a/apps/store/src/components/PriceCalculator/SsnSeSection.tsx
+++ b/apps/store/src/components/PriceCalculator/SsnSeSection.tsx
@@ -3,11 +3,7 @@ import { useTranslation } from 'next-i18next'
 import { type FormEventHandler } from 'react'
 import { Button, Space } from 'ui'
 import { PersonalNumberField } from '@/components/PersonalNumberField/PersonalNumberField'
-import { useBankIdContext } from '@/services/bankId/BankIdContext'
-import {
-  ShopSessionAuthenticationStatus,
-  useShopSessionCustomerUpdateMutation,
-} from '@/services/graphql/generated'
+import { useShopSessionCustomerUpdateMutation } from '@/services/graphql/generated'
 import type { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useErrorMessage } from '@/utils/useErrorMessage'
 
@@ -17,7 +13,6 @@ type Props = { shopSession: ShopSession; onCompleted: () => void }
 
 export const SsnSeSection = ({ shopSession, onCompleted }: Props) => {
   const { t } = useTranslation('purchase-form')
-  const { showLoginPrompt } = useBankIdContext()
   const [updateCustomer, result] = useShopSessionCustomerUpdateMutation({
     // priceIntent.suggestedData may be updated based on customer.ssn
     refetchQueries: 'active',
@@ -26,13 +21,7 @@ export const SsnSeSection = ({ shopSession, onCompleted }: Props) => {
       const { shopSession } = data.shopSessionCustomerUpdate
       if (!shopSession) return
 
-      const { authenticationStatus } = shopSession.customer ?? {}
-      if (authenticationStatus === ShopSessionAuthenticationStatus.AuthenticationRequired) {
-        const ssn = shopSession.customer!.ssn!
-        showLoginPrompt({ ssn, onCompleted })
-      } else {
-        onCompleted()
-      }
+      onCompleted()
     },
     onError(error) {
       datadogLogs.logger.debug('Failed to update customer ssn', { error })

--- a/apps/store/src/features/carDealership/useAcceptExtension.ts
+++ b/apps/store/src/features/carDealership/useAcceptExtension.ts
@@ -40,17 +40,14 @@ export const useAcceptExtension = (params: Params) => {
   }, [showError, currentOperation])
 
   const performSign = () => {
-    const { ssn, authenticationStatus } = params.shopSession.customer ?? {}
+    const { ssn } = params.shopSession.customer ?? {}
 
-    if (!ssn || !authenticationStatus) {
-      return LOGGER.info(
-        `Impossible to sign shopSession: ${params.shopSession.id} - lacking 'ssn' and 'authenticationStatus'`,
-      )
+    if (!ssn) {
+      return LOGGER.info(`Impossible to sign shopSession: ${params.shopSession.id} - lacking 'ssn'`)
     }
 
     startCheckoutSign({
       shopSessionId: params.shopSession.id,
-      customerAuthenticationStatus: authenticationStatus,
       ssn,
 
       async onSuccess() {

--- a/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
+++ b/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
@@ -4,7 +4,7 @@ import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
-import type { FormEventHandler, ReactNode} from 'react';
+import type { FormEventHandler, ReactNode } from 'react'
 import { useCallback, useRef } from 'react'
 import { BankIdIcon, Button, Heading, HedvigLogo, mq, Space, theme } from 'ui'
 import { CheckoutStep } from '@/components/CheckoutHeader/Breadcrumbs'
@@ -21,13 +21,8 @@ import { TextWithLink } from '@/components/TextWithLink'
 import { useAppErrorHandleContext } from '@/services/appErrors/AppErrorContext'
 import { BankIdState } from '@/services/bankId/bankId.types'
 import { useBankIdContext } from '@/services/bankId/BankIdContext'
-import type {
-  Money,
-  ProductOfferFragment} from '@/services/graphql/generated';
-import {
-  useManyPetsFillCartMutation,
-  useShopSessionQuery,
-} from '@/services/graphql/generated'
+import type { Money, ProductOfferFragment } from '@/services/graphql/generated'
+import { useManyPetsFillCartMutation, useShopSessionQuery } from '@/services/graphql/generated'
 import { setupShopSessionServiceClientSide } from '@/services/shopSession/ShopSession.helpers'
 import type { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
@@ -241,13 +236,12 @@ const useSignMigration = (
       }
 
       const shopSessionId = shopSession.id
-      const { authenticationStatus: customerAuthenticationStatus, ssn } = shopSession.customer
+      const { ssn } = shopSession.customer
       manypetsLogger.setContextProperty('shopSessionId', shopSessionId)
 
       datadogRum.addAction('ManyPets StartingSigning', {
         shopSessionId,
         entriesCount: shopSession.cart.entries.length,
-        customerAuthenticationStatus,
       })
 
       try {
@@ -272,7 +266,6 @@ const useSignMigration = (
 
         manypetsLogger.info('ManyPets StartingCheckoutSign')
         startCheckoutSign({
-          customerAuthenticationStatus,
           shopSessionId,
           ssn,
           async onSuccess() {

--- a/apps/store/src/features/widget/SignPage.tsx
+++ b/apps/store/src/features/widget/SignPage.tsx
@@ -25,7 +25,6 @@ import { SIGN_FORM_ID } from '@/constants/sign.constants'
 import {
   MemberPaymentConnectionStatus,
   type ProductOfferFragment,
-  ShopSessionAuthenticationStatus,
   useCartEntryRemoveMutation,
   useCurrentMemberLazyQuery,
 } from '@/services/graphql/generated'
@@ -40,7 +39,6 @@ import { publishWidgetEvent } from './publishWidgetEvent'
 type Props = {
   shopSession: ShopSession
   priceIntentId: string
-  customerAuthenticationStatus: ShopSessionAuthenticationStatus
   ssn: string
   shouldCollectEmail: boolean
   shouldCollectName: boolean
@@ -64,7 +62,6 @@ export const SignPage = (props: Props) => {
   const [handleSubmitSign, { loading, userError }] = useHandleSubmitCheckout({
     shopSessionId: props.shopSession.id,
     ssn: props.ssn,
-    customerAuthenticationStatus: props.customerAuthenticationStatus,
     async onSuccess() {
       datadogLogs.logger.info('Widget Sign | Sign Success', { shopSessionId: props.shopSession.id })
       publishWidgetEvent.signed()
@@ -75,7 +72,6 @@ export const SignPage = (props: Props) => {
       tracking.reportPurchase({
         cart: props.shopSession.cart,
         memberId: data.currentMember.id,
-        isNewMember: props.customerAuthenticationStatus === ShopSessionAuthenticationStatus.None,
         customer: data.currentMember,
       })
 
@@ -111,8 +107,6 @@ export const SignPage = (props: Props) => {
     })
     handleSubmitSign(event)
   }
-
-  const userErrorMessage = userError?.message
 
   const mainOffer = props.shopSession.cart.entries.find(
     (item) => item.product.name === props.productName,
@@ -249,9 +243,9 @@ export const SignPage = (props: Props) => {
                           <Text size="xs">{t('USP_TEXT')}</Text>
                         </UspWrapper>
 
-                        {userErrorMessage ? (
+                        {userError ? (
                           <Text as="p" size="xs" color="textSecondary" align="center">
-                            {userErrorMessage}
+                            {userError}
                           </Text>
                         ) : (
                           <TextWithLink

--- a/apps/store/src/graphql/ShopSessionCustomerFragment.graphql
+++ b/apps/store/src/graphql/ShopSessionCustomerFragment.graphql
@@ -1,5 +1,4 @@
 fragment ShopSessionCustomer on ShopSessionCustomer {
-    authenticationStatus
     missingFields
     ssn
 }

--- a/apps/store/src/pages/[locale]/checkout/index.tsx
+++ b/apps/store/src/pages/[locale]/checkout/index.tsx
@@ -27,15 +27,7 @@ const NextCheckoutPage: NextPage<NextPageProps> = (props) => {
 
   if (!shopSession?.customer) return null
 
-  const { authenticationStatus } = shopSession.customer
-
-  return (
-    <CheckoutPage
-      {...props}
-      shopSession={shopSession}
-      customerAuthenticationStatus={authenticationStatus}
-    />
-  )
+  return <CheckoutPage {...props} shopSession={shopSession} />
 }
 
 export const getServerSideProps: GetServerSideProps<NextPageProps> = async (context) => {

--- a/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
+++ b/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
@@ -101,7 +101,6 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
         ssn: customer.ssn,
         shouldCollectEmail: getShouldCollectEmail(customer),
         shouldCollectName: getShouldCollectName(customer),
-        customerAuthenticationStatus: customer.authenticationStatus,
         shopSessionId: context.params.shopSessionId,
         content: story.content.checkoutPageContent,
         flow: context.params.flow,

--- a/apps/store/src/services/PriceCalculator/PriceCalculator.helpers.ts
+++ b/apps/store/src/services/PriceCalculator/PriceCalculator.helpers.ts
@@ -1,4 +1,4 @@
-import type { ShopSessionCustomer } from '@/services/graphql/generated'
+import type { ShopSessionCustomerFragment } from '@/services/graphql/generated'
 import type { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import { getShouldCollectEmail } from '@/utils/customer'
 import { SE_ACCIDENT } from './data/SE_ACCIDENT'
@@ -10,7 +10,7 @@ import { SE_PET_CAT } from './data/SE_PET_CAT'
 import { SE_PET_DOG } from './data/SE_PET_DOG'
 import { SE_STUDENT_APARTMENT } from './data/SE_STUDENT_APARTMENT'
 import { SE_WIDGET_APARTMENT, SE_WIDGET_APARTMENT_NO_COMPARE } from './data/SE_WIDGET_APARTMENT'
-import type { InputField} from './Field.types';
+import type { InputField } from './Field.types'
 import { MIXED_BREED_OPTION_ID } from './Field.types'
 import type { Form, FormSection, JSONData, Template } from './PriceCalculator.types'
 
@@ -63,7 +63,7 @@ export const prefillData = ({ form, data, valueField }: FillDataParams): Form =>
 }
 
 type SetupFormOptions = {
-  customer: ShopSessionCustomer | null | undefined
+  customer: ShopSessionCustomerFragment | null | undefined
   priceIntent: PriceIntent
   template: Template
 }

--- a/apps/store/src/services/Tracking/Tracking.ts
+++ b/apps/store/src/services/Tracking/Tracking.ts
@@ -170,12 +170,10 @@ export class Tracking {
   public async reportPurchase({
     cart,
     memberId,
-    isNewMember,
     customer,
   }: {
     cart: CartFragmentFragment
     memberId: string
-    isNewMember: boolean
     customer: {
       email: string
       firstName?: string
@@ -187,7 +185,6 @@ export class Tracking {
     const userData = await getLegacyUserData(this.context, customer, cart)
     event.ecommerce.userData = userData
     event.ecommerce.transaction_id = cart.id
-    event.new_customer = isNewMember
     this.reportEcommerceEvent(event)
     this.reportAdtractionEvent(cart, customer.email)
   }

--- a/apps/store/src/services/bankId/bankId.types.ts
+++ b/apps/store/src/services/bankId/bankId.types.ts
@@ -1,5 +1,4 @@
 import { type ApolloError } from '@apollo/client'
-import type { ShopSessionAuthenticationStatus } from '@/services/graphql/generated'
 
 export enum BankIdState {
   Idle = 'Idle',
@@ -22,7 +21,6 @@ export type BankIdLoginOperation = {
 export type BankIdSignOperation = {
   type: 'sign'
   ssn: string
-  customerAuthenticationStatus: ShopSessionAuthenticationStatus
   state: BankIdState
   error?: string
   qrCodeData?: string
@@ -45,7 +43,6 @@ export type BankIdLoginOptions = {
 export type StartLoginOptions = { ssn: string; onSuccess?: () => void | Promise<void> }
 
 export type CheckoutSignOptions = {
-  customerAuthenticationStatus: ShopSessionAuthenticationStatus
   shopSessionId: string
   ssn: string
   onSuccess: () => void | Promise<void>

--- a/apps/store/src/services/bankId/bankIdReducer.ts
+++ b/apps/store/src/services/bankId/bankIdReducer.ts
@@ -1,7 +1,6 @@
 import { datadogRum } from '@datadog/browser-rum'
 import type { Dispatch } from 'react'
-import type { ShopSessionAuthenticationStatus } from '@/services/graphql/generated'
-import type { BankIdOperation} from './bankId.types';
+import type { BankIdOperation } from './bankId.types'
 import { BankIdState } from './bankId.types'
 
 export type BankIdAction =
@@ -24,7 +23,6 @@ type StartLoginAction = {
 type StartSignAction = {
   type: 'startCheckoutSign'
   ssn: string
-  customerAuthenticationStatus: ShopSessionAuthenticationStatus
 }
 type PropertiesUpdateAction = {
   type: 'propertiesUpdate'
@@ -111,7 +109,6 @@ export const bankIdReducer = (
           type: 'sign',
           state: BankIdState.Starting,
           ssn: action.ssn,
-          customerAuthenticationStatus: action.customerAuthenticationStatus,
         },
       }
     case 'cancel':

--- a/apps/store/src/services/bankId/useBankIdCheckoutSign.ts
+++ b/apps/store/src/services/bankId/useBankIdCheckoutSign.ts
@@ -2,12 +2,11 @@ import { type ApolloError } from '@apollo/client'
 import { datadogRum } from '@datadog/browser-rum'
 import { useTranslation } from 'next-i18next'
 import { useCallback, useRef } from 'react'
-import type { Subscription } from 'zen-observable-ts';
+import type { Subscription } from 'zen-observable-ts'
 import { Observable } from 'zen-observable-ts'
 import { exchangeAuthorizationCode } from '@/services/authApi/oauth'
 import { saveAuthTokens } from '@/services/authApi/persist'
 import {
-  ShopSessionAuthenticationStatus,
   ShopSessionSigningStatus,
   useShopSessionSigningLazyQuery,
   useShopSessionStartSignMutation,
@@ -15,20 +14,16 @@ import {
 import type { BankIdState, BankIdSignOperation, CheckoutSignOptions } from './bankId.types'
 import { apiStatusToBankIdState, bankIdLogger } from './bankId.utils'
 import type { BankIdDispatch } from './bankIdReducer'
-import { useBankIdLoginApi } from './useBankIdLogin'
 
 export type Options = {
   dispatch: BankIdDispatch
 }
 
 export const useBankIdCheckoutSign = ({ dispatch }: Options) => {
-  const { startLogin, cancelLogin } = useBankIdLoginApi({ dispatch })
-
   const { startSign, cancelSign } = useBankIdCheckoutSignApi({ dispatch })
 
   const startCheckoutSign = useCallback(
     async ({
-      customerAuthenticationStatus,
       shopSessionId,
       ssn,
       onSuccess,
@@ -45,29 +40,18 @@ export const useBankIdCheckoutSign = ({ dispatch }: Options) => {
         }
       }
 
-      dispatch({ type: 'startCheckoutSign', ssn, customerAuthenticationStatus })
+      dispatch({ type: 'startCheckoutSign', ssn })
       datadogRum.addAction('bankIdSign start')
 
-      if (customerAuthenticationStatus === ShopSessionAuthenticationStatus.AuthenticationRequired) {
-        bankIdLogger.info('Authentication required for returning member')
-        startLogin({
-          ssn,
-          onSuccess() {
-            startSign({ shopSessionId, onSuccess: handleSuccess, onError })
-          },
-        })
-      } else {
-        startSign({ shopSessionId, onSuccess: handleSuccess, onError })
-      }
+      startSign({ shopSessionId, onSuccess: handleSuccess, onError })
     },
-    [dispatch, startLogin, startSign],
+    [dispatch, startSign],
   )
 
   const cancelCheckoutSign = useCallback(() => {
-    cancelLogin()
     cancelSign()
     dispatch({ type: 'cancel' })
-  }, [cancelLogin, cancelSign, dispatch])
+  }, [cancelSign, dispatch])
 
   return {
     startCheckoutSign,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Remove usage of shopSession.customer.authenticationStatus

Logic changes
- Rely on checkout form fields to decide if we need to call `shopSessionCustomerUpdate` with email and/or names before signing.  This is backed by `shopSession.customer.missingFields`
- Always show BankID icon on sign button
- We've lost `new_customer` value of purchase events, waiting for a discussion to either remove it or address in separate PR

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

After recent signing changes we always require BankID sign during purchase, there's no need for separate returning member flow

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
