### PR TITLE
Reorganize PurchaseForm so that its context providers wrap only form instead of full page

### DIFF
--- a/apps/store/src/app/[locale]/appDebug/[[...slug]]/ProductCmsPage.tsx
+++ b/apps/store/src/app/[locale]/appDebug/[[...slug]]/ProductCmsPage.tsx
@@ -1,25 +1,22 @@
-import { Suspense } from 'react'
 import { ProductPageBlock } from '@/blocks/ProductPageBlock'
 import { BankIdDialog } from '@/components/BankIdDialog/BankIdDialog'
 import { PageBannerTriggers } from '@/components/Banner/PageBannerTriggers'
 import { fetchProductData } from '@/components/ProductData/fetchProductData'
 import { ProductDataProvider } from '@/components/ProductData/ProductDataProvider'
 import { PageDebugDialog } from '@/components/ProductPage/PageDebugDialog'
-import { PriceIntentContextProvider } from '@/components/ProductPage/PriceIntentContext'
 import { ProductPageContextProvider } from '@/components/ProductPage/ProductPageContext'
-import { ProductPageTrackingProvider } from '@/components/ProductPage/ProductPageTrackingProvider'
 import { ProductPageViewTracker } from '@/components/ProductPage/ProductPageViewTrack'
 import { fetchProductReviewsMetadata } from '@/features/memberReviews/memberReviews'
 import { ProductReviewsMetadataProvider } from '@/features/memberReviews/ProductReviewsMetadataProvider'
 import { getApolloClient } from '@/services/apollo/app-router/rscClient'
 import { BankIdContextProvider } from '@/services/bankId/BankIdContext'
 import { getPriceTemplate } from '@/services/PriceCalculator/PriceCalculator.helpers'
+import type { ProductStory } from '@/services/storyblok/storyblok'
 import type { RoutingLocale } from '@/utils/l10n/types'
 
 type ProductCmsPageProps = {
   locale: RoutingLocale
-  // TODO: Improve type, we may have it in pages router already
-  story: any
+  story: ProductStory
 }
 
 export const ProductCmsPage = async ({ locale, story }: ProductCmsPageProps) => {
@@ -50,21 +47,15 @@ export const ProductCmsPage = async ({ locale, story }: ProductCmsPageProps) => 
       selectedTypeOfContract={initialSelectedTypeOfContract}
     >
       <ProductPageContextProvider story={story} priceTemplate={priceTemplate}>
-        <Suspense>
-          <PriceIntentContextProvider>
-            <ProductPageTrackingProvider>
-              <ProductReviewsMetadataProvider productReviewsMetadata={productReviewsMetadata}>
-                <BankIdContextProvider>
-                  <ProductPageBlock blok={story.content} />
-                  <PageDebugDialog />
-                  <ProductPageViewTracker />
-                  <PageBannerTriggers blok={story.content} />
-                  <BankIdDialog />
-                </BankIdContextProvider>
-              </ProductReviewsMetadataProvider>
-            </ProductPageTrackingProvider>
-          </PriceIntentContextProvider>
-        </Suspense>
+        <ProductReviewsMetadataProvider productReviewsMetadata={productReviewsMetadata}>
+          <BankIdContextProvider>
+            <ProductPageBlock blok={story.content} />
+            <PageDebugDialog />
+            <ProductPageViewTracker />
+            <PageBannerTriggers blok={story.content} />
+            <BankIdDialog />
+          </BankIdContextProvider>
+        </ProductReviewsMetadataProvider>
       </ProductPageContextProvider>
     </ProductDataProvider>
   )

--- a/apps/store/src/blocks/ProductPageBlock.tsx
+++ b/apps/store/src/blocks/ProductPageBlock.tsx
@@ -1,9 +1,9 @@
 'use client'
 import styled from '@emotion/styled'
-import type { SbBlokData } from '@storyblok/react';
+import type { SbBlokData } from '@storyblok/react'
 import { storyblokEditable, StoryblokComponent } from '@storyblok/react'
 import { motion, useInView, useScroll } from 'framer-motion'
