### PR TITLE
chore: disable chat (contact us) for all pages

### DIFF
--- a/apps/store/src/components/ContactUs/ContactUs.tsx
+++ b/apps/store/src/components/ContactUs/ContactUs.tsx
@@ -124,11 +124,6 @@ export const ContactUs = () => {
                       <span>{t('FAQ_OPTION_VALUE')}</span>
                     </LinkButton>
 
-                    <LinkButton href="#" aria-disabled="true">
-                      <span>{t('CHAT_OPTION_LABEL')}</span>
-                      <span>{t('CHAT_UNAVAILABLE_LABEL')}</span>
-                    </LinkButton>
-
                     <LinkButton
                       data-dd-action-name="Contact us | phone"
                       href={PageLink.help({ locale }).pathname}


### PR DESCRIPTION
## Describe your changes

- Remove "web chat" from _contact us_ widget.

**Before**

<img width="1123" alt="before" src="https://github.com/HedvigInsurance/racoon/assets/19200662/4a9cce91-ab6f-42e5-af0f-6bcda2a89dd3">

**After**

<img width="1123" alt="after" src="https://github.com/HedvigInsurance/racoon/assets/19200662/5be70a30-b087-48a4-ac5f-740afe052c9c">

## Justify why they are needed

Requested from Sonny. More information [here](https://hedviginsurance.slack.com/archives/CMRN3MU07/p1714332040511579)
