### PR TITLE
Add uppercase option for TextField

### DIFF
--- a/apps/store/src/components/ForeverPage/ForeverPage.css.ts
+++ b/apps/store/src/components/ForeverPage/ForeverPage.css.ts
@@ -1,0 +1,25 @@
+import { createVar, style } from '@vanilla-extract/css'
+import { minWidth, tokens } from 'ui'
+import { HEADER_HEIGHT_MOBILE, HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header.constants'
+
+const headerHeight = createVar()
+
+export const layout = style({
+  vars: {
+    [headerHeight]: HEADER_HEIGHT_MOBILE,
+  },
+  display: 'grid',
+  gridTemplateRows: '1fr auto',
+  alignItems: 'center',
+  height: `calc(100vh - ${headerHeight})`,
+  paddingBlock: tokens.space.md,
+
+  '@media': {
+    [minWidth.lg]: {
+      paddingBlock: tokens.space.xl,
+      vars: {
+        [headerHeight]: HEADER_HEIGHT_DESKTOP,
+      },
+    },
+  },
+})

--- a/apps/store/src/components/ForeverPage/ForeverPage.tsx
+++ b/apps/store/src/components/ForeverPage/ForeverPage.tsx
@@ -1,17 +1,16 @@
-import styled from '@emotion/styled'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import type { FormEventHandler } from 'react'
 import { useState } from 'react'
-import { Button, mq, Space, theme } from 'ui'
+import { Button, Space } from 'ui'
 import * as GridLayout from '@/components/GridLayout/GridLayout'
-import { HEADER_HEIGHT_MOBILE, HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header.constants'
 import { TextField } from '@/components/TextField/TextField'
 import { TextWithLink } from '@/components/TextWithLink'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { useRedeemCampaign } from '@/utils/useCampaign'
+import { layout } from './ForeverPage.css'
 import { usePrintTextEffect } from './usePrintTextEffect'
 
 export type Props = { code: string }
@@ -41,12 +40,12 @@ export const ForeverPage = ({ code: initialCode }: Props) => {
   }
 
   return (
-    <Layout>
+    <div className={layout}>
       <GridLayout.Root as="main">
         <GridLayout.Content width="1/3" align="center">
           <form onSubmit={handleSubmit}>
             <Space y={errorMessage ? 1 : 0.25}>
-              <UppercaseTextField
+              <TextField
                 name="code"
                 label={t('FOREVER_PAGE_INPUT_TEXT')}
                 value={code}
@@ -54,6 +53,7 @@ export const ForeverPage = ({ code: initialCode }: Props) => {
                 required={true}
                 message={errorMessage}
                 warning={!!errorMessage}
+                upperCaseInput={true}
               />
               <Button type="submit" loading={showLoading} fullWidth={true}>
                 {t('FOREVER_PAGE_BTN_LABEL')}
@@ -75,24 +75,6 @@ export const ForeverPage = ({ code: initialCode }: Props) => {
           </TextWithLink>
         </GridLayout.Content>
       </GridLayout.Root>
-    </Layout>
+    </div>
   )
 }
-
-const Layout = styled.div({
-  '--header-height': HEADER_HEIGHT_MOBILE,
-  display: 'grid',
-  gridTemplateRows: '1fr auto',
-  alignItems: 'center',
-  height: 'calc(100vh - var(--header-height))',
-  paddingBlock: theme.space.md,
-
-  [mq.lg]: {
-    '--header-height': HEADER_HEIGHT_DESKTOP,
-    paddingBlock: theme.space.xl,
-  },
-})
-
-const UppercaseTextField = styled(TextField)({
-  textTransform: 'uppercase',
-})

--- a/apps/store/src/components/ShopBreakdown/AddCampaignForm/AddCampaignForm.css.ts
+++ b/apps/store/src/components/ShopBreakdown/AddCampaignForm/AddCampaignForm.css.ts
@@ -1,0 +1,8 @@
+import { style } from '@vanilla-extract/css'
+import { tokens } from 'ui'
+
+export const wrapper = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr minmax(33%, min-content)',
+  gap: tokens.space.xs,
+})

--- a/apps/store/src/components/ShopBreakdown/AddCampaignForm/AddCampaignForm.tsx
+++ b/apps/store/src/components/ShopBreakdown/AddCampaignForm/AddCampaignForm.tsx
@@ -1,8 +1,8 @@
-import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
 import type { FormEventHandler } from 'react'
-import { Button, theme } from 'ui'
+import { Button } from 'ui'
 import { TextField } from '@/components/TextField/TextField'
+import { wrapper } from './AddCampaignForm.css'
 
 const FORM_CAMPAIGN_CODE = 'campaignCode'
 
@@ -26,27 +26,20 @@ export const AddCampaignForm = (props: Props) => {
 
   return (
     <form onSubmit={handleSubmit}>
-      <Wrapper>
-        <UppercaseTextField
+      <div className={wrapper}>
+        <TextField
           name={FORM_CAMPAIGN_CODE}
           label={t('CAMPAIGN_CODE_INPUT_LABEL')}
           size="small"
           warning={!!props.errorMessage}
           message={props.errorMessage}
           required={true}
+          upperCaseInput={true}
         />
         <Button type="submit" variant="primary-alt" loading={props.loading} fullWidth={true}>
           {t('CHECKOUT_ADD_DISCOUNT_BUTTON')}
         </Button>
-      </Wrapper>
+      </div>
     </form>
   )
 }
-
-const Wrapper = styled.div({
-  display: 'grid',
-  gridTemplateColumns: '1fr minmax(33%, min-content)',
-  gap: theme.space.xs,
-})
-
-const UppercaseTextField = styled(TextField)({ textTransform: 'uppercase' })

--- a/apps/store/src/components/ShopBreakdown/DiscountField.tsx
+++ b/apps/store/src/components/ShopBreakdown/DiscountField.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { Text, theme } from 'ui'
 import Collapsible from '@/components/Collapsible/Collapsible'
 import { Switch } from '@/components/Switch'
-import { AddCampaignForm } from './AddCampaignForm'
+import { AddCampaignForm } from './AddCampaignForm/AddCampaignForm'
 import { AddedCampaignForm } from './AddedCampaignForm'
 
 type Props = {

--- a/apps/store/src/components/TextField/TextField.css.ts
+++ b/apps/store/src/components/TextField/TextField.css.ts
@@ -131,6 +131,10 @@ export const baseInput = style({
   },
 })
 
+export const upperCaseInputStyle = style({
+  textTransform: 'uppercase',
+})
+
 export const input = styleVariants({
   small: [baseInput, { fontSize: tokens.fontSizes.lg }],
   large: [baseInput, { fontSize: tokens.fontSizes.xl }],

--- a/apps/store/src/components/TextField/TextField.tsx
+++ b/apps/store/src/components/TextField/TextField.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import clsx from 'clsx'
 import type { ChangeEventHandler, InputHTMLAttributes, MouseEventHandler } from 'react'
 import { useId, useRef, useState } from 'react'
 import { sprinkles } from 'ui/src/theme/sprinkles.css'
@@ -11,6 +12,7 @@ import {
   inputLabel,
   inputWrapper,
   messageWithIcon,
+  upperCaseInputStyle,
   wrapper,
 } from './TextField.css'
 
@@ -27,6 +29,7 @@ export type Props = BaseInputProps & {
   message?: string
   onValueChange?: (value: string) => void
   onClear?: () => void
+  upperCaseInput?: boolean
 }
 
 export const TextField = (props: Props) => {
@@ -41,6 +44,7 @@ export const TextField = (props: Props) => {
     id,
     onValueChange,
     onClear,
+    upperCaseInput,
     ...inputProps
   } = props
   const [value, setValue] = useState(defaultValue || '')
@@ -87,7 +91,7 @@ export const TextField = (props: Props) => {
         </label>
         <div className={inputWrapper[size]}>
           <input
-            className={input[size]}
+            className={clsx(input[size], upperCaseInput && upperCaseInputStyle)}
             {...inputProps}
             id={identifier}
             ref={inputRef}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Refactor from emotion and added a uppercase prop to target input to make it more explicit. Previously the css was added on TextFIeld but then applied to the input element which was less obvious.

### Before
<img width="711" alt="Screenshot 2024-06-25 at 15 56 56" src="https://github.com/HedvigInsurance/racoon/assets/6661511/d8a5cecf-7fc4-4df2-9068-85bccd9e6610">

### After
<img width="612" alt="Screenshot 2024-06-25 at 16 31 35" src="https://github.com/HedvigInsurance/racoon/assets/6661511/57c0a192-86af-4a15-a054-205bf59bd0c6">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
