### PR TITLE
Make app router pages smaller by reducing translations size in global 404 page

### DIFF
--- a/apps/store/src/app/[locale]/layout.tsx
+++ b/apps/store/src/app/[locale]/layout.tsx
@@ -1,73 +1,35 @@
 import { notFound } from 'next/navigation'
 import type { ReactNode } from 'react'
-import { Suspense } from 'react'
-import { ProductMetadataProvider } from '@/appComponents/providers/ProductMetadataProvider'
-import { StoryblokProvider } from '@/appComponents/providers/StoryblokProvider'
-import { RootLayout } from '@/appComponents/RootLayout/RootLayout'
-import { AppErrorDialog } from '@/components/AppErrorDialog'
-import { CookieConsent } from '@/components/CookieConsent/CookieConsent'
-import { GlobalBannerDynamic } from '@/components/GlobalBanner/GlobalBannerDynamic'
-import { fetchGlobalProductMetadata } from '@/components/LayoutWithMenu/fetchProductMetadata'
-import { CompanyReviewsMetadataProvider } from '@/features/memberReviews/CompanyReviewsMetadataProvider'
-import { fetchCompanyReviewsMetadata } from '@/features/memberReviews/memberReviews'
-import { getApolloClient } from '@/services/apollo/app-router/rscClient'
-import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
-import type { GlobalStory } from '@/services/storyblok/storyblok'
-import { getStoryBySlug } from '@/services/storyblok/storyblok.rsc'
-import { TrackingProvider } from '@/services/Tracking/TrackingContext'
-import { Features } from '@/utils/Features'
+import { initTranslations } from '@/app/i18n'
+import { TranslationsProvider } from '@/appComponents/providers/TranslationsProvider'
+import { StoreLayout } from '@/appComponents/StoreLayout'
 import { locales } from '@/utils/l10n/locales'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import type { RoutingLocale } from '@/utils/l10n/types'
-import { AppTrackingTriggers } from './AppTrackingTriggers'
-import { StoryblokLayout } from './StoryblokLayout'
 
 export type LocalizedLayoutProps<P = unknown> = P & {
   children: ReactNode
   params: { locale: RoutingLocale }
 }
 
