### PR TITLE
Fix i18next resource duplication (translation loader)

### DIFF
--- a/apps/store/src/app/[locale]/test/page.tsx
+++ b/apps/store/src/app/[locale]/test/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { fetchGlobalProductMetadata } from '@/components/LayoutWithMenu/fetchProductMetadata'
 import { getApolloClient } from '@/services/apollo/app-router/rscClient'
 import type { RoutingLocale } from '@/utils/l10n/types'
-import { initTranslationsServerSide } from '../../i18n'
+import { initTranslations } from '../../i18n'
 import { ClientComponent } from './ClientComponent'
 import { wrapper } from './styles.css'
 
@@ -11,7 +11,7 @@ type Props = {
 }
 
 const Page = async (props: Props) => {
-  const { t } = await initTranslationsServerSide(props.params.locale)
+  const { t } = await initTranslations(props.params.locale)
   // Same graphql request as in layout, only one network request gets executed thanks to Apollo SSR cache
   const apolloClient = getApolloClient(props.params.locale)
   const productMetadata = await fetchGlobalProductMetadata({ apolloClient })

--- a/apps/store/src/app/i18n.ts
+++ b/apps/store/src/app/i18n.ts
@@ -3,11 +3,12 @@ import { createInstance } from 'i18next'
 import type { I18n } from 'next-i18next'
 import { initReactI18next } from 'react-i18next/initReactI18next'
 import nextI18nextConfig from '../../next-i18next.config.cjs'
+import type { I18nNamespaces } from '../@types/i18next'
 
 // Every i18n namespace must be added here in order to preload translations
 // We may consider having multiple TranslationsProvider instances each with its own namespaces
 // for optimization in the future
-const allNamespaces = [
+const allNamespaces: ReadonlyArray<keyof I18nNamespaces> = [
   'common',
   'bankid',
   'carDealership',
@@ -22,17 +23,22 @@ const allNamespaces = [
   'widget',
 ]
 
-const allLocales = ['en', 'dk', 'dk-en', 'no', 'no-en', 'se-en', 'se', 'sv-se']
+const allLocales = ['en', 'dk', 'dk-en', 'no', 'no-en', 'se-en', 'se', 'sv-se'] as const
+
+type Options = {
+  i18nInstance?: I18n
+  resources?: Resource
+  ns?: ReadonlyArray<keyof I18nNamespaces>
+}
 
 export const initTranslations = async (
   locale: string,
-  i18nInstance?: I18n,
-  resources?: Resource,
+  { i18nInstance, resources, ns }: Options = {},
 ) => {
   const i18n = i18nInstance ?? createInstance()
   i18n.use(initReactI18next)
-  if (resources === undefined) {
-    i18n.use(requireTranslationsBackend)
+  if (resources == null) {
+    i18n.use(importBackend)
   }
 
   const preload = [locale]
@@ -44,12 +50,15 @@ export const initTranslations = async (
   }
   const options: InitOptions = {
     lng: locale,
-    ns: allNamespaces,
+    ns: ns ?? allNamespaces,
     supportedLngs: allLocales,
-    preload: resources ? [] : preload,
+    preload,
     resources,
     // It's a safe default when result it not fed into `dangerouslySetInnerHTML` which we currently never do
     interpolation: { escapeValue: false },
+    // We always provide translations in advance, no need to wait for their load client-side
+    // https://react.i18next.com/latest/usetranslation-hook#not-using-suspense
+    react: { useSuspense: false },
     ...nextI18nextConfig,
   }
   await i18n.init(options)
@@ -61,17 +70,17 @@ export const initTranslations = async (
   }
 }
 
-const requireTranslationsBackend: BackendModule = {
+const importBackend: BackendModule = {
   type: 'backend',
   async read(language, namespace, callback) {
     try {
-      const resource = await import(`../../public/locales/${language}/${namespace}.json`)
-      callback(null, resource)
+      const resourceModule = await import(`../../public/locales/${language}/${namespace}.json`)
+      // GOTCHA: resourceModule exposes both `default` and name exports for top-level keys
+      // If we pass it down completely, we double JSON size that is transferred to client component tree
+      callback(null, resourceModule.default)
     } catch (err: unknown) {
       callback(err as CallbackError, null)
     }
   },
   init: () => {},
 }
-
-export const initTranslationsServerSide = (locale: string) => initTranslations(locale)

--- a/apps/store/src/app/switcher/[id]/submitSwitchConfirmation.ts
+++ b/apps/store/src/app/switcher/[id]/submitSwitchConfirmation.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { initTranslationsServerSide } from '@/app/i18n'
+import { initTranslations } from '@/app/i18n'
 import type { FormStateWithErrors, Message } from '@/app/types/formStateTypes'
 import { getApolloClient } from '@/services/apollo/app-router/rscClient'
 import {
@@ -20,7 +20,7 @@ export const submitSwitchConfirmation = async (
   const expiryDate = formData.get('expiryDate') as string
   const id = formData.get('id') as string
 
-  const { t } = await initTranslationsServerSide(DEFAULT_LOCALE)
+  const { t } = await initTranslations(DEFAULT_LOCALE)
 
   if (!expiryDate) {
     return {

--- a/apps/store/src/appComponents/RootLayout/RootLayout.tsx
+++ b/apps/store/src/appComponents/RootLayout/RootLayout.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react'
 import { Provider as BalancerProvider } from 'react-wrap-balancer'
 import globalCss from 'ui/src/global.css'
 import { mainTheme } from 'ui'
-import { initTranslationsServerSide } from '@/app/i18n'
+import { initTranslations } from '@/app/i18n'
 import { TranslationsProvider } from '@/appComponents/providers/TranslationsProvider'
 import { NavigationProgressIndicator } from '@/appComponents/RootLayout/NavigationProgressIndicator'
 import { OrgStructuredData } from '@/appComponents/RootLayout/OrgStructuredData'
@@ -24,7 +24,7 @@ export async function RootLayout({
   locale = 'se',
   children,
 }: PropsWithChildren<{ locale?: RoutingLocale }>) {
-  const { resources } = await initTranslationsServerSide(locale)
+  const { resources } = await initTranslations(locale)
 
   return (
     <html lang={getLocaleOrFallback(locale).htmlLang}>

--- a/apps/store/src/appComponents/providers/TranslationsProvider.tsx
+++ b/apps/store/src/appComponents/providers/TranslationsProvider.tsx
@@ -12,14 +12,14 @@ import type { RoutingLocale } from '@/utils/l10n/types'
 type Props = {
   children: ReactNode
   locale: RoutingLocale
-  resources: Resource
+  resources?: Resource
 }
 
 export const TranslationsProvider = ({ children, locale, resources }: Props) => {
   const i18nRef = useRef<I18n>()
   if (i18nRef.current == null) {
     i18nRef.current = createInstance()
-    initTranslations(locale, i18nRef.current, resources)
+    initTranslations(locale, { i18nInstance: i18nRef.current, resources })
   }
 
   return <I18nextProvider i18n={i18nRef.current}>{children}</I18nextProvider>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Fix JSON import usage when loading translation files and documented original problem
- Refactor `initTranslations` for better naming and ease of future optimization

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

This saves 27KB from HTML size of every page in app router. Actually, x2 that until another source of duplication is fixed in next PR

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
