### PR TITLE
GEN-2063 - feat(widget): enable switching for car in sign page

### DIFF
--- a/apps/store/src/components/Cancellation/CancellationForm.tsx
+++ b/apps/store/src/components/Cancellation/CancellationForm.tsx
@@ -2,7 +2,6 @@ import { InputStartDay } from '@/components/InputDay/InputStartDay'
 import {
   type ProductOfferFragment,
   useCancellationRequestedUpdateMutation,
-  usePriceIntentQuery,
   useStartDateUpdateMutation,
   ExternalInsuranceCancellationOption,
 } from '@/services/graphql/generated'
@@ -12,18 +11,14 @@ import { BankSigneringInvalidRenewalDateCancellation } from './BankSigneringInva
 import { IEXCancellation } from './IEXCancellation'
 
 type Props = {
-  priceIntentId: string
+  productOfferIds: Array<string>
   offer: ProductOfferFragment
 }
 
 export const CancellationForm = (props: Props) => {
-  const { data } = usePriceIntentQuery({ variables: { priceIntentId: props.priceIntentId } })
-  if (!data) throw new Error('Cancellation | Missing data')
-
-  const productOfferIds = data.priceIntent.offers.map((item) => item.id)
   const [mutate] = useCancellationRequestedUpdateMutation()
   const handleAutoSwitchChange = (checked: boolean) => {
-    mutate({ variables: { productOfferIds, requested: checked } })
+    mutate({ variables: { productOfferIds: props.productOfferIds, requested: checked } })
   }
 
   const startDate = convertToDate(props.offer.startDate) ?? undefined
@@ -31,7 +26,7 @@ export const CancellationForm = (props: Props) => {
   const handleChangeStartDate = (date: Date) => {
     updateStartDate({
       variables: {
-        productOfferIds,
+        productOfferIds: props.productOfferIds,
         startDate: formatAPIDate(date),
       },
     })

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -136,6 +136,11 @@ export const OfferPresenter = (props: Props) => {
     return tier
   }, [tiers, selectedOffer])
 
+  const productOfferIds = useMemo(
+    () => props.priceIntent.offers.map(({ id }) => id),
+    [props.priceIntent.offers],
+  )
+
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     addToCart(selectedOffer.id)
@@ -179,7 +184,7 @@ export const OfferPresenter = (props: Props) => {
                 />
               )}
 
-              <CancellationForm priceIntentId={priceIntent.id} offer={selectedOffer} />
+              <CancellationForm productOfferIds={productOfferIds} offer={selectedOffer} />
 
               <Button
                 type="submit"

--- a/apps/store/src/features/widget/SwitchPage.tsx
+++ b/apps/store/src/features/widget/SwitchPage.tsx
@@ -37,6 +37,11 @@ export const SwitchPage = (props: Props) => {
     return cartOffer
   }, [props.priceIntent.offers, props.shopSession.cart.entries])
 
+  const productOfferIds = useMemo(
+    () => props.priceIntent.offers.map(({ id }) => id),
+    [props.priceIntent.offers],
+  )
+
   const locale = useRoutingLocale()
 
   return (
@@ -59,7 +64,7 @@ export const SwitchPage = (props: Props) => {
                 campaign={props.shopSession.cart.redeemedCampaign ?? undefined}
               />
               <Space y={0.25}>
-                <CancellationForm priceIntentId={props.priceIntent.id} offer={offer} />
+                <CancellationForm productOfferIds={productOfferIds} offer={offer} />
                 <ButtonNextLink
                   href={PageLink.widgetSign({
                     locale,


### PR DESCRIPTION
## Describe your changes

* Widget: Enable switching for car in the sign page.

https://github.com/HedvigInsurance/racoon/assets/19200662/8141cbb9-cd90-44f2-9d12-86d8f285545b

## Justify why they are needed

For start, we're using the same `CancellationForm` we have for `OfferPresenter` today. Later on I'll be changing the styles to match the design.