### PR TITLE
GEN-2050 - feat(widget): enable tier selector for car

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/ProductTierSelector.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ProductTierSelector.tsx
@@ -10,15 +10,21 @@ type Props = {
   offers: Array<ProductOfferFragment>
   selectedOffer: ProductOfferFragment
   onValueChange: (offerId: string) => void
+  defaultOpen?: boolean
 }
 
-export const ProductTierSelector = ({ offers, selectedOffer, onValueChange }: Props) => {
+export const ProductTierSelector = ({
+  offers,
+  selectedOffer,
+  onValueChange,
+  defaultOpen,
+}: Props) => {
   const { t } = useTranslation('purchase-form')
   const getVariantDescription = useGetVariantDescription()
   const formatter = useFormatter()
 
   return (
-    <TierSelector.Root defaultOpen={true}>
+    <TierSelector.Root defaultOpen={defaultOpen ?? true}>
       <TierSelector.Header>
         <Text>{t('TIER_SELECTOR_SELECTED_LABEL', { ns: 'purchase-form' })}</Text>
         <ToggleText>

--- a/apps/store/src/components/ProductPage/PurchaseForm/useTiersAndDeductibles.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/useTiersAndDeductibles.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react'
+import { type ProductOfferFragment } from '@/services/graphql/generated'
+import { getOffersByPrice } from '@/utils/getOffersByPrice'
+
+type Params = {
+  offers: Array<ProductOfferFragment>
+  selectedOffer: ProductOfferFragment
+}
+
+export function useTiersAndDeductibles({ offers, selectedOffer }: Params) {
+  return useMemo(() => {
+    const sortedOffers = getOffersByPrice(offers)
+
+    const tiers: Array<ProductOfferFragment> = []
+    const usedTiers = new Set<string>()
+    for (const offer of sortedOffers) {
+      const typeOfContract = offer.variant.typeOfContract
+      if (usedTiers.has(typeOfContract)) continue
+
+      usedTiers.add(typeOfContract)
+      tiers.push(typeOfContract === selectedOffer.variant.typeOfContract ? selectedOffer : offer)
+    }
+
+    const deductibles = sortedOffers.filter(
+      (item) => item.variant.typeOfContract === selectedOffer.variant.typeOfContract,
+    )
+
+    return { tiers, deductibles }
+  }, [offers, selectedOffer])
+}

--- a/apps/store/src/features/widget/ConfirmationPage.tsx
+++ b/apps/store/src/features/widget/ConfirmationPage.tsx
@@ -10,7 +10,7 @@ import { useDiscountProps } from '@/components/ShopBreakdown/useDiscountExplanat
 import type { ShopSession } from '@/services/shopSession/ShopSession.types'
 import type { ConfirmationStory } from '@/services/storyblok/storyblok'
 import { Header } from './Header'
-import { ProductItemContainer } from './ProductItemContainer'
+import { ProductItem } from './ProductItem'
 import { publishWidgetEvent } from './publishWidgetEvent'
 
 type Props = {
@@ -39,7 +39,12 @@ export const ConfirmationPage = (props: Props) => {
             </Heading>
             <Space y={1}>
               {props.shopSession.cart.entries.map((item) => (
-                <ProductItemContainer key={item.id} offer={item} disableStartDate={true} />
+                <ProductItem
+                  key={item.id}
+                  shopSessionId={props.shopSession.id}
+                  selectedOffer={item}
+                  disableStartDate={true}
+                />
               ))}
 
               {discount && (

--- a/apps/store/src/features/widget/ProductItemContainer.tsx
+++ b/apps/store/src/features/widget/ProductItemContainer.tsx
@@ -1,98 +1,34 @@
-import { useTranslation } from 'next-i18next'
-import { useMemo, type ReactNode, type ComponentProps } from 'react'
-import { useGetStartDateProps } from '@/components/ProductItem/useGetStartDateProps'
-import { useStartDateUpdateMutation, type ProductOfferFragment } from '@/services/graphql/generated'
-import { getOfferPrice } from '@/utils/getOfferPrice'
+import { type ComponentProps } from 'react'
+import { useTiersAndDeductibles } from '@/components/ProductPage/PurchaseForm/useTiersAndDeductibles'
 import { ProductItem } from './ProductItem'
-
-type Offer = Pick<
-  ProductOfferFragment,
-  | 'id'
-  | 'cost'
-  | 'priceIntentData'
-  | 'startDate'
-  | 'displayItems'
-  | 'deductible'
-  | 'variant'
-  | 'product'
-  | 'exposure'
-  | 'cancellation'
->
+import type { Offer } from './widget.types'
 
 type Props = {
-  offer: Offer
-  children?: ReactNode
-  defaultExpanded?: boolean
-  variant?: ComponentProps<typeof ProductItem>['variant']
-  onDelete?: ComponentProps<typeof ProductItem>['onDelete']
-  disableStartDate?: boolean
-}
+  offers: Array<Offer>
+  selectedOffer: Offer
+} & Pick<
+  ComponentProps<typeof ProductItem>,
+  'shopSessionId' | 'variant' | 'onDelete' | 'defaultExpanded' | 'disableStartDate' | 'children'
+>
 
 export const ProductItemContainer = (props: Props) => {
-  const { t } = useTranslation('cart')
-
-  const getStartDateProps = useGetStartDateProps()
-  const { tooltip } = getStartDateProps({
-    data: props.offer.priceIntentData,
-    startDate: props.offer.startDate,
+  const { tiers, deductibles } = useTiersAndDeductibles({
+    offers: props.offers,
+    selectedOffer: props.selectedOffer,
   })
-
-  const price = getOfferPrice(props.offer.cost)
-
-  const productDetails = useMemo(() => {
-    const items = props.offer.displayItems.map((item) => ({
-      title: item.displayTitle,
-      value: item.displayValue,
-    }))
-    const tierLevelDisplayName = getTierLevelDisplayName(props.offer)
-    if (tierLevelDisplayName) {
-      items.push({ title: t('DATA_TABLE_TIER_LABEL'), value: tierLevelDisplayName })
-    }
-    const deductibleDisplayName = props.offer.deductible?.displayName
-    if (deductibleDisplayName) {
-      items.push({ title: t('DATA_TABLE_DEDUCTIBLE_LABEL'), value: deductibleDisplayName })
-    }
-    return items
-  }, [props.offer, t])
-
-  const productDocuments = props.offer.variant.documents.map((item) => ({
-    title: item.displayName,
-    url: item.url,
-  }))
-
-  const [updateStartDate, result] = useStartDateUpdateMutation()
-  const handleChangeStartDate = (startDate: string) => {
-    updateStartDate({
-      variables: { productOfferIds: [props.offer.id], startDate },
-    })
-  }
 
   return (
     <ProductItem
-      title={props.offer.product.displayNameFull}
-      pillowSrc={props.offer.product.pillowImage.src}
-      price={price}
-      productDetails={productDetails}
-      productDocuments={productDocuments}
+      shopSessionId={props.shopSessionId}
+      selectedOffer={props.selectedOffer}
+      tiers={tiers}
+      deductibles={deductibles}
       defaultExpanded={props.defaultExpanded}
       variant={props.variant}
-      exposure={props.offer.exposure.displayNameShort}
-      tooltip={tooltip}
-      autoSwitch={props.offer.cancellation.requested}
-      startDate={props.offer.startDate}
-      onChangeStartDate={handleChangeStartDate}
       disableStartDate={props.disableStartDate ?? false}
-      loading={result.loading}
       onDelete={props.onDelete}
     >
       {props.children}
     </ProductItem>
   )
-}
-
-const getTierLevelDisplayName = (item: Pick<ProductOfferFragment, 'variant' | 'product'>) => {
-  // TODO: small hack, move logic to API
-  return item.variant.displayName !== item.product.displayNameFull
-    ? item.variant.displayName
-    : undefined
 }

--- a/apps/store/src/features/widget/SignPage.tsx
+++ b/apps/store/src/features/widget/SignPage.tsx
@@ -24,9 +24,10 @@ import { TextWithLink } from '@/components/TextWithLink'
 import { SIGN_FORM_ID } from '@/constants/sign.constants'
 import {
   MemberPaymentConnectionStatus,
-  type ProductOfferFragment,
   useCartEntryRemoveMutation,
   useCurrentMemberLazyQuery,
+  type ProductOfferFragment,
+  type PriceIntentFragment,
 } from '@/services/graphql/generated'
 import { type ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useTracking } from '@/services/Tracking/useTracking'
@@ -38,15 +39,15 @@ import { publishWidgetEvent } from './publishWidgetEvent'
 
 type Props = {
   shopSession: ShopSession
-  priceIntentId: string
+  priceIntent: PriceIntentFragment
   ssn: string
   shouldCollectEmail: boolean
   shouldCollectName: boolean
-  suggestedEmail?: string
   flow: string
-  content?: Array<SbBlokData>
   productName: string
+  suggestedEmail?: string
   showBackButton?: boolean
+  content?: Array<SbBlokData>
 }
 
 export const SignPage = (props: Props) => {
@@ -150,7 +151,11 @@ export const SignPage = (props: Props) => {
               <Space y={1}>
                 <ShopBreakdown>
                   {mainOffer && (
-                    <ProductItemContainer offer={mainOffer}>
+                    <ProductItemContainer
+                      shopSessionId={props.shopSession.id}
+                      offers={props.priceIntent.offers}
+                      selectedOffer={mainOffer}
+                    >
                       <ButtonNextLink
                         variant="secondary"
                         size="medium"
@@ -158,7 +163,7 @@ export const SignPage = (props: Props) => {
                           locale,
                           flow: props.flow,
                           shopSessionId: props.shopSession.id,
-                          priceIntentId: props.priceIntentId,
+                          priceIntentId: props.priceIntent.id,
                         })}
                       >
                         {t('cart:CART_ENTRY_EDIT_BUTTON')}
@@ -174,7 +179,12 @@ export const SignPage = (props: Props) => {
                         exit={{ opacity: 0, height: 0 }}
                         style={{ position: 'relative' }}
                       >
-                        <ProductItemContainer offer={item} onDelete={handleRemoveCartItem(item)} />
+                        <ProductItemContainer
+                          shopSessionId={props.shopSession.id}
+                          offers={[item]}
+                          selectedOffer={item}
+                          onDelete={handleRemoveCartItem(item)}
+                        />
                         {result.loading && <ProductItemLoadingOverlay />}
                       </motion.div>
                     ))}

--- a/apps/store/src/features/widget/widget.types.ts
+++ b/apps/store/src/features/widget/widget.types.ts
@@ -1,0 +1,15 @@
+import { type ProductOfferFragment } from '@/services/graphql/generated'
+
+export type Offer = Pick<
+  ProductOfferFragment,
+  | 'id'
+  | 'cost'
+  | 'priceIntentData'
+  | 'startDate'
+  | 'displayItems'
+  | 'deductible'
+  | 'variant'
+  | 'product'
+  | 'exposure'
+  | 'cancellation'
+>

--- a/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
+++ b/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
@@ -9,7 +9,7 @@ import { SignPage } from '@/features/widget/SignPage'
 import { fetchFlowStory } from '@/features/widget/widget.helpers'
 import { initializeApolloServerSide } from '@/services/apollo/client'
 import { hideChatOnPage } from '@/services/CustomerFirst'
-import { useShopSessionQuery } from '@/services/graphql/generated'
+import { usePriceIntentQuery, useShopSessionQuery } from '@/services/graphql/generated'
 import { priceIntentServiceInitServerSide } from '@/services/priceIntent/PriceIntentService'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
@@ -17,8 +17,9 @@ import { getShouldCollectEmail, getShouldCollectName } from '@/utils/customer'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { patchNextI18nContext } from '@/utils/patchNextI18nContext'
 
-type Props = Omit<ComponentPropsWithoutRef<typeof SignPage>, 'shopSession'> & {
+type Props = Omit<ComponentPropsWithoutRef<typeof SignPage>, 'shopSession' | 'priceIntent'> & {
   shopSessionId: string
+  priceIntentId: string
   productData: ProductData
   pageTitle: string
 }
@@ -29,7 +30,12 @@ const NextWidgetSignPage = (props: Props) => {
   })
   const shopSession = shopSessionResult.data?.shopSession
 
-  if (!shopSession) return null
+  const priceIntentResult = usePriceIntentQuery({
+    variables: { priceIntentId: props.priceIntentId },
+  })
+  const priceIntent = priceIntentResult.data?.priceIntent
+
+  if (!shopSession || !priceIntent) return null
 
   return (
     <>
@@ -38,7 +44,7 @@ const NextWidgetSignPage = (props: Props) => {
       </Head>
       <ProductDataProvider productData={props.productData}>
         <TrackingProvider shopSession={shopSession} productData={props.productData}>
-          <SignPage shopSession={shopSession} {...props} />
+          <SignPage shopSession={shopSession} priceIntent={priceIntent} {...props} />
         </TrackingProvider>
       </ProductDataProvider>
     </>


### PR DESCRIPTION
## Describe your changes

* Extract tiers/deductibles definition into a hook: `useTiersAndDeductibles`; `OfferPresenter` and widget's `ProductItemContainer` now uses it to get tiers and deductibles.
* `ProductItemContainer`/`ProductItem` refactoring: move presentational logic from the container to the item
* `ProductItem`/`ProductItemContainer`: updated so they support tiers selection 

https://github.com/HedvigInsurance/racoon/assets/19200662/3cdb8a72-6afe-49ec-9d25-44ecf2d717ee

Discussion points

1. We probably need some sort of loading state for when changing tiers/deductibles. Checking with WIlliam.
2. Observe that we're using current implementation/design for _Tier Selector_. The idea is to modify the UI to match latest designs later.
3. Observe that other parts of the page - like perils - doesn't get update when tiers are selected. That's gonna be added later.
4. Our current model is simple: once in sign/checkout/cart pages, the source of truth is whatever offer you have into your shop session cart. Adding "editing" at the this point means needing to have access to the price intent(s) that generate those offers so we can replace what you have in your cart. _Hedvig Embeded_ is a subset of Hedvig-dot-com by consisting of a linear flow flow purchasing a single product, so we need to handle with only one price intent. But things could be complicated if more than one product is in the cart...

## Justify why they are needed

First step towards enabling car+pet for Hedvig Embeded.  