### PR TITLE
Add support for multiple experiments

### DIFF
--- a/apps/store/experiments/quickAdd.json
+++ b/apps/store/experiments/quickAdd.json
@@ -1,0 +1,15 @@
+{
+  "name": "Quick Add Experiment",
+  "variants": [
+    {
+      "name": "Original",
+      "id": 0,
+      "weight": 50
+    },
+    {
+      "name": "Variant",
+      "id": 1,
+      "weight": 50
+    }
+  ]
+}

--- a/apps/store/src/components/QuickAdd/QuickAddOfferContainer.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddOfferContainer.tsx
@@ -1,4 +1,3 @@
-import { getCookie } from 'cookies-next'
 import { useTranslation } from 'next-i18next'
 import type { ReactNode } from 'react'
 import { sprinkles } from 'ui/src/theme/sprinkles.css'
@@ -12,8 +11,8 @@ import {
   type OfferRecommendationFragment,
   type ProductRecommendationFragment,
 } from '@/services/graphql/generated'
-import { EXPERIMENT_COOKIE_NAME } from '@/services/Tracking/experiment.constants'
-import { getExperimentVariant } from '@/services/Tracking/experiment.helpers'
+import { Experiments } from '@/services/Tracking/experiment.constants'
+import { getExperimentVariantByName } from '@/services/Tracking/experiment.helpers'
 import { trackExperimentImpression } from '@/services/Tracking/trackExperimentImpression'
 import { useTracking } from '@/services/Tracking/useTracking'
 import { getOfferPrice } from '@/utils/getOfferPrice'
