### PR TITLE
seo(navigation-header): make sure navigations links are available in the DOM

### DIFF
--- a/apps/store/src/blocks/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock.tsx
@@ -8,13 +8,13 @@ import { Space, theme } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { Header } from '@/components/Header/Header'
 import {
-  navigationContent,
   navigationItem,
   navigationMenuWrapper,
   navigationProductList,
   navigationSecondaryItem,
   navigationSecondaryList,
 } from '@/components/Header/Header.css'
+import { NavigationContent } from '@/components/Header/NavigationContent'
 import {
   NavigationLink,
   ProductNavigationLink,
@@ -23,7 +23,6 @@ import {
 import { NavigationTrigger } from '@/components/Header/NavigationTrigger'
 import { ShoppingCartMenuItem } from '@/components/Header/ShoppingCartMenuItem'
 import { TopMenuDesktop } from '@/components/Header/TopMenuDesktop/TopMenuDesktop'
-import { TopMenuMobile } from '@/components/Header/TopMenuMobile/TopMenuMobile'
 import { useProductMetadata } from '@/components/LayoutWithMenu/productMetadataHooks'
 import type {
   ExpectedBlockType,
@@ -85,7 +84,7 @@ export const NestedNavContainerBlock = ({ blok }: NestedNavContainerBlockProps) 
       <NavigationTrigger href={getLinkFieldURL(firstNavItem.link, firstNavItem.name)}>
         {blok.name}
       </NavigationTrigger>
-      <NavigationMenuPrimitive.Content className={navigationContent}>
+      <NavigationContent>
         <div className={navigationMenuWrapper}>
           <NavigationMenuPrimitive.Sub defaultValue={blok.name}>
             <NavigationMenuPrimitive.List className={navigationSecondaryList}>
@@ -106,7 +105,7 @@ export const NestedNavContainerBlock = ({ blok }: NestedNavContainerBlockProps) 
             </NavigationMenuPrimitive.List>
           </NavigationMenuPrimitive.Sub>
         </div>
-      </NavigationMenuPrimitive.Content>
+      </NavigationContent>
     </NavigationMenuPrimitive.Item>
   )
 }
@@ -188,9 +187,7 @@ export const ProductNavContainerBlock = ({ blok, variant }: ProductNavContainerB
         {...storyblokEditable(blok)}
       >
         <NavigationTrigger href={PageLink.store({ locale })}>{blok.name}</NavigationTrigger>
-        <NavigationMenuPrimitive.Content className={navigationContent}>
-          {content}
-        </NavigationMenuPrimitive.Content>
+        <NavigationContent>{content}</NavigationContent>
       </NavigationMenuPrimitive.Item>
     )
   }
@@ -206,10 +203,11 @@ const ButtonNextLinkFullWidth = styled(ButtonNextLink)({ width: '100%' })
 
 type NestedNavigationBlockProps = {
   blok: HeaderBlockProps['blok']['navMenuContainer'][number]
-  variant: 'mobile' | 'desktop'
 }
 
