### PR TITLE
feature: [RND-704] Move Swedish homepage to hedvig.com root

### DIFF
--- a/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
+++ b/apps/store/src/components/HeadSeoInfo/HeadSeoInfo.tsx
@@ -6,7 +6,7 @@ import { getImgSrc } from '@/services/storyblok/Storyblok.helpers'
 import { isBrowser } from '@/utils/env'
 import { organization } from '@/utils/jsonSchema'
 import { getLocaleOrFallback, isRoutingLocale } from '@/utils/l10n/localeUtils'
-import { ORIGIN_URL } from '@/utils/PageLink'
+import { ORIGIN_URL, removeSEHomepageLangSegment } from '@/utils/PageLink'
 
 type Props = {
   story: ISbStoryData<SEOData>
@@ -77,7 +77,7 @@ const AlternateLink = ({ fullSlug }: { fullSlug: string }) => {
     <Head>
       <link
         rel="alternate"
-        href={`${ORIGIN_URL}/${removeTrailingSlash(fullSlug)}`}
+        href={removeSEHomepageLangSegment(`${ORIGIN_URL}/${fullSlug}`)}
         hrefLang={getHrefLang(fullSlug)}
       />
     </Head>
@@ -91,8 +91,4 @@ const getHrefLang = (fullSlug: string) => {
   }
 
   return 'x-default'
-}
-
-const removeTrailingSlash = (url: string) => {
-  return url.endsWith('/') ? url.slice(0, -1) : url
 }

--- a/apps/store/src/components/PageBreadcrumbs/PageBreadcrumbs.tsx
+++ b/apps/store/src/components/PageBreadcrumbs/PageBreadcrumbs.tsx
@@ -21,7 +21,7 @@ export const PageBreadcrumbs = (props: Props) => {
       '@type': 'ListItem',
       position: index + 1,
       name: item.label,
-      ...(item.href && { item: item.href }),
+      ...(item.href && { item: removeSEHomepageLangSegment(item.href) }),
     })),
   }
 

--- a/apps/store/src/components/PageBreadcrumbs/PageBreadcrumbs.tsx
+++ b/apps/store/src/components/PageBreadcrumbs/PageBreadcrumbs.tsx
@@ -1,8 +1,9 @@
 import { clsx } from 'clsx'
 import Link from 'next/link'
-import type { ComponentProps} from 'react';
+import type { ComponentProps } from 'react'
 import { Children, type ReactNode } from 'react'
 import { Text } from 'ui'