-const Layout = async ({ children, params: { locale } }: LocalizedLayoutProps) => {
+export default async function LocalizedStoreLayout({
+  children,
+  params: { locale },
+}: LocalizedLayoutProps) {
   // GOTCHA: We cannot exclude unknown locales with `dynamicParams = false` since it apparently overrides
   // `dynamicParams` in `[[...slug]]` child dir which breaks our desired CMS rendering config
   // NextJs issue: https://github.com/vercel/next.js/issues/42940
   if (!isRoutingLocale(locale)) {
     return notFound()
   }
-  const apolloClient = getApolloClient(locale)
-  const [companyReviewsMetadata, productMetadata, globalStory] = await Promise.all([
-    fetchCompanyReviewsMetadata(),
-    fetchGlobalProductMetadata({ apolloClient }),
-    getStoryBySlug<GlobalStory>('global', { locale }),
-  ])
-
+  const { resources } = await initTranslations(locale)
   return (
-    <>
-      <RootLayout locale={locale}>
-        <ProductMetadataProvider productMetadata={productMetadata}>
-          <CompanyReviewsMetadataProvider companyReviewsMetadata={companyReviewsMetadata}>
-            <AppErrorProvider>
-              <TrackingProvider>
-                <AppErrorDialog />
-                <GlobalBannerDynamic />
-                <StoryblokProvider>
-                  <StoryblokLayout globalStory={globalStory}>{children}</StoryblokLayout>
-                </StoryblokProvider>
-                <Suspense>
-                  <AppTrackingTriggers />
-                </Suspense>
-              </TrackingProvider>
-            </AppErrorProvider>
-          </CompanyReviewsMetadataProvider>
-        </ProductMetadataProvider>
-        {Features.enabled('COOKIE_BANNER_INP_IMPROVEMENT') && <CookieConsent />}
-      </RootLayout>
-    </>
+    <TranslationsProvider locale={locale} resources={resources}>
+      <StoreLayout locale={locale}>{children}</StoreLayout>
+    </TranslationsProvider>
   )
 }
 
 export const generateStaticParams = () => {
   return Object.values(locales).map(({ routingLocale }) => ({ locale: routingLocale }))
 }
-
-export default Layout

--- a/apps/store/src/app/not-found.tsx
+++ b/apps/store/src/app/not-found.tsx
@@ -1,15 +1,22 @@
-import { NotFoundPageContent } from '@/appComponents/RootLayout/NotFoundPageContent' // Fallback to se/not-found
-import { FALLBACK_LOCALE } from '@/utils/l10n/locales'
+import { initTranslations } from '@/app/i18n'
+import { TranslationsProvider } from '@/appComponents/providers/TranslationsProvider'
+import { NotFoundPageContent } from '@/appComponents/RootLayout/NotFoundPageContent'
+import { StoreLayout } from '@/appComponents/StoreLayout'
+import { FALLBACK_LOCALE } from '@/utils/l10n/locales' // Fallback to se/not-found
 import { toRoutingLocale } from '@/utils/l10n/localeUtils'
-import LocaleLayout from './[locale]/layout'
 
 // Global fallback, has to be located at the top of app dir
 // Hence manual import and usage of layout
 // We're doing locale-specific 404s at [locale]/not-found
-export default function NotFound() {
+export default async function RootNotFoundPage() {
+  const locale = toRoutingLocale(FALLBACK_LOCALE)
+  // Only loading common namespace since this page's React tree is added to every normal page - size matters
+  const { resources } = await initTranslations(locale, { ns: ['common'] })
   return (
-    <LocaleLayout params={{ locale: toRoutingLocale(FALLBACK_LOCALE) }}>
-      <NotFoundPageContent />
-    </LocaleLayout>
+    <TranslationsProvider locale={locale} resources={resources}>
+      <StoreLayout locale={locale}>
+        <NotFoundPageContent />
+      </StoreLayout>
+    </TranslationsProvider>
   )
 }

--- a/apps/store/src/appComponents/RootLayout/RootLayout.tsx
+++ b/apps/store/src/appComponents/RootLayout/RootLayout.tsx
@@ -4,8 +4,6 @@ import { Suspense } from 'react'
 import { Provider as BalancerProvider } from 'react-wrap-balancer'
 import globalCss from 'ui/src/global.css'
 import { mainTheme } from 'ui'
-import { initTranslations } from '@/app/i18n'
-import { TranslationsProvider } from '@/appComponents/providers/TranslationsProvider'
 import { NavigationProgressIndicator } from '@/appComponents/RootLayout/NavigationProgressIndicator'
 import { OrgStructuredData } from '@/appComponents/RootLayout/OrgStructuredData'
 import { ShopSessionProvider } from '@/services/shopSession/ShopSessionContext'
@@ -20,12 +18,10 @@ import { DebugError } from './DebugError'
 const noop = (val: any) => {}
 noop(globalCss)
 
-export async function RootLayout({
+export function RootLayout({
   locale = 'se',
   children,
 }: PropsWithChildren<{ locale?: RoutingLocale }>) {
-  const { resources } = await initTranslations(locale)
-
   return (
     <html lang={getLocaleOrFallback(locale).htmlLang}>
       {/* False alert, next/head does now work with app router */}
@@ -41,9 +37,7 @@ export async function RootLayout({
 
         <ApolloProvider locale={locale}>
           <ShopSessionProvider>
-            <TranslationsProvider locale={locale} resources={resources}>
-              <BalancerProvider>{children}</BalancerProvider>
-            </TranslationsProvider>
+            <BalancerProvider>{children}</BalancerProvider>
           </ShopSessionProvider>
         </ApolloProvider>
       </body>

--- a/apps/store/src/appComponents/StoreLayout.tsx
+++ b/apps/store/src/appComponents/StoreLayout.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react'
+import { Suspense } from 'react'
+import { AppTrackingTriggers } from '@/app/[locale]/AppTrackingTriggers'
+import { StoryblokLayout } from '@/app/[locale]/StoryblokLayout'
+import { ProductMetadataProvider } from '@/appComponents/providers/ProductMetadataProvider'
+import { StoryblokProvider } from '@/appComponents/providers/StoryblokProvider'
+import { RootLayout } from '@/appComponents/RootLayout/RootLayout'
+import { AppErrorDialog } from '@/components/AppErrorDialog'
+import { CookieConsent } from '@/components/CookieConsent/CookieConsent'
+import { GlobalBannerDynamic } from '@/components/GlobalBanner/GlobalBannerDynamic'
+import { fetchGlobalProductMetadata } from '@/components/LayoutWithMenu/fetchProductMetadata'
+import { CompanyReviewsMetadataProvider } from '@/features/memberReviews/CompanyReviewsMetadataProvider'
+import { fetchCompanyReviewsMetadata } from '@/features/memberReviews/memberReviews'
+import { getApolloClient } from '@/services/apollo/app-router/rscClient'
+import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
+import type { GlobalStory } from '@/services/storyblok/storyblok'
+import { getStoryBySlug } from '@/services/storyblok/storyblok.rsc'
+import { TrackingProvider } from '@/services/Tracking/TrackingContext'
+import { Features } from '@/utils/Features'
+import type { RoutingLocale } from '@/utils/l10n/types'
+
+type StoreLayoutProps = {
+  locale: RoutingLocale
+  children: ReactNode
+}
+
+// Used in global not-found page and in CMS pages
+export async function StoreLayout({ locale, children }: StoreLayoutProps) {
+  const apolloClient = getApolloClient(locale)
+  const [companyReviewsMetadata, productMetadata, globalStory] = await Promise.all([
+    fetchCompanyReviewsMetadata(),
+    fetchGlobalProductMetadata({ apolloClient }),
+    getStoryBySlug<GlobalStory>('global', { locale }),
+  ])
+
+  return (
+    <RootLayout locale={locale}>
+      <ProductMetadataProvider productMetadata={productMetadata}>
+        <CompanyReviewsMetadataProvider companyReviewsMetadata={companyReviewsMetadata}>
+          <AppErrorProvider>
+            <TrackingProvider>
+              <AppErrorDialog />
+              <GlobalBannerDynamic />
+              <StoryblokProvider>
+                <StoryblokLayout globalStory={globalStory}>{children}</StoryblokLayout>
+              </StoryblokProvider>
+              <Suspense>
+                <AppTrackingTriggers />
+              </Suspense>
+            </TrackingProvider>
+          </AppErrorProvider>
+        </CompanyReviewsMetadataProvider>
+      </ProductMetadataProvider>
+      {Features.enabled('COOKIE_BANNER_INP_IMPROVEMENT') && <CookieConsent />}
+    </RootLayout>
+  )
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

Make root 404 page much smaller by only providing `common` translation namespace.  This page is added to HTML of every page on the site.

Before: /se - 255 KB uncompressed
After: /se - 227 KB uncompressed

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
