### PR TITLE
Prevent overwriting campaign code during retargeting

### DIFF
--- a/apps/store/src/features/retargeting/ShopSessionRetargeting.graphql
+++ b/apps/store/src/features/retargeting/ShopSessionRetargeting.graphql
@@ -5,6 +5,7 @@ query ShopSessionRetargeting($shopSessionId: UUID!) {
       entries {
         id
       }
+      campaignsEnabled
     }
     priceIntents(filters: { uniqueConfirmed: true }) {
       ...RetargetingPriceIntent

--- a/apps/store/src/features/retargeting/getUserRedirect.ts
+++ b/apps/store/src/features/retargeting/getUserRedirect.ts
@@ -28,6 +28,11 @@ export const getUserRedirect = (
 
   if (!data) return fallbackRedirect
 
+  // Ignore campaign code if it cannot be changed (partner session, active bundle discount, etc)
+  if (data.shopSession.cart.campaignsEnabled === false) {
+    delete userParams.campaignCode
+  }
+
   if (hasAddedCartEntries(data)) {
     return {
       type: RedirectType.Cart,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Ignore campaign code during retargeting if campaigns are currently disabled. Known cases
- Partner session
- Active bundle discount

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

This fixes potential problem with CRM retargeting links for sessions with active bundle discounts.  We want to keep bundle campaign code and ignore discount code in query params in this case 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
