### PR TITLE
Exclude header and footer blocks from Storyblok component registry - we're using them explicitly and don't need to include component code into client bundle

### DIFF
--- a/apps/store/src/services/storyblok/commonStoryblokComponents.ts
+++ b/apps/store/src/services/storyblok/commonStoryblokComponents.ts
@@ -12,12 +12,7 @@ import { ContactSupportBlock } from '@/blocks/ContactSupportBlock'
 import { ContentBlock } from '@/blocks/ContentBlock'
 import { CookieListBlock } from '@/blocks/CookieListBlock'
 import { DownloadableContentItemBlock } from '@/blocks/DownloadableContentItemBlock'
-import { FooterBlock, FooterLinkBlock, FooterSectionBlock } from '@/blocks/FooterBlock/FooterBlock'
 import { GridBlock } from '@/blocks/GridBlock'
-import { HeaderBlock } from '@/blocks/HeaderBlock/HeaderBlock'
-import { NavItemBlock } from '@/blocks/HeaderBlock/NavItemBlock'
-import { NestedNavContainerBlock } from '@/blocks/HeaderBlock/NestedNavContainerBlock'
-import { ProductNavContainerBlock } from '@/blocks/HeaderBlock/ProductNavContainerBlock'
 import { HeadingBlock } from '@/blocks/HeadingBlock'
 import { HeadingLabelBlock } from '@/blocks/HeadingLabelBlock'
 import { HeroBlock } from '@/blocks/HeroBlock'
@@ -74,11 +69,7 @@ export const commonStoryblokComponents = {
   content: ContentBlock,
   cookieList: CookieListBlock,
   downloadableContentItem: DownloadableContentItemBlock,
-  footer: FooterBlock,
-  footerLink: FooterLinkBlock,
-  footerSection: FooterSectionBlock,
   grid: GridBlock,
-  header: HeaderBlock,
   heading: HeadingBlock,
   headingLabel: HeadingLabelBlock,
   hero: HeroBlock,
@@ -89,15 +80,12 @@ export const commonStoryblokComponents = {
   insurableLimits: InsurableLimitsBlock,
   mediaList: MediaListBlock,
   modal: ModalBlock,
-  navItem: NavItemBlock,
-  nestedNavContainer: NestedNavContainerBlock,
   page: PageBlock,
   perils: PerilsBlock,
   product: ProductPageBlock,
   productCard: ProductCardBlock,
   productDocuments: ProductDocumentsBlock,
   productGrid: ProductGridBlock,
-  productNavContainer: ProductNavContainerBlock,
   productPillow: ProductPillowBlock,
   productPillows: ProductPillowsBlock,
   productReviews: ProductReviewsBlock,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Exclude header and footer blocks from `comonStoryblokComponents` - we always use them directly.  In app router this allows us to not include RSC part into client bundle

This saves 0.5% of client bundle size, so quite minor

Approved by Peter: https://hedviginsurance.slack.com/archives/C041SD67G82/p1718880368490219

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
