### PR TITLE
Fix layout shift in mobile version of ProductHero by replacing Space and SpaceFlex with vanilla-extract styles

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/ProductHero/ProductHero.css.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ProductHero/ProductHero.css.ts
@@ -1,5 +1,18 @@
 import { style } from '@vanilla-extract/css'
+import { sprinkles } from 'ui/src/theme/sprinkles.css'
+import { theme } from 'ui'
+
+export const wrapper = style([
+  sprinkles({ display: 'flex', flexDirection: 'column', alignItems: 'center' }),
+  {
+    rowGap: theme.space.md,
+  },
+])
 
 export const pillow = style({
   marginInline: 'auto',
+})
+
+export const textWrapper = style({
+  rowGap: theme.space.sm,
 })

--- a/apps/store/src/components/ProductPage/PurchaseForm/ProductHero/ProductHero.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ProductHero/ProductHero.tsx
@@ -1,7 +1,6 @@
-import { Heading, Space, Text } from 'ui'
+import { Heading, Text } from 'ui'
 import { Pillow } from '@/components/Pillow/Pillow'
-import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
-import { pillow } from './ProductHero.css'
+import { pillow, textWrapper, wrapper } from './ProductHero.css'
 
 type Props = {
   name: string
@@ -12,7 +11,7 @@ type Props = {
 
 export const ProductHero = (props: Props) => {
   return (
-    <SpaceFlex space={1} direction="vertical" align="center">
+    <div className={wrapper}>
       <Pillow
         className={pillow}
         size={props.size === 'small' ? 'large' : 'xxlarge'}
@@ -20,14 +19,14 @@ export const ProductHero = (props: Props) => {
         priority={true}
       />
 
-      <Space y={0.75}>
+      <div className={textWrapper}>
         <Heading as="h1" variant="standard.24" align="center">
           {props.name}
         </Heading>
         <Text size="xs" color="textSecondary" align="center">
           {props.description}
         </Text>
-      </Space>
-    </SpaceFlex>
+      </div>
+    </div>
   )
 }

--- a/packages/ui/src/theme/sprinkles.css.ts
+++ b/packages/ui/src/theme/sprinkles.css.ts
@@ -24,6 +24,7 @@ const textColors = {
 
 const unresponsiveProperties = defineProperties({
   properties: {
+    alignItems: ['flex-start', 'center', 'flex-end'],
     textAlign: ['left', 'center', 'right'],
     color: textColors,
     display: ['flex', 'grid'],


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Get rid of `Space` and `SpaceFlex` in `ProductHero` block
- Support `alignItems` in sprinkles

This fixes layout shift shown on attached video below

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/GLY3tSM85RFBvAf6lFNA/d0323d37-e2ac-404f-bead-b84c977108c1.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/GLY3tSM85RFBvAf6lFNA/d0323d37-e2ac-404f-bead-b84c977108c1.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/d0323d37-e2ac-404f-bead-b84c977108c1.mov">Screen Recording 2024-06-03 at 12.53.00.mov</video>

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
