### PR TITLE
fix(storyblok): previwing widget flow content type

### DIFF
--- a/apps/store/src/features/widget/StartFlow.helpers.ts
+++ b/apps/store/src/features/widget/StartFlow.helpers.ts
@@ -11,13 +11,10 @@ import { parseCustomerDataSearchParams } from './parseSearchParams'
 import { shopSessionCustomerUpdate } from './shopSessionCustomerUpdate'
 import { STORYBLOK_WIDGET_FOLDER_SLUG } from './widget.constants'
 
-export const redirectIfRunningInStoryblokEditor = (
-  url: URL,
-  locale: RoutingLocale,
-): Redirect | undefined => {
+export const redirectIfRunningInStoryblokEditor = (url: URL): Redirect | undefined => {
   const runningInStoryblokEditor = url.searchParams.has('_storyblok')
   if (runningInStoryblokEditor) {
-    url.pathname = url.pathname.replace('/widget/flows', `${locale}/widget/preview`)
+    url.pathname = url.pathname.replace('widget/flows', 'widget/preview')
     return { destination: url.href, permanent: false }
   }
 }

--- a/apps/store/src/pages/[locale]/widget/flows/[...slug].tsx
+++ b/apps/store/src/pages/[locale]/widget/flows/[...slug].tsx
@@ -21,7 +21,7 @@ export const getServerSideProps: GetServerSideProps<any, Params> = async (contex
   if (!isRoutingLocale(context.locale)) return { notFound: true }
 
   const url = new URL(context.resolvedUrl, ORIGIN_URL)
-  const redirect = redirectIfRunningInStoryblokEditor(url, context.locale)
+  const redirect = redirectIfRunningInStoryblokEditor(url)
   if (redirect) return { redirect }
 
   const flowMetadata = await fetchFlowMetadata({


### PR DESCRIPTION
## Describe your changes

* Fix previewing of _Widget Flow_ content type. Locale is part of the URL now so we need to change how preview URL get's contructed.

https://github.com/HedvigInsurance/racoon/assets/19200662/758f9f59-20c2-4d84-9ab3-51af20c1b74b

Redirect URLs are being malformed.

<img width="985" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/3e723b9a-171d-4cf1-822a-07f8413b5842">
