### PR TITLE
fix/load GTM at initial page load to avoid dropped affiliate tracking and fix bug where consent isn't updated correctly after consent is given

### DIFF
--- a/apps/store/src/components/CookieConsent/CookieConsent.tsx
+++ b/apps/store/src/components/CookieConsent/CookieConsent.tsx
@@ -39,10 +39,11 @@ export function CookieConsent() {
   const { t } = useTranslation(['cookieConsent', 'common'])
   const locale = useRoutingLocale()
 
-  // Make sure we don't show the cookie banner or load GTM before we have read the OneTrust cookie
+  // 1. Make sure we don't show the cookie banner before we have read the OneTrust cookie
+  // 2. Initialize GTM on initial load to ensure consent values are sent from the start
   const [cookieConsent, setCookieConsent] = useState<CookieConsent>({
     showBanner: false,
-    initializeGtm: false,
+    initializeGtm: true,
     action: null,
   })
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
We have a bug with the consent/tracking feature released last week.

- For some reason consent is not update correctly in GTM when we defer loading the script. Might be a timing issue, we try to send update before script is fully loaded
- Affiliate tracking is dropped when consent aren't updated properly

Immediate fix is to load GTM on page load as we did before. Let's see if we can find a way around it. But if it's too flaky I see the risk of loosing tracking and affiliate tracking is more significant than the savings in first page load. 

We will still omit loading OneTrust script other than strictly necessary which is the biggest win 
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
We have a bug with the consent/tracking feature released last week.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
