### PR TITLE
Optimize PurchaseForm rendering performance when submitting a section

### DIFF
--- a/apps/store/src/components/PersonalNumberField/PersonalNumberField.tsx
+++ b/apps/store/src/components/PersonalNumberField/PersonalNumberField.tsx
@@ -2,6 +2,7 @@
 
 import Personnummer from 'personnummer'
 import type { InputHTMLAttributes } from 'react'
+import { memo } from 'react'
 import { useState } from 'react'
 import type { Props as TextFieldProps } from '@/components/TextField/TextField'
 import { TextField } from '@/components/TextField/TextField'
@@ -19,7 +20,7 @@ export type Props = Omit<
  * Personal Number input field.
  * Only supports Swedish personal numbers.
  */
-export const PersonalNumberField = (props: Props) => {
+export const PersonalNumberField = memo((props: Props) => {
   const { value: propValue, defaultValue, label, warning, onClear, ...baseProps } = props
 
   const [value, setValue] = useState(() => {
@@ -59,4 +60,5 @@ export const PersonalNumberField = (props: Props) => {
       )}
     </>
   )
-}
+})
+PersonalNumberField.displayName = 'PersonalNumberField'

--- a/apps/store/src/components/Pillow/Pillow.tsx
+++ b/apps/store/src/components/Pillow/Pillow.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import Image from 'next/image'
+import { memo } from 'react'
 import { getImgSrc } from '@/services/storyblok/Storyblok.helpers'
 
 type PillowProps = {
@@ -10,7 +11,7 @@ type PillowProps = {
   className?: string
 }
 
-export const Pillow = ({ alt, src, priority, ...props }: PillowProps) => {
+export const Pillow = memo(({ alt, src, priority, ...props }: PillowProps) => {
   if (!src) return <FallbackPillow {...props} size={props.size} />
   return (
     <StyledImage
@@ -24,7 +25,8 @@ export const Pillow = ({ alt, src, priority, ...props }: PillowProps) => {
       quality={70}
     />
   )
-}
+})
+Pillow.displayName = 'Pillow'
 
 const StyledImage = styled(Image)<PillowProps>(({ size = 'medium' }) => getSize(size))
 

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorAccordion.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorAccordion.tsx
@@ -1,7 +1,7 @@
 import { datadogRum } from '@datadog/browser-rum'
 import { useRouter } from 'next/navigation'
 import { type ReactNode, useCallback, useState } from 'react'
-import { SsnSeSection } from '@/components/PriceCalculator/SsnSeSection'
+import { SSN_SE_SECTION_ID, SsnSeSection } from '@/components/PriceCalculator/SsnSeSection'
 import { OPEN_PRICE_CALCULATOR_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam'
 import type { Form, FormSection } from '@/services/PriceCalculator/PriceCalculator.types'
 import type { ShopSession } from '@/services/shopSession/ShopSession.types'
@@ -31,7 +31,7 @@ export const PriceCalculatorAccordion = ({
 
   const handleActiveSectionChange = useCallback(
     (sectionId: string) => {
-      if (sectionId === SsnSeSection.sectionId && shopSession.customer?.ssn) {
+      if (sectionId === SSN_SE_SECTION_ID && shopSession.customer?.ssn) {
         setShowChangeSsnDialog(true)
       } else {
         onActiveSectionChange(sectionId)
@@ -40,14 +40,15 @@ export const PriceCalculatorAccordion = ({
     [onActiveSectionChange, shopSession.customer?.ssn],
   )
 
+  const ssnSectionNextIndex =
+    form.sections.findIndex((section) => section.id === SSN_SE_SECTION_ID) + 1
+  const ssnSectionNextId = form.sections[ssnSectionNextIndex]?.id
   const handleSsnSectionCompleted = useCallback(() => {
-    const nextSectionIndex =
-      form.sections.findIndex((section) => section.id === SsnSeSection.sectionId) + 1
-    if (!form.sections[nextSectionIndex]) {
-      throw new Error(`Failed to find section after ${SsnSeSection.sectionId}`)
+    if (!ssnSectionNextId) {
+      throw new Error(`Failed to find section after ${SSN_SE_SECTION_ID}`)
     }
-    onActiveSectionChange(form.sections[nextSectionIndex].id)
-  }, [form.sections, onActiveSectionChange])
+    onActiveSectionChange(ssnSectionNextId)
+  }, [ssnSectionNextId, onActiveSectionChange])
 
   const handleAcceptChangeSsn = useCallback(() => {
     datadogRum.addAction('Cleared shopSession to change SSN in price calculator', {
@@ -77,9 +78,13 @@ export const PriceCalculatorAccordion = ({
       >
         {form.sections.map((section, index) => {
           let content
-          if (section.id === SsnSeSection.sectionId) {
+          if (section.id === SSN_SE_SECTION_ID) {
             content = (
-              <SsnSeSection shopSession={shopSession} onCompleted={handleSsnSectionCompleted} />
+              <SsnSeSection
+                shopSessionId={shopSession.id}
+                ssn={shopSession.customer?.ssn}
+                onCompleted={handleSsnSectionCompleted}
+              />
             )
           } else {
             content = children(section, index)

--- a/apps/store/src/components/PriceCalculator/SsnSeSection.tsx
+++ b/apps/store/src/components/PriceCalculator/SsnSeSection.tsx
@@ -1,17 +1,16 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { useTranslation } from 'next-i18next'
-import { type FormEventHandler } from 'react'
+import { type FormEventHandler, memo } from 'react'
 import { Button, Space } from 'ui'
 import { PersonalNumberField } from '@/components/PersonalNumberField/PersonalNumberField'
 import { useShopSessionCustomerUpdateMutation } from '@/services/graphql/generated'
-import type { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useErrorMessage } from '@/utils/useErrorMessage'
 
 const SsnFieldName = 'ssn'
 
-type Props = { shopSession: ShopSession; onCompleted: () => void }
+type Props = { shopSessionId: string; ssn?: string | null; onCompleted: () => void }
 
-export const SsnSeSection = ({ shopSession, onCompleted }: Props) => {
+export const SsnSeSection = memo(({ shopSessionId, ssn, onCompleted }: Props) => {
   const { t } = useTranslation('purchase-form')
   const [updateCustomer, result] = useShopSessionCustomerUpdateMutation({
     // priceIntent.suggestedData may be updated based on customer.ssn
@@ -32,7 +31,7 @@ export const SsnSeSection = ({ shopSession, onCompleted }: Props) => {
     event.preventDefault()
     const ssn = event.currentTarget[SsnFieldName].value
     if (typeof ssn !== 'string') throw new Error('No SSN found in SSN section form')
-    updateCustomer({ variables: { input: { shopSessionId: shopSession.id, ssn } } })
+    updateCustomer({ variables: { input: { shopSessionId: shopSessionId, ssn } } })
   }
 
   const errorMessage = useErrorMessage(result.error)
@@ -43,7 +42,7 @@ export const SsnSeSection = ({ shopSession, onCompleted }: Props) => {
         <PersonalNumberField
           label={t('FIELD_SSN_SE_LABEL')}
           name={SsnFieldName}
-          defaultValue={shopSession.customer?.ssn ?? ''}
+          defaultValue={ssn ?? ''}
           required={true}
           warning={!!errorMessage}
           message={errorMessage}
@@ -54,6 +53,7 @@ export const SsnSeSection = ({ shopSession, onCompleted }: Props) => {
       </Space>
     </form>
   )
-}
+})
+SsnSeSection.displayName = 'SsnSeSection'
 
-SsnSeSection.sectionId = 'ssn-se'
+export const SSN_SE_SECTION_ID = 'ssn-se'

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -5,7 +5,8 @@ import { clsx } from 'clsx'
 import { motion } from 'framer-motion'
 import { usePathname } from 'next/navigation'
 import { useTranslation } from 'next-i18next'
-import type { ReactNode } from 'react'
+import type { ReactNode} from 'react';
+import { useMemo } from 'react'
 import { Suspense } from 'react'
 import { useCallback, useRef, useState } from 'react'
 import { Button, Heading, Space, framerTransitions } from 'ui'
@@ -222,6 +223,13 @@ type ProductHeroContainerProps = {
 const ProductHeroContainer = (props: ProductHeroContainerProps) => {
   const { content } = useProductPageContext()
   const productData = useProductData()
+  const pillow = useMemo(
+    () => ({
+      src: productData.pillowImage.src,
+      alt: productData.pillowImage.alt ?? undefined,
+    }),
+    [productData],
+  )
   return (
     <div
       className={clsx(
@@ -234,10 +242,7 @@ const ProductHeroContainer = (props: ProductHeroContainerProps) => {
       <ProductHero
         name={content.product.name}
         description={content.product.description}
-        pillow={{
-          src: productData.pillowImage.src,
-          alt: productData.pillowImage.alt ?? undefined,
-        }}
+        pillow={pillow}
         size={props.size}
       />
       {props.children}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Collection of low-risk optimizations for purchase form rendering
- memo, useCallback, etc to prevent rerenders
- only pass relevant props to `SsnSeSection` to avoid rerendrers on every change in `shopSession`

Results:
Scripting time for submitting SSN and Address sections in SE_APARTMENT_RENT reduced ~20% (239ms -> 197ms)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Purchase form section buttons are among the slowest elements on the site right now

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