+import { removeSEHomepageLangSegment } from '@/utils/PageLink'
 import { breadcrumbItem, breadcrumbsLink, breadcrumbsList } from './PageBreadcrumbs.css'
 
 export type BreadcrumbListItem = {
@@ -29,7 +30,7 @@ export const PageBreadcrumbs = (props: Props) => {
       <List>
         {props.items.map((item) =>
           item.href ? (
-            <ItemLink key={item.href} href={item.href}>
+            <ItemLink key={item.href} href={removeSEHomepageLangSegment(item.href)}>
               {item.label}
             </ItemLink>
           ) : (

--- a/apps/store/src/middleware.ts
+++ b/apps/store/src/middleware.ts
@@ -39,6 +39,14 @@ const localeMiddleware = (req: NextRequest): NextResponse | undefined => {
   const redirectToLocale = (locale: string) => {
     const targetUrl = req.nextUrl.clone()
     targetUrl.pathname = `/${locale}${targetUrl.pathname}`
+
+    if (
+      locale === locales['sv-SE'].routingLocale ||
+      locale === locales[FALLBACK_LOCALE].routingLocale
+    ) {
+      return NextResponse.rewrite(targetUrl)
+    }
+
     return NextResponse.redirect(targetUrl, 308)
   }
 

--- a/apps/store/src/middleware.ts
+++ b/apps/store/src/middleware.ts
@@ -45,7 +45,7 @@ const localeMiddleware = (req: NextRequest): NextResponse | undefined => {
 
       // Set the Swedish homepage path to `/`
       // The `redirectToLocale` function will be invoked with the default locale which is Swedish
-      // URL will rewritten to serve the Swedish page on `/`
+      // URL will be rewritten to serve the Swedish page on `/`
       return NextResponse.redirect(targetUrl, 308)
     }
 
@@ -58,10 +58,10 @@ const localeMiddleware = (req: NextRequest): NextResponse | undefined => {
     targetUrl.pathname = `/${locale}${targetUrl.pathname}`
 
     // This function is invoked when requesting a non-localized route
-    // To redirect it to the relevant localized version
+    // to redirect it to the relevant localized version
     // When called with a the Swedish or default locales
-    // We rewrite the URL instead of redirecting
-    // To display the translated pages without changing the URL
+    // we rewrite the URL instead of redirecting to display
+    // the translated pages without changing the URL
     if (
       locale === locales['sv-SE'].routingLocale ||
       locale === locales[FALLBACK_LOCALE].routingLocale

--- a/apps/store/src/middleware.ts
+++ b/apps/store/src/middleware.ts
@@ -37,12 +37,7 @@ const localeMiddleware = (req: NextRequest): NextResponse | undefined => {
 
   // Localized route
   if (isRoutingLocale(firstSegment)) {
-    const isSwedish = firstSegment === locales['sv-SE'].routingLocale
-
-    // URL only have a locale
-    const isHomePage = url.pathname.split('/').length === 2
-
-    const isSwedishHomepage = isSwedish && isHomePage
+    const isSwedishHomepage = url.pathname === '/se'
 
     if (isSwedishHomepage) {
       const targetUrl = req.nextUrl.clone()

--- a/apps/store/src/pages/sitemap.xml.ts
+++ b/apps/store/src/pages/sitemap.xml.ts
@@ -1,11 +1,7 @@
 import type { ISbStoryData } from '@storyblok/js'
 import type { GetServerSideProps } from 'next'
 import { getStoryblokApi } from '@/services/storyblok/api'
-import { ORIGIN_URL } from '@/utils/PageLink'
-
-const removeTrailingSlash = (url: string) => {
-  return url.endsWith('/') ? url.slice(0, -1) : url
-}
+import { ORIGIN_URL, removeTrailingSlash } from '@/utils/PageLink'
 
 const generateSiteMap = (pages: Array<ISbStoryData>) => {
   return `<?xml version="1.0" encoding="UTF-8"?>

--- a/apps/store/src/pages/sitemap.xml.ts
+++ b/apps/store/src/pages/sitemap.xml.ts
@@ -1,7 +1,7 @@
 import type { ISbStoryData } from '@storyblok/js'
 import type { GetServerSideProps } from 'next'
 import { getStoryblokApi } from '@/services/storyblok/api'
-import { ORIGIN_URL, removeTrailingSlash } from '@/utils/PageLink'
+import { ORIGIN_URL, removeSEHomepageLangSegment } from '@/utils/PageLink'
 
 const generateSiteMap = (pages: Array<ISbStoryData>) => {
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -10,7 +10,7 @@ const generateSiteMap = (pages: Array<ISbStoryData>) => {
        .map((page) => {
          return `
           <url>
-            <loc>${`${ORIGIN_URL}/${removeTrailingSlash(page.full_slug)}`}</loc>
+            <loc>${removeSEHomepageLangSegment(`${ORIGIN_URL}/${page.full_slug}`)}</loc>
           </url>
         `
        })

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -354,14 +354,18 @@ const REVIEWS_URL: Partial<Record<RoutingLocale, URL>> = {
   'se-en': new URL('/se-en/hedvig/reviews', ORIGIN_URL),
 }
 
+export const removeTrailingSlash = (url: string) => {
+  return url.endsWith('/') ? url.slice(0, -1) : url
+}
+
 export const removeSEHomepageLangSegment = (urlString: string): string => {
   const url = new URL(urlString)
-  const isSwedishHomepage = url.pathname === '/se'
+
+  const isSwedishHomepage = removeTrailingSlash(url.pathname) === '/se'
 
   if (isSwedishHomepage) {
     url.pathname = '/'
   }
 
-  // and this part
-  return url.toString()
+  return removeTrailingSlash(url.toString())
 }

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -2,6 +2,7 @@ import { datadogLogs } from '@datadog/browser-logs'
 import { QueryParam as CheckoutPageQueryParam } from '@/components/CheckoutPage/CheckoutPage.constants'
 import { QueryParam as CheckoutTrustlyQueryParam } from '@/components/CheckoutPaymentTrustlyPage/CheckoutPaymentTrustlyPage constants'
 import type { RoutingLocale } from '@/utils/l10n/types'
+import { locales } from './l10n/locales'
 
 class ExtendedURL extends URL {
   constructor(url: string, base?: string) {
@@ -53,6 +54,9 @@ type MemberLoginPage = BaseParams & {
 
 export const PageLink = {
   home: ({ locale }: BaseParams) => {
+    if (locale === locales['sv-SE'].routingLocale) {
+      return new URL(ORIGIN_URL)
+    }
     return new URL(locale, ORIGIN_URL)
   },
   // TODO: we probably want a better setup for locale-specific slugs than just hardcoding them

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -359,9 +359,9 @@ export const removeTrailingSlash = (url: string) => {
 }
 
 export const removeSEHomepageLangSegment = (urlString: string): string => {
-  const url = new URL(urlString)
+  const url = new URL(removeTrailingSlash(urlString))
 
-  const isSwedishHomepage = removeTrailingSlash(url.pathname) === '/se'
+  const isSwedishHomepage = url.pathname === '/se'
 
   if (isSwedishHomepage) {
     url.pathname = '/'

--- a/apps/store/src/utils/PageLink.ts
+++ b/apps/store/src/utils/PageLink.ts
@@ -353,3 +353,15 @@ const REVIEWS_URL: Partial<Record<RoutingLocale, URL>> = {
   se: new URL('/se/hedvig/omdomen', ORIGIN_URL),
   'se-en': new URL('/se-en/hedvig/reviews', ORIGIN_URL),
 }
+
+export const removeSEHomepageLangSegment = (urlString: string): string => {
+  const url = new URL(urlString)
+  const isSwedishHomepage = url.pathname === '/se'
+
+  if (isSwedishHomepage) {
+    url.pathname = '/'
+  }
+
+  // and this part
+  return url.toString()
+}


### PR DESCRIPTION
<!--
PR title: RND-704 / Feature / Move Swedish homepage to hedvig.com root
-->

## Describe your changes
Serve the Swedish homepage under hedvig.com instead of hedvig.com/se.

All internal pages still use the `/se` URL segment.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Requested by Peter for branding and SEO reasons.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