@@ -63,8 +62,7 @@ export function QuickAddOfferContainer(props: Props) {
   const homeInsuranceInCart =
     props.cart.entries.find((entry) => HOME_INSURANCES.includes(entry.product.name)) ?? null
 
-  const experimentCookie = getCookie(EXPERIMENT_COOKIE_NAME)
-  const experimentVariant = getExperimentVariant(experimentCookie)
+  const experimentVariant = getExperimentVariantByName('QUICK_ADD')
   const showDefaultVariant = !experimentVariant || experimentVariant.id === 0
 
   if (showDefaultVariant) {
@@ -149,7 +147,7 @@ export function QuickAddOfferContainer(props: Props) {
     )
   }
 
-  trackExperimentImpression(tracking)
+  trackExperimentImpression(Experiments.getId('QUICK_ADD'), tracking)
 
   return (
     <div className={quickAddSection}>

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -26,7 +26,6 @@ import { OneTrustStyles } from '@/services/OneTrust'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
 import { ShopSessionProvider, useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { initStoryblok } from '@/services/storyblok/storyblok'
-import { trackExperimentImpression } from '@/services/Tracking/trackExperimentImpression'
 import { Tracking } from '@/services/Tracking/Tracking'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
 import { trackPageViews } from '@/services/Tracking/trackPageViews'
@@ -72,7 +71,6 @@ if (typeof window !== 'undefined') {
     const { countryCode } = getCountryByLocale(routingLocale)
     tracking.reportAppInit(countryCode)
 
-    trackExperimentImpression(tracking)
     trackPageViews(tracking)
   })
 }

--- a/apps/store/src/services/Tracking/experiment.constants.ts
+++ b/apps/store/src/services/Tracking/experiment.constants.ts
@@ -1,5 +1,5 @@
 export const EXPERIMENT_COOKIE_NAME = 'hedvig-experiment'
-import experimentJson from '../../../experiment.json'
+import quickAddExperiment from '../../../experiments/quickAdd.json'
 
 export type Experiment = {
   id: string
@@ -15,11 +15,25 @@ export type ExperimentVariant = {
   slug?: string
 }
 
-const EXPERIMENT_ID = process.env.NEXT_PUBLIC_EXPERIMENT_ID
+const experimentConfig = {
+  QUICK_ADD: process.env.NEXT_PUBLIC_EXPERIMENT_ID_QUICK_ADD,
+} as const
 
-export const CURRENT_EXPERIMENT: Experiment | undefined = EXPERIMENT_ID
-  ? {
-      ...experimentJson,
-      id: EXPERIMENT_ID,
-    }
-  : undefined
+export type ExperimentConfig = keyof typeof experimentConfig
+
+export const Experiments = {
+  getId(experiment: ExperimentConfig) {
+    return experimentConfig[experiment]
+  },
+}
+
+export const CURRENT_EXPERIMENTS: Array<Experiment> | undefined = [
+  ...(experimentConfig.QUICK_ADD
+    ? [
+        {
+          id: experimentConfig.QUICK_ADD,
+          ...quickAddExperiment,
+        },
+      ]
+    : []),
+]

--- a/apps/store/src/services/Tracking/experiment.helpers.ts
+++ b/apps/store/src/services/Tracking/experiment.helpers.ts
@@ -1,15 +1,26 @@
-import { CURRENT_EXPERIMENT, type Experiment, type ExperimentVariant } from './experiment.constants'
+import { getCookie } from 'cookies-next'
+import type {
+  ExperimentConfig} from './experiment.constants';
+import {
+  CURRENT_EXPERIMENTS,
+  EXPERIMENT_COOKIE_NAME,
+  Experiments,
+  type Experiment,
+  type ExperimentVariant,
+} from './experiment.constants'
 
-export const getCurrentExperiment = (): Experiment | undefined => {
-  return CURRENT_EXPERIMENT
+export const getCurrentExperiments = (): Array<Experiment> | undefined => {
+  return CURRENT_EXPERIMENTS
 }
 
 export const getExperimentVariant = (cookieValue?: string): ExperimentVariant | undefined => {
   if (!cookieValue) return
-  const currentExperiment = getCurrentExperiment()
-  if (!currentExperiment) return
 
   const [experimentId, rawVariantId] = cookieValue.split('.')
+  const currentExperiments = getCurrentExperiments()
+  const currentExperiment = currentExperiments?.find((experiment) => experiment.id === experimentId)
+
+  if (!currentExperiment) return
 
   if (experimentId !== currentExperiment.id) {
     console.info(
@@ -31,6 +42,17 @@ export const getExperimentVariant = (cookieValue?: string): ExperimentVariant | 
   }
 
   return variant
+}
+
+export const getExperimentVariantByName = (
+  experimentName: ExperimentConfig,
+): ExperimentVariant | undefined => {
+  const experimentId = Experiments.getId(experimentName)
+  if (!experimentId) return
+
+  const cookieValue = getCookie(`${EXPERIMENT_COOKIE_NAME}:${experimentId}`)
+
+  return getExperimentVariant(cookieValue)
 }
 
 export const experimentImpressionVariantId = (

--- a/apps/store/src/services/Tracking/trackExperimentImpression.ts
+++ b/apps/store/src/services/Tracking/trackExperimentImpression.ts
@@ -1,27 +1,17 @@
 import { getCookie } from 'cookies-next'
 import { type Tracking } from '@/services/Tracking/Tracking'
 import { EXPERIMENT_COOKIE_NAME } from './experiment.constants'
-import {
-  experimentImpressionVariantId,
-  getCurrentExperiment,
-  getExperimentVariant,
-} from './experiment.helpers'
+import { getExperimentVariant } from './experiment.helpers'
 
-export const trackExperimentImpression = (tracking: Tracking) => {
+export const trackExperimentImpression = (experimentId: string | undefined, tracking: Tracking) => {
   if (typeof window === 'undefined') return
-  const currentExperiment = getCurrentExperiment()
-  if (!currentExperiment) return
+  if (!experimentId) return
 
-  if (currentExperiment.slug && window.location.pathname !== currentExperiment.slug) return
-
-  const cookieValue = getCookie(EXPERIMENT_COOKIE_NAME)
+  const cookieValue = getCookie(`${EXPERIMENT_COOKIE_NAME}:${experimentId}`)
   if (typeof cookieValue !== 'string') return
 
   const experimentVariant = getExperimentVariant(cookieValue)
   if (!experimentVariant) return
 
-  tracking.reportExperimentImpression(
-    currentExperiment.id,
-    experimentImpressionVariantId(currentExperiment, experimentVariant),
-  )
+  tracking.reportExperimentImpression(experimentId, cookieValue)
 }

--- a/apps/store/src/services/Tracking/trackPageViews.ts
+++ b/apps/store/src/services/Tracking/trackPageViews.ts
@@ -1,5 +1,4 @@
 import router from 'next/router'
-import { trackExperimentImpression } from '@/services/Tracking/trackExperimentImpression'
 import { type Tracking } from '@/services/Tracking/Tracking'
 
 export const trackPageViews = (tracking: Tracking) => {
@@ -8,7 +7,6 @@ export const trackPageViews = (tracking: Tracking) => {
     router.events.on('routeChangeComplete', (url: string, { shallow = false } = {}) => {
       if (!shallow) {
         tracking.reportPageView(url)
-        trackExperimentImpression(tracking)
       }
     })
   })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add support for multiple experiments

To make it a smaller change I removed support for page experiment, will add it back. 

- Make `CURRENT_EXPERIMENTS` an array `Experiment` items
- Expose experiment env variables through `Experiments` similar to how we do it with `Features`  
- Set a cookie for each experiment like this: `hedvig-experiment:f6c758d3-2f8b-4d12-94fd-b486b1b3bbec`
- `trackExperimentImpression` now takes a `experimentId` to determine what experiment to track


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Support for running multiple A/B tests

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
