### PR TITLE
fix(navigation): links work fine and are avaiable in the markup

### DIFF
--- a/apps/store/src/blocks/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock.tsx
@@ -89,18 +89,18 @@ export const NestedNavContainerBlock = ({ blok }: NestedNavContainerBlockProps) 
           <NavigationMenuPrimitive.Sub defaultValue={blok.name}>
             <NavigationMenuPrimitive.List className={navigationSecondaryList}>
               {filteredNavItems.map((nestedBlock) => (
-                <SecondaryNavigationLink
+                <NavigationMenuPrimitive.Item
                   key={nestedBlock._uid}
-                  href={getLinkFieldURL(nestedBlock.link, nestedBlock.name)}
+                  className={navigationSecondaryItem}
+                  value={nestedBlock.name}
+                  {...storyblokEditable(nestedBlock)}
                 >
-                  <NavigationMenuPrimitive.Item
-                    className={navigationSecondaryItem}
-                    value={nestedBlock.name}
-                    {...storyblokEditable(nestedBlock)}
+                  <SecondaryNavigationLink
+                    href={getLinkFieldURL(nestedBlock.link, nestedBlock.name)}
                   >
                     {nestedBlock.name}
-                  </NavigationMenuPrimitive.Item>
-                </SecondaryNavigationLink>
+                  </SecondaryNavigationLink>
+                </NavigationMenuPrimitive.Item>
               ))}
             </NavigationMenuPrimitive.List>
           </NavigationMenuPrimitive.Sub>

--- a/apps/store/src/components/Header/NavigationContent.tsx
+++ b/apps/store/src/components/Header/NavigationContent.tsx
@@ -12,7 +12,12 @@ export function NavigationContent({ className, ...forwardedProps }: NavigationMe
       {...forwardedProps}
       // For SEO reasons, we want to force the content to be mounted so navigation links are
       // accessible to search engines.
-      // forceMount={true}
+      forceMount={true}
+      // Gotcha: For some reason when 'forceMount' is enable for navigation content, radix
+      // considers clicks inside the content as outside clicks. This is a workaround to
+      // prevent the behavior of closing the navigation menu when clicking on a link inside
+      // the navigation content.
+      onPointerDownOutside={(event) => event.preventDefault()}
     />
   )
 }


### PR DESCRIPTION
## Describe your changes

Second attempt for making navigations links available for SEO.
Despite being present on the markup, they should work as expected when clicking on them.

Related with #4358 