### PR TITLE
Make sure we load cookie list from OneTrust on /cookies page

### DIFF
--- a/apps/store/src/blocks/CookieListBlock.tsx
+++ b/apps/store/src/blocks/CookieListBlock.tsx
@@ -1,14 +1,26 @@
 'use client'
 import styled from '@emotion/styled'
+import { useSetAtom } from 'jotai'
+import { useTranslation } from 'next-i18next'
+import { useEffect } from 'react'
 import { mq, theme } from 'ui'
+import { loadOneTrustAtom } from '@/components/CookieConsent/OneTrustAtom'
 import * as GridLayout from '@/components/GridLayout/GridLayout'
 
 export const CookieListBlock = () => {
+  const { t } = useTranslation('cookieConsent')
+  const setLoadOneTrust = useSetAtom(loadOneTrustAtom)
+
+  // Load OneTrust script to display the cookie list and handle user preferences
+  useEffect(() => {
+    setLoadOneTrust(true)
+  }, [setLoadOneTrust])
+
   return (
     <GridLayout.Root>
       <GridLayout.Content width={{ base: '1', md: '2/3', xxl: '1/2' }} align={'center'}>
         <PreferenceButton id="ot-sdk-btn" className="ot-sdk-show-settings">
-          Cookies Settings
+          {t('COOKIE_CONSENT_SETTINGS_BUTTON')}
         </PreferenceButton>
         <OneTrustCookieInfo id="ot-sdk-cookie-policy"></OneTrustCookieInfo>
       </GridLayout.Content>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
On /hedvig/cookies page, the list of cookies along with descriptions is fetched via the OneTrsut script. Make sure we load the script on page load to display the content and make sure user an update cookie preferences 

<img width="1050" alt="Screenshot 2024-05-13 at 10 58 40" src="https://github.com/HedvigInsurance/racoon/assets/6661511/cc013d44-9d28-4727-821c-b61a5a0e442e">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Ensure we comply with GDPR

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
