### PR TITLE
Fix missing shopSessionId in view_item, select_item, open_price_calculator events

### DIFF
--- a/apps/store/src/app/[locale]/[[...slug]]/ProductCmsPage.tsx
+++ b/apps/store/src/app/[locale]/[[...slug]]/ProductCmsPage.tsx
@@ -5,7 +5,6 @@ import { PageBannerTriggers } from '@/components/Banner/PageBannerTriggers'
 import { fetchProductData } from '@/components/ProductData/fetchProductData'
 import { ProductDataProvider } from '@/components/ProductData/ProductDataProvider'
 import { ProductPageContextProvider } from '@/components/ProductPage/ProductPageContext'
-import { ProductPageViewTracker } from '@/components/ProductPage/ProductPageViewTrack'
 import { fetchProductReviewsMetadata } from '@/features/memberReviews/memberReviews'
 import { ProductReviewsMetadataProvider } from '@/features/memberReviews/ProductReviewsMetadataProvider'
 import { getApolloClient } from '@/services/apollo/app-router/rscClient'
@@ -50,7 +49,6 @@ export const ProductCmsPage = async ({ locale, story }: ProductCmsPageProps) => 
         <ProductReviewsMetadataProvider productReviewsMetadata={productReviewsMetadata}>
           <BankIdContextProvider>
             <StoryblokStory story={story} bridgeOptions={storyblokBridgeOptions} />
-            <ProductPageViewTracker />
             <PageBannerTriggers blok={story.content} />
             <BankIdDialog />
           </BankIdContextProvider>

--- a/apps/store/src/components/ProductPage/PriceIntentTrackingProvider.tsx
+++ b/apps/store/src/components/ProductPage/PriceIntentTrackingProvider.tsx
@@ -4,7 +4,7 @@ import { usePriceIntent } from '@/components/ProductPage/PriceIntentContext'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
 
