### PR TITLE
Restore device info reporting for app router

### DIFF
--- a/apps/store/src/app/[locale]/AppTrackingTriggers.tsx
+++ b/apps/store/src/app/[locale]/AppTrackingTriggers.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useParams, usePathname } from 'next/navigation'
 import { useEffect } from 'react'
+import { useReportDeviceInfo } from '@/services/Tracking/useReportDeviceInfo'
 import { useTracking } from '@/services/Tracking/useTracking'
 import { getCountryByLocale } from '@/utils/l10n/countryUtils'
 import { FALLBACK_LOCALE } from '@/utils/l10n/locales'
@@ -9,6 +10,7 @@ import type { RoutingLocale } from '@/utils/l10n/types'
 
 export function AppTrackingTriggers() {
   const tracking = useTracking()
+  useReportDeviceInfo()
 
   const { locale = toRoutingLocale(FALLBACK_LOCALE) } = useParams() ?? {}
   useEffect(() => {

--- a/apps/store/src/services/Tracking/useReportDeviceInfo.ts
+++ b/apps/store/src/services/Tracking/useReportDeviceInfo.ts
@@ -24,13 +24,16 @@ export const useReportDeviceInfo = () => {
         // Ignore few ancient browsers, universal support for randomUUID appeared in 2021
         if (typeof crypto.randomUUID !== 'function') return
 
+        const data = {
+          deviceType,
+          osName,
+          browserName,
+        }
+        // console.debug('deviceInfo', data)
+
         const deviceInfoEvent = {
           type: TrackingEvent.DeviceInfo,
-          data: {
-            deviceType,
-            osName,
-            browserName,
-          },
+          data,
           id: crypto.randomUUID(),
           sessionId: shopSession.id,
           clientTimestamp: new Date().toISOString(),


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

We only had deviceInfo reporting in pages router.  Restoring it to app router now

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
