### PR TITLE
Support custom campaign codes in widget flow

### DIFF
--- a/apps/store/src/features/widget/StartFlow.helpers.ts
+++ b/apps/store/src/features/widget/StartFlow.helpers.ts
@@ -25,7 +25,7 @@ type FetchFlowMetadataParams = {
   draftMode?: boolean
 }
 
-type FlowMetadata = { flow: string; partnerName: string }
+type FlowMetadata = { flow: string; partnerName: string; campaignCode?: string }
 
 export const fetchFlowMetadata = async (
   params: FetchFlowMetadataParams,
@@ -35,10 +35,13 @@ export const fetchFlowMetadata = async (
     locale: params.locale,
     version: params.draftMode ? 'draft' : undefined,
   })
-  const flow = String(story.id)
 
   if (isWidgetFlowStory(story)) {
-    return { flow, partnerName: story.content.partner }
+    return {
+      flow: String(story.id),
+      partnerName: story.content.partner,
+      campaignCode: story.content.campaignCode,
+    }
   }
 
   console.warn('Story is not a widget flow story:', story.slug)

--- a/apps/store/src/features/widget/createPartnerShopSession.ts
+++ b/apps/store/src/features/widget/createPartnerShopSession.ts
@@ -16,7 +16,7 @@ type MutationVariables = VariablesOf<typeof ShopSessionCreatePartnerDocument>['i
 type CreatePartnerShopSessionParams = {
   apolloClient: ApolloClient<unknown>
   searchParams: URLSearchParams
-} & Pick<MutationVariables, 'countryCode' | 'partnerName'>
+} & Pick<MutationVariables, 'countryCode' | 'partnerName' | 'campaignCode'>
 
 export const createPartnerShopSession = async (
   params: CreatePartnerShopSessionParams,
@@ -37,6 +37,7 @@ export const createPartnerShopSession = async (
       input: {
         countryCode: params.countryCode,
         partnerName: params.partnerName,
+        campaignCode: params.campaignCode,
         initiatedFrom: 'WIDGET',
         ...variables,
       },

--- a/apps/store/src/pages/[locale]/widget/flows/[...slug].tsx
+++ b/apps/store/src/pages/[locale]/widget/flows/[...slug].tsx
@@ -40,6 +40,7 @@ export const getServerSideProps: GetServerSideProps<any, Params> = async (contex
     apolloClient,
     countryCode: getCountryByLocale(context.locale).countryCode,
     partnerName: flowMetadata.partnerName,
+    campaignCode: flowMetadata.campaignCode,
     searchParams: url.searchParams,
   })
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

If Storyblok specifies campaignCode for widget flow, pass it to create session mutation

Part of supporting multiple campaign codes for Avy

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
