### PR TITLE
Remove Space component from header and footer

### DIFF
--- a/apps/store/src/blocks/FooterBlock/FooterBlock.tsx
+++ b/apps/store/src/blocks/FooterBlock/FooterBlock.tsx
@@ -1,6 +1,6 @@
 import { storyblokEditable } from '@storyblok/react'
 import Link from 'next/link'
-import { Space, Text } from 'ui'
+import { Text, yStack } from 'ui'
 import { LanguageSelectForm } from '@/blocks/FooterBlock/LanguageSelectForm'
 import * as GridLayout from '@/components/GridLayout/GridLayout'
 import type { ExpectedBlockType, LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
@@ -43,16 +43,16 @@ type FooterSectionProps = SbBaseBlockProps<{
 export const FooterSectionBlock = ({ blok }: FooterSectionProps) => {
   const filteredFooterLinks = filterByBlockType(blok.footerLinks, FooterLinkBlock.blockName)
   return (
-    <Space y={1.5} {...storyblokEditable(blok)}>
+    <div className={yStack({ gap: 'lg' })} {...storyblokEditable(blok)}>
       <Text size="sm" color="textSecondary">
         {blok.title}
       </Text>
-      <Space y={0.5}>
+      <div className={yStack({ gap: 'xs' })}>
         {filteredFooterLinks.map((nestedBlock) => (
           <FooterLinkBlock key={nestedBlock._uid} blok={nestedBlock} />
         ))}
-      </Space>
-    </Space>
+      </div>
+    </div>
   )
 }
 FooterSectionBlock.blockName = 'footerSection' as const

--- a/apps/store/src/blocks/HeaderBlock/ProductNavContainerBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock/ProductNavContainerBlock.tsx
@@ -1,9 +1,7 @@
 'use client'
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import { storyblokEditable } from '@storyblok/react'
-import { clsx } from 'clsx'
 import { useTranslation } from 'next-i18next'
-import { Space } from 'ui'
 import type { ButtonBlockProps } from '@/blocks/ButtonBlock'
 import { NavItemBlock, type NavItemBlockProps } from '@/blocks/HeaderBlock/NavItemBlock'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
@@ -58,32 +56,26 @@ export const ProductNavContainerBlock = ({ blok, variant }: ProductNavContainerB
   })
 
   const content = (
-    <div className={clsx(navigationMenuWrapper)}>
-      <Space y={{ base: 1.5, lg: 1 }}>
-        <NavigationMenuPrimitive.Sub defaultValue={blok.name}>
-          <NavigationMenuPrimitive.List className={navigationProductList}>
-            {productNavItems.map((item) => (
-              <NavigationMenuPrimitive.Item key={item.name} value={item.name}>
-                <ProductNavigationLink
-                  href={item.url}
-                  pillowImageSrc={item.image}
-                  label={item.label}
-                >
-                  {item.name}
-                </ProductNavigationLink>
-              </NavigationMenuPrimitive.Item>
-            ))}
-          </NavigationMenuPrimitive.List>
-        </NavigationMenuPrimitive.Sub>
-        <ButtonNextLink
-          href={PageLink.store({ locale })}
-          variant="secondary"
-          size="medium"
-          fullWidth={true}
-        >
-          {t('NAVIGATION_STORE_LINK')}
-        </ButtonNextLink>
-      </Space>
+    <div className={navigationMenuWrapper}>
+      <NavigationMenuPrimitive.Sub defaultValue={blok.name}>
+        <NavigationMenuPrimitive.List className={navigationProductList}>
+          {productNavItems.map((item) => (
+            <NavigationMenuPrimitive.Item key={item.name} value={item.name}>
+              <ProductNavigationLink href={item.url} pillowImageSrc={item.image} label={item.label}>
+                {item.name}
+              </ProductNavigationLink>
+            </NavigationMenuPrimitive.Item>
+          ))}
+        </NavigationMenuPrimitive.List>
+      </NavigationMenuPrimitive.Sub>
+      <ButtonNextLink
+        href={PageLink.store({ locale })}
+        variant="secondary"
+        size="medium"
+        fullWidth={true}
+      >
+        {t('NAVIGATION_STORE_LINK')}
+      </ButtonNextLink>
     </div>
   )
 

--- a/apps/store/src/components/Header/Header.css.ts
+++ b/apps/store/src/components/Header/Header.css.ts
@@ -196,8 +196,10 @@ export const navigationContent = style({
   },
 })
 
+// Same component reused between mobile and desktop menus
 export const navigationMenuWrapper = style({
   paddingBottom: tokens.space.xl,
+  rowGap: tokens.space.lg,
 
   '@media': {
     [minWidth.lg]: {
@@ -205,6 +207,7 @@ export const navigationMenuWrapper = style({
       boxShadow: tokens.shadow.default,
       borderRadius: tokens.radius.sm,
       padding: tokens.space.md,
+      rowGap: tokens.space.md,
     },
   },
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Replace `Space` component with gap styles in header and footer

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

I hate `<Space>` in our code - it targets child elements in non-obvious and computationally expensive way. There's also a risk of layout shift if any of its children add inline style tag

gap / rowGap / columnGap is simpler idiomatic way to get the same effect

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
