### PR TITLE
Dynamic server-side rendering of CMS pages for speed test

### DIFF
--- a/apps/store/next.config.mjs
+++ b/apps/store/next.config.mjs
@@ -15,6 +15,12 @@ const config = {
       '*': ['./next-i18next.config.cjs', './public/locales/**/*'],
     },
   },
+  logging: {
+    fetches: {
+      // Detailed fetch logs in dev move
+      fullUrl: true,
+    },
+  },
   reactStrictMode: true,
   swcMinify: true,
   compiler: {

--- a/apps/store/src/app/[locale]/appDebug/[[...slug]]/ProductCmsPage.tsx
+++ b/apps/store/src/app/[locale]/appDebug/[[...slug]]/ProductCmsPage.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { ProductPageBlock } from '@/blocks/ProductPageBlock'
 import { BankIdDialog } from '@/components/BankIdDialog/BankIdDialog'
 import { PageBannerTriggers } from '@/components/Banner/PageBannerTriggers'
@@ -49,19 +50,21 @@ export const ProductCmsPage = async ({ locale, story }: ProductCmsPageProps) => 
       selectedTypeOfContract={initialSelectedTypeOfContract}
     >
       <ProductPageContextProvider story={story} priceTemplate={priceTemplate}>
-        <PriceIntentContextProvider>
-          <ProductPageTrackingProvider>
-            <ProductReviewsMetadataProvider productReviewsMetadata={productReviewsMetadata}>
-              <BankIdContextProvider>
-                <ProductPageBlock blok={story.content} />
-                <PageDebugDialog />
-                <ProductPageViewTracker />
-                <PageBannerTriggers blok={story.content} />
-                <BankIdDialog />
-              </BankIdContextProvider>
-            </ProductReviewsMetadataProvider>
-          </ProductPageTrackingProvider>
-        </PriceIntentContextProvider>
+        <Suspense>
+          <PriceIntentContextProvider>
+            <ProductPageTrackingProvider>
+              <ProductReviewsMetadataProvider productReviewsMetadata={productReviewsMetadata}>
+                <BankIdContextProvider>
+                  <ProductPageBlock blok={story.content} />
+                  <PageDebugDialog />
+                  <ProductPageViewTracker />
+                  <PageBannerTriggers blok={story.content} />
+                  <BankIdDialog />
+                </BankIdContextProvider>
+              </ProductReviewsMetadataProvider>
+            </ProductPageTrackingProvider>
+          </PriceIntentContextProvider>
+        </Suspense>
       </ProductPageContextProvider>
     </ProductDataProvider>
   )

