### PR TITLE
Fix color being overridden in Text component due to vanilla extract bug

### DIFF
--- a/packages/ui/src/components/Text/Text.css.ts
+++ b/packages/ui/src/components/Text/Text.css.ts
@@ -2,6 +2,9 @@ import { style } from '@vanilla-extract/css'
 
 export const textBase = style({
   whiteSpace: 'pre-wrap',
+})
+
+export const textFallbackColor = style({
   color: 'inherit',
 })
 

--- a/packages/ui/src/components/Text/Text.tsx
+++ b/packages/ui/src/components/Text/Text.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react'
 import Balancer from 'react-wrap-balancer'
 import type { FontSizeProps } from '../../theme'
 import { type Sprinkles, sprinkles } from '../../theme/sprinkles.css'
-import { textBase, textStrikethrough, textUppercase } from './Text.css'
+import { textBase, textFallbackColor, textStrikethrough, textUppercase } from './Text.css'
 
 type TextStyleProps = {
   align?: Sprinkles['textAlign']
@@ -31,6 +31,8 @@ export const getTextStyles = ({
 }: TextStyleProps) => {
   return clsx(
     textBase,
+    // Fix for vanilla-extract bug where base styles color override the color prop
+    color ? undefined : textFallbackColor,
     sprinkles({ color: color, textAlign: align, fontSize: size }),
     strikethrough && textStrikethrough,
     uppercase && textUppercase,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
The workaround is to only set color `inherit` when no color is passed in props

#### The bug
<img width="395" alt="Screenshot 2024-05-06 at 14 47 05" src="https://github.com/HedvigInsurance/racoon/assets/6661511/ee6fc0dd-f5b8-4cc6-9e3e-09f0273891d3">


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Fix color being overridden in Text component due to vanilla extract bug

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
