### PR TITLE
Provide early fallback UI for PurchaseForm without waiting for Suspense to resolve

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -54,9 +54,16 @@ export type PurchaseFormProps = {
   showAverageRating?: boolean
 }
 
+// TODO: Merge Layout here
 export function PurchaseForm(props: PurchaseFormProps) {
   return (
-    <Suspense>
+    <Suspense
+      fallback={
+        <Layout>
+          {() => <IdleState loading={true} showAverageRating={props.showAverageRating} />}
+        </Layout>
+      }
+    >
       <PriceIntentContextProvider>
         <ProductPageTrackingProvider>
           <PurchaseFormInner {...props} />


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Prevent render delay of PurchaseForm in app router by providing default initial state as Suspense fallback

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Fixes big layout shift when purchase form loading state appeared only after initial render

## Checklist before requesting a review

- [x] I have performed a self-review of my code
