### PR TITLE
Remove poster as background image since we use poster attribute on video element

### DIFF
--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -207,11 +207,6 @@ export const Video = ({
         {...autoplayAttributes}
         {...delegated}
         style={{
-          ...(poster && {
-            backgroundImage: `url(${poster})`,
-            backgroundRepeat: 'no-repeat',
-            backgroundSize: 'cover',
-          }),
           ...assignInlineVars({
             [heightPortraitVar]: aspectRatioPortrait === '100' ? '100vh' : null,
             [maxHeightPortraitVar]: maxHeightPortrait ? `${maxHeightPortrait}vh` : null,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- We accidentally used both background image and poster on video 
- This also solves hydration missmatch error
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
