### PR TITLE
Update ProductGrid to follow main site grid

### DIFF
--- a/apps/store/src/blocks/ProductGridBlock.tsx
+++ b/apps/store/src/blocks/ProductGridBlock.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import styled from '@emotion/styled'
 import { storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
-import { mq, theme } from 'ui'
 import type { ProductCardBlockProps } from '@/blocks/ProductCardBlock'
 import { ProductCardBlock } from '@/blocks/ProductCardBlock'
 import { ProductGrid } from '@/components/ProductGrid/ProductGrid'
@@ -20,18 +18,8 @@ export const ProductGridBlock = ({ blok }: ProductGridBlockProps) => {
     [blok.items],
   )
   return (
-    <Wrapper>
-      <ProductGrid title={blok.title} items={items} {...storyblokEditable(blok)}>
-        {(nestedBlock) => <ProductCardBlock key={nestedBlock.key} blok={nestedBlock} />}
-      </ProductGrid>
-    </Wrapper>
+    <ProductGrid title={blok.title} items={items} {...storyblokEditable(blok)}>
+      {(nestedBlock) => <ProductCardBlock key={nestedBlock.key} blok={nestedBlock} />}
+    </ProductGrid>
   )
 }
-
-const Wrapper = styled.div({
-  paddingInline: theme.space.xs,
-
-  [mq.md]: {
-    paddingInline: theme.space.lg,
-  },
-})

--- a/apps/store/src/components/ProductGrid/ProductGrid.css.ts
+++ b/apps/store/src/components/ProductGrid/ProductGrid.css.ts
@@ -1,0 +1,24 @@
+import { style } from '@vanilla-extract/css'
+import { minWidth, tokens } from 'ui'
+import { MAX_WIDTH } from '../GridLayout/GridLayout.constants'
+
+export const productGrid = style({
+  display: 'grid',
+  rowGap: tokens.space.xxxl,
+  columnGap: tokens.space.xs,
+  alignItems: 'end',
+  gridTemplateColumns: `repeat(auto-fit, minmax(20rem, 1fr))`,
+  maxWidth: MAX_WIDTH,
+  marginInline: 'auto',
+  paddingInline: tokens.space.md,
+
+  '@media': {
+    [minWidth.md]: {
+      rowGap: tokens.space.xl,
+      columnGap: tokens.space.md,
+    },
+    [minWidth.lg]: {
+      paddingInline: tokens.space.lg,
+    },
+  },
+})

--- a/apps/store/src/components/ProductGrid/ProductGrid.stories.tsx
+++ b/apps/store/src/components/ProductGrid/ProductGrid.stories.tsx
@@ -7,6 +7,11 @@ import { ProductGrid } from './ProductGrid'
 const meta: Meta<typeof ProductGrid> = {
   component: ProductGrid,
   argTypes: {},
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
 }
 
 export default meta

--- a/apps/store/src/components/ProductGrid/ProductGrid.tsx
+++ b/apps/store/src/components/ProductGrid/ProductGrid.tsx
@@ -1,7 +1,6 @@
-import styled from '@emotion/styled'
 import { Fragment } from 'react'
-import { mq, Space, theme } from 'ui'
-import { MAX_WIDTH } from '../GridLayout/GridLayout.constants'
+import { Space, Text } from 'ui'
+import { productGrid } from './ProductGrid.css'
 
 export type ProductGridProps<Item> = {
   title?: string
@@ -15,37 +14,17 @@ export const ProductGrid = <ItemType extends { key: string }>({
   children,
 }: ProductGridProps<ItemType>) => {
   return (
-    <Wrapper y={1.5}>
-      {title && <Title>{title}</Title>}
-      <Grid>
+    <Space y={1.5}>
+      {title && (
+        <Text align="center" color="textSecondary" size="xs" uppercase={true}>
+          {title}
+        </Text>
+      )}
+      <div className={productGrid}>
         {items.map((item) => (
           <Fragment key={item.key}>{children(item)}</Fragment>
         ))}
-      </Grid>
-    </Wrapper>
+      </div>
+    </Space>
   )
 }
-
-const Wrapper = styled(Space)({
-  maxWidth: MAX_WIDTH,
-  height: '100%',
-  marginInline: 'auto',
-})
-
-const Title = styled.p({
-  fontSize: theme.fontSizes.xs,
-  color: theme.colors.gray600,
-  textTransform: 'uppercase',
-  textAlign: 'center',
-})
-
-const Grid = styled.div({
-  display: 'grid',
-  gap: `${theme.space.xxxl} ${theme.space.xs}`,
-  alignItems: 'end',
-  gridTemplateColumns: `repeat(auto-fit, minmax(20rem, 1fr))`,
-
-  [mq.md]: {
-    gap: '2rem 1rem',
-  },
-})

--- a/apps/store/src/components/ProductRecommendationList/ProductRecommendationList.tsx
+++ b/apps/store/src/components/ProductRecommendationList/ProductRecommendationList.tsx
@@ -1,10 +1,10 @@
-import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { Heading, mq, Space, theme } from 'ui'
+import { Heading, Space } from 'ui'
 import type { ImageSize } from '@/blocks/ProductCardBlock'
 import { ProductCard } from '@/components/ProductCard/ProductCard'
 import type { ProductRecommendationFragment } from '@/services/graphql/generated'
 import { getStoryblokImageSize } from '@/services/storyblok/Storyblok.helpers'
+import { productGrid } from '../ProductGrid/ProductGrid.css'
 
 type Props = {
   recommendations: Array<ProductRecommendationFragment>
@@ -14,17 +14,17 @@ export const ProductRecommendationList = ({ recommendations }: Props) => {
   const { t } = useTranslation('cart')
 
   return (
-    <Wrapper y={{ base: 1.5, md: 3 }}>
+    <Space y={{ base: 1.5, md: 3 }}>
       <Heading as="h2" variant="standard.24" align="center">
         {t('RECOMMENDATIONS_HEADING')}
       </Heading>
 
-      <List>
+      <div className={productGrid}>
         {recommendations.map((item) => (
           <FeaturedProduct key={item.id} recommendation={item} />
         ))}
-      </List>
-    </Wrapper>
+      </div>
+    </Space>
   )
 }
 
@@ -63,22 +63,3 @@ const calculateAspectRatio = ({
   // TODO: properly evaluate aspect ratio
   return `${width} / ${height}` as ImageSize['aspectRatio']
 }
-
-const Wrapper = styled(Space)({
-  paddingInline: theme.space.xs,
-  [mq.lg]: { paddingInline: theme.space.lg },
-})
-
-// TODO: reuse styles as product grid
-const List = styled.div({
-  display: 'grid',
-  rowGap: theme.space.xxxl,
-  columnGap: theme.space.xs,
-  alignItems: 'end',
-  gridTemplateColumns: `repeat(auto-fit, minmax(20rem, 1fr))`,
-
-  [mq.md]: {
-    rowGap: theme.space.xl,
-    columnGap: theme.space.md,
-  },
-})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Align ProductGrid with the rest of the site
- Use ProductGrid styles in ProductRecommendations 

<img width="1664" alt="Screenshot 2024-05-30 at 17 41 36" src="https://github.com/HedvigInsurance/racoon/assets/6661511/a108ec85-fa8f-44a0-a227-03d991bae00c">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Design update, we don't want the site to be too wide on larger screens and align with the new UI kit updates

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
