### PR TITLE
GEN-2050 - fix(useTiersAndDeductibles): handle case where no tiers/deductibles are present

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/useTiersAndDeductibles.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/useTiersAndDeductibles.ts
@@ -9,8 +9,9 @@ type Params = {
 
 export function useTiersAndDeductibles({ offers, selectedOffer }: Params) {
   return useMemo(() => {
-    const sortedOffers = getOffersByPrice(offers)
+    if (offers.length === 1) return { tiers: [], deductibles: [] }
 
+    const sortedOffers = getOffersByPrice(offers)
     const tiers: Array<ProductOfferFragment> = []
     const usedTiers = new Set<string>()
     for (const offer of sortedOffers) {


### PR DESCRIPTION
## Describe your changes

* Fix an issue with `useTiersAndDeductibles` hook

## Justify why they are needed

I've introduced an issue with where we'd be showing tier selector even for cases tiers/deductibles are not applicable

<img width="575" alt="Screenshot 2024-05-02 at 11 54 23" src="https://github.com/HedvigInsurance/racoon/assets/19200662/8c6348cc-263e-4447-9dbd-d4edc002f305">

