### PR TITLE
Keep on loading OneTrust to ensure consent is not dropped

### DIFF
--- a/apps/store/src/components/CookieConsent/CookieConsent.tsx
+++ b/apps/store/src/components/CookieConsent/CookieConsent.tsx
@@ -73,9 +73,6 @@ export function CookieConsent() {
           ...prevState,
           initializeGtm: true,
         }))
-
-        // Omit loading OneTrust script after updated consent
-        setLoadOneTrust(false)
       }
 
       if (cookieConsent.action === 'openSettings') {
@@ -93,9 +90,6 @@ export function CookieConsent() {
             ...prevState,
             initializeGtm: true,
           }))
-
-          // Omit loading OneTrust script after updated consent
-          setLoadOneTrust(false)
         })
       }
     }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Not loading OneTrust after consent was given caused our Consent tag in Google Tag Manager to set the all categories as `denied`. That's because the tag was looking at categories from the `OneTrustGroupsUpdated` event that's being sent by the OneTrust script. 

Rollback for now. We will need to go over the tags in GTM listen at consent mode categories instead next week
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
GTM tracking is currently not working as expected
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
