### PR TITLE
Fix yarn cache path on Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ This Turborepo monorepo includes the following packages and apps:
 
 - `store`: Hedvig.com website
 - `ui`: Hedvig UI library (React)
-- `scripts`: ESLint configurations
-- `tsconfig`: TypeScript configs used throughout the monorepo
+- `estlit-config-custom`: ESLint configurations
 
 Every package/app is 100% written in Typescript.
 

--- a/apps/store/next.config.mjs
+++ b/apps/store/next.config.mjs
@@ -54,7 +54,7 @@ const config = {
     ]
   },
   webpack(config) {
-    // Suppress known warnings from webpack.cache.PackFileCacheStrategy/webpack.FileSystemInfo comlpaining about PNP modules
+    // Suppress known warnings from webpack.cache.PackFileCacheStrategy/webpack.FileSystemInfo complaining about PNP modules
     config.infrastructureLogging = { level: 'error' }
     return config
   },

--- a/apps/store/vercel.json
+++ b/apps/store/vercel.json
@@ -3,7 +3,7 @@
   "framework": "nextjs",
   "buildCommand": "cd ../.. && yarn turbo run codegen --filter=store --force && STORYBLOK_CACHE_VERSION=$(node ./apps/store/scripts/storyblok-cache-version.cjs) yarn turbo run build --filter=store && ./apps/store/scripts/upload-sourcemaps-vercel.sh",
   "ignoreCommand": "../../bin/vercel-ignore-step.sh",
-  "installCommand": "cd ../.. && YARN_CACHE_FOLDER=./.next/cache/yarn-cache yarn install --immutable",
+  "installCommand": "cd ../.. && YARN_CACHE_FOLDER=./apps/store/.next/cache/yarn-cache yarn install --immutable",
   "regions": [
     "arn1"
   ],


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Update our Vercel install command to make yarn cache reusable between builds

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Previous solution stopped working some time ago. I guess matching `.next` dir outside app dir was not intended and Vercel fixed it

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
