### PR TITLE
Update eslint config to prefer inline type imports

### DIFF
--- a/apps/store/src/appComponents/StoreLayout.tsx
+++ b/apps/store/src/appComponents/StoreLayout.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from 'react'
-import { Suspense } from 'react'
+import { type ReactNode, Suspense } from 'react'
 import { AppTrackingTriggers } from '@/app/[locale]/AppTrackingTriggers'
 import { StoryblokLayout } from '@/app/[locale]/StoryblokLayout'
 import { ProductMetadataProvider } from '@/appComponents/providers/ProductMetadataProvider'
@@ -13,11 +12,11 @@ import { CompanyReviewsMetadataProvider } from '@/features/memberReviews/Company
 import { fetchCompanyReviewsMetadata } from '@/features/memberReviews/memberReviews'
 import { getApolloClient } from '@/services/apollo/app-router/rscClient'
 import { AppErrorProvider } from '@/services/appErrors/AppErrorContext'
-import type { GlobalStory } from '@/services/storyblok/storyblok'
+import { type GlobalStory } from '@/services/storyblok/storyblok'
 import { getStoryBySlug } from '@/services/storyblok/storyblok.rsc'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
 import { Features } from '@/utils/Features'
-import type { RoutingLocale } from '@/utils/l10n/types'
+import { type RoutingLocale } from '@/utils/l10n/types'
 
 type StoreLayoutProps = {
   locale: RoutingLocale

--- a/packages/eslint-config-custom/eslint-config-custom.cjs
+++ b/packages/eslint-config-custom/eslint-config-custom.cjs
@@ -48,7 +48,9 @@ module.exports = {
     ],
     '@typescript-eslint/ban-ts-comment': ['error', { 'ts-expect-error': 'allow-with-description' }],
     '@typescript-eslint/no-unused-vars': 'error', // Also covers unused import
-    '@typescript-eslint/consistent-type-imports': 'error',
+    '@typescript-eslint/consistent-type-imports': ['error', {
+      fixStyle: 'inline-type-imports',
+    }],
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-empty-interface': 'off',


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Apply eslint change we agreed on few Frontend forums ago.  When fixing type imports, eslint will now inline `type` inside the same import statement instead of splitting type imports from normal imports

This does not affect existing code that uses separate imports - we'll just stop creating more of it

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