-export const ProductPageTrackingProvider = (props: { children: React.ReactNode }) => {
+export const PriceIntentTrackingProvider = (props: { children: React.ReactNode }) => {
   const { shopSession } = useShopSession()
   const [priceIntent] = usePriceIntent()
   const productData = useProductData()

--- a/apps/store/src/components/ProductPage/ProductPage.tsx
+++ b/apps/store/src/components/ProductPage/ProductPage.tsx
@@ -4,7 +4,7 @@ import { PageBannerTriggers } from '@/components/Banner/PageBannerTriggers'
 import { PageBreadcrumbs } from '@/components/PageBreadcrumbs/PageBreadcrumbs'
 import { ProductDataProvider } from '@/components/ProductData/ProductDataProvider'
 import { PriceIntentContextProvider } from '@/components/ProductPage/PriceIntentContext'
-import { ProductPageTrackingProvider } from '@/components/ProductPage/ProductPageTrackingProvider'
+import { PriceIntentTrackingProvider } from '@/components/ProductPage/PriceIntentTrackingProvider'
 import { ProductPageViewTracker } from '@/components/ProductPage/ProductPageViewTrack'
 import { ProductReviewsMetadataProvider } from '@/features/memberReviews/ProductReviewsMetadataProvider'
 import { type ProductPageProps } from './ProductPage.types'
@@ -19,7 +19,7 @@ export const ProductPage = ({ story, ...props }: ProductPageProps) => {
     >
       <ProductPageContextProvider {...props} story={story}>
         <PriceIntentContextProvider>
-          <ProductPageTrackingProvider>
+          <PriceIntentTrackingProvider>
             <ProductReviewsMetadataProvider productReviewsMetadata={props.productReviewsMetadata}>
               <StoryblokComponent blok={story.content} />
               {props.breadcrumbs && <PageBreadcrumbs items={props.breadcrumbs} />}
@@ -27,7 +27,7 @@ export const ProductPage = ({ story, ...props }: ProductPageProps) => {
               <ProductPageViewTracker />
               <PageBannerTriggers blok={story.content} />
             </ProductReviewsMetadataProvider>
-          </ProductPageTrackingProvider>
+          </PriceIntentTrackingProvider>
         </PriceIntentContextProvider>
       </ProductPageContextProvider>
     </ProductDataProvider>

--- a/apps/store/src/components/ProductPage/ProductPageViewTrack.tsx
+++ b/apps/store/src/components/ProductPage/ProductPageViewTrack.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect } from 'react'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
+import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { useTracking } from '@/services/Tracking/useTracking'
 
 // Optimization - since tracking depends on shopSession,
@@ -9,9 +10,12 @@ export const ProductPageViewTracker = () => {
   // TODO: Provide some tracking API to use with router.ready to check if current page
   //  is the first during window lifetime -> then replace effect with event subscriptions
   const { id, displayNameFull } = useProductData()
+  const { shopSession } = useShopSession()
   const tracking = useTracking()
   useEffect(() => {
-    tracking.reportViewProductPage({ id, displayNameFull })
-  }, [tracking, id, displayNameFull])
+    if (shopSession?.id != null) {
+      tracking.reportViewProductPage({ id, displayNameFull })
+    }
+  }, [tracking, id, displayNameFull, shopSession?.id])
   return null
 }

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -5,7 +5,7 @@ import { clsx } from 'clsx'
 import { motion } from 'framer-motion'
 import { usePathname } from 'next/navigation'
 import { useTranslation } from 'next-i18next'
-import type { ReactNode} from 'react';
+import type { ReactNode } from 'react'
 import { useMemo } from 'react'
 import { Suspense } from 'react'
 import { useCallback, useRef, useState } from 'react'
@@ -20,9 +20,10 @@ import {
   PriceIntentContextProvider,
   usePriceIntent,
 } from '@/components/ProductPage/PriceIntentContext'
+import { PriceIntentTrackingProvider } from '@/components/ProductPage/PriceIntentTrackingProvider'
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { ProductPageDebugDialog } from '@/components/ProductPage/ProductPageDebugDialog'
-import { ProductPageTrackingProvider } from '@/components/ProductPage/ProductPageTrackingProvider'
+import { ProductPageViewTracker } from '@/components/ProductPage/ProductPageViewTrack'
 import {
   purchaseFormHeroWrapper,
   purchaseFormPriceLoaderWrapper,
@@ -77,10 +78,11 @@ export function PurchaseForm(props: PurchaseFormProps) {
           fallback={<IdleState loading={true} showAverageRating={props.showAverageRating} />}
         >
           <PriceIntentContextProvider>
-            <ProductPageTrackingProvider>
+            <PriceIntentTrackingProvider>
               <PurchaseFormInner {...props} notifyProductAdded={notifyProductAdded} />
               <ProductPageDebugDialog />
-            </ProductPageTrackingProvider>
+              <ProductPageViewTracker />
+            </PriceIntentTrackingProvider>
           </PriceIntentContextProvider>
         </Suspense>
       </div>

--- a/apps/store/src/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam.ts
@@ -1,5 +1,6 @@
 import { useSearchParams } from 'next/navigation'
 import { useEffect, useRef } from 'react'
+import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 
 export const OPEN_PRICE_CALCULATOR_QUERY_PARAM = 'openPriceCalculator'
 
@@ -10,16 +11,17 @@ type Params = {
 export const useOpenPriceCalculatorQueryParam = ({ onQueryParamDetected }: Params) => {
   const triggeredRef = useRef(false)
   const isPriceCalculatorExpanded = useIsPriceCalculatorExpanded()
+  const { shopSession } = useShopSession()
 
   useEffect(() => {
-    if (isPriceCalculatorExpanded && !triggeredRef.current) {
+    if (isPriceCalculatorExpanded && shopSession?.id && !triggeredRef.current) {
       // Guards against repeated triggers in case any other query param changes
       // GOTCHA: We've tried removing query param via shallow router.replace, but it triggers some weird
       // window.location change, and this problem only ever happens in production
       triggeredRef.current = true
       onQueryParamDetected()
     }
-  }, [onQueryParamDetected, isPriceCalculatorExpanded])
+  }, [onQueryParamDetected, isPriceCalculatorExpanded, shopSession?.id])
 }
 
 export const useIsPriceCalculatorExpanded = () => {

--- a/apps/store/src/services/Tracking/useTracking.ts
+++ b/apps/store/src/services/Tracking/useTracking.ts
@@ -1,11 +1,14 @@
-import { useContext, useMemo } from 'react'
+import { useContext, useRef } from 'react'
 import { Tracking } from './Tracking'
 import { TrackingContext } from './TrackingContext'
 
 export const useTracking = () => {
   const data = useContext(TrackingContext)
 
-  return useMemo(() => {
-    return new Tracking(data)
-  }, [data])
+  // Optimization: keep single instance then update context in-place
+  // Makes sure returned value is stable and callbacks depending on it are not recreated
+  // every time something in the context changes
+  const trackingRef = useRef(new Tracking())
+  trackingRef.current.context = data
+  return trackingRef.current
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

- Fix missing product page context in view tracking by moving reporting component inside product-specific tracking context provider
- Make `useTracker` return a stable instance so that callbacks depending on tracking context are not recreated
- Modify select_item and open_price_calculator events so that they are reported only after we know shop_session_id

## Justify why they are needed

Found some issues in tracking setup, fixing those before adding new events for bundle discounts

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
