### PR TITLE
feature: [Maker Days 24] Show manual switch cancellation info

### DIFF
--- a/apps/store/src/components/Cancellation/CancellationForm.tsx
+++ b/apps/store/src/components/Cancellation/CancellationForm.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'next-i18next'
 import { InputStartDay } from '@/components/InputDay/InputStartDay'
 import {
   type ProductOfferFragment,
@@ -6,6 +7,7 @@ import {
   ExternalInsuranceCancellationOption,
 } from '@/services/graphql/generated'
 import { convertToDate, formatAPIDate } from '@/utils/date'
+import { InfoCard } from '../InfoCard/InfoCard'
 import { BankSigneringCancellation } from './BankSigneringCancellation'
 import { BankSigneringInvalidRenewalDateCancellation } from './BankSigneringInvalidRenewalDateCancellation'
 import { IEXCancellation } from './IEXCancellation'
@@ -22,6 +24,8 @@ export const CancellationForm = (props: Props) => {
   }
 
   const startDate = convertToDate(props.offer.startDate) ?? undefined
+  const { t } = useTranslation('purchase-form')
+
   const [updateStartDate, updateStartDateResult] = useStartDateUpdateMutation()
   const handleChangeStartDate = (date: Date) => {
     updateStartDate({
@@ -38,20 +42,28 @@ export const CancellationForm = (props: Props) => {
     loading: updateStartDateResult.loading,
   }
 
+  const switcherCompanyName = props.offer.cancellation.externalInsurer?.displayName
+
   const autoSwitchProps = {
     requested: props.offer.cancellation.requested,
     onAutoSwitchChange: handleAutoSwitchChange,
-    companyName: props.offer.cancellation.externalInsurer?.displayName ?? 'Unknown',
+    companyName: switcherCompanyName ?? 'Unknown',
   }
 
   switch (props.offer.cancellation.option) {
     case ExternalInsuranceCancellationOption.None:
       return (
-        <InputStartDay
-          date={startDate}
-          onChange={handleChangeStartDate}
-          loading={updateStartDateResult.loading}
-        />
+        <>
+          {switcherCompanyName && (
+            <InfoCard>{t('MANUAL_SWITCH_INFO', { COMPANY_NAME: switcherCompanyName })}</InfoCard>
+          )}
+
+          <InputStartDay
+            date={startDate}
+            onChange={handleChangeStartDate}
+            loading={updateStartDateResult.loading}
+          />
+        </>
       )
 
     case ExternalInsuranceCancellationOption.Iex:


### PR DESCRIPTION
<!--
PR title: Maker Days 24 / Feature / Show manual switch cancellation info
-->

## Describe your changes
Show InfoCard with a message about manual switching cancellation

<img width="446" alt="Screenshot 2024-05-15 at 16 40 04" src="https://github.com/HedvigInsurance/racoon/assets/15573370/4c0ad55a-8f7d-4bc0-9757-1b542920e523">


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Remind customer to check current insurance expiration date and cancel it.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