-import type { ReactNode } from 'react';
+import type { ReactNode } from 'react'
 import { useState, useEffect, useRef } from 'react'
 import { theme, mq } from 'ui'
 import * as GridLayout from '@/components/GridLayout/GridLayout'

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -5,18 +5,23 @@ import styled from '@emotion/styled'
 import { motion } from 'framer-motion'
 import { useRouter } from 'next/navigation'
 import { useTranslation } from 'next-i18next'
-import type { ReactNode} from 'react';
+import type { ReactNode } from 'react'
+import { Suspense } from 'react'
 import { useCallback, useRef, useState } from 'react'
 import { Button, Heading, mq, Space, theme } from 'ui'
-import type { CartToastAttributes } from '@/components/CartNotification/CartToast';
+import type { CartToastAttributes } from '@/components/CartNotification/CartToast'
 import { CartToast } from '@/components/CartNotification/CartToast'
 import type { ProductItemProps } from '@/components/CartNotification/ProductItem'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { PriceCalculatorDynamic } from '@/components/PriceCalculator/PriceCalculatorDynamic'
 import { completePriceLoader, PriceLoader } from '@/components/PriceLoader'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
-import { usePriceIntent } from '@/components/ProductPage/PriceIntentContext'
+import {
+  PriceIntentContextProvider,
+  usePriceIntent,
+} from '@/components/ProductPage/PriceIntentContext'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
+import { ProductPageTrackingProvider } from '@/components/ProductPage/ProductPageTrackingProvider'
 import {
   useIsPriceCalculatorExpanded,
   useOpenPriceCalculatorQueryParam,
@@ -24,8 +29,7 @@ import {
 import { ProductAverageRating } from '@/components/ProductReviews/ProductAverageRating'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { BankSigneringEvent } from '@/services/bankSignering'
-import type {
-  ProductOfferFragment} from '@/services/graphql/generated';
+import type { ProductOfferFragment } from '@/services/graphql/generated'
 import {
   ExternalInsuranceCancellationOption,
   usePriceIntentConfirmMutation,
@@ -50,7 +54,19 @@ export type PurchaseFormProps = {
   showAverageRating?: boolean
 }
 
-export const PurchaseForm = (props: PurchaseFormProps) => {
+export function PurchaseForm(props: PurchaseFormProps) {
+  return (
+    <Suspense>
+      <PriceIntentContextProvider>
+        <ProductPageTrackingProvider>
+          <PurchaseFormInner {...props} />
+        </ProductPageTrackingProvider>
+      </PriceIntentContextProvider>
+    </Suspense>
+  )
+}
+
+const PurchaseFormInner = (props: PurchaseFormProps) => {
   const { t } = useTranslation('purchase-form')
   const { priceTemplate } = useProductPageContext()
   const productData = useProductData()

--- a/apps/store/src/mocks/storyblok.ts
+++ b/apps/store/src/mocks/storyblok.ts
@@ -54,5 +54,9 @@ export const productStoryBRF: ProductStory = {
     announcement: [],
     robots: 'index',
     globalStory: globalStory,
+    coverageLabel: 'Coverage',
+    overviewLabel: 'Overview',
+    coverage: [],
+    overview: [],
   },
 }

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -124,6 +124,10 @@ export type ProductStory = ISbStoryData<
     globalStory: GlobalStory
     hideChat?: boolean
     showAverageRating?: boolean
+    overviewLabel: string
+    coverageLabel: string
+    overview: Array<SbBlokData>
+    coverage: Array<SbBlokData>
   } & SEOData
 >
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Reorganize `PurchaseForm` parent contexts so that they are placed inside as-small-as-possible `Suspense` block.  This fixes search params access in context providers

PriceIntentContext is still a mess and should be eventually refactored to use jotai atom families instead of React state + effects to sync - but that's for the future

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Allows to render most of product page content statically, without layout shift

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
