### PR TITLE
GEN-2070  -  feat(widget-tier-selector): enable comparison table modal

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/ComparisonTableModal.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ComparisonTableModal.tsx
@@ -1,14 +1,13 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { useMemo } from 'react'
-import { Button, Dialog, PlusIcon } from 'ui'
+import { useMemo, type ReactNode } from 'react'
+import { Button, Dialog } from 'ui'
 import type { Table } from '@/components/ComparisonTable/ComparisonTable.types'
 import { TableMarkers } from '@/components/ComparisonTable/ComparisonTable.types'
 import { DesktopComparisonTable } from '@/components/ComparisonTable/DesktopComparisonTable'
 import { MobileComparisonTable } from '@/components/ComparisonTable/MobileComparisonTable'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
 import * as GridLayout from '@/components/GridLayout/GridLayout'
-import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import type { ProductOfferFragment } from '@/services/graphql/generated'
 import { sendDialogEvent } from '@/utils/dialogEvent'
 import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
@@ -16,9 +15,10 @@ import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
 type Props = {
   tiers: Array<ProductOfferFragment>
   selectedTierId: string
+  children: ReactNode
 }
 
-export const ComparisonTableModal = ({ tiers, selectedTierId }: Props) => {
+export const ComparisonTableModal = ({ tiers, selectedTierId, children }: Props) => {
   const { t } = useTranslation('purchase-form')
   const variant = useResponsiveVariant('md')
   const { table, selectedTierDisplayName } = useTableData(tiers, selectedTierId)
@@ -29,16 +29,7 @@ export const ComparisonTableModal = ({ tiers, selectedTierId }: Props) => {
 
   return (
     <FullscreenDialog.Root onOpenChange={handleOpenChange}>
-      <SpaceFlex direction="vertical" align="center">
-        <Dialog.Trigger asChild>
-          <Button variant="ghost" size="small">
-            <SpaceFlex space={0.5} align="center">
-              <PlusIcon />
-              {t('COMPARE_COVERAGE_BUTTON')}
-            </SpaceFlex>
-          </Button>
-        </Dialog.Trigger>
-      </SpaceFlex>
+      <Dialog.Trigger asChild>{children}</Dialog.Trigger>
 
       <FullscreenDialog.Modal
         Footer={

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -5,7 +5,7 @@ import { useInView } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
 import type { RefObject } from 'react'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Button, Space, Text, theme } from 'ui'
+import { Button, Space, Text, PlusIcon, theme } from 'ui'
 import { CancellationForm } from '@/components/Cancellation/CancellationForm'
 import { ScrollPast } from '@/components/ProductPage/ScrollPast/ScrollPast'
 import { ScrollToTopButton } from '@/components/ProductPage/ScrollToButton/ScrollToButton'
@@ -210,7 +210,16 @@ export const OfferPresenter = (props: Props) => {
         </form>
 
         {tiers.length > 1 && (
-          <ComparisonTableModal tiers={tiers} selectedTierId={selectedTier.id} />
+          <SpaceFlex direction="vertical" align="center">
+            <ComparisonTableModal tiers={tiers} selectedTierId={selectedTier.id}>
+              <Button variant="ghost" size="small">
+                <SpaceFlex space={0.5} align="center">
+                  <PlusIcon />
+                  {t('COMPARE_COVERAGE_BUTTON')}
+                </SpaceFlex>
+              </Button>
+            </ComparisonTableModal>
+          </SpaceFlex>
         )}
       </Space>
       <ScrollPast targetRef={scrollPastRef}>

--- a/apps/store/src/components/ProductPage/PurchaseForm/ProductTierSelector.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ProductTierSelector.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'next-i18next'
+import { type ReactNode } from 'react'
 import { Text } from 'ui'
 import * as TierSelector from '@/components/TierSelector/TierSelector'
 import type { ProductOfferFragment } from '@/services/graphql/generated'
@@ -9,6 +10,7 @@ type Props = {
   selectedOffer: ProductOfferFragment
   onValueChange: (offerId: string) => void
   defaultOpen?: boolean
+  children?: ReactNode
 }
 
 export const ProductTierSelector = ({
@@ -16,6 +18,7 @@ export const ProductTierSelector = ({
   selectedOffer,
   onValueChange,
   defaultOpen,
+  children,
 }: Props) => {
   const { t } = useTranslation('purchase-form')
   const getVariantDescription = useGetVariantDescription()
@@ -46,6 +49,7 @@ export const ProductTierSelector = ({
             />
           ))}
         </TierSelector.OptionsList>
+        {children}
       </TierSelector.Content>
     </TierSelector.Root>
   )

--- a/apps/store/src/features/widget/ProductItem.css.ts
+++ b/apps/store/src/features/widget/ProductItem.css.ts
@@ -117,3 +117,7 @@ export const separator = style({
   height: 1,
   backgroundColor: theme.colors.borderOpaque2,
 })
+
+export const compareButtonWrapper = style({
+  padding: theme.space.md,
+})

--- a/apps/store/src/features/widget/ProductItem.tsx
+++ b/apps/store/src/features/widget/ProductItem.tsx
@@ -9,6 +9,7 @@ import { InputDay } from '@/components/InputDay/InputDay'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { Price } from '@/components/Price'
 import { useGetStartDateProps } from '@/components/ProductItem/useGetStartDateProps'
+import { ComparisonTableModal } from '@/components/ProductPage/PurchaseForm/ComparisonTableModal'
 import { ProductTierSelector } from '@/components/ProductPage/PurchaseForm/ProductTierSelector'
 import { Tooltip } from '@/components/Tooltip/Tooltip'
 import { type ProductOfferFragment } from '@/services/graphql/generated'
@@ -27,6 +28,7 @@ import {
   fakeInput,
   fakeInputRow,
   separator,
+  compareButtonWrapper,
 } from './ProductItem.css'
 import { type Offer } from './widget.types'
 
@@ -201,7 +203,15 @@ function EditUI(props: EditUIProps) {
           selectedOffer={props.selectedOffer}
           onValueChange={handleChangeTierLevel}
           defaultOpen={false}
-        />
+        >
+          <div className={compareButtonWrapper}>
+            <ComparisonTableModal tiers={props.tiers} selectedTierId={props.selectedOffer.id}>
+              <Button size="medium" fullWidth={true}>
+                Compare tiers
+              </Button>
+            </ComparisonTableModal>
+          </div>
+        </ProductTierSelector>
       )}
     </Space>
   )


### PR DESCRIPTION
## Describe your changes

* Add _Comparison Table Modal_ for Widget's Product Item tier selector.

https://github.com/HedvigInsurance/racoon/assets/19200662/147bfe45-b743-4953-bac7-cdaf507168bb

## Justify why they are needed

Observe that the new design for comparison table will be added later, while here I'm just using the implementation we have today.