### PR TITLE
chore: resolve unknow tier warning

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/useTiersAndDeductibles.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/useTiersAndDeductibles.ts
@@ -9,8 +9,6 @@ type Params = {
 
 export function useTiersAndDeductibles({ offers, selectedOffer }: Params) {
   return useMemo(() => {
-    if (offers.length === 1) return { tiers: [], deductibles: [] }
-
     const sortedOffers = getOffersByPrice(offers)
     const tiers: Array<ProductOfferFragment> = []
     const usedTiers = new Set<string>()

--- a/apps/store/src/features/widget/ProductItem.tsx
+++ b/apps/store/src/features/widget/ProductItem.tsx
@@ -169,7 +169,7 @@ export const ProductItem = (props: Props) => {
         />
       )}
 
-      {props.tiers && props.tiers.length > 0 && (
+      {props.tiers && props.tiers.length > 1 && (
         <ProductTierSelector
           offers={props.tiers}
           selectedOffer={props.selectedOffer}


### PR DESCRIPTION
## Describe your changes

- Solve "unknow tier" warning.

Other parts of our app solve cases only one tier is available by now showing tier selector (OfferPresenter for example), so I've updated `useTiersAndDeductibles` hook by not returning early when only one offer is provided and, instead, did the same for widget.
