### PR TITLE
Optimize ProductPageBlock rendering by making lower content area render lazily

### DIFF
--- a/apps/store/src/utils/useIdleCallback.ts
+++ b/apps/store/src/utils/useIdleCallback.ts
@@ -1,0 +1,18 @@
+// Delay execution with requestIdleCallback. Fallback to requestAnimationFrame (RIC not supported in Safari)
+import { useEffect } from 'react'
+
+export const useIdleCallback = (callback: () => void) => {
+  useEffect(() => {
+    let schedule
+    let cancel
+    if (typeof window.requestIdleCallback === 'function') {
+      schedule = window.requestIdleCallback
+      cancel = window.cancelIdleCallback
+    } else {
+      schedule = window.requestAnimationFrame
+      cancel = window.cancelAnimationFrame
+    }
+    const callbackId = schedule(callback)
+    return () => cancel(callbackId)
+  }, [callback])
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Improve rendering speed of product pages by rendering general content (below "Coverage") lazily when it comes into view

Before
![Screenshot 2024-06-03 at 14.21.10.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/c1ac6c41-ce65-4a20-a6f4-c60b85823c35.png)

After
![Screenshot 2024-06-03 at 14.21.02.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/d3311fce-35d7-449e-b500-01712820afc3.png)


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

"See your price" is one of known slow elements and this optimization makes it faster thanks to rendering much smaller tree when opening just top part of product page

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
