### PR TITLE
GEN-2063 - refact(ProductItem): add presentation modes

### DIFF
--- a/apps/store/src/features/widget/ConfirmationPage.tsx
+++ b/apps/store/src/features/widget/ConfirmationPage.tsx
@@ -43,7 +43,7 @@ export const ConfirmationPage = (props: Props) => {
                   key={item.id}
                   shopSessionId={props.shopSession.id}
                   selectedOffer={item}
-                  disableStartDate={true}
+                  mode="view"
                 />
               ))}
 

--- a/apps/store/src/features/widget/ProductItemContainer.tsx
+++ b/apps/store/src/features/widget/ProductItemContainer.tsx
@@ -8,12 +8,7 @@ type Props = {
   selectedOffer: Offer
 } & Pick<
   ComponentProps<typeof ProductItem>,
-  | 'shopSessionId'
-  | 'greenVariant'
-  | 'onDelete'
-  | 'defaultExpanded'
-  | 'disableStartDate'
-  | 'children'
+  'shopSessionId' | 'greenVariant' | 'onDelete' | 'defaultExpanded' | 'mode' | 'children'
 >
 
 export const ProductItemContainer = (props: Props) => {
@@ -30,8 +25,8 @@ export const ProductItemContainer = (props: Props) => {
       deductibles={deductibles}
       defaultExpanded={props.defaultExpanded}
       greenVariant={props.greenVariant}
-      disableStartDate={props.disableStartDate ?? false}
       onDelete={props.onDelete}
+      mode={props.mode}
     >
       {props.children}
     </ProductItem>


### PR DESCRIPTION
## Describe your changes

* Feat: add "presentation modes" for widget `ProductItem`: `edit` and `view`.

## Justify why they are needed

That component is currently being used on two contexts:

1. In the _sign page_, where some editing should be possible like start date, tier and deductible selector and auto switching request.

<img width="375" alt="Screenshot 2024-05-06 at 09 25 18" src="https://github.com/HedvigInsurance/racoon/assets/19200662/841d2183-89cc-47a5-b56c-929984f658c2">

2. In the _confirmation page_, where most of the UI and information displayed equals the one used in the _sign page_ with the exception of not being able to editing stuff.

<img width="375" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/41c4d1e0-e89c-47c6-aea3-eae383eb5dd3">

This change is a about a API addition to toggle between the two modes.