### PR TITLE
Reliably handle Offer -> Checkout navigation scenario by creating new priceIntent if presious one was used to add offer to cart

### DIFF
--- a/apps/store/public/mockServiceWorker.js
+++ b/apps/store/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.3.0'
+const PACKAGE_VERSION = '2.3.1'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -2,7 +2,7 @@ import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
 import { useInView } from 'framer-motion'
-import { usePathname, useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { useTranslation } from 'next-i18next'
 import type { MouseEventHandler, ReactNode, RefObject } from 'react'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -169,15 +169,6 @@ export const OfferPresenter = (props: Props) => {
     }
     addToCart(selectedOffer.id)
   }
-
-  const pathname = usePathname()
-  const initialPathnameRef = useRef(pathname)
-  useEffect(() => {
-    // Finished navigating to checkout page, we can clean up now
-    if (isNavigatingToCheckout && initialPathnameRef.current !== pathname) {
-      resetPriceIntent()
-    }
-  }, [isNavigatingToCheckout, pathname, resetPriceIntent])
 
   return (
     <>

--- a/apps/store/src/graphql/ProductOfferFragment.graphql
+++ b/apps/store/src/graphql/ProductOfferFragment.graphql
@@ -62,6 +62,7 @@ fragment ProductOffer on ProductOffer {
       currencyCode
     }
   }
+  priceIntentId
   priceIntentData
   deductible {
     displayName


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Reimplement logic for clearing priceIntent after it was used for adding item to cart

Old solution did not work reliably since product -> checkout navigation crossed app router -> pages router barrier and was a full page reload

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
