### PR TITLE
Close CartToast on page change, for example, following bundle extra product link

### DIFF
--- a/apps/store/public/locales/en/cart.json
+++ b/apps/store/public/locales/en/cart.json
@@ -71,6 +71,7 @@
   "NUMBER_COINSURED_OPTION_LABEL_zero": "You",
   "OFFER_PRICE_LABEL": "Your offer:",
   "QUICK_ADD_BADGE_LABEL": "Popular",
+  "QUICK_ADD_BUNDLE_HEADER": "Popular add-on",
   "QUICK_ADD_BUTTON": "Add",
   "QUICK_ADD_BUTTON_BUNDLE": "Upgrade",
   "QUICK_ADD_DISMISS": "No, thanks",

--- a/apps/store/public/locales/en/purchase-form.json
+++ b/apps/store/public/locales/en/purchase-form.json
@@ -5,7 +5,7 @@
   "AUTO_SWITCH_INVALID_START_DATE_MESSAGE": "Because your insurance at {{company}} expires soon, you have to manually cancel it. Don't worry, we will email instructions.",
   "AUTO_SWITCH_START_DATE_LABEL": "End date {{company}}",
   "BUNDLE_DISCOUNT_CART_TOAST_SUMMARY": "You got a {{percentage}} discount on your entire purchase in cart.",
-  "BUNDLE_DISCOUNT_FIRST_OFFER": "Get a {{percentage}} discount\nif you add more insurances",
+  "BUNDLE_DISCOUNT_FIRST_OFFER": "Get a {{percentage}} discount if you \nadd more insurances",
   "BUNDLE_DISCOUNT_SECOND_OFFER": "You get {{percentage}} off your entire purchase",
   "BUTTON_LABEL_GET_PRICE": "See your price",
   "CART_TOAST_HEADING": "Added to cart",

--- a/apps/store/public/locales/sv-se/cart.json
+++ b/apps/store/public/locales/sv-se/cart.json
@@ -71,6 +71,7 @@
   "NUMBER_COINSURED_OPTION_LABEL_zero": "Du",
   "OFFER_PRICE_LABEL": "Ditt erbjudande:",
   "QUICK_ADD_BADGE_LABEL": "Populärt",
+  "QUICK_ADD_BUNDLE_HEADER": "Populärt tillval",
   "QUICK_ADD_BUTTON": "Lägg till",
   "QUICK_ADD_BUTTON_BUNDLE": "Uppgradera",
   "QUICK_ADD_DISMISS": "Nej tack",

--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -88,11 +88,16 @@ export const CartPage = () => {
               </Space>
 
               {offerRecommendation && (
-                <QuickAddOfferContainer
-                  cart={shopSession.cart}
-                  shopSessionId={shopSession.id}
-                  {...offerRecommendation}
-                />
+                <Space y={1}>
+                  <Heading variant="standard.18" as={'h2'}>
+                    {t('QUICK_ADD_BUNDLE_HEADER')}
+                  </Heading>
+                  <QuickAddOfferContainer
+                    cart={shopSession.cart}
+                    shopSessionId={shopSession.id}
+                    {...offerRecommendation}
+                  />
+                </Space>
               )}
               <CheckoutButton />
             </Space>

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -3,7 +3,7 @@ import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
 import { motion } from 'framer-motion'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { useTranslation } from 'next-i18next'
 import type { ReactNode } from 'react'
 import { Suspense } from 'react'
@@ -232,6 +232,7 @@ type LayoutProps = {
 }
 
 const Layout = ({ children }: LayoutProps) => {
+  const pathname = usePathname()
   const toastRef = useRef<CartToastAttributes | null>(null)
   const notifyProductAdded = (item: ProductItemProps) => {
     toastRef.current?.publish(item)
@@ -240,7 +241,8 @@ const Layout = ({ children }: LayoutProps) => {
   return (
     <>
       <PurchaseFormTop>{children(notifyProductAdded)}</PurchaseFormTop>
-      <CartToast ref={toastRef} />
+      {/* key=pathname makes sure we re-init the toast if current page changes */}
+      <CartToast key={pathname} ref={toastRef} />
     </>
   )
 }

--- a/apps/store/src/features/bundleDiscount/BundleDiscountOfferTooltip.tsx
+++ b/apps/store/src/features/bundleDiscount/BundleDiscountOfferTooltip.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'next-i18next'
 import { DiscountTooltip } from '@/components/ProductPage/PurchaseForm/DiscountTooltip/DiscountTooltip'
+import { useCartEntryToReplace } from '@/components/ProductPage/useCartEntryToReplace'
 import {
   BUNDLE_DISCOUNT_ELIGIBLE_PRODUCT_IDS,
   BUNDLE_DISCOUNT_PERCENTAGE,
@@ -9,13 +10,17 @@ import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 export function BundleDiscountOfferTooltip() {
   const { t } = useTranslation('purchase-form')
   const { shopSession } = useShopSession()
+  const isEditingCartItem = useCartEntryToReplace() != null
   if (shopSession == null) {
     return null
   }
-  const numberOfEligibleCartItems = shopSession.cart.entries.filter((item) =>
+  let numberOfEligibleCartItems = shopSession.cart.entries.filter((item) =>
     BUNDLE_DISCOUNT_ELIGIBLE_PRODUCT_IDS.has(item.product.id),
   ).length
+  if (isEditingCartItem) {
+    numberOfEligibleCartItems -= 1
+  }
   const key =
-    numberOfEligibleCartItems === 0 ? 'BUNDLE_DISCOUNT_FIRST_OFFER' : 'BUNDLE_DISCOUNT_SECOND_OFFER'
+    numberOfEligibleCartItems < 1 ? 'BUNDLE_DISCOUNT_FIRST_OFFER' : 'BUNDLE_DISCOUNT_SECOND_OFFER'
   return <DiscountTooltip subtitle={t(key, { percentage: BUNDLE_DISCOUNT_PERCENTAGE })} />
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Automatically hide cart toast when we follow bundle discount product link from cart toast or change current page in any other way

Fixes bug described here: https://hedviginsurance.slack.com/archives/C0738V9GV9S/p1715961003502579

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
