### PR TITLE
Don't set video css variables to empty value

### DIFF
--- a/apps/store/src/components/Video/Video.stories.tsx
+++ b/apps/store/src/components/Video/Video.stories.tsx
@@ -31,8 +31,8 @@ export const ProductVideo: Story = {
       { url: 'https://cdn.dev.hedvigit.com/assets/videos/HEDVIG_FILM01_1x1_15sec_CLEAN.mp4' },
     ],
     aspectRatioPortrait: '4 / 6',
-    maxHeightPortrait: 80,
+    maxHeightPortrait: '80',
     aspectRatioLandscape: '1 / 1',
-    maxHeightLandscape: 90,
+    maxHeightLandscape: '90',
   },
 }

--- a/apps/store/src/components/Video/Video.tsx
+++ b/apps/store/src/components/Video/Video.tsx
@@ -37,8 +37,8 @@ type AspectRatioPortrait = '4 / 5' | '4 / 6' | '9 / 16' | '100'
 type VideoSize = {
   aspectRatioLandscape?: AspectRatioLandscape
   aspectRatioPortrait?: AspectRatioPortrait
-  maxHeightLandscape?: number
-  maxHeightPortrait?: number
+  maxHeightLandscape?: string
+  maxHeightPortrait?: string
   roundedCorners?: boolean
 }
 
@@ -206,16 +206,26 @@ export const Video = ({
         muted={muted}
         {...autoplayAttributes}
         {...delegated}
-        style={{
-          ...assignInlineVars({
-            [heightPortraitVar]: aspectRatioPortrait === '100' ? '100vh' : null,
-            [maxHeightPortraitVar]: maxHeightPortrait ? `${maxHeightPortrait}vh` : null,
+        style={assignInlineVars({
+          ...(aspectRatioPortrait && {
+            [heightPortraitVar]: aspectRatioPortrait === '100' ? '100vh' : aspectRatioPortrait,
+          }),
+          ...(maxHeightPortrait && {
+            [maxHeightPortraitVar]: `${maxHeightPortrait}vh`,
+          }),
+          ...(aspectRatioPortrait && {
             [aspectRatioPortraitVar]: aspectRatioPortrait === '100' ? null : aspectRatioPortrait,
-            [heightLandscapeVar]: aspectRatioLandscape === '100' ? '100vh' : null,
-            [maxHeightLandscapeVar]: maxHeightLandscape ? `${maxHeightLandscape}vh` : null,
+          }),
+          ...(aspectRatioLandscape && {
+            [heightLandscapeVar]: aspectRatioLandscape === '100' ? '100vh' : aspectRatioLandscape,
+          }),
+          ...(maxHeightLandscape && {
+            [maxHeightLandscapeVar]: `${maxHeightLandscape}vh`,
+          }),
+          ...(aspectRatioLandscape && {
             [aspectRatioLandscapeVar]: aspectRatioLandscape === '100' ? null : aspectRatioLandscape,
           }),
-        }}
+        })}
       >
         {sources.map((source) => {
           const sourceProps = {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Fix hydration issue where css variables was set to empty string

<img width="689" alt="Screenshot 2024-05-10 at 16 24 00" src="https://github.com/HedvigInsurance/racoon/assets/6661511/fcd1bcdd-2f6e-44f4-a7c7-adf8dd2ba1b1">


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