--- a/apps/store/src/app/[locale]/appDebug/[[...slug]]/StoryBreadcrumbs.tsx
+++ b/apps/store/src/app/[locale]/appDebug/[[...slug]]/StoryBreadcrumbs.tsx
@@ -18,14 +18,19 @@ export async function StoryBreadcrumbs(props: Props) {
 
   const parentBreadcrumbs: Array<BreadcrumbListItem> = []
   if (slug.length > 1) {
-    const parentStories = await getParentStories(slug.join('/'), { locale: props.params.locale })
-    parentStories.forEach((item) => {
-      const slugWithoutTrailingSlash = item.full_slug.replace(/\/$/, '')
-      parentBreadcrumbs.push({
-        label: item.name,
-        href: `${ORIGIN_URL}/${slugWithoutTrailingSlash}`,
+    try {
+      const parentStories = await getParentStories(slug.join('/'), { locale: props.params.locale })
+      parentStories.forEach((item) => {
+        const slugWithoutTrailingSlash = item.full_slug.replace(/\/$/, '')
+        parentBreadcrumbs.push({
+          label: item.name,
+          href: `${ORIGIN_URL}/${slugWithoutTrailingSlash}`,
+        })
       })
-    })
+    } catch (err) {
+      console.log(`Failed to get breadcrumbs for ${JSON.stringify(props.params)}`, err)
+      return null
+    }
   }
 
   const items = [...parentBreadcrumbs, { label: props.currentPageTitle }]

--- a/apps/store/src/app/[locale]/appDebug/[[...slug]]/page.tsx
+++ b/apps/store/src/app/[locale]/appDebug/[[...slug]]/page.tsx
@@ -103,6 +103,9 @@ export async function generateStaticParams({
 // See https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams
 export const dynamicParams = true
 
+// DEBUG: Force dynamic server-side rendering
+export const dynamic = 'force-dynamic'
+
 // Cache speeds up development mode by deduplicating requests between metadata and main renderer
 const fetchStory = cache(async (locale: RoutingLocale, slug = '') => {
   try {

--- a/apps/store/src/app/[locale]/layout.tsx
+++ b/apps/store/src/app/[locale]/layout.tsx
@@ -27,7 +27,7 @@ const Layout = async ({ children, params: { locale } }: LocalizedLayoutProps) =>
   const [companyReviewsMetadata, productMetadata, globalStory] = await Promise.all([
     fetchCompanyReviewsMetadata(),
     fetchGlobalProductMetadata({ apolloClient }),
-    getStoryBySlug<GlobalStory>('global', { version: 'published', locale }),
+    getStoryBySlug<GlobalStory>('global', { locale }),
   ])
 
   return (

--- a/apps/store/src/app/layout.tsx
+++ b/apps/store/src/app/layout.tsx
@@ -10,7 +10,6 @@ type Props = {
 }
 
 export default function RootAppLayout({ children }: Props) {
-  return <JotaiProvider>{children}</JotaiProvider>
   return (
     <>
       <JotaiProvider>{children}</JotaiProvider>

--- a/apps/store/src/pages/[locale]/widget/[[...slug]].tsx
+++ b/apps/store/src/pages/[locale]/widget/[[...slug]].tsx
@@ -84,7 +84,7 @@ export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = a
 
 export const getStaticPaths: GetStaticPaths = async (context) => {
   if (process.env.SKIP_BUILD_STATIC_GENERATION === 'true') {
-    console.info('Skipping static generation for widget landing pages...')
+    console.info('Pages router widget pages: skipping static generation')
     return { paths: [], fallback: 'blocking' }
   }
 

--- a/apps/store/src/services/shopSession/ShopSessionService.ts
+++ b/apps/store/src/services/shopSession/ShopSessionService.ts
@@ -8,12 +8,13 @@ import type {
   ShopSessionOutcomeIdQuery,
   ShopSessionOutcomeIdQueryVariables,
   ShopSessionQuery,
-  ShopSessionQueryVariables} from '@/services/graphql/generated';
+  ShopSessionQueryVariables,
+} from '@/services/graphql/generated'
 import {
   ShopSessionCreateDocument,
   ShopSessionDocument,
   ShopSessionOutcomeDocument,
-  ShopSessionOutcomeIdDocument
+  ShopSessionOutcomeIdDocument,
 } from '@/services/graphql/generated'
 import type { SimplePersister } from '@/services/persister/Persister.types'
 import type { ShopSession } from '@/services/shopSession/ShopSession.types'
@@ -83,7 +84,7 @@ export class ShopSessionService {
     >({
       mutation: ShopSessionCreateDocument,
       variables,
-      // TODO: Investigate if we can do it by returning shopSession recond on top instead of shopSessionCreate
+      // TODO: Investigate if we can do it by returning shopSession record on top instead of shopSessionCreate
       update: (cache, result) => {
         const shopSession = result.data?.shopSessionCreate
         if (shopSession) {

--- a/apps/store/src/services/storyblok/Storyblok.constant.ts
+++ b/apps/store/src/services/storyblok/Storyblok.constant.ts
@@ -1,5 +1,19 @@
+// TODO: get rid of this import, services should avoid feature-imports
+import { STORYBLOK_MANYPETS_FOLDER_SLUG } from '@/features/manyPets/manyPets.constants'
+import { STORYBLOK_WIDGET_FOLDER_SLUG } from '@/features/widget/widget.constants'
+
 export const GLOBAL_STORY_PROP_NAME = 'globalStory'
 export const STORY_PROP_NAME = 'story'
+// NOTE: Excluding by content_type would be easier to support,
+// but according to the docs it's only possible to do if we fetch full stories, not links
+export const LINKS_EXCLUDE_PATHS = new Set([
+  'reusable-blocks',
+  'product-metadata',
+  'car-buyer',
+  'global',
+  STORYBLOK_MANYPETS_FOLDER_SLUG,
+  STORYBLOK_WIDGET_FOLDER_SLUG,
+])
 
 // From 1w visitor stats for period ending 29.04.2024
 export const MOST_VISITED_PATHS = new Set([

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -1,4 +1,5 @@
 import { type ISbStoryData, type SbBlokData } from '@storyblok/react'
+import type { RoutingLocale } from '@/utils/l10n/types'
 import type { LinkField, ProductStory, WidgetFlowStory } from './storyblok'
 
 export const filterByBlockType = <BlockData extends SbBlokData>(
@@ -86,4 +87,15 @@ export const getLinkRel = (link: Pick<LinkField, 'rel' | 'target'>) => {
   }
 
   return undefined
+}
+
+export type LinkData = Pick<
+  ISbStoryData,
+  'id' | 'slug' | 'name' | 'parent_id' | 'position' | 'uuid' | 'is_startpage'
+> & { is_folder: boolean; path: string; published: boolean; real_path: string }
+
+export type PageLink = {
+  link: LinkData
+  locale: RoutingLocale
+  slugParts: Array<string>
 }

--- a/apps/store/src/services/storyblok/storyblok.serverOnly.ts
+++ b/apps/store/src/services/storyblok/storyblok.serverOnly.ts
@@ -2,14 +2,14 @@ import 'server-only'
 import type { ISbStoryData } from '@storyblok/react'
 import { apiPlugin, getStoryblokApi, storyblokInit } from '@storyblok/react/rsc'
 import { BLOG_ARTICLE_CONTENT_TYPE } from '@/features/blog/blog.constants'
-import type { StoryblokVersion, StoryOptions } from '@/services/storyblok/storyblok'
+import type { StoryOptions } from '@/services/storyblok/storyblok'
+import { LINKS_EXCLUDE_PATHS } from '@/services/storyblok/Storyblok.constant'
+import type { LinkData, PageLink } from '@/services/storyblok/Storyblok.helpers'
 import { storyblokComponents } from '@/services/storyblok/storyblokComponents'
-import type { Language } from '@/utils/l10n/types'
+import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 
 // Overall app router setup for Storyblok based on
 // https://www.storyblok.com/tp/add-a-headless-cms-to-next-js-13-in-5-minutes
-
-const cvCacheTag = 'storyblok.cv'
 
 storyblokInit({
   accessToken: process.env.NEXT_PUBLIC_STORYBLOK_ACCESS_TOKEN,
@@ -17,35 +17,29 @@ storyblokInit({
   components: storyblokComponents,
 })
 
-export const fetchStoryblokCacheVersion = async ({
-  cache = 'force-cache',
-}: {
-  cache: RequestCache
-}): Promise<number> => {
-  const storyblokApi = getStoryblokApi()
-  await storyblokApi.getStory('/se', {}, { cache, next: { tags: [cvCacheTag] } })
-  return storyblokApi.cacheVersion()
-}
-
-const primeCache = () => fetchStoryblokCacheVersion({ cache: 'force-cache' })
-
-export type StoryblokFetchParams = {
-  version?: StoryblokVersion
-  language?: Language
-  resolve_relations?: string
-}
-
 export const getStoryBySlug = async <T extends ISbStoryData>(
   slug: string,
-  { version, locale }: StoryOptions,
+  { locale, version = 'published' }: StoryOptions,
 ): Promise<T> => {
-  const storyblokApi = getStoryblokApi()
-  await primeCache()
-  const { data } = await storyblokApi.getStory(`${locale}/${slug}`, {
-    version,
-    resolve_links: 'url',
-    resolve_relations: `reusableBlockReference.reference,${BLOG_ARTICLE_CONTENT_TYPE}.categories,page.abTestOrigin`,
-  })
+  const storyblokApi = await getStoryblokApiWithCache()
+  const fullSlug = slug.length > 0 ? `${locale}/${slug}` : locale
+  const { data } = await storyblokApi
+    .getStory(
+      fullSlug,
+      {
+        version,
+        resolve_links: 'url',
+        resolve_relations: `reusableBlockReference.reference,${BLOG_ARTICLE_CONTENT_TYPE}.categories,page.abTestOrigin`,
+      },
+      {
+        // Use 'no-cache' for debugging caching issue
+        cache: 'force-cache',
+      },
+    )
+    .catch((err) => {
+      console.log(`Failed to get story ${fullSlug}`, err)
+      throw err
+    })
   return data.story as T
 }
 
@@ -54,9 +48,57 @@ export const getParentStories = async (slug: string, { version, locale }: StoryO
   const parentSlugs = absoluteSlug
     .split('/')
     .slice(0, -1)
-    .map((_, index, array) => array.slice(0, index + 1).join('/'))
+    .map((_, index, array) =>
+      array
+        .slice(0, index + 1)
+        .join('/')
+        .replaceAll(/(^\/|\/$)/g, ''),
+    )
 
   // Individual per-story requests probably mean better cache hit ratio and less traffic overall
   // We used to fetch all parents with single requests in pages router instead
-  return await Promise.all(parentSlugs.map((slug) => getStoryBySlug(slug, { version, locale })))
+  return await Promise.all(parentSlugs.map((slug) => getStoryBySlug(slug, { locale, version })))
+}
+
+export const getCmsPageLinks = async (startsWith?: string) => {
+  const storyblokApi = await getStoryblokApiWithCache()
+  const {
+    data: { links },
+  } = (await storyblokApi.get('cdn/links/', {
+    ...(startsWith && { starts_with: startsWith }),
+    version: 'published',
+  })) as unknown as { data: { links: Record<string, LinkData> } }
+
+  const pageLinks: Array<PageLink> = []
+  for (const link of Object.values(links)) {
+    if (link.is_folder) continue
+    const [locale, ...slugParts] = link.slug.split('/')
+    if (!isRoutingLocale(locale)) continue
+    if (LINKS_EXCLUDE_PATHS.has(slugParts[0])) continue
+    pageLinks.push({
+      link,
+      locale,
+      slugParts,
+    })
+  }
+  return pageLinks
+}
+
+const getStoryblokApiWithCache = async (): Promise<ReturnType<typeof getStoryblokApi>> => {
+  const cacheVersion = await fetchStoryblokCacheVersion()
+  const storyblokApi = getStoryblokApi()
+  // fetchStoryblokCacheVersion might be returning from cache, so we want to update current instance
+  storyblokApi.setCacheVersion(cacheVersion)
+  return storyblokApi
+}
+
+const cvCacheTag = 'storyblok.cv'
+const fetchStoryblokCacheVersion = async (): Promise<number> => {
+  const storyblokApi = getStoryblokApi()
+  await storyblokApi.getStory(
+    'se',
+    {},
+    { cache: 'force-cache', next: { tags: [cvCacheTag], revalidate: 60 } },
+  )
+  return storyblokApi.cacheVersion()
 }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -1,27 +1,18 @@
 import * as process from 'process'
-import type {
-  ISbStoriesParams,
-  ISbStoryData,
-  SbBlokData,
-  StoryblokClient} from '@storyblok/react';
-import {
-  apiPlugin,
-  getStoryblokApi,
-  storyblokInit,
-} from '@storyblok/react'
+import type { ISbStoriesParams, ISbStoryData, SbBlokData, StoryblokClient } from '@storyblok/react'
+import { apiPlugin, getStoryblokApi, storyblokInit } from '@storyblok/react'
 import type { FooterBlockProps } from '@/blocks/FooterBlock'
 import type { HeaderBlockProps } from '@/blocks/HeaderBlock'
 import type { ReusableBlockReferenceProps } from '@/blocks/ReusableBlockReference'
 import { type ContentAlignment, type ContentWidth } from '@/components/GridLayout/GridLayout.helper'
 import type { BreadcrumbListItem } from '@/components/PageBreadcrumbs/PageBreadcrumbs'
 import { BLOG_ARTICLE_CONTENT_TYPE } from '@/features/blog/blog.constants'
-// TODO: get rid of this import, services should avoid feature-imports
-import { STORYBLOK_MANYPETS_FOLDER_SLUG } from '@/features/manyPets/manyPets.constants'
-import { STORYBLOK_WIDGET_FOLDER_SLUG } from '@/features/widget/widget.constants'
+import type { LinkData, PageLink } from '@/services/storyblok/Storyblok.helpers'
 import { isBrowser } from '@/utils/env'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
-import type { Language, RoutingLocale } from '@/utils/l10n/types'
+import type { Language } from '@/utils/l10n/types'
 import type { GLOBAL_STORY_PROP_NAME, STORY_PROP_NAME } from './Storyblok.constant'
+import { LINKS_EXCLUDE_PATHS } from './Storyblok.constant'
 import { storyblokComponents } from './storyblokComponents'
 
 export type SbBaseBlockProps<T> = {
@@ -173,17 +164,6 @@ export type ConfirmationStory = ISbStoryData & {
   }
 }
 
-type LinkData = Pick<
-  ISbStoryData,
-  'id' | 'slug' | 'name' | 'parent_id' | 'position' | 'uuid' | 'is_startpage'
-> & { is_folder: boolean; path: string; published: boolean; real_path: string }
-
-type PageLink = {
-  link: LinkData
-  locale: RoutingLocale
-  slugParts: Array<string>
-}
-
 export const initStoryblok = () => {
   // https://github.com/storyblok/storyblok-react/issues/156#issuecomment-1197764828
   let shouldUseBridge = false
@@ -267,18 +247,9 @@ export const getPageLinks = async (params?: GetPageLinksParams): Promise<Array<P
   return pageLinks
 }
 
-// NOTE: Excluding by content_type would be easier to support,
-// but according to the docs it's only possible to do if we fetch full stories, not links
-const EXCLUDE_FOLDERS = new Set([
-  'reusable-blocks',
-  'product-metadata',
-  'car-buyer',
-  STORYBLOK_MANYPETS_FOLDER_SLUG,
-  STORYBLOK_WIDGET_FOLDER_SLUG,
-])
-export const getFilteredPageLinks = async () => {
-  const allLinks = await getPageLinks()
-  return allLinks.filter(({ slugParts }) => !EXCLUDE_FOLDERS.has(slugParts[0]))
+export const getFilteredPageLinks = async (params?: GetPageLinksParams) => {
+  const allLinks = await getPageLinks(params)
+  return allLinks.filter(({ slugParts }) => !LINKS_EXCLUDE_PATHS.has(slugParts[0]))
 }
 
 export const getGlobalStory = (options: StoryOptions): Promise<GlobalStory> => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

This draft PR is created to measure effects of skipping static rendering for large CMS pages

Results from Vercel preview deployment , measuring `se/forsakringar/djurforsakring` category page in Lighthouse
- app router, no static rendering: 1100ms response time (rendering stuff in RSC is not free even if all external data comes from cache very quickly), FCP 1.2s, speed index 2.6s
- pages router, static rendering: 190ms response time, FCP 1.1s, speed index 2.6s
- app router, static rendering (in different branch): 50ms response time (streaming makes it faster than pages router static page), FCP 1.1s, speed index 2.1s

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
