### PR TITLE
GEN-2065 - styles(TierSelector): new design

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/DeductibleSelector.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/DeductibleSelector.tsx
@@ -1,5 +1,4 @@
 import { datadogLogs } from '@datadog/browser-logs'
-import styled from '@emotion/styled'
 import Link from 'next/link'
 import { useTranslation } from 'next-i18next'
 import { useMemo } from 'react'
@@ -51,10 +50,14 @@ export const DeductibleSelector = ({ offers, selectedOffer, onValueChange }: Pro
   return (
     <TierSelector.Root defaultOpen={true}>
       <TierSelector.Header>
-        <Text>{t('DEDUCTIBLE_SELECTOR_TITLE')}</Text>
-        {selectedOffer.deductible && (
-          <ToggleText>{selectedOffer.deductible.displayName}</ToggleText>
-        )}
+        <div>
+          <Text size="xs" color="textTranslucentSecondary">
+            {t('DEDUCTIBLE_SELECTOR_TITLE')}
+          </Text>
+          {selectedOffer.deductible && (
+            <Text size="xl">{selectedOffer.deductible.displayName}</Text>
+          )}
+        </div>
       </TierSelector.Header>
 
       <TierSelector.Content>
@@ -80,7 +83,3 @@ export const DeductibleSelector = ({ offers, selectedOffer, onValueChange }: Pro
     </TierSelector.Root>
   )
 }
-
-const ToggleText = styled(Text)({
-  '[data-state=open] &': { display: 'none' },
-})

--- a/apps/store/src/components/ProductPage/PurchaseForm/ProductTierSelector.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ProductTierSelector.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import { Text } from 'ui'
 import * as TierLevelRadioGroup from '@/components/TierSelector/TierLevelRadioGroup'
@@ -26,10 +25,14 @@ export const ProductTierSelector = ({
   return (
     <TierSelector.Root defaultOpen={defaultOpen ?? true}>
       <TierSelector.Header>
-        <Text>{t('TIER_SELECTOR_SELECTED_LABEL', { ns: 'purchase-form' })}</Text>
-        <ToggleText>
-          {selectedOffer.variant.displayNameSubtype || selectedOffer.variant.displayName}
-        </ToggleText>
+        <div>
+          <Text size="xs" color="textTranslucentSecondary">
+            {t('TIER_SELECTOR_SELECTED_LABEL', { ns: 'purchase-form' })}
+          </Text>
+          <Text size="xl">
+            {selectedOffer.variant.displayNameSubtype || selectedOffer.variant.displayName}
+          </Text>
+        </div>
       </TierSelector.Header>
 
       <TierSelector.Content>
@@ -76,7 +79,3 @@ const useGetVariantDescription = () => {
     }
   }
 }
-
-const ToggleText = styled(Text)({
-  '[data-state=open] &': { display: 'none' },
-})

--- a/apps/store/src/components/TierSelector/TierLevelRadioGroup.tsx
+++ b/apps/store/src/components/TierSelector/TierLevelRadioGroup.tsx
@@ -3,7 +3,8 @@ import * as RadioGroup from '@radix-ui/react-radio-group'
 import { Space, Text, theme } from 'ui'
 
 export const Root = styled(RadioGroup.Root)({
-  padding: theme.space.xs,
+  paddingBlock: theme.space.md,
+  paddingInline: theme.space.xxs,
 })
 
 type ItemProps = {
@@ -33,13 +34,13 @@ export const Item = ({ title, price, description, value }: ItemProps) => {
 
 const RadioGroupItem = styled(RadioGroup.Item)({
   width: '100%',
-  padding: theme.space.xs,
-  borderRadius: theme.radius.xxs,
+  paddingInline: theme.space.sm,
+  paddingBlock: theme.space.md,
+  borderRadius: theme.radius.md,
   cursor: 'pointer',
 
   '&[data-state=checked]': {
     backgroundColor: theme.colors.backgroundStandard,
-    boxShadow: theme.shadow.default,
   },
 })
 

--- a/apps/store/src/components/TierSelector/TierSelector.css.ts
+++ b/apps/store/src/components/TierSelector/TierSelector.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css'
 import { theme } from 'ui/src/theme'
 
 export const root = style({
-  backgroundColor: theme.colors.opaque1,
+  backgroundColor: theme.colors.translucent1,
   borderRadius: theme.radius.sm,
 })
 
@@ -10,22 +10,18 @@ export const trigger = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  textAlign: 'center',
+  gap: theme.space.sm,
   width: '100%',
-  height: '3rem',
-  borderRadius: theme.radius.xxs,
+  height: '4.5rem',
+  borderRadius: theme.radius.sm,
   paddingInline: theme.space.md,
-})
-
-export const triggerBody = style({
-  display: 'flex',
-  alignContent: 'center',
-  justifyContent: 'space-between',
-  width: '100%',
-  paddingRight: theme.space.md,
+  ':focus-visible': {
+    boxShadow: theme.shadow.focus,
+  },
 })
 
 export const triggerIcon = style({
+  flexShrink: 0,
   transition: 'transform 300ms',
   selectors: {
     '[data-state=open] &': { transform: 'rotate(180deg)' },
@@ -34,11 +30,11 @@ export const triggerIcon = style({
 
 export const separator = style({
   height: 1,
-  marginInline: theme.space.md,
   backgroundColor: theme.colors.borderOpaque2,
 })
 
 export const footer = style({
   paddingInline: theme.space.md,
   paddingBlock: theme.space.sm,
+  textAlign: 'center',
 })

--- a/apps/store/src/components/TierSelector/TierSelector.tsx
+++ b/apps/store/src/components/TierSelector/TierSelector.tsx
@@ -1,30 +1,31 @@
-import { type ReactNode } from 'react'
+import { clsx } from 'clsx'
+import { type ReactNode, type ComponentProps } from 'react'
 import { ChevronIcon, theme } from 'ui'
 import Collapsible from '@/components/Collapsible/Collapsible'
-import { root, trigger, triggerBody, triggerIcon, separator, footer } from './TierSelector.css'
+import { root, trigger, triggerIcon, separator, footer } from './TierSelector.css'
 
-type RootProps = { children: ReactNode; defaultOpen?: boolean }
+type RootProps = ComponentProps<typeof Collapsible.Root>
 
-export const Root = ({ children, defaultOpen }: RootProps) => {
-  return (
-    <Collapsible.Root className={root} defaultOpen={defaultOpen}>
-      {children}
-    </Collapsible.Root>
-  )
+export const Root = ({ className, ...delegated }: RootProps) => {
+  return <Collapsible.Root className={clsx(root, className)} {...delegated} />
 }
 
-export const Header = ({ children }: { children: ReactNode }) => {
+type HeaderProps = ComponentProps<typeof Collapsible.Trigger>
+
+export const Header = ({ className, children, ...delegated }: HeaderProps) => {
   return (
-    <Collapsible.Trigger className={trigger}>
-      <div className={triggerBody}>{children}</div>
+    <Collapsible.Trigger className={clsx(trigger, className)} {...delegated}>
+      {children}
       <ChevronIcon className={triggerIcon} size={theme.space.md} />
     </Collapsible.Trigger>
   )
 }
 
-export const Content = ({ children }: { children: ReactNode }) => {
+type ContentProps = ComponentProps<typeof Collapsible.Content>
+
+export const Content = ({ children, ...delegated }: ContentProps) => {
   return (
-    <Collapsible.Content>
+    <Collapsible.Content {...delegated}>
       <Separator />
       {children}
     </Collapsible.Content>


### PR DESCRIPTION
## Describe your changes

* Redesign `TierSelector` and `ProductTierSelector`/`DeductableTierSelector`

<img width="386" alt="Screenshot 2024-05-07 at 15 33 31" src="https://github.com/HedvigInsurance/racoon/assets/19200662/5330c356-7a4f-4f6f-93cd-16ba806bfa08">

**New Design**

<img alt="image" width="375" src="https://github.com/HedvigInsurance/racoon/assets/19200662/55ccfc1a-392b-4a15-a7be-49abfedca88a" />
<img alt="image" width="375" src="https://github.com/HedvigInsurance/racoon/assets/19200662/6218657b-7207-4e20-989e-bbe6c3263847)" />

---

**Notes**

Observe we're still showing tier option description even though that was removed from the new design. I think they're quite important so I decided to keep it as it is until I double check it.

## Justify why they are needed

Gonna use those new designs as part of _Car + Pet on Widget_ project

[Figma file](https://www.figma.com/file/zXJCE6JlNdnVWW99PmIqfG/Widget?type=design&node-id=956-4485&mode=design&t=YmmGjDcgnvOLOZi7-0)
