### PR TITLE
GEN-2072 - feat(widget-confirmation): add switching assistant section

### DIFF
--- a/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection.tsx
+++ b/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection.tsx
@@ -2,11 +2,9 @@ import { useTranslation } from 'next-i18next'
 import { Heading, Space, Text } from 'ui'
 import { CardSkeleton, ContractCard } from '../ContractCard'
 import { useSwitchingContracts } from '../useSwitchingContracts'
+import type { SwitchingAssistantData } from './SwitchingAssistantSection.types'
 
-type Props = {
-  shopSessionOutcomeId: string
-  companyDisplayName: string
-}
+export type Props = SwitchingAssistantData
 
 export const SwitchingAssistantSection = (props: Props) => {
   const { t } = useTranslation('checkout')

--- a/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection.types.ts
+++ b/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection.types.ts
@@ -1,0 +1,4 @@
+export type SwitchingAssistantData = {
+  shopSessionOutcomeId: string
+  companyDisplayName: string
+}

--- a/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/fetchSwitchingData.ts
+++ b/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/fetchSwitchingData.ts
@@ -1,0 +1,33 @@
+import { type ShopSessionService } from '@/services/shopSession/ShopSessionService'
+import type { SwitchingAssistantData } from './SwitchingAssistantSection.types'
+
+export async function fetchSwitchingData(
+  shopSessionService: ShopSessionService,
+  shopSessionOutcomeId: string,
+): Promise<SwitchingAssistantData | null> {
+  const outcome = await fetchOutcomeData(shopSessionService, shopSessionOutcomeId)
+  if (!outcome) return null
+
+  const switchingContract = outcome.createdContracts.find(
+    (item) => !!item.externalInsuranceCancellation?.bankSignering,
+  )
+  if (!switchingContract) return null
+
+  const externalInsurer = switchingContract.externalInsuranceCancellation?.externalInsurer
+  if (!externalInsurer) return null
+
+  return {
+    shopSessionOutcomeId: outcome.id,
+    companyDisplayName: externalInsurer.displayName,
+  }
+}
+
+async function fetchOutcomeData(shopSessionService: ShopSessionService, shopSessionId: string) {
+  const shopSessionOutcomeId = await shopSessionService.fetchOutcomeId(shopSessionId)
+  if (!shopSessionOutcomeId) {
+    return null
+  }
+
+  const outcome = await shopSessionService.fetchOutcome(shopSessionOutcomeId)
+  return outcome
+}

--- a/apps/store/src/features/widget/ConfirmationPage.tsx
+++ b/apps/store/src/features/widget/ConfirmationPage.tsx
@@ -2,6 +2,8 @@ import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
 import { Button, Heading, Space, mq, theme } from 'ui'
 import { StaticContent } from '@/components/ConfirmationPage/StaticContent'
+import { SwitchingAssistantSection } from '@/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection'
+import type { SwitchingAssistantData } from '@/components/ConfirmationPage/SwitchingAssistantSection/SwitchingAssistantSection.types'
 import * as GridLayout from '@/components/GridLayout/GridLayout'
 import { Discount } from '@/components/ShopBreakdown/Discount'
 import { Divider } from '@/components/ShopBreakdown/ShopBreakdown'
@@ -18,6 +20,7 @@ type Props = {
   title: string
   shopSession: ShopSession
   backToAppButton?: string
+  switching?: SwitchingAssistantData
 }
 
 export const ConfirmationPage = (props: Props) => {
@@ -34,31 +37,35 @@ export const ConfirmationPage = (props: Props) => {
       <GridLayout.Root>
         <GridLayout.Content width="1/3" align="center">
           <Space y={4}>
-            <Heading as="h1" variant="standard.24" align="center">
-              {props.title}
-            </Heading>
-            <Space y={1}>
-              {props.shopSession.cart.entries.map((item) => (
-                <ProductItem
-                  key={item.id}
-                  shopSessionId={props.shopSession.id}
-                  selectedOffer={item}
-                  mode="view"
-                />
-              ))}
+            <Space y={{ base: 3, lg: 4.5 }}>
+              <Heading as="h1" variant="standard.24" align="center">
+                {props.title}
+              </Heading>
+              <Space y={1}>
+                {props.shopSession.cart.entries.map((item) => (
+                  <ProductItem
+                    key={item.id}
+                    shopSessionId={props.shopSession.id}
+                    selectedOffer={item}
+                    mode="view"
+                  />
+                ))}
 
-              {discount && (
-                <>
-                  <Discount {...discount} />
-                  <Divider />
-                </>
-              )}
+                {discount && (
+                  <>
+                    <Discount {...discount} />
+                    <Divider />
+                  </>
+                )}
 
-              <TotalAmountContainer cart={props.shopSession.cart} />
-              {props.backToAppButton && (
-                <Button onClick={handleClickBackToApp}>{props.backToAppButton}</Button>
-              )}
+                <TotalAmountContainer cart={props.shopSession.cart} />
+                {props.backToAppButton && (
+                  <Button onClick={handleClickBackToApp}>{props.backToAppButton}</Button>
+                )}
+              </Space>
             </Space>
+
+            {props.switching && <SwitchingAssistantSection {...props.switching} />}
           </Space>
         </GridLayout.Content>
       </GridLayout.Root>

--- a/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/confirmation.tsx
+++ b/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/confirmation.tsx
@@ -4,6 +4,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { type ComponentProps } from 'react'
 import { fetchConfirmationStory } from '@/components/ConfirmationPage/fetchConfirmationStory'
 import { SuccessAnimation } from '@/components/ConfirmationPage/SuccessAnimation/SuccessAnimation'
+import { fetchSwitchingData } from '@/components/ConfirmationPage/SwitchingAssistantSection/fetchSwitchingData'
 import { ConfirmationPage } from '@/features/widget/ConfirmationPage'
 import { addApolloState, initializeApolloServerSide } from '@/services/apollo/client'
 import { hideChatOnPage } from '@/services/CustomerFirst'
@@ -33,13 +34,14 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
     locale: context.locale,
   })
   const shopSessionService = setupShopSessionServiceServerSide({ apolloClient })
-  const [translations, story, confirmationStory] = await Promise.all([
+  const [translations, flowStory, confirmationStory, switchingData] = await Promise.all([
     serverSideTranslations(context.locale),
     getStoryById<WidgetFlowStory>({
       id: context.params.flow,
       version: context.draftMode ? 'draft' : undefined,
     }),
     fetchConfirmationStory(context.locale),
+    fetchSwitchingData(shopSessionService, context.params.shopSessionId),
     shopSessionService.fetchById(context.params.shopSessionId),
   ])
 
@@ -50,7 +52,8 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
       ...hideChatOnPage(),
       title: confirmationStory.content.title,
       staticContent: confirmationStory.content,
-      backToAppButton: story.content.backToAppButtonLabel,
+      backToAppButton: flowStory.content.backToAppButtonLabel,
+      ...(switchingData ? { switching: switchingData } : {}),
     },
   })
 }


### PR DESCRIPTION
## Describe your changes

* Adds _Switching Assistant_ section for Widget Confirmation pages

<img width="375px" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/33d95eb6-e9ac-4445-8851-f6d26d2c110e" />

## Justify why they are needed

Part of enabling car into Widget flows.