### PR TITLE
GEN-2254 - feat(storyblok): add StoryCarouselBlock component

### DIFF
--- a/apps/store/src/blocks/StoryCarouselBlock.tsx
+++ b/apps/store/src/blocks/StoryCarouselBlock.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { storyblokEditable } from '@storyblok/react'
+import { yStack } from 'ui'
+import { StoryCarousel } from '@/components/StoryCarousel/StoryCarousel'
+import { type StoryblokAsset, type SbBaseBlockProps } from '@/services/storyblok/storyblok'
+
+type StoryCarouselProps = SbBaseBlockProps<{
+  images: Array<StoryblokAsset>
+  duration?: number
+}>
+
+export function StoryCarouselBlock({ blok }: StoryCarouselProps) {
+  const images = blok.images.map((image) => ({
+    id: image.filename,
+    src: image.filename,
+    alt: image.alt,
+  }))
+  // Gotcha: even though defined as a number in storyblock, it get delivered as a string
+  const duration = Number(blok.duration)
+
+  if (images.length === 0) {
+    console.log('[StoryCarouselBlock] No images found in block. Skipping rendering.')
+    return null
+  }
+
+  return (
+    <div className={yStack({ alignItems: 'center', px: 'sm' })}>
+      <StoryCarousel images={images} duration={duration} {...storyblokEditable(blok)} />
+    </div>
+  )
+}

--- a/apps/store/src/services/storyblok/commonStoryblokComponents.ts
+++ b/apps/store/src/services/storyblok/commonStoryblokComponents.ts
@@ -46,6 +46,7 @@ import { ReusableBlockReference } from '@/blocks/ReusableBlockReference'
 import { RichTextBlock } from '@/blocks/RichTextBlock/RichTextBlock'
 import { SelectInsuranceGridBlock } from '@/blocks/SelectInsuranceGridBlock'
 import { SpacerBlock } from '@/blocks/SpacerBlock'
+import { StoryCarouselBlock } from '@/blocks/StoryCarouselBlock'
 import { TabsBlock } from '@/blocks/TabsBlock'
 import { TextBlock } from '@/blocks/TextBlock'
 import { TextContentBlock } from '@/blocks/TextContentBlock'
@@ -121,5 +122,6 @@ export const commonStoryblokComponents = {
   videoBlock: VideoBlock,
   widgetFlow: WidgetFlowBlock,
   widgetFlowStartButton: WidgetFlowStartButtonBlock,
+  storyCarousel: StoryCarouselBlock,
   ...blockAliases,
 }


### PR DESCRIPTION
## Describe your changes

* Added `StoryCarouselBlock` component so editors can leverage `StoryCarousel` on their stories.

Can be tested [here](https://app.storyblok.com/#/me/spaces/165473/stories/0/0/512113692)

## Justify why they are needed

Part of Hedvig new designs project. [Figma file](https://www.figma.com/design/vylWsbAVqZTuG8fUEIf0zs/Tiers-%26-Addons?node-id=888-18580&t=JZ49xRvbJWCNrvQj-0)

<img width="375px" src="https://github.com/HedvigInsurance/racoon/assets/19200662/bf00be19-4fc7-4fa4-9fa8-3d3230c10286" />




