### PR TITLE
Send necessary cookie category on app init

### DIFF
--- a/apps/store/src/services/gtm.tsx
+++ b/apps/store/src/services/gtm.tsx
@@ -51,6 +51,7 @@ type DataLayerObject = {
   userProperties?: GTMUserProperties
   offerData?: Record<string, unknown>
   eventData?: Record<string, string>
+  OnetrustActiveGroups?: string
   pageData?: GTMPageData
   ecommerce?: GTMEcommerceData
   shopSession?: GTMShopSessionData
@@ -133,6 +134,12 @@ export const initializeGtm = (countryCode: CountryCode) => {
       country: countryCode,
       environment: getGtmEnvironment(),
     },
+  })
+
+  // Update OneTrust active groups for necessary category on app init
+  pushToGTMDataLayer({
+    event: 'OneTrustGroupsUpdated',
+    OnetrustActiveGroups: ',C0001,',
   })
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Make sure we send necessary cookie category on app init to trigger necessary script tags in GTM.

This fixes issue were Addrevenue utm values wasn't stored in localStorage
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Necessary category wasn't sent until OneTrust script was loaded after the user interacts with the cookie consent banner
Reported by Simon

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
