### PR TITLE
GEN-2383 - feat(WidgetFlowStartButtonBlock): allow UI changes via storyblok

### DIFF
--- a/apps/store/src/blocks/WidgetFlowStartButtonBlock.tsx
+++ b/apps/store/src/blocks/WidgetFlowStartButtonBlock.tsx
@@ -3,21 +3,30 @@ import { storyblokEditable } from '@storyblok/react'
 import { useSearchParams } from 'next/navigation'
 import type { ReactNode } from 'react'
 import { Suspense, useEffect, useState } from 'react'
-import { ButtonNextLink } from '@/components/ButtonNextLink'
+import { ButtonNextLink, type ButtonNextLinkProps } from '@/components/ButtonNextLink'
 import type { LinkField, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
 import { mergeSearchParams } from '@/utils/mergeSearchParams'
 
-type Props = SbBaseBlockProps<{
-  text: string
-  link: LinkField
-}>
+type Props = SbBaseBlockProps<
+  {
+    text: string
+    link: LinkField
+  } & Pick<StartButtonProps, 'size' | 'fullWidth'>
+>
 
 export function WidgetFlowStartButtonBlock({ blok }: Props) {
+  const { link, text, fullWidth = true, size = 'large' } = blok
+
   return (
     <Suspense>
-      <StartButton {...storyblokEditable(blok)} href={getLinkFieldURL(blok.link)}>
-        {blok.text}
+      <StartButton
+        {...storyblokEditable(blok)}
+        href={getLinkFieldURL(link)}
+        size={size}
+        fullWidth={fullWidth}
+      >
+        {text}
       </StartButton>
     </Suspense>
   )
@@ -26,6 +35,8 @@ export function WidgetFlowStartButtonBlock({ blok }: Props) {
 type StartButtonProps = {
   href: string
   children: ReactNode
+  size: ButtonNextLinkProps['size']
+  fullWidth: ButtonNextLinkProps['fullWidth']
 } & ReturnType<typeof storyblokEditable>
 
 function StartButton({ href, children, ...forwardedProps }: StartButtonProps) {
@@ -43,8 +54,6 @@ function StartButton({ href, children, ...forwardedProps }: StartButtonProps) {
       href={targetHref}
       onClick={() => setLoading(true)}
       variant="primary"
-      fullWidth={true}
-      size="large"
       loading={loading}
     >
       {children}

--- a/apps/store/src/components/ButtonNextLink.tsx
+++ b/apps/store/src/components/ButtonNextLink.tsx
@@ -2,7 +2,9 @@ import Link from 'next/link'
 import type { ButtonProps } from 'ui'
 import { Button } from 'ui'
 
-export const ButtonNextLink = ({ children, ...props }: ButtonProps<typeof Link>) => {
+export type ButtonNextLinkProps = ButtonProps<typeof Link>
+
+export const ButtonNextLink = ({ children, ...props }: ButtonNextLinkProps) => {
   return (
     <Button as={Link} {...props}>
       {children}


### PR DESCRIPTION
## Describe your changes

* Allow UI changes via storyblok to `WidgetFlowStartButtonBlock`

<img width="600" alt="Screenshot 2024-06-24 at 13 39 54" src="https://github.com/HedvigInsurance/racoon/assets/19200662/8b270f5c-f281-45bc-92df-d1f43f69fbec">

## Justify why they are needed

With that we can change _verisure_ widget pages so they use `WidgetFlowStartButtonBlock` instead of `ButtonBlock`.
More info can be found in the [ticket](https://www.notion.so/hedviginsurance/Widget-start-flow-button-Enable-styling-customizations-9e4c2979e18541579bde581ffa422556?pvs=4).

Note: Make sure to update widget pages after this get merged.