### PR TITLE
Adjust space in navigation product list

### DIFF
--- a/apps/store/src/components/Header/Header.css.ts
+++ b/apps/store/src/components/Header/Header.css.ts
@@ -1,5 +1,5 @@
 import { createVar, style } from '@vanilla-extract/css'
-import { minWidth, tokens } from 'ui'
+import { minWidth, tokens, yStack } from 'ui'
 import { zIndexes } from '@/utils/zIndex'
 import { MAX_WIDTH } from '../GridLayout/GridLayout.constants'
 import {
@@ -245,20 +245,18 @@ export const navigationSecondaryList = style({
   },
 })
 
-export const navigationProductList = style({
-  display: 'flex',
-  flexDirection: 'column',
-  rowGap: tokens.space.xs,
-  fontSize: tokens.fontSizes.md,
-  color: tokens.colors.textPrimary,
+export const navigationProductList = style([
+  yStack({ gap: 'xs' }),
+  {
+    marginBottom: tokens.space.lg,
+    fontSize: tokens.fontSizes.md,
+    color: tokens.colors.textPrimary,
 
-  '@media': {
-    [minWidth.lg]: {
-      minWidth: '16rem',
-      columnGap: 0,
-      gridTemplateColumns: 'none',
-      gridAutoColumns: '7.5rem',
-      gridAutoFlow: 'column',
+    '@media': {
+      [minWidth.lg]: {
+        minWidth: '16rem',
+        marginBottom: tokens.space.md,
+      },
     },
   },
-})
+])


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add back space to navigation product list (as specified in FIgma) and remove unused styles

### Before
![image (7)](https://github.com/HedvigInsurance/racoon/assets/6661511/692962a6-1ec4-44db-b3ed-8fe8b1b39f06)

### After
<img width="392" alt="Screenshot 2024-06-25 at 11 31 06" src="https://github.com/HedvigInsurance/racoon/assets/6661511/a31cc324-5551-4cf1-a3c6-0b9d20050c24">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Space had disappeared, reported by Peter
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
