### PR TITLE
Prevent errors from browsers without crypto.randomUUID when reporting internal events

### DIFF
--- a/apps/store/src/services/Tracking/useReportDeviceInfo.ts
+++ b/apps/store/src/services/Tracking/useReportDeviceInfo.ts
@@ -21,6 +21,9 @@ export const useReportDeviceInfo = () => {
         if (reportedRef.current) return
         reportedRef.current = true
 
+        // Ignore few ancient browsers, universal support for randomUUID appeared in 2021
+        if (typeof crypto.randomUUID !== 'function') return
+
         const deviceInfoEvent = {
           type: TrackingEvent.DeviceInfo,
           data: {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Subj

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Few of "crypto.randomUUID is not a function" errors appeared in Datadog, we want to prevent them

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
