### PR TITLE
Explicitly pass locale to ApolloClient in app router

### DIFF
--- a/apps/store/src/app/[locale]/appDebug/[[...slug]]/ProductCmsPage.tsx
+++ b/apps/store/src/app/[locale]/appDebug/[[...slug]]/ProductCmsPage.tsx
@@ -21,13 +21,13 @@ type ProductCmsPageProps = {
   story: any
 }
 
-export const ProductCmsPage = async ({ story }: ProductCmsPageProps) => {
+export const ProductCmsPage = async ({ locale, story }: ProductCmsPageProps) => {
   const priceTemplate = getPriceTemplate(story.content.priceFormTemplateId)
   if (priceTemplate === undefined) {
     throw new Error(`Unknown price template: ${story.content.priceFormTemplateId}`)
   }
 
-  const apolloClient = await getApolloClient()
+  const apolloClient = getApolloClient(locale)
   const productName = story.content.productId
   const [productData, productReviewsMetadata] = await Promise.all([
     fetchProductData({

--- a/apps/store/src/app/[locale]/appDebug/[[...slug]]/page.tsx
+++ b/apps/store/src/app/[locale]/appDebug/[[...slug]]/page.tsx
@@ -16,6 +16,11 @@ type Props = {
 
 export default async function CmsPage(props: Props) {
   const story = await fetchStory(props.params)
+  // Patching incorrect data from Storyblok for /se-en/
+  let { hideBreadcrumbs } = story.content
+  if ((props.params.slug?.length ?? 0) < 1) {
+    hideBreadcrumbs = true
+  }
   if (isProductStory(story)) {
     return (
       <>
@@ -27,9 +32,7 @@ export default async function CmsPage(props: Props) {
   return (
     <>
       <PageBlock blok={story.content} />
-      {!story.content.hideBreadcrumbs && (
-        <StoryBreadcrumbs params={props.params} currentPageTitle={story.name} />
-      )}
+      {!hideBreadcrumbs && <StoryBreadcrumbs params={props.params} currentPageTitle={story.name} />}
     </>
   )
 }

--- a/apps/store/src/app/[locale]/layout.tsx
+++ b/apps/store/src/app/[locale]/layout.tsx
@@ -23,7 +23,7 @@ export type LocalizedLayoutProps<P = unknown> = P & {
 
 // TODO: How do we cache/invalidate companyReviewsMetadata ?
 const Layout = async ({ children, params: { locale } }: LocalizedLayoutProps) => {
-  const apolloClient = await getApolloClient()
+  const apolloClient = getApolloClient(locale)
   const [companyReviewsMetadata, productMetadata, globalStory] = await Promise.all([
     fetchCompanyReviewsMetadata(),
     fetchGlobalProductMetadata({ apolloClient }),

--- a/apps/store/src/app/[locale]/test/page.tsx
+++ b/apps/store/src/app/[locale]/test/page.tsx
@@ -13,13 +13,19 @@ type Props = {
 const Page = async (props: Props) => {
   const { t } = await initTranslationsServerSide(props.params.locale)
   // Same graphql request as in layout, only one network request gets executed thanks to Apollo SSR cache
-  const apolloClient = await getApolloClient()
+  const apolloClient = getApolloClient(props.params.locale)
   const productMetadata = await fetchGlobalProductMetadata({ apolloClient })
 
-  console.log('productMetadata@page, items:', productMetadata.length)
   return (
     <div className={wrapper}>
       <h1>Server-side translation: {t('404_PAGE_MESSAGE')}</h1>
+      <br />
+      <h3>Available products</h3>
+      <ul>
+        {productMetadata.map((item) => (
+          <li key={item.id}>- {item.displayNameFull}</li>
+        ))}
+      </ul>
       <br />
       <Suspense>
         <ClientComponent />

--- a/apps/store/src/app/debugger/actions.ts
+++ b/apps/store/src/app/debugger/actions.ts
@@ -20,7 +20,7 @@ import type { PriceIntentService } from '@/services/priceIntent/PriceIntentServi
 import { setupShopSession } from '@/services/shopSession/app-router/ShopSession.utils'
 import type { RoutingLocale } from '@/utils/l10n/types'
 import { PageLink } from '@/utils/PageLink'
-import type { FormStateWithErrors } from 'app/types/formStateTypes'
+import type { FormStateWithErrors } from '../types/formStateTypes'
 
 const DEFAULT_LOCALE: RoutingLocale = 'se-en'
 const DEFAULT_COUNTRY_CODE = CountryCode.Se
@@ -48,8 +48,7 @@ export const createCustomerSession = async (
       }
     }
 
-    const apolloClient = await getApolloClient()
-
+    const apolloClient = getApolloClient(DEFAULT_LOCALE)
     const shopSessionService = setupShopSession(apolloClient)
     const shopSession = await shopSessionService.create({ countryCode: DEFAULT_COUNTRY_CODE })
     console.log(`Created new ShopSession: ${shopSession.id}`)

--- a/apps/store/src/app/layout.tsx
+++ b/apps/store/src/app/layout.tsx
@@ -2,8 +2,6 @@ import { Provider as JotaiProvider } from 'jotai'
 import type { Metadata, Viewport } from 'next'
 import type { ReactNode } from 'react'
 import { theme } from 'ui'
-import { ApolloProvider } from '@/appComponents/providers/ApolloProvider'
-import { ShopSessionProvider } from '@/services/shopSession/ShopSessionContext'
 import { ORIGIN_URL } from '@/utils/PageLink'
 import { AppInitTriggers } from './AppInitTriggers'
 
@@ -12,13 +10,10 @@ type Props = {
 }
 
 export default function RootAppLayout({ children }: Props) {
+  return <JotaiProvider>{children}</JotaiProvider>
   return (
     <>
-      <ApolloProvider>
-        <ShopSessionProvider>
-          <JotaiProvider>{children}</JotaiProvider>
-        </ShopSessionProvider>
-      </ApolloProvider>
+      <JotaiProvider>{children}</JotaiProvider>
       <AppInitTriggers />
     </>
   )

--- a/apps/store/src/appComponents/RootLayout/RootLayout.tsx
+++ b/apps/store/src/appComponents/RootLayout/RootLayout.tsx
@@ -1,14 +1,15 @@
-import { Provider as JotaiProvider } from 'jotai'
-import type { PropsWithChildren} from 'react';
+import type { PropsWithChildren } from 'react'
 import { Suspense } from 'react'
 import { Provider as BalancerProvider } from 'react-wrap-balancer'
 import globalCss from 'ui/src/global.css'
 import { TranslationsProvider } from '@/appComponents/providers/TranslationsProvider'
 import { OrgStructuredData } from '@/appComponents/RootLayout/OrgStructuredData'
+import { ShopSessionProvider } from '@/services/shopSession/ShopSessionContext'
 import { contentFontClassName } from '@/utils/fonts'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
 import type { RoutingLocale } from '@/utils/l10n/types'
-import { initTranslationsServerSide } from 'app/i18n'
+import { initTranslationsServerSide } from '../../app/i18n'
+import { ApolloProvider } from '../providers/ApolloProvider'
 import { DebugError } from './DebugError'
 
 // Trick compiler into thinking we need global.css import for anything other than side effects
@@ -34,11 +35,13 @@ export async function RootLayout({
           <DebugError />
         </Suspense>
 
-        <TranslationsProvider locale={locale} resources={resources}>
-          <JotaiProvider>
-            <BalancerProvider>{children}</BalancerProvider>
-          </JotaiProvider>
-        </TranslationsProvider>
+        <ApolloProvider locale={locale}>
+          <ShopSessionProvider>
+            <TranslationsProvider locale={locale} resources={resources}>
+              <BalancerProvider>{children}</BalancerProvider>
+            </TranslationsProvider>
+          </ShopSessionProvider>
+        </ApolloProvider>
       </body>
     </html>
   )

--- a/apps/store/src/appComponents/providers/ApolloProvider.tsx
+++ b/apps/store/src/appComponents/providers/ApolloProvider.tsx
@@ -6,35 +6,44 @@ import {
   NextSSRApolloClient,
   NextSSRInMemoryCache,
 } from '@apollo/experimental-nextjs-app-support/ssr'
-import { type PropsWithChildren } from 'react'
+import type { ReactNode } from 'react'
+import { useCallback } from 'react'
 import { createHeadersLink } from '@/services/apollo/createHeadersLink'
 import { errorLink } from '@/services/apollo/errorLink'
 import { httpLink } from '@/services/apollo/httpLink'
-import { languageLink } from '@/services/apollo/languageLink'
 import { userErrorLink } from '@/services/apollo/userErrorLink'
+import { toIsoLocale } from '@/utils/l10n/localeUtils'
+import type { RoutingLocale } from '@/utils/l10n/types'
 
-const makeClient = () => {
-  const headersLink = createHeadersLink()
-
-  return new NextSSRApolloClient({
-    name: 'Web:Racoon:Store',
-    cache: new NextSSRInMemoryCache(),
-
-    link: ApolloLink.from([
-      // Has to be the first to process output last
-      // We re-raise userError results as errors, we don't want errorLink to see those
-      userErrorLink,
-      errorLink,
-      headersLink,
-      languageLink,
-      httpLink,
-    ]),
-
-    ssrMode: typeof window === 'undefined',
-    connectToDevTools: process.env.NODE_ENV === 'development',
-  })
+type Props = {
+  locale: RoutingLocale
+  children: ReactNode
 }
 
-export const ApolloProvider = ({ children }: PropsWithChildren) => {
+export const ApolloProvider = ({ children, locale }: Props) => {
+  const makeClient = useMakeApolloClient(locale)
   return <ApolloNextAppProvider makeClient={makeClient}>{children}</ApolloNextAppProvider>
+}
+
+const useMakeApolloClient = (locale: RoutingLocale) => {
+  return useCallback(
+    () =>
+      new NextSSRApolloClient({
+        name: 'Web:Racoon:Store',
+        cache: new NextSSRInMemoryCache(),
+
+        link: ApolloLink.from([
+          // Has to be the first to process output last
+          // We re-raise userError results as errors, we don't want errorLink to see those
+          userErrorLink,
+          errorLink,
+          createHeadersLink({ 'Hedvig-language': toIsoLocale(locale) }),
+          httpLink,
+        ]),
+
+        ssrMode: typeof window === 'undefined',
+        connectToDevTools: process.env.NODE_ENV === 'development',
+      }),
+    [locale],
+  )
 }

--- a/apps/store/src/services/apollo/app-router/rscClient.ts
+++ b/apps/store/src/services/apollo/app-router/rscClient.ts
@@ -1,11 +1,39 @@
 import { ApolloClient, ApolloLink, InMemoryCache } from '@apollo/client'
 import { registerApolloClient } from '@apollo/experimental-nextjs-app-support/rsc'
-import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
+import { FALLBACK_LOCALE } from '@/utils/l10n/locales'
+import { toRoutingLocale } from '@/utils/l10n/localeUtils'
 import type { RoutingLocale } from '@/utils/l10n/types'
 import { errorLink } from '../errorLink'
 import { httpLink } from '../httpLink'
 import { userErrorLink } from '../userErrorLink'
 import { serverStaticHeadersLink } from './serverStaticHeadersLink'
+
+// Passing locale through module-level static var is ugly, but it works
+// When `registerApolloClient` stops complaining about passed params, we should switch to it
+let currentLocale = toRoutingLocale(FALLBACK_LOCALE)
+export const getApolloClient = (locale: RoutingLocale): ApolloClient<any> => {
+  currentLocale = locale
+  return getClient()
+}
+
+// TODO: Support RSC client for dynamic pages too (auth headers, hedvig-shop-session-id header)
+const { getClient } = registerApolloClient(() => {
+  return new ApolloClient({
+    name: 'Web:Racoon:Store',
+
+    link: ApolloLink.from([
+      // Has to be the first to process output last
+      // We re-raise userError results as errors, we don't want errorLink to see those
+      userErrorLink,
+      errorLink,
+      serverStaticHeadersLink({ locale: currentLocale }),
+      requestLogger,
+      httpLink,
+    ]),
+
+    cache: new InMemoryCache(),
+  })
+})
 
 // Set to true to debug GQL requests in server components
 const logRequests = process.env.NODE_ENV === 'development'
@@ -18,33 +46,3 @@ const requestLogger = new ApolloLink((operation, forward) => {
   }
   return forward(operation)
 })
-
-type RscClientParams =
-  | {
-      locale: RoutingLocale
-    }
-  | undefined
-
-// TODO: Support RSC client for dynamic pages too (auth headers, hedvig-shop-session-id header)
-const { getClient } = registerApolloClient(
-  // @ts-expect-error apollo did not declare parametrised version, but it works
-  (params: RscClientParams) => {
-    const locale = getLocaleOrFallback(params?.locale).routingLocale
-    return new ApolloClient({
-      name: 'Web:Racoon:Store',
-
-      link: ApolloLink.from([
-        // Has to be the first to process output last
-        // We re-raise userError results as errors, we don't want errorLink to see those
-        userErrorLink,
-        errorLink,
-        serverStaticHeadersLink({ locale }),
-        requestLogger,
-        httpLink,
-      ]),
-
-      cache: new InMemoryCache(),
-    })
-  },
-)
-export const getApolloClient = getClient


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

App router
- pass locale to `ApolloClient` creation function explicitly
- move Apollo provider so that it's in locale-aware part of layout
- show available product titles on test app router page

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

We broke language link in app router during some previous refactorings - client always used default language, which resulted in a mix of languages when showing content

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