-const NestedNavigationBlock = ({ blok, variant }: NestedNavigationBlockProps) => {
+const NestedNavigationBlock = ({ blok }: NestedNavigationBlockProps) => {
+  const variant = useResponsiveVariant('lg')
+
   const navContainer = checkBlockType<NestedNavContainerBlockProps['blok']>(
     blok,
     NestedNavContainerBlock.blockName,
@@ -227,7 +225,7 @@ const NestedNavigationBlock = ({ blok, variant }: NestedNavigationBlockProps) =>
       <ProductNavContainerBlock
         key={productNavContainer._uid}
         blok={productNavContainer}
-        variant={variant}
+        variant={variant === 'mobile' ? 'mobile' : 'desktop'}
       />
     )
   }
@@ -247,8 +245,6 @@ export type HeaderBlockProps = SbBaseBlockProps<{
 // Performance considerations
 // - this block is important for site-wide INP since it's present on most pages and is used often
 export const HeaderBlock = ({ blok }: HeaderBlockProps) => {
-  const variant = useResponsiveVariant('lg')
-
   const productNavItem = useMemo(
     () =>
       blok.navMenuContainer.find((item) =>
@@ -261,20 +257,12 @@ export const HeaderBlock = ({ blok }: HeaderBlockProps) => {
   )
   return (
     <Header {...storyblokEditable(blok)}>
-      {variant === 'desktop' && (
-        <TopMenuDesktop>
-          {blok.navMenuContainer.map((item) => (
-            <NestedNavigationBlock key={item._uid} blok={item} variant="desktop" />
-          ))}
-        </TopMenuDesktop>
-      )}
-      {variant === 'mobile' && (
-        <TopMenuMobile defaultValue={productNavItem}>
-          {blok.navMenuContainer.map((item) => (
-            <NestedNavigationBlock key={item._uid} blok={item} variant="mobile" />
-          ))}
-        </TopMenuMobile>
-      )}
+      <TopMenuDesktop defaultValue={productNavItem}>
+        {blok.navMenuContainer.map((item) => (
+          <NestedNavigationBlock key={item._uid} blok={item} />
+        ))}
+      </TopMenuDesktop>
+
       <ShoppingCartMenuItem />
     </Header>
   )

--- a/apps/store/src/components/Header/Header.css.ts
+++ b/apps/store/src/components/Header/Header.css.ts
@@ -101,8 +101,16 @@ export const navigation = style({
 export const topMenuDesktop = style([
   navigation,
   {
-    // Ensure menu is left-aligned while cart item is right-aligned
-    flexGrow: 1,
+    // Visually hide menu on mobile. It still needs to be present in the DOM for SEO purposes
+    display: 'none',
+
+    '@media': {
+      [minWidth.lg]: {
+        display: 'revert',
+        // Ensure menu is left-aligned while cart item is right-aligned
+        flexGrow: 1,
+      },
+    },
   },
 ])
 
@@ -171,6 +179,15 @@ export const navigationSecondaryItem = style({
 })
 
 export const navigationContent = style({
+  // For SEO reasons, navigation content get's always mounted and it's appearance is toggled via CSS
+  selectors: {
+    '&[data-state="open"]': {
+      display: 'block',
+    },
+    '&[data-state="closed"]': {
+      display: 'none',
+    },
+  },
   '@media': {
     [minWidth.lg]: {
       position: 'absolute',

--- a/apps/store/src/components/Header/NavigationContent.tsx
+++ b/apps/store/src/components/Header/NavigationContent.tsx
@@ -1,0 +1,18 @@
+import {
+  Content as NavigationMenuContent,
+  type NavigationMenuContentProps,
+} from '@radix-ui/react-navigation-menu'
+import clsx from 'clsx'
+import { navigationContent } from './Header.css'
+
+export function NavigationContent({ className, ...forwardedProps }: NavigationMenuContentProps) {
+  return (
+    <NavigationMenuContent
+      className={clsx(navigationContent, className)}
+      {...forwardedProps}
+      // For SEO reasons, we want to force the content to be mounted so navigation links are
+      // accessible to search engines.
+      forceMount={true}
+    />
+  )
+}

--- a/apps/store/src/components/Header/TopMenuDesktop/TopMenuDesktop.tsx
+++ b/apps/store/src/components/Header/TopMenuDesktop/TopMenuDesktop.tsx
@@ -1,29 +1,39 @@
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import { usePathname } from 'next/navigation'
 import { useState, useEffect, type ReactNode } from 'react'
+import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
 import { navigationPrimaryList, topMenuDesktop } from '../Header.css'
+import { TopMenuMobile } from '../TopMenuMobile/TopMenuMobile'
 
 export type TopMenuDesktopProps = {
   children: ReactNode
+  defaultValue?: string
 }
 
-export const TopMenuDesktop = ({ children }: TopMenuDesktopProps) => {
+export const TopMenuDesktop = ({ children, defaultValue }: TopMenuDesktopProps) => {
   const [activeItem, setActiveItem] = useState('')
   const pathname = usePathname()
+  const variant = useResponsiveVariant('lg')
 
   useEffect(() => {
     setActiveItem('')
   }, [pathname])
 
   return (
-    <NavigationMenuPrimitive.Root
-      className={topMenuDesktop}
-      value={activeItem}
-      onValueChange={setActiveItem}
-    >
-      <NavigationMenuPrimitive.List className={navigationPrimaryList}>
-        {children}
-      </NavigationMenuPrimitive.List>
-    </NavigationMenuPrimitive.Root>
+    <>
+      <NavigationMenuPrimitive.Root
+        className={topMenuDesktop}
+        value={activeItem}
+        onValueChange={setActiveItem}
+      >
+        <NavigationMenuPrimitive.List className={navigationPrimaryList}>
+          {children}
+        </NavigationMenuPrimitive.List>
+      </NavigationMenuPrimitive.Root>
+
+      {variant === 'mobile' && (
+        <TopMenuMobile defaultValue={defaultValue}>{children}</TopMenuMobile>
+      )}
+    </>
   )
 }

--- a/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
+++ b/apps/store/src/components/Header/TopMenuMobile/TopMenuMobile.tsx
@@ -28,10 +28,12 @@ export function TopMenuMobile(props: Props) {
   const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
   const [isContentVisible, setIsContentVisible] = useState(false)
+
   // Close on navigation
   useEffect(() => {
     setIsOpen(false)
   }, [pathname])
+
   // Poor man's useDeferredValue that waits for the next UI frame
   // Waiting for next render loop is too early since major part of rendering work happens
   // in `Presence` inner component after dialog content is rendered
@@ -43,70 +45,69 @@ export function TopMenuMobile(props: Props) {
   const { children, defaultValue } = props
   const { t } = useTranslation('common')
   const locale = useRoutingLocale()
+
   return (
-    <>
-      <DialogPrimitive.Root
-        defaultOpen={false}
-        open={isOpen}
-        onOpenChange={(newValue: boolean) => startTransition(() => setIsOpen(newValue))}
-      >
-        <DialogPrimitive.Trigger asChild={true}>
-          <Button className={buttonTrigger} variant="ghost" size="medium">
-            {t('NAV_MENU_DIALOG_OPEN')}
-          </Button>
-        </DialogPrimitive.Trigger>
-        <DialogContent>
-          <div className={contentWrapper}>
-            <div className={topMenuHeader}>
-              <div className={logoWrapper}>
-                <LogoHomeLink />
-              </div>
-              <DialogPrimitive.Close asChild={true}>
-                <Button className={buttonTrigger} variant="ghost" size="medium">
-                  {t('NAV_MENU_DIALOG_CLOSE')}
-                </Button>
-              </DialogPrimitive.Close>
-              <ShoppingCartMenuItem />
+    <DialogPrimitive.Root
+      defaultOpen={false}
+      open={isOpen}
+      onOpenChange={(newValue: boolean) => startTransition(() => setIsOpen(newValue))}
+    >
+      <DialogPrimitive.Trigger asChild={true}>
+        <Button className={buttonTrigger} variant="ghost" size="medium">
+          {t('NAV_MENU_DIALOG_OPEN')}
+        </Button>
+      </DialogPrimitive.Trigger>
+      <DialogContent>
+        <div className={contentWrapper}>
+          <div className={topMenuHeader}>
+            <div className={logoWrapper}>
+              <LogoHomeLink />
             </div>
-            {isContentVisible && (
-              <NavigationMenuPrimitive.Root className={navigation} defaultValue={defaultValue}>
-                <NavigationMenuPrimitive.List className={navigationPrimaryList}>
-                  <div>{children}</div>
-                  <div className={buttonWrapper}>
-                    <Button
-                      as="a"
-                      href={getAppStoreLink('apple', locale).toString()}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      variant="secondary"
-                      size="medium"
-                    >
-                      <SpaceFlex space={0.5} align="center">
-                        <AppleIcon />
-                        App Store
-                      </SpaceFlex>
-                    </Button>
-                    <Button
-                      as="a"
-                      href={getAppStoreLink('google', locale).toString()}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      variant="secondary"
-                      size="medium"
-                    >
-                      <SpaceFlex space={0.5} align="center">
-                        <AndroidIcon />
-                        Google Play
-                      </SpaceFlex>
-                    </Button>
-                  </div>
-                </NavigationMenuPrimitive.List>
-              </NavigationMenuPrimitive.Root>
-            )}
+            <DialogPrimitive.Close asChild={true}>
+              <Button className={buttonTrigger} variant="ghost" size="medium">
+                {t('NAV_MENU_DIALOG_CLOSE')}
+              </Button>
+            </DialogPrimitive.Close>
+            <ShoppingCartMenuItem />
           </div>
-        </DialogContent>
-      </DialogPrimitive.Root>
-    </>
+          {isContentVisible && (
+            <NavigationMenuPrimitive.Root className={navigation} defaultValue={defaultValue}>
+              <NavigationMenuPrimitive.List className={navigationPrimaryList}>
+                <div>{children}</div>
+                <div className={buttonWrapper}>
+                  <Button
+                    as="a"
+                    href={getAppStoreLink('apple', locale).toString()}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    variant="secondary"
+                    size="medium"
+                  >
+                    <SpaceFlex space={0.5} align="center">
+                      <AppleIcon />
+                      App Store
+                    </SpaceFlex>
+                  </Button>
+                  <Button
+                    as="a"
+                    href={getAppStoreLink('google', locale).toString()}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    variant="secondary"
+                    size="medium"
+                  >
+                    <SpaceFlex space={0.5} align="center">
+                      <AndroidIcon />
+                      Google Play
+                    </SpaceFlex>
+                  </Button>
+                </div>
+              </NavigationMenuPrimitive.List>
+            </NavigationMenuPrimitive.Root>
+          )}
+        </div>
+      </DialogContent>
+    </DialogPrimitive.Root>
   )
 }
 


### PR DESCRIPTION
## Describe your changes

* Get navigation links back to SSR markup 
  * We always render 'desktop' navigation markup on the server
  * For mobile, we hide 'desktop' navigation via CSS and then render 'mobile' version.
 
More info on this slack [thread](https://hedviginsurance.slack.com/archives/C041SD67G82/p1718117670710749).

![Screenshot 2024-06-12 at 11 14 15](https://github.com/HedvigInsurance/racoon/assets/19200662/e865ec21-d8b6-46bb-a7c5-30a543019c1a)

## Justify why they are needed

For SEO reasons, it's important navigation links be present in the SSR markup.
