### PR TITLE
Update A/B test setup to work with component experiments

### DIFF
--- a/apps/store/next.config.mjs
+++ b/apps/store/next.config.mjs
@@ -168,7 +168,7 @@ const securityHeaders = [
 const getExperimentVariantRedirects = () => {
   if (typeof process.env.NEXT_PUBLIC_EXPERIMENT_ID !== 'string') return []
 
-  const variantSlug = experimentJson.variants.find((item) => item.slug).slug
+  const variantSlug = experimentJson.variants.find((item) => item.slug)?.slug
   if (!variantSlug) return []
 
   return [

--- a/apps/store/src/services/Tracking/experiment.constants.ts
+++ b/apps/store/src/services/Tracking/experiment.constants.ts
@@ -5,7 +5,7 @@ export type Experiment = {
   id: string
   name: string
   variants: Array<ExperimentVariant>
-  slug: string
+  slug?: string
 }
 
 export type ExperimentVariant = {

--- a/apps/store/src/services/Tracking/experiment.helpers.ts
+++ b/apps/store/src/services/Tracking/experiment.helpers.ts
@@ -4,7 +4,8 @@ export const getCurrentExperiment = (): Experiment | undefined => {
   return CURRENT_EXPERIMENT
 }
 
-export const getExperimentVariant = (cookieValue: string): ExperimentVariant | undefined => {
+export const getExperimentVariant = (cookieValue?: string): ExperimentVariant | undefined => {
+  if (!cookieValue) return
   const currentExperiment = getCurrentExperiment()
   if (!currentExperiment) return
 
@@ -37,4 +38,8 @@ export const experimentImpressionVariantId = (
   variant: ExperimentVariant,
 ) => {
   return `${experiment.id}.${variant.id}`
+}
+
+export const getExperimentId = (experimentVariant: string) => {
+  return experimentVariant.split('.')[0]
 }

--- a/apps/store/src/services/Tracking/trackExperimentImpression.ts
+++ b/apps/store/src/services/Tracking/trackExperimentImpression.ts
@@ -11,7 +11,8 @@ export const trackExperimentImpression = (tracking: Tracking) => {
   if (typeof window === 'undefined') return
   const currentExperiment = getCurrentExperiment()
   if (!currentExperiment) return
-  if (window.location.pathname !== currentExperiment.slug) return
+
+  if (currentExperiment.slug && window.location.pathname !== currentExperiment.slug) return
 
   const cookieValue = getCookie(EXPERIMENT_COOKIE_NAME)
   if (typeof cookieValue !== 'string') return


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
In the previous A/B test setup we only run page level experiments where we rewrote the url to another page for experiment variants.  

To add support for component level experiments, make slug optional but still support page A/B tests
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
New A/B test setup

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
