### PR TITLE
Add support for Heading in TickerBlock

### DIFF
--- a/apps/store/src/blocks/TickerBlock.tsx
+++ b/apps/store/src/blocks/TickerBlock.tsx
@@ -1,28 +1,53 @@
 'use client'
 
-import styled from '@emotion/styled'
+import { StoryblokComponent } from '@storyblok/react'
+import type { FontSizes } from 'ui'
 import { theme } from 'ui'
 import { Ticker, TickerItem } from '@/components/Ticker/Ticker'
+import type { ExpectedBlockType } from '@/services/storyblok/storyblok'
 import { type SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import type { HeadingBlockProps } from './HeadingBlock'
+import type { TextBlockProps } from './TextBlock'
 
 type Props = SbBaseBlockProps<{
   topMargin: boolean
   uspText?: string
+  showCheckIcon?: boolean
+  tickerItems?: ExpectedBlockType<HeadingBlockProps | TextBlockProps>
+  tickerHeight: FontSizes
+  tickerHeightDesktop?: FontSizes
 }>
 
-export const TickerBlock = (props: Props) => {
-  const uspList = props.blok.uspText?.split('\n') ?? []
+export const TickerBlock = ({ blok }: Props) => {
+  const tickerItems = blok.tickerItems ?? []
+  /* TODO: Deprecated, remove when Storyblok content has migrated to tickerItems */
+  const uspList = blok.uspText?.split('\n') ?? []
+  const showTickerItems = tickerItems.length > 1
+
+  const sizes = {
+    _: blok.tickerHeight,
+    ...(blok.tickerHeightDesktop && { md: blok.tickerHeightDesktop }),
+  }
 
   return (
     <>
-      {props.blok.topMargin && <Spacer />}
-      <Ticker>
-        {uspList.map((item, index) => (
-          <TickerItem key={index}>{item}</TickerItem>
-        ))}
+      {/* TODO: Top margin will be deprecated, remove once migrated */}
+      {blok.topMargin && <div style={{ height: theme.space.md }} />}
+      <Ticker size={sizes}>
+        {showTickerItems
+          ? tickerItems.map((nestedBlock) => (
+              <TickerItem key={nestedBlock._uid} showCheckIcon={blok.showCheckIcon}>
+                <StoryblokComponent blok={nestedBlock} nested={true}>
+                  {nestedBlock}
+                </StoryblokComponent>
+              </TickerItem>
+            ))
+          : uspList.map((item, index) => (
+              <TickerItem key={index} showCheckIcon={true}>
+                {item}
+              </TickerItem>
+            ))}
       </Ticker>
     </>
   )
 }
-
-const Spacer = styled.div({ height: theme.space.xs })

--- a/apps/store/src/components/Ticker/Ticker.css.ts
+++ b/apps/store/src/components/Ticker/Ticker.css.ts
@@ -1,0 +1,23 @@
+import { style } from '@vanilla-extract/css'
+import { theme } from 'ui'
+
+export const list = style({
+  position: 'relative',
+  // Add slight offset since line-height and height are not the same
+  top: '0.1em',
+  height: '1.4em',
+  overflow: 'hidden',
+})
+
+export const listItem = style({
+  position: 'absolute',
+  inset: 0,
+})
+
+export const tickerItemWrapper = style({
+  height: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: theme.space.xs,
+})

--- a/apps/store/src/components/Ticker/Ticker.stories.tsx
+++ b/apps/store/src/components/Ticker/Ticker.stories.tsx
@@ -1,4 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react'
+import { Heading } from 'ui'
 import { Ticker, TickerItem } from './Ticker'
 
 const meta: Meta<typeof Ticker> = {
@@ -11,10 +12,32 @@ type Story = StoryObj<typeof Ticker>
 
 export const Primary: Story = {
   render: () => (
-    <Ticker>
-      <TickerItem>First item</TickerItem>
-      <TickerItem>Second item</TickerItem>
-      <TickerItem>Third item</TickerItem>
+    <Ticker size={'xs'}>
+      <TickerItem showCheckIcon={true}>First item</TickerItem>
+      <TickerItem showCheckIcon={true}>Second item</TickerItem>
+      <TickerItem showCheckIcon={true}>Third item</TickerItem>
+    </Ticker>
+  ),
+}
+
+export const WithHeading: Story = {
+  render: () => (
+    <Ticker size={10}>
+      <TickerItem>
+        <Heading as="h2" variant={{ _: 'serif.40', md: 'serif.72' }}>
+          Hemförsäkring
+        </Heading>
+      </TickerItem>
+      <TickerItem>
+        <Heading as="h2" variant={{ _: 'serif.40', md: 'serif.72' }}>
+          Bilförsäkring
+        </Heading>
+      </TickerItem>
+      <TickerItem>
+        <Heading as="h2" variant={{ _: 'serif.40', md: 'serif.72' }}>
+          Djurförsäkring
+        </Heading>
+      </TickerItem>
     </Ticker>
   ),
 }

--- a/apps/store/src/components/Ticker/Ticker.tsx
+++ b/apps/store/src/components/Ticker/Ticker.tsx
@@ -1,13 +1,23 @@
-import styled from '@emotion/styled'
-import type { Variants} from 'framer-motion';
+import clsx from 'clsx'
+import type { Variants } from 'framer-motion'
 import { AnimatePresence, motion } from 'framer-motion'
 import { type ReactNode, useEffect, useState, Children } from 'react'
-import { CheckIcon, Text, theme } from 'ui'
+import { sprinkles } from 'ui/src/theme/sprinkles.css'
+import type { FontSizeProps, FontSizes } from 'ui'
+import { CheckIcon } from 'ui'
+import { list, listItem, tickerItemWrapper } from './Ticker.css'
 
 const DURATION = 1
 
+export type TickerHeight = {
+  tickerHeight: FontSizes
+  tickerHeightDesktop: FontSizes
+}
+
 type Props = {
   children: Iterable<ReactNode>
+  showCheckIcon?: boolean
+  size: FontSizeProps
 }
 
 export const Ticker = (props: Props) => {
@@ -22,15 +32,19 @@ export const Ticker = (props: Props) => {
     return () => clearInterval(interval)
   }, [childrenCount])
 
+  // Font size is used as height for the ticker to make animation of items responsive
+  const classNames = clsx(list, sprinkles({ fontSize: props.size }))
+
   return (
-    <List>
+    <ul className={classNames}>
       <AnimatePresence initial={false}>
         {Children.map(props.children, (child, index) => {
           if (index !== visibleIndex) return null
 
           return (
-            <ListItem
+            <motion.li
               key={index}
+              className={listItem}
               transition={TRANSITION}
               variants={ANIMATION}
               initial="pushDown"
@@ -38,15 +52,15 @@ export const Ticker = (props: Props) => {
               exit="pushUp"
             >
               {child}
-            </ListItem>
+            </motion.li>
           )
         })}
       </AnimatePresence>
-    </List>
+    </ul>
   )
 }
 
-const DRIFT_HEIGHT = '1.5rem'
+const DRIFT_HEIGHT = '0.8em'
 const ANIMATION: Variants = {
   pushDown: { y: DRIFT_HEIGHT, opacity: 0 },
   original: { y: 0, opacity: 1 },
@@ -54,36 +68,16 @@ const ANIMATION: Variants = {
 }
 const TRANSITION = { duration: DURATION, ease: 'anticipate' }
 
-const List = styled.ul({
-  position: 'relative',
-  height: '2.5rem',
-  overflow: 'hidden',
-})
-
-const ListItem = styled(motion.li)({
-  position: 'absolute',
-  inset: 0,
-})
-
 type TickerItemProps = {
-  children: string
+  children: React.ReactNode
+  showCheckIcon?: boolean
 }
 
 export const TickerItem = (props: TickerItemProps) => {
   return (
-    <TickerItemWrapper>
-      <CheckIcon size="1rem" />
-      <Text as="p" size="xs">
-        {props.children}
-      </Text>
-    </TickerItemWrapper>
+    <div className={tickerItemWrapper}>
+      {props.showCheckIcon && <CheckIcon size="1rem" />}
+      {props.children}
+    </div>
   )
 }
-
-const TickerItemWrapper = styled.div({
-  height: '100%',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  gap: theme.space.xs,
-})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add support for adding Heading block and Text Block to allow different fonts and sizes for the ticker.
In order to for the animation to work, we need a height to calculate the animation from. We can't derive it from the nested blocks so the best way I found was to add a setting for it Storyblok. 

After deploy we need to migrate the content in Storyblok before we remove the deprecated fields in code

#### Ticker with heading component
https://github.com/HedvigInsurance/racoon/assets/6661511/83fc23ed-40b1-495c-80e7-5432c36359d3

#### Ticker with text component
https://github.com/HedvigInsurance/racoon/assets/6661511/9be0eb3d-96b5-43c9-8778-8c2bdda0e871



<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
For the new Home campaign we what to have a ticker animation of headings
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
