### PR TITLE
Remove 'headerBgTransparentColor' CSS var, it was always the same as 'bodyBgColor'

### DIFF
--- a/apps/store/src/app/[locale]/StoryblokLayout.css.ts
+++ b/apps/store/src/app/[locale]/StoryblokLayout.css.ts
@@ -1,11 +1,6 @@
 import { style } from '@vanilla-extract/css'
 import { colors } from 'ui/src/theme'
-import {
-  bodyBgColor,
-  bodyTextColor,
-  footerBgColor,
-  headerBgTransparentColor,
-} from 'ui/src/theme/vars.css'
+import { bodyBgColor, bodyTextColor, footerBgColor } from 'ui/src/theme/vars.css'
 
 export const wrapper = style({
   minHeight: '100vh',
@@ -16,7 +11,6 @@ export const wrapper = style({
         [bodyBgColor]: colors.dark,
         [bodyTextColor]: colors.textNegative,
         [footerBgColor]: colors.dark,
-        [headerBgTransparentColor]: 'hsla(0, 0%, 7%, 0)',
       },
       color: bodyTextColor,
       backgroundColor: bodyBgColor,

--- a/apps/store/src/blocks/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock.tsx
@@ -274,7 +274,7 @@ export const HeaderBlock = ({ blok, ...headerProps }: HeaderBlockProps) => {
   )
 
   return (
-    <Header key={pathname} {...storyblokEditable(blok)} opaque={isOpen} {...headerProps}>
+    <Header key={pathname} {...storyblokEditable(blok)} {...headerProps}>
       {variant === 'desktop' && (
         <TopMenuDesktop>{blok.navMenuContainer.map(NestedNavigationBlock)}</TopMenuDesktop>
       )}

--- a/apps/store/src/components/Header/Header.tsx
+++ b/apps/store/src/components/Header/Header.tsx
@@ -2,7 +2,7 @@
 import type { Transition } from 'framer-motion'
 import { motion } from 'framer-motion'
 import type { ReactNode } from 'react'
-import { bodyBgColor, headerBgTransparentColor } from 'ui/src/theme/vars.css'
+import { bodyBgColor } from 'ui/src/theme/vars.css'
 import { LogoHomeLink } from '@/components/LogoHomeLink'
 import { isBrowser } from '@/utils/env'
 import { useScrollState } from '@/utils/useScrollState'
@@ -33,15 +33,14 @@ type AnimationVariant = keyof typeof ANIMATION_VARIANTS | undefined
 
 type HeaderProps = {
   children: ReactNode
-  opaque?: boolean
 }
 
 export const Header = (props: HeaderProps) => {
-  const { children, opaque = false } = props
+  const { children } = props
   const scrollState = useScrollState({ threshold: MENU_BAR_HEIGHT_PX * 2 })
 
   const initialStyles = {
-    backgroundColor: opaque ? bodyBgColor : headerBgTransparentColor,
+    backgroundColor: bodyBgColor,
   }
 
   let animate: AnimationVariant = undefined

--- a/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.css.ts
+++ b/apps/store/src/components/LayoutWithMenu/LayoutWithMenu.css.ts
@@ -1,11 +1,6 @@
 import { style } from '@vanilla-extract/css'
 import { colors } from 'ui/src/theme'
-import {
-  bodyBgColor,
-  bodyTextColor,
-  footerBgColor,
-  headerBgTransparentColor,
-} from 'ui/src/theme/vars.css'
+import { bodyBgColor, bodyTextColor, footerBgColor } from 'ui/src/theme/vars.css'
 
 export const wrapper = style({
   minHeight: '100vh',
@@ -16,7 +11,6 @@ export const wrapper = style({
         [bodyBgColor]: colors.dark,
         [bodyTextColor]: colors.textNegative,
         [footerBgColor]: colors.dark,
-        [headerBgTransparentColor]: 'hsla(0, 0%, 7%, 0)',
       },
       color: bodyTextColor,
       backgroundColor: bodyBgColor,

--- a/packages/ui/src/global.css.ts
+++ b/packages/ui/src/global.css.ts
@@ -10,7 +10,6 @@ import {
   bodyBgColor,
   bodyTextColor,
   footerBgColor,
-  headerBgTransparentColor,
   inputBgColor,
   inputSelectedItemBgColor,
 } from './theme/vars.css'
@@ -39,7 +38,6 @@ globalStyle('body', {
     [bodyBgColor]: colors.backgroundStandard,
     [bodyTextColor]: colors.textPrimary,
     [footerBgColor]: colors.gray100,
-    [headerBgTransparentColor]: colors.grayTranslucentDark1000,
     [inputBgColor]: colors.translucent1,
     [inputSelectedItemBgColor]: colors.backgroundStandard,
   },

--- a/packages/ui/src/theme/vars.css.ts
+++ b/packages/ui/src/theme/vars.css.ts
@@ -3,8 +3,6 @@ import { createVar } from '@vanilla-extract/css'
 export const bodyBgColor = createVar()
 export const bodyTextColor = createVar()
 
-export const headerBgTransparentColor = createVar()
-
 export const footerBgColor = createVar()
 
 export const inputBgColor = createVar()


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Simplify our theme vars since `headerBgTransparentColor` was always the same as `bodyBgColor`

This allows to simplify state management for `TopMenuMobile` (next PR)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
