### PR TITLE
GEN-2065 - styles(InputDay): update styles

### DIFF
--- a/apps/store/src/components/InputDay/InputDay.css.ts
+++ b/apps/store/src/components/InputDay/InputDay.css.ts
@@ -2,7 +2,6 @@ import { style, fallbackVar, keyframes, styleVariants, globalStyle } from '@vani
 import { theme } from 'ui/src/theme'
 import { inputBgColor } from 'ui/src/theme/vars.css'
 
-const paddingRight = '1.25rem'
 const bgColor = fallbackVar(inputBgColor, theme.colors.translucent1)
 
 const slideUpAndFadeAnimation = keyframes({
@@ -16,51 +15,29 @@ const slideDownAndFadeAnimation = keyframes({
 })
 
 export const trigger = style({
-  position: 'relative',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: theme.space.sm,
   width: '100%',
   height: '4.5rem',
   borderRadius: theme.radius.sm,
+  paddingInline: theme.space.md,
   backgroundColor: bgColor,
   cursor: 'pointer',
   ':focus-visible': {
     boxShadow: theme.shadow.focus,
-    borderRadius: theme.radius.sm,
   },
 })
 
 export const label = style({
-  position: 'absolute',
-  left: theme.space.md,
-  top: theme.space.sm,
-  fontSize: theme.fontSizes.xs,
   overflow: 'visible',
   whiteSpace: 'nowrap',
   textOverflow: 'ellipsis',
-  color: theme.colors.textSecondary,
-  selectors: {
-    '&[data-disabled=true]': {
-      color: theme.colors.textSecondary,
-    },
-  },
-})
-
-export const innerWrapper = style({
-  width: '100%',
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  paddingTop: theme.space.xl,
-  paddingRight: `${paddingRight}`,
-  paddingBottom: theme.space.sm,
-  paddingLeft: theme.space.md,
 })
 
 export const iconWrapper = style({
-  position: 'absolute',
-  right: `${paddingRight}`,
-  top: '50%',
-  transform: 'translateY(-50%)',
+  flexShrink: 0,
 })
 
 const chevronIconBase = style({

--- a/apps/store/src/components/InputDay/InputDay.tsx
+++ b/apps/store/src/components/InputDay/InputDay.tsx
@@ -11,15 +11,7 @@ import { Language } from '@/utils/l10n/types'
 import { useCurrentLocale } from '@/utils/l10n/useCurrentLocale'
 import { useFormatter } from '@/utils/useFormatter'
 import { useHighlightAnimation } from '@/utils/useHighlightAnimation'
-import {
-  trigger,
-  label,
-  innerWrapper,
-  iconWrapper,
-  chevronIcon,
-  popoverContent,
-  dayPicker,
-} from './InputDay.css'
+import { trigger, label, iconWrapper, chevronIcon, popoverContent, dayPicker } from './InputDay.css'
 
 import 'react-day-picker/dist/style.css'
 
@@ -82,28 +74,26 @@ export const InputDay = (props: InputDayProps) => {
         className={clsx(trigger, props.className)}
         disabled={props.disabled}
       >
-        <label className={label} htmlFor={inputId} data-disabled={props.disabled}>
-          {props.label}
-        </label>
-        <div className={innerWrapper}>
-          {dateValue ? (
-            <Text size="xl">{formatter.fromNow(dateValue)}</Text>
-          ) : (
-            <Text size="xl" color="textTertiary">
-              {t('DATE_INPUT_EMPTY_LABEL')}
+        <div>
+          <label htmlFor={inputId}>
+            <Text className={label} as="span" size="xs" color="textTranslucentSecondary">
+              {props.label}
             </Text>
-          )}
+          </label>
+          <Text size="xl" color={dateValue ? 'textPrimary' : 'textTertiary'}>
+            {dateValue ? formatter.fromNow(dateValue) : t('DATE_INPUT_EMPTY_LABEL')}
+          </Text>
+        </div>
 
-          <div className={iconWrapper}>
-            {/* eslint-disable-next-line no-nested-ternary */}
-            {props.loading ? (
-              <LoadingDots color={theme.colors.textPrimary} />
-            ) : props.disabled ? (
-              <LockIcon size="1rem" color={theme.colors.textSecondary} />
-            ) : (
-              <ChevronIcon className={chevronIcon.animated} size="1rem" />
-            )}
-          </div>
+        <div className={iconWrapper}>
+          {/* eslint-disable-next-line no-nested-ternary */}
+          {props.loading ? (
+            <LoadingDots color={theme.colors.textPrimary} />
+          ) : props.disabled ? (
+            <LockIcon size="1rem" color={theme.colors.textSecondary} />
+          ) : (
+            <ChevronIcon className={chevronIcon.animated} size="1rem" />
+          )}
         </div>
 
         <input


### PR DESCRIPTION
## Describe your changes

* Make some small style changes to `InputDay` component

## Justify why they are needed

With the redesign of TIerSelector (previous PR on the stack), InputDay end up being a little bit off.

<img width="356" alt="Screenshot 2024-05-08 at 09 53 40" src="https://github.com/HedvigInsurance/racoon/assets/19200662/6b3d39f8-a45d-4295-a378-f9a0ba5ad1ad">

This PR is about adjusting it.

<img width="327" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/d393ee39-1cd6-4938-b636-c726702fbe97">


