### PR TITLE
Remove flickering background color on mobile menu trigger

### DIFF
--- a/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.css.ts
+++ b/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.css.ts
@@ -16,6 +16,17 @@ export const buttonWrapper = style({
   paddingTop: theme.space.lg,
 })
 
+export const buttonTrigger = style({
+  // Avoid flickering background-color on button when toggling menu on non-hover devices
+  '@media': {
+    '(hover: none)': {
+      ':active': {
+        backgroundColor: 'transparent',
+      },
+    },
+  },
+})
+
 export const topMenuHeader = style({
   display: 'flex',
   alignItems: 'center',

--- a/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
+++ b/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
@@ -11,7 +11,13 @@ import { getAppStoreLink } from '@/utils/appStoreLinks'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { logoWrapper, navigation, navigationPrimaryList } from '../Header.css'
 import { ShoppingCartMenuItem } from '../ShoppingCartMenuItem'
-import { buttonWrapper, contentWrapper, dialogOverlay, topMenuHeader } from './TopMenuMobile.css'
+import {
+  buttonTrigger,
+  buttonWrapper,
+  contentWrapper,
+  dialogOverlay,
+  topMenuHeader,
+} from './TopMenuMobile.css'
 
 type Props = {
   defaultValue?: string
@@ -45,7 +51,7 @@ export function TopMenuMobile(props: Props) {
         onOpenChange={(newValue: boolean) => startTransition(() => setIsOpen(newValue))}
       >
         <DialogPrimitive.Trigger asChild={true}>
-          <Button variant="ghost" size="medium">
+          <Button className={buttonTrigger} variant="ghost" size="medium">
             {t('NAV_MENU_DIALOG_OPEN')}
           </Button>
         </DialogPrimitive.Trigger>
@@ -56,7 +62,7 @@ export function TopMenuMobile(props: Props) {
                 <LogoHomeLink />
               </div>
               <DialogPrimitive.Close asChild={true}>
-                <Button variant="ghost" size="medium">
+                <Button className={buttonTrigger} variant="ghost" size="medium">
                   {t('NAV_MENU_DIALOG_CLOSE')}
                 </Button>
               </DialogPrimitive.Close>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Just noticed when toggling on the phone, active/hover state cause the trigger button to flicker. 
So I'd say either remove it for that button or make it permanent when open

### Before

https://github.com/HedvigInsurance/racoon/assets/6661511/d1e9746a-12b3-406f-908c-63503d299880



### After
https://github.com/HedvigInsurance/racoon/assets/6661511/8f0b575c-f728-4ff9-a7ea-5a1c487e70dd




<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
