### PR TITLE
Add sessionData to determine if an experiment is in store or widget

### DIFF
--- a/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
+++ b/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
@@ -23,6 +23,7 @@ type Props = Omit<ComponentPropsWithoutRef<typeof SignPage>, 'shopSession' | 'pr
   productData: ProductData
   pageTitle: string
   initialSelectedTypeOfContract?: string
+  partner?: string
 }
 
 const NextWidgetSignPage = (props: Props) => {
@@ -47,7 +48,11 @@ const NextWidgetSignPage = (props: Props) => {
         productData={props.productData}
         selectedTypeOfContract={props.initialSelectedTypeOfContract}
       >
-        <TrackingProvider shopSession={shopSession} productData={props.productData}>
+        <TrackingProvider
+          shopSession={shopSession}
+          productData={props.productData}
+          partner={props.partner}
+        >
           <SignPage shopSession={shopSession} priceIntent={priceIntent} {...props} />
         </TrackingProvider>
       </ProductDataProvider>
@@ -120,6 +125,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
         shopSessionId: context.params.shopSessionId,
         content: story.content.checkoutPageContent,
         flow: context.params.flow,
+        partner: partnerName,
         priceIntentId: priceIntent.id,
         // TODO: check if we want to control this via CMS
         ...hideChatOnPage(),

--- a/apps/store/src/services/Tracking/Tracking.ts
+++ b/apps/store/src/services/Tracking/Tracking.ts
@@ -97,6 +97,7 @@ export class Tracking {
         experiment_id: experimentId,
         variant_id: variantId,
       },
+      ...Tracking.sessionData(this.context),
     }
     console.debug(event.event, variantId)
     pushToGTMDataLayer(event)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add `sessionData` to experiment impression event to know if it was sent from store or from a the widget

<img width="1490" alt="Screenshot 2024-06-18 at 17 18 20" src="https://github.com/HedvigInsurance/racoon/assets/6661511/07ed05b2-cdf1-46e9-b50a-1630e2935b07">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Easier to make analysis by channel 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
