### PR TITLE
fix: Update large Buttons to be full width 

### DIFF
--- a/apps/store/src/app/debugger/iframe/page.tsx
+++ b/apps/store/src/app/debugger/iframe/page.tsx
@@ -31,7 +31,7 @@ function IFrameDebuggerPage({ searchParams }: Props) {
         <form method="GET">
           <Space y={0.25}>
             <TextField name="url" label="Iframe URL" defaultValue={url} />
-            <Button type="submit" variant="primary-alt">
+            <Button type="submit" variant="primary-alt" fullWidth={true}>
               Reload
             </Button>
           </Space>

--- a/apps/store/src/appComponents/SubmitButton.tsx
+++ b/apps/store/src/appComponents/SubmitButton.tsx
@@ -8,7 +8,7 @@ export function SubmitButton({ children, ...props }: ComponentPropsWithoutRef<'b
   const { pending } = useFormStatus()
 
   return (
-    <Button type="submit" loading={pending} disabled={pending} {...props}>
+    <Button type="submit" loading={pending} disabled={pending} fullWidth={true} {...props}>
       {children}
     </Button>
   )

--- a/apps/store/src/components/AppErrorDialog.tsx
+++ b/apps/store/src/components/AppErrorDialog.tsx
@@ -23,7 +23,7 @@ export const AppErrorDialog = () => {
         Footer={
           <>
             <FullscreenDialog.Close asChild>
-              <Button type="button" variant="primary">
+              <Button type="button" variant="primary" fullWidth={true}>
                 {t('ERROR_DIALOG_CLOSE')}
               </Button>
             </FullscreenDialog.Close>

--- a/apps/store/src/components/BankIdDialog/BankIdDialog.tsx
+++ b/apps/store/src/components/BankIdDialog/BankIdDialog.tsx
@@ -96,7 +96,7 @@ export function BankIdDialog() {
                 })
               }
             />
-            <Button variant="ghost" onClick={cancelLogin}>
+            <Button variant="ghost" onClick={cancelLogin} fullWidth={true}>
               {t('LOGIN_BANKID_SKIP')}
             </Button>
           </>
@@ -142,7 +142,9 @@ export function BankIdDialog() {
               </div>
 
               <FullscreenDialog.Close asChild>
-                <Button variant="ghost">{t('BANKID_CANCEL')}</Button>
+                <Button variant="ghost" fullWidth={true}>
+                  {t('BANKID_CANCEL')}
+                </Button>
               </FullscreenDialog.Close>
             </Space>
           </Space>
@@ -202,7 +204,9 @@ export function BankIdDialog() {
         )
         Footer = (
           <FullscreenDialog.Close asChild>
-            <Button variant="ghost">{t('BANKID_CANCEL')}</Button>
+            <Button variant="ghost" fullWidth={true}>
+              {t('BANKID_CANCEL')}
+            </Button>
           </FullscreenDialog.Close>
         )
         break

--- a/apps/store/src/components/BankIdLoginForm.tsx
+++ b/apps/store/src/components/BankIdLoginForm.tsx
@@ -15,7 +15,11 @@ export const BankIdLoginForm = ({ state, title, onLoginStart }: Props) => {
   }
   return (
     <form onSubmit={handleSubmit}>
-      <Button type="submit" loading={state !== BankIdState.Idle && state !== BankIdState.Error}>
+      <Button
+        type="submit"
+        loading={state !== BankIdState.Idle && state !== BankIdState.Error}
+        fullWidth={true}
+      >
         <ButtonContent>
           <BankIdIcon color="white" />
           {title}

--- a/apps/store/src/components/CartNotification/CartToast.tsx
+++ b/apps/store/src/components/CartNotification/CartToast.tsx
@@ -93,11 +93,12 @@ export const CartToast = forwardRef<CartToastAttributes>((_, forwardedRef) => {
                   href={PageLink.cart({ locale }).pathname}
                   variant="primary"
                   onClick={handleClickLink('Primary')}
+                  fullWidth={true}
                 >
                   {t('CART_TOAST_PRIMARY_LINK')}
                 </ButtonNextLink>
 
-                <Button onClick={handleClose} variant="ghost">
+                <Button onClick={handleClose} variant="ghost" fullWidth={true}>
                   {t('DIALOG_CLOSE', { ns: 'common' })}
                 </Button>
               </SpaceFlex>

--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -150,6 +150,7 @@ const CheckoutButton = () => {
     <ButtonNextLink
       href={PageLink.checkout({ locale, expandCart: true }).toRelative()}
       onClick={handleClickCheckout}
+      fullWidth={true}
     >
       {t('CHECKOUT_BUTTON')}
     </ButtonNextLink>
@@ -232,7 +233,7 @@ const EmptyState = (props: EmptyStateProps) => {
                       {t('CART_EMPTY_SUMMARY')}
                     </Text>
                   </Space>
-                  <ButtonNextLink href={PageLink.store({ locale })}>
+                  <ButtonNextLink href={PageLink.store({ locale })} fullWidth={true}>
                     {t('GO_TO_STORE_BUTTON')}
                   </ButtonNextLink>
                 </Space>

--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -289,7 +289,7 @@ const TextLink = styled(Link)({
 type SignButtonProps = PropsWithChildren<{ loading: boolean }>
 const SignButton = ({ children, loading }: SignButtonProps) => {
   return (
-    <Button type="submit" loading={loading}>
+    <Button type="submit" loading={loading} fullWidth={true}>
       <StyledSignButtonContent>
         <BankIdIcon color="white" />
         {children}

--- a/apps/store/src/components/DebugDialog/DebugResumeSessionSection.tsx
+++ b/apps/store/src/components/DebugDialog/DebugResumeSessionSection.tsx
@@ -34,7 +34,7 @@ export function DebugResumeSessionSection() {
         <TextField name={INPUT_NAME} label="Resume shop session" variant="small" />
       </div>
 
-      <Button variant="secondary" size="medium" type="submit">
+      <Button variant="secondary" size="medium" type="submit" fullWidth={true}>
         Go
       </Button>
     </Layout>

--- a/apps/store/src/components/ForeverPage/ForeverPage.tsx
+++ b/apps/store/src/components/ForeverPage/ForeverPage.tsx
@@ -55,7 +55,7 @@ export const ForeverPage = ({ code: initialCode }: Props) => {
                 message={errorMessage}
                 warning={!!errorMessage}
               />
-              <Button type="submit" loading={showLoading}>
+              <Button type="submit" loading={showLoading} fullWidth={true}>
                 {t('FOREVER_PAGE_BTN_LABEL')}
               </Button>
             </Space>

--- a/apps/store/src/components/InitiateCarCancellationPage/InitiateCarCancellationPage.tsx
+++ b/apps/store/src/components/InitiateCarCancellationPage/InitiateCarCancellationPage.tsx
@@ -130,7 +130,9 @@ const LoginForm = (props: { ssn?: string; onSuccess: () => void }) => {
           required={true}
           defaultValue={props.ssn}
         />
-        <Button type="submit">{t('LOGIN_BUTTON_TEXT')}</Button>
+        <Button type="submit" fullWidth={true}>
+          {t('LOGIN_BUTTON_TEXT')}
+        </Button>
       </Space>
     </form>
   )

--- a/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
+++ b/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
@@ -165,7 +165,13 @@ export const ExtraBuildingsField = ({
                   </InputRadio.Root>
                 </Space>
 
-                <Button type="submit" variant="primary" loading={loading} disabled={loading}>
+                <Button
+                  type="submit"
+                  variant="primary"
+                  loading={loading}
+                  disabled={loading}
+                  fullWidth={true}
+                >
                   <SpaceFlex space={0.5} align="center">
                     <PlusIcon size="1rem" />
                     <div>{t('FIELD_EXTRA_BUILDINGS_MODAL_ADD')}</div>

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorSection.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorSection.tsx
@@ -46,7 +46,7 @@ export const PriceCalculatorSection = ({ section, loading, onSubmit, last, child
         {children}
 
         <Space as="footer" y={0.25}>
-          <Button type="submit" disabled={loading} loading={loading}>
+          <Button type="submit" disabled={loading} loading={loading} fullWidth={true}>
             {translateLabel(section.submitLabel)}
           </Button>
 

--- a/apps/store/src/components/PriceCalculator/SsnSeSection.tsx
+++ b/apps/store/src/components/PriceCalculator/SsnSeSection.tsx
@@ -47,7 +47,7 @@ export const SsnSeSection = memo(({ shopSessionId, ssn, onCompleted }: Props) =>
           warning={!!errorMessage}
           message={errorMessage}
         />
-        <Button type="submit" loading={result.loading}>
+        <Button type="submit" loading={result.loading} fullWidth={true}>
           {t('SUBMIT_LABEL_PROCEED')}
         </Button>
       </Space>

--- a/apps/store/src/components/PriceCalculator/Warning/WarningPrompt/WarningPrompt.tsx
+++ b/apps/store/src/components/PriceCalculator/Warning/WarningPrompt/WarningPrompt.tsx
@@ -26,8 +26,10 @@ export const WarningPrompt = ({ header, message, onClickConfirm, onClickEdit }: 
         </SpaceFlex>
 
         <Space y={0.25}>
-          <Button onClick={onClickConfirm}>{t('PRICE_INTENT_WARNING_ACCEPT_BUTTON_LABEL')}</Button>
-          <Button onClick={onClickEdit} variant="ghost">
+          <Button onClick={onClickConfirm} fullWidth={true}>
+            {t('PRICE_INTENT_WARNING_ACCEPT_BUTTON_LABEL')}
+          </Button>
+          <Button onClick={onClickEdit} variant="ghost" fullWidth={true}>
             {t('PRICE_INTENT_WARNING_EDIT_BUTTON_LABEL')}
           </Button>
         </Space>

--- a/apps/store/src/components/ProductItem/EditActionButton.tsx
+++ b/apps/store/src/components/ProductItem/EditActionButton.tsx
@@ -41,11 +41,11 @@ export const EditActionButton = (props: Props) => {
         center={true}
         Footer={
           <>
-            <Button onClick={handleConfirmEdit} loading={state === 'loading'}>
+            <Button onClick={handleConfirmEdit} loading={state === 'loading'} fullWidth={true}>
               {t('EDIT_CONFIRMATION_MODAL_CONTINUE')}
             </Button>
             <FullscreenDialog.Close asChild={true}>
-              <Button type="button" variant="ghost">
+              <Button type="button" variant="ghost" fullWidth={true}>
                 {t('EDIT_CONFIRMATION_MODAL_CANCEL')}
               </Button>
             </FullscreenDialog.Close>

--- a/apps/store/src/components/ProductItem/RemoveActionButton.tsx
+++ b/apps/store/src/components/ProductItem/RemoveActionButton.tsx
@@ -60,11 +60,11 @@ export const RemoveActionButton = (props: Props) => {
         center={true}
         Footer={
           <>
-            <Button onClick={handleClickRemove} loading={result.loading}>
+            <Button onClick={handleClickRemove} loading={result.loading} fullWidth={true}>
               {t('REMOVE_ENTRY_MODAL_CONFIRM_BUTTON')}
             </Button>
             <FullscreenDialog.Close asChild={true}>
-              <Button type="button" variant="ghost">
+              <Button type="button" variant="ghost" fullWidth={true}>
                 {t('REMOVE_ENTRY_MODAL_CANCEL_BUTTON')}
               </Button>
             </FullscreenDialog.Close>

--- a/apps/store/src/components/ProductPage/PurchaseForm/ComparisonTableModal.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ComparisonTableModal.tsx
@@ -39,7 +39,7 @@ export const ComparisonTableModal = ({ tiers, selectedTierId, children }: Props)
         Footer={
           <>
             <FullscreenDialog.Close asChild>
-              <Button type="button" variant="secondary">
+              <Button type="button" variant="secondary" fullWidth={true}>
                 {t('CLOSE_COMPARISON_MODAL')}
               </Button>
             </FullscreenDialog.Close>

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -225,6 +225,7 @@ export const OfferPresenter = (props: Props) => {
               onClick={handleAddToCart}
               loading={loadingAddToCart && addToCartRedirect === AddToCartRedirect.Cart}
               disabled={loadingAddToCart}
+              fullWidth={true}
             >
               {t('ADD_TO_CART_BUTTON_LABEL')}
             </Button>
@@ -237,6 +238,7 @@ export const OfferPresenter = (props: Props) => {
                 (loadingAddToCart && addToCartRedirect === AddToCartRedirect.Checkout)
               }
               disabled={loadingAddToCart}
+              fullWidth={true}
             >
               {t('QUICK_CHECKOUT_BUTTON_LABEL')}
             </Button>

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -266,7 +266,7 @@ const IdleState = ({ loading, onClick, showAverageRating }: IdleStateProps) => {
       <div ref={ref}>
         <ProductHeroContainer size="large">
           <Space y={1}>
-            <Button loading={loading} onClick={onClick}>
+            <Button loading={loading} onClick={onClick} fullWidth={true}>
               {t('OPEN_PRICE_CALCULATOR_BUTTON')}
             </Button>
             {showAverageRating && <ProductAverageRating />}
@@ -275,7 +275,9 @@ const IdleState = ({ loading, onClick, showAverageRating }: IdleStateProps) => {
       </div>
       <ScrollPast targetRef={ref}>
         <div className={purchaseFormStickyButtonWrapper}>
-          <Button onClick={onClick}>{t('OPEN_PRICE_CALCULATOR_BUTTON')}</Button>
+          <Button onClick={onClick} fullWidth={true}>
+            {t('OPEN_PRICE_CALCULATOR_BUTTON')}
+          </Button>
         </div>
       </ScrollPast>
     </>

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseFormErrorDialog.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseFormErrorDialog.tsx
@@ -19,11 +19,11 @@ export const PurchaseFormErrorDialog = (props: Props) => {
         center={true}
         Footer={
           <>
-            <Button type="button" onClick={props.onEditClick}>
+            <Button type="button" onClick={props.onEditClick} fullWidth={true}>
               {t('GENERAL_ERROR_DIALOG_PRIMARY_BUTTON')}
             </Button>
             <FullscreenDialog.Close asChild={true}>
-              <Button type="button" variant="ghost">
+              <Button type="button" variant="ghost" fullWidth={true}>
                 {t('DIALOG_BUTTON_CANCEL', { ns: 'common' })}
               </Button>
             </FullscreenDialog.Close>

--- a/apps/store/src/components/ProductPage/ScrollToButton/ScrollToButton.tsx
+++ b/apps/store/src/components/ProductPage/ScrollToButton/ScrollToButton.tsx
@@ -12,7 +12,7 @@ export const ScrollToTopButton = ({ children, type }: ScrollToTopButtonProps) =>
 
   return (
     <Wrapper>
-      <Button type={type} onClick={handleClick}>
+      <Button type={type} onClick={handleClick} fullWidth={true}>
         {children}
       </Button>
     </Wrapper>

--- a/apps/store/src/components/QuickPurchaseForm/QuickPurchaseForm.tsx
+++ b/apps/store/src/components/QuickPurchaseForm/QuickPurchaseForm.tsx
@@ -57,7 +57,7 @@ export const QuickPurchaseForm = ({
         message={error?.ssn}
         hidden={!showSsnField}
       />
-      <Button type="submit" loading={submitting}>
+      <Button type="submit" loading={submitting} fullWidth={true}>
         {t('BUTTON_LABEL_GET_PRICE')}
       </Button>
       {error?.general && <GeneralErrorMessage>{error.general}</GeneralErrorMessage>}

--- a/apps/store/src/components/ShopBreakdown/AddCampaignForm.tsx
+++ b/apps/store/src/components/ShopBreakdown/AddCampaignForm.tsx
@@ -35,7 +35,7 @@ export const AddCampaignForm = (props: Props) => {
           message={props.errorMessage}
           required={true}
         />
-        <Button type="submit" variant="primary-alt" loading={props.loading}>
+        <Button type="submit" variant="primary-alt" loading={props.loading} fullWidth={true}>
           {t('CHECKOUT_ADD_DISCOUNT_BUTTON')}
         </Button>
       </Wrapper>

--- a/apps/store/src/features/blog/BlogArticleListBlock/BlogArticleListBlock.css.ts
+++ b/apps/store/src/features/blog/BlogArticleListBlock/BlogArticleListBlock.css.ts
@@ -13,5 +13,3 @@ export const buttonWrapper = style({
   display: 'flex',
   justifyContent: 'center',
 })
-
-export const inlineButtonLink = style({ width: 'auto' })

--- a/apps/store/src/features/blog/BlogArticleListBlock/BlogArticleListBlock.tsx
+++ b/apps/store/src/features/blog/BlogArticleListBlock/BlogArticleListBlock.tsx
@@ -12,7 +12,7 @@ import { useFormatter } from '@/utils/useFormatter'
 import { ArticleTeaser } from '../ArticleTeaser/ArticleTeaser'
 import { BLOG_ARTICLE_LIST_BLOCK } from '../blog.constants'
 import { useBlogArticleTeasers } from '../useBlog'
-import { buttonWrapper, inlineButtonLink, articleList } from './BlogArticleListBlock.css'
+import { buttonWrapper, articleList } from './BlogArticleListBlock.css'
 
 type Props = SbBaseBlockProps<{
   categories?: Array<string>
@@ -67,7 +67,6 @@ export function BlogArticleListBlock(props: Props) {
           {!showAll && (
             <div className={buttonWrapper}>
               <ButtonNextLink
-                className={inlineButtonLink}
                 href={`${pathname}?${SHOW_ALL_QUERY_PARAM}=1`}
                 shallow={true}
                 scroll={false}

--- a/apps/store/src/features/carDealership/CarBuyerValidationPage.tsx
+++ b/apps/store/src/features/carDealership/CarBuyerValidationPage.tsx
@@ -98,7 +98,7 @@ export const CarBuyerValidationPage = (props: Props) => {
                     options={TIER_OPTIONS}
                   />
                   <Space y={0.5}>
-                    <Button type="submit" loading={state.type === 'LOADING'}>
+                    <Button type="submit" loading={state.type === 'LOADING'} fullWidth={true}>
                       Validera kund
                     </Button>
                     <Text as="p" size="xs" align="center" color="textSecondary">

--- a/apps/store/src/features/carDealership/ConfirmPayWithoutExtensionButton.tsx
+++ b/apps/store/src/features/carDealership/ConfirmPayWithoutExtensionButton.tsx
@@ -20,7 +20,7 @@ export const ConfirmPayWithoutExtensionButton = (props: Props) => {
   return (
     <FullScreenDialog.Root>
       <FullScreenDialog.Trigger asChild={true}>
-        <Button variant="primary">
+        <Button variant="primary" fullWidth={true}>
           <SpaceFlex space={0.5} align="center">
             <BankIdIcon />
             {t('CONNECT_PAYMENT_BUTTON')}
@@ -32,9 +32,11 @@ export const ConfirmPayWithoutExtensionButton = (props: Props) => {
         center={true}
         Footer={
           <>
-            <Button onClick={handleClick}>{t('PAY_WITHOUT_EXTENSION_DIALOG_CONFIRM')}</Button>
+            <Button onClick={handleClick} fullWidth={true}>
+              {t('PAY_WITHOUT_EXTENSION_DIALOG_CONFIRM')}
+            </Button>
             <FullScreenDialog.Close asChild={true}>
-              <Button type="button" variant="ghost">
+              <Button type="button" variant="ghost" fullWidth={true}>
                 {t('PAY_WITHOUT_EXTENSION_DIALOG_CANCEL')}
               </Button>
             </FullScreenDialog.Close>

--- a/apps/store/src/features/carDealership/MyMoneyConsentConfirmation/MyMoneyConsentConfirmation.tsx
+++ b/apps/store/src/features/carDealership/MyMoneyConsentConfirmation/MyMoneyConsentConfirmation.tsx
@@ -43,10 +43,10 @@ export function MyMoneyConsentConfirmation({ children, loading, onClose, onConti
 
           <SpaceFlex space={0.5} direction="vertical">
             <Dialog.Close asChild>
-              <Button>{t('MY_MONEY_CONSENT_CONFIRMATION_BACK_BUTTON')}</Button>
+              <Button fullWidth={true}>{t('MY_MONEY_CONSENT_CONFIRMATION_BACK_BUTTON')}</Button>
             </Dialog.Close>
 
-            <Button onClick={onContinue} loading={loading} variant="ghost">
+            <Button fullWidth={true} onClick={onContinue} loading={loading} variant="ghost">
               {t('MY_MONEY_CONSENT_CONFIRMATION_CONTINUE_BUTTON')}
             </Button>
           </SpaceFlex>

--- a/apps/store/src/features/carDealership/TrialExtensionForm/TrialExtensionForm.tsx
+++ b/apps/store/src/features/carDealership/TrialExtensionForm/TrialExtensionForm.tsx
@@ -213,7 +213,7 @@ export const TrialExtensionForm = ({
 type SignButtonProps = ComponentPropsWithoutRef<typeof Button>
 const SignButton = ({ children, ...props }: SignButtonProps) => {
   return (
-    <Button {...props}>
+    <Button fullWidth={true} {...props}>
       <SpaceFlex space={0.5} align="center">
         <BankIdIcon />
         {children}

--- a/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
+++ b/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
@@ -101,7 +101,7 @@ export const ManyPetsMigrationPage = ({
                 <TotalAmount currencyCode={totalCost.currencyCode} amount={totalCost.amount} />
                 {latestAdoptionDate && <LatestAdoptionNote date={latestAdoptionDate} />}
 
-                <SignButton ref={signButtonRef} type="submit" loading={loading}>
+                <SignButton ref={signButtonRef} type="submit" loading={loading} fullWidth={true}>
                   {signButtonContent}
                 </SignButton>
 

--- a/apps/store/src/features/memberArea/PaymentsSection/PaymentConnection.tsx
+++ b/apps/store/src/features/memberArea/PaymentsSection/PaymentConnection.tsx
@@ -47,7 +47,7 @@ export const PaymentConnection = ({ startButtonText }: { startButtonText: string
 
   return (
     <>
-      <Button loading={result.loading} onClick={handleClickStart}>
+      <Button loading={result.loading} onClick={handleClickStart} fullWidth={true}>
         {startButtonText}
       </Button>
 

--- a/apps/store/src/features/memberArea/pages/LoginPage/LoginPage.tsx
+++ b/apps/store/src/features/memberArea/pages/LoginPage/LoginPage.tsx
@@ -81,7 +81,7 @@ const LoginForm = ({
               required={true}
             />
           </div>
-          <Button type="submit" loading={!!currentOperation}>
+          <Button type="submit" loading={!!currentOperation} fullWidth={true}>
             <SpaceFlex space={0.5} align="center">
               <BankIdIcon />
               {t('bankid:LOGIN_BANKID')}

--- a/apps/store/src/features/sas/SasEurobonusSection.tsx
+++ b/apps/store/src/features/sas/SasEurobonusSection.tsx
@@ -58,7 +58,7 @@ export const SasEurobonusSection = ({
           <Text>{t('SAS_BONUS_NUMBER_SAVED')}</Text>
         </SpaceFlex>
       ) : (
-        <Button type="submit" loading={state === 'loading'}>
+        <Button type="submit" loading={state === 'loading'} fullWidth={true}>
           {t('SAS_BONUS_NUMBER_SAVE_BUTTON')}
         </Button>
       )}

--- a/apps/store/src/features/widget/ConfirmationPage.tsx
+++ b/apps/store/src/features/widget/ConfirmationPage.tsx
@@ -60,7 +60,9 @@ export const ConfirmationPage = (props: Props) => {
 
                 <TotalAmountContainer cart={props.shopSession.cart} />
                 {props.backToAppButton && (
-                  <Button onClick={handleClickBackToApp}>{props.backToAppButton}</Button>
+                  <Button onClick={handleClickBackToApp} fullWidth={true}>
+                    {props.backToAppButton}
+                  </Button>
                 )}
               </Space>
             </Space>

--- a/apps/store/src/features/widget/SelectProductPage.tsx
+++ b/apps/store/src/features/widget/SelectProductPage.tsx
@@ -103,7 +103,12 @@ export const SelectProductPage = (props: Props) => {
                   </Space>
                 </RadioOptionList.Root>
 
-                <CustomButton type="submit" variant="primary" aria-disabled={!productName}>
+                <CustomButton
+                  type="submit"
+                  variant="primary"
+                  aria-disabled={!productName}
+                  fullWidth={true}
+                >
                   {t('SELECT_CONTINUE_BUTTON')}
                 </CustomButton>
               </Space>

--- a/apps/store/src/features/widget/SignPage.tsx
+++ b/apps/store/src/features/widget/SignPage.tsx
@@ -312,7 +312,7 @@ const Wrapper = styled(Space)({
 type SignButtonProps = PropsWithChildren<{ loading: boolean; showBankIdIcon: boolean }>
 const SignButton = ({ children, loading, showBankIdIcon }: SignButtonProps) => {
   return (
-    <Button type="submit" loading={loading}>
+    <Button type="submit" loading={loading} fullWidth={true}>
       <StyledSignButtonContent>
         {showBankIdIcon && <BankIdIcon color="white" />}
         {children}

--- a/apps/store/src/features/widget/SwitchPage.tsx
+++ b/apps/store/src/features/widget/SwitchPage.tsx
@@ -72,6 +72,7 @@ export const SwitchPage = (props: Props) => {
                     shopSessionId: props.shopSession.id,
                     priceIntentId: props.priceIntent.id,
                   })}
+                  fullWidth={true}
                 >
                   {t('widget:SELECT_CONTINUE_BUTTON')}
                 </ButtonNextLink>

--- a/apps/store/src/pages/[locale]/payment/connect-legacy/start.tsx
+++ b/apps/store/src/pages/[locale]/payment/connect-legacy/start.tsx
@@ -24,7 +24,9 @@ const Page = (props: Props) => {
   return (
     <Layout title={title}>
       <form method="POST" action={authUrl}>
-        <Button type="submit">{startButton}</Button>
+        <Button type="submit" fullWidth={true}>
+          {startButton}
+        </Button>
       </form>
     </Layout>
   )

--- a/apps/store/src/pages/[locale]/payment/connect/start.tsx
+++ b/apps/store/src/pages/[locale]/payment/connect/start.tsx
@@ -47,7 +47,9 @@ const Page = () => {
         <form onSubmit={handleSubmit}>
           <IframePlaceholder>
             <WideSpace y={0.5}>
-              <Button loading={loading}>{t('FLOW_ACTIVATION_BUTTON')}</Button>
+              <Button loading={loading} fullWidth={true}>
+                {t('FLOW_ACTIVATION_BUTTON')}
+              </Button>
             </WideSpace>
           </IframePlaceholder>
         </form>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Mistakenly thought `medium` was the default size for `Button` component but it's `large`. So that meant a bunch of buttons got too narrow. Adding `fullWidth` prop fixes that

### The bug
![image](https://github.com/HedvigInsurance/racoon/assets/6661511/53ab2258-4460-4295-bd68-675705caecf1)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
UI bug

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
