### PR TITLE
Fix bundle size calculation when editing cart item

### DIFF
--- a/apps/store/src/features/bundleDiscount/BundleDiscountOfferTooltip.tsx
+++ b/apps/store/src/features/bundleDiscount/BundleDiscountOfferTooltip.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'next-i18next'
 import { DiscountTooltip } from '@/components/ProductPage/PurchaseForm/DiscountTooltip/DiscountTooltip'
+import { useCartEntryToReplace } from '@/components/ProductPage/useCartEntryToReplace'
 import {
   BUNDLE_DISCOUNT_ELIGIBLE_PRODUCT_IDS,
   BUNDLE_DISCOUNT_PERCENTAGE,
@@ -9,13 +10,17 @@ import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 export function BundleDiscountOfferTooltip() {
   const { t } = useTranslation('purchase-form')
   const { shopSession } = useShopSession()
+  const isEditingCartItem = useCartEntryToReplace() != null
   if (shopSession == null) {
     return null
   }
-  const numberOfEligibleCartItems = shopSession.cart.entries.filter((item) =>
+  let numberOfEligibleCartItems = shopSession.cart.entries.filter((item) =>
     BUNDLE_DISCOUNT_ELIGIBLE_PRODUCT_IDS.has(item.product.id),
   ).length
+  if (isEditingCartItem) {
+    numberOfEligibleCartItems -= 1
+  }
   const key =
-    numberOfEligibleCartItems === 0 ? 'BUNDLE_DISCOUNT_FIRST_OFFER' : 'BUNDLE_DISCOUNT_SECOND_OFFER'
+    numberOfEligibleCartItems < 1 ? 'BUNDLE_DISCOUNT_FIRST_OFFER' : 'BUNDLE_DISCOUNT_SECOND_OFFER'
   return <DiscountTooltip subtitle={t(key, { percentage: BUNDLE_DISCOUNT_PERCENTAGE })} />
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix off-by-one error when we counted current offer twice while editing cart item. Now bundle discount shows correct tooltip when the only eligible cart item is being edited - "Buy more and get X% off your entire purchase"

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
