### PR TITLE
Statically render only most popular pages

### DIFF
--- a/apps/store/.env.local.example
+++ b/apps/store/.env.local.example
@@ -32,9 +32,6 @@ VERCEL_URL=localhost
 
 # Vercel
 
-# When this is true, don't prerender any static pages
-SKIP_BUILD_STATIC_GENERATION=<true>
-
 # Feature Flags
 NEXT_PUBLIC_FEATURE_INSURELY=<true>
 NEXT_PUBLIC_FEATURE_SAS_PARTNERSHIP=true

--- a/apps/store/src/services/storyblok/Storyblok.constant.ts
+++ b/apps/store/src/services/storyblok/Storyblok.constant.ts
@@ -1,2 +1,24 @@
 export const GLOBAL_STORY_PROP_NAME = 'globalStory'
 export const STORY_PROP_NAME = 'story'
+
+// From 1w visitor stats for period ending 29.04.2024
+export const MOST_VISITED_PATHS = new Set([
+  '/se',
+  '/se/forsakringar',
+  // All product and category pages
+  '/se/forsakringar/hemforsakring',
+  '/se/forsakringar/hemforsakring/hyresratt',
+  '/se/forsakringar/hemforsakring/student',
+  '/se/forsakringar/hemforsakring/bostadsratt',
+  '/se/forsakringar/hemforsakring/villaforsakring',
+  '/se/forsakringar/bilforsakring',
+  '/se/forsakringar/djurforsakring',
+  '/se/forsakringar/hundforsakring',
+  '/se/forsakringar/kattforsakring',
+  '/se/forsakringar/olycksfallsforsakring',
+  // Other
+  '/se/hjalp',
+  '/se/hjalp/kundservice',
+  '/se/hjalp/faq',
+  '/se/hedvig',
+])


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Manually list most popular pages and only pre-build those instead of all CMS pages

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Makes build faster. Would be more important for app router since builds are slower there right now

Also would allow us to detect errors that break static rendering of product pages before merging into `main`

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
