### PR TITLE
fix(blog): make storyblok preview work again

### DIFF
--- a/apps/store/src/app/[locale]/[[...slug]]/BlogStoryContainer.tsx
+++ b/apps/store/src/app/[locale]/[[...slug]]/BlogStoryContainer.tsx
@@ -4,7 +4,9 @@ import type { SbBlokData } from '@storyblok/react'
 import type { ReactNode } from 'react'
 import {
   BLOG_ARTICLE_CATEGORIES_PAGE_PROP,
+  BLOG_ARTICLE_CATEGORY_CONTENT_TYPE,
   BLOG_ARTICLE_CATEGORY_LIST_BLOCK,
+  BLOG_ARTICLE_CONTENT_TYPE,
   BLOG_ARTICLE_LIST_BLOCK,
   BLOG_ARTICLE_TEASERS_PAGE_PROP,
 } from '@/features/blog/blog.constants'
@@ -12,6 +14,7 @@ import { convertToBlogArticleCategory } from '@/features/blog/blog.helpers'
 import type { BlogArticleContentType, BlogArticleTeaser } from '@/features/blog/blog.types'
 import type { BlogPageProps } from '@/features/blog/BlogContextProvider'
 import { BlogContextProvider } from '@/features/blog/BlogContextProvider'
+import { BlogStoryblokProvider } from '@/features/blog/BlogStoryblokProvider'
 import { getImgSrc, getStoryblokImageSize } from '@/services/storyblok/Storyblok.helpers'
 import { getBlogArticles, getBlogCategories } from '@/services/storyblok/storyblok.rsc'
 import type { RoutingLocale } from '@/utils/l10n/types'
@@ -40,7 +43,16 @@ export async function BlogStoryContainer({ locale, story, children }: Props) {
     )
   }
   await Promise.all(requests)
-  return <BlogContextProvider blogPageProps={blogPageProps}>{children}</BlogContextProvider>
+
+  const isBlogArticlePage = story.content.component === BLOG_ARTICLE_CONTENT_TYPE
+  const isBlogCategoryPage = story.content.component === BLOG_ARTICLE_CATEGORY_CONTENT_TYPE
+  const shouldLoadBlogBlocks = isBlogArticlePage || isBlogCategoryPage
+
+  return (
+    <BlogContextProvider blogPageProps={blogPageProps}>
+      {shouldLoadBlogBlocks ? <BlogStoryblokProvider>{children}</BlogStoryblokProvider> : children}
+    </BlogContextProvider>
+  )
 }
 
 const findBlock = (story: ISbStoryData, component: string) => {

--- a/apps/store/src/features/blog/BlogContextProvider.tsx
+++ b/apps/store/src/features/blog/BlogContextProvider.tsx
@@ -5,7 +5,6 @@ import type {
   BLOG_ARTICLE_TEASERS_PAGE_PROP,
 } from '@/features/blog/blog.constants'
 import type { BlogArticleCategory, BlogArticleTeaser } from '@/features/blog/blog.types'
-import { BlogStoryblokProvider } from '@/features/blog/BlogStoryblokProvider'
 import { BlogContext, parseBlogContext } from '@/features/blog/useBlog'
 
 type Props = {
@@ -19,11 +18,9 @@ export type BlogPageProps = {
 }
 
 export function BlogContextProvider({ blogPageProps, children }: Props) {
-  const hasBlogContext = Object.values(blogPageProps ?? {}).some(Boolean)
-
   return (
     <BlogContext.Provider value={parseBlogContext(blogPageProps ?? {})}>
-      {hasBlogContext ? <BlogStoryblokProvider>{children}</BlogStoryblokProvider> : children}
+      {children}
     </BlogContext.Provider>
   )
 }

--- a/apps/store/src/features/blog/BlogStoryblokProvider.tsx
+++ b/apps/store/src/features/blog/BlogStoryblokProvider.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { setComponents } from '@storyblok/react'
 import type { ReactNode } from 'react'
 import { blogBlocks } from '@/features/blog/blogBlocks'


### PR DESCRIPTION
## Describe your changes

- Make sure we load blog blocks for Blog Article and Blog Category content types, fixing previewing then on Storyblok

## Justify why they are needed

Issue caught by Peter and mentioned [here](https://hedviginsurance.slack.com/archives/C02JPS466NS/p1718020297897609)
