### PR TITLE
Remove default 100% width on large Button variant

### DIFF
--- a/apps/store/src/blocks/ButtonBlock.tsx
+++ b/apps/store/src/blocks/ButtonBlock.tsx
@@ -13,6 +13,7 @@ export type ButtonBlockProps = SbBaseBlockProps<{
   link: LinkField
   variant: ComponentProps<typeof Button>['variant']
   size: ComponentProps<typeof Button>['size']
+  fullWidth?: boolean
 }>
 
 export const ButtonBlock = ({ blok, nested }: ButtonBlockProps) => {
@@ -22,6 +23,7 @@ export const ButtonBlock = ({ blok, nested }: ButtonBlockProps) => {
       href={getLinkFieldURL(blok.link, blok.text)}
       variant={blok.variant ?? 'primary'}
       size={blok.size ?? 'medium'}
+      fullWidth={blok.fullWidth}
       target={blok.link.target}
       rel={blok.link.rel}
       title={blok.link.title}

--- a/apps/store/src/blocks/WidgetFlowStartButtonBlock.tsx
+++ b/apps/store/src/blocks/WidgetFlowStartButtonBlock.tsx
@@ -43,6 +43,7 @@ function StartButton({ href, children, ...forwardedProps }: StartButtonProps) {
       href={targetHref}
       onClick={() => setLoading(true)}
       variant="primary"
+      fullWidth={true}
       size="large"
       loading={loading}
     >

--- a/packages/ui/src/components/Button/Button.css.ts
+++ b/packages/ui/src/components/Button/Button.css.ts
@@ -191,7 +191,7 @@ const SIZE_STYLES = {
   },
   large: {
     height: HEIGHT.large,
-    width: '100%',
+    minWidth: '18.75rem',
     paddingInline: tokens.space.xl,
     fontSize: tokens.fontSizes.md,
     textAlign: 'center',

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryFn } from '@storybook/react'
-import { Space, CheckIcon } from 'ui'
+import { CheckIcon, yStack } from 'ui'
 import { Button } from './Button'
 
 const meta: Meta<typeof Button> = {
@@ -11,8 +11,8 @@ export default meta
 
 const Template: StoryFn<typeof Button> = (props) => {
   return (
-    <Space y={2} style={{ maxWidth: '20rem' }}>
-      <Space y={1}>
+    <div className={yStack({ gap: 'xl' })}>
+      <div className={yStack({ gap: 'md' })}>
         <div>
           <Button {...props} variant="primary" />
         </div>
@@ -28,9 +28,9 @@ const Template: StoryFn<typeof Button> = (props) => {
         <div>
           <Button {...props} variant="ghost" />
         </div>
-      </Space>
+      </div>
 
-      <Space y={1}>
+      <div className={yStack({ gap: 'md' })}>
         <div>
           <Button {...props} variant="primary" disabled />
         </div>
@@ -46,9 +46,9 @@ const Template: StoryFn<typeof Button> = (props) => {
         <div>
           <Button {...props} variant="ghost" disabled />
         </div>
-      </Space>
+      </div>
 
-      <Space y={1}>
+      <div className={yStack({ gap: 'md' })}>
         <div>
           <Button {...props} variant="primary" loading />
         </div>
@@ -64,8 +64,8 @@ const Template: StoryFn<typeof Button> = (props) => {
         <div>
           <Button {...props} variant="ghost" loading />
         </div>
-      </Space>
-    </Space>
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Large `Button` has width set to 100% by default, always been a bit odd behaviour. Let's remove it an use a prop for it when needed and set a min width according to UI kit.

<img width="896" alt="Screenshot 2024-06-18 at 17 23 44" src="https://github.com/HedvigInsurance/racoon/assets/6661511/f47cabda-2e62-4a3a-a70e-e7a2a0c749b6">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
