### PR TITLE
Add separate context for shopSessionId

### DIFF
--- a/apps/store/src/appComponents/providers/ShopSessionTrackingProvider.tsx
+++ b/apps/store/src/appComponents/providers/ShopSessionTrackingProvider.tsx
@@ -1,10 +1,10 @@
 'use client'
 import { type ReactNode } from 'react'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
 
 type Props = { children: ReactNode }
 export const ShopSessionTrackingProvider = ({ children }: Props) => {
-  const { shopSession } = useShopSession()
-  return <TrackingProvider shopSession={shopSession}>{children}</TrackingProvider>
+  const shopSessionId = useShopSessionId()
+  return <TrackingProvider shopSessionId={shopSessionId}>{children}</TrackingProvider>
 }

--- a/apps/store/src/components/BankIdDialog/BankIdDialog.tsx
+++ b/apps/store/src/components/BankIdDialog/BankIdDialog.tsx
@@ -23,7 +23,7 @@ import type { BankIdOperation } from '@/services/bankId/bankId.types'
 import { BankIdState } from '@/services/bankId/bankId.types'
 import { bankIdLogger } from '@/services/bankId/bankId.utils'
 import { useBankIdContext } from '@/services/bankId/BankIdContext'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { wait } from '@/utils/wait'
 import {
   qrCode,
@@ -37,7 +37,7 @@ import {
 
 export function BankIdDialog() {
   const { t } = useTranslation('bankid')
-  const { shopSession } = useShopSession()
+  const shopSessionId = useShopSessionId()
   const { startLogin, cancelLogin, cancelCheckoutSign, currentOperation } = useBankIdContext()
 
   useTriggerBankIdOnSameDevice(currentOperation)
@@ -52,7 +52,7 @@ export function BankIdDialog() {
       cancelCurrentOperation()
 
       const logPrefix = currentOperation.type === 'login' ? 'Login' : 'Sign'
-      const logMessageContext = shopSession ? { shopSessionId: shopSession.id } : undefined
+      const logMessageContext = shopSessionId ? { shopSessionId } : undefined
       bankIdLogger.info(`${logPrefix} | Operation cancelled`, logMessageContext)
     }
   }

--- a/apps/store/src/components/CartPage/PageDebugDialog.tsx
+++ b/apps/store/src/components/CartPage/PageDebugDialog.tsx
@@ -6,7 +6,7 @@ import { CopyToClipboard } from '@/components/DebugDialog/CopyToClipboard'
 import { DebugDialog } from '@/components/DebugDialog/DebugDialog'
 import { DebugShopSessionSection } from '@/components/DebugDialog/DebugShopSessionSection'
 import { DebugTextKeys } from '@/components/DebugDialog/DebugTextKeys'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useShopSession, useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 
@@ -40,16 +40,16 @@ const LinkToCartSection = () => {
 }
 
 const LinkToRetargetingSection = () => {
-  const { shopSession } = useShopSession()
+  const shopSessionId = useShopSessionId()
   const locale = useRoutingLocale()
   const retargetingLink = useMemo(() => {
-    if (!shopSession) return null
+    if (shopSessionId == null) return null
 
     return PageLink.retargeting({
       locale,
-      shopSessionId: shopSession.id,
+      shopSessionId,
     }).toString()
-  }, [shopSession, locale])
+  }, [shopSessionId, locale])
 
   return <CopyToClipboard label="Copy re-targeting link">{retargetingLink ?? ''}</CopyToClipboard>
 }

--- a/apps/store/src/components/DebugDialog/DebugResumeSessionSection.tsx
+++ b/apps/store/src/components/DebugDialog/DebugResumeSessionSection.tsx
@@ -2,18 +2,14 @@ import styled from '@emotion/styled'
 import { usePathname } from 'next/navigation'
 import { Button, theme } from 'ui'
 import { TextField } from '@/components/TextField/TextField'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 
 const INPUT_NAME = 'shopSessionId'
 
 export function DebugResumeSessionSection() {
-  const { shopSession } = useShopSession()
   const pathname = usePathname()
   const locale = useRoutingLocale()
-
-  if (!shopSession) return null
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()

--- a/apps/store/src/components/DebugDialog/DebugShopSessionSection.tsx
+++ b/apps/store/src/components/DebugDialog/DebugShopSessionSection.tsx
@@ -1,19 +1,19 @@
 import { usePathname } from 'next/navigation'
 import { Button, Space } from 'ui'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { PageLink } from '@/utils/PageLink'
 import { CopyToClipboard } from './CopyToClipboard'
 import { DebugResumeSessionSection } from './DebugResumeSessionSection'
 
 export const DebugShopSessionSection = () => {
-  const { shopSession } = useShopSession()
+  const shopSessionId = useShopSessionId()
   const pathname = usePathname()
 
-  if (!shopSession || !pathname) return null
+  if (!shopSessionId || !pathname) return null
 
   return (
     <Space y={0.25}>
-      <CopyToClipboard label="Shop Session">{shopSession.id}</CopyToClipboard>
+      <CopyToClipboard label="Shop Session">{shopSessionId}</CopyToClipboard>
 
       <Button
         as="a"

--- a/apps/store/src/components/ForeverPage/ForeverPage.tsx
+++ b/apps/store/src/components/ForeverPage/ForeverPage.tsx
@@ -6,7 +6,7 @@ import { Button, Space } from 'ui'
 import * as GridLayout from '@/components/GridLayout/GridLayout'
 import { TextField } from '@/components/TextField/TextField'
 import { TextWithLink } from '@/components/TextWithLink'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { useRedeemCampaign } from '@/utils/useCampaign'
@@ -22,11 +22,11 @@ export const ForeverPage = ({ code: initialCode }: Props) => {
   const [code, setCode] = useState('')
   usePrintTextEffect({ value: initialCode, onValueChange: setCode })
 
-  const { shopSession } = useShopSession()
+  const shopSessionId = useShopSessionId()
   const locale = useRoutingLocale()
   const redirectUrl = PageLink.store({ locale })
   const [addCampaign, { errorMessage, loading, called }] = useRedeemCampaign({
-    shopSessionId: shopSession?.id ?? '',
+    shopSessionId: shopSessionId ?? '',
     onCompleted() {
       router.push(redirectUrl)
     },

--- a/apps/store/src/components/ProductPage/PriceIntentTrackingProvider.tsx
+++ b/apps/store/src/components/ProductPage/PriceIntentTrackingProvider.tsx
@@ -1,16 +1,20 @@
 'use client'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { usePriceIntent } from '@/components/ProductPage/PriceIntentContext'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
 
 export const PriceIntentTrackingProvider = (props: { children: React.ReactNode }) => {
-  const { shopSession } = useShopSession()
+  const shopSessionId = useShopSessionId()
   const [priceIntent] = usePriceIntent()
   const productData = useProductData()
 
   return (
-    <TrackingProvider shopSession={shopSession} priceIntent={priceIntent} productData={productData}>
+    <TrackingProvider
+      shopSessionId={shopSessionId}
+      priceIntent={priceIntent}
+      productData={productData}
+    >
       {props.children}
     </TrackingProvider>
   )

--- a/apps/store/src/components/ProductPage/ProductPageDebugDialog.tsx
+++ b/apps/store/src/components/ProductPage/ProductPageDebugDialog.tsx
@@ -6,7 +6,7 @@ import { CopyToClipboard } from '@/components/DebugDialog/CopyToClipboard'
 import { DebugDialog } from '@/components/DebugDialog/DebugDialog'
 import { DebugShopSessionSection } from '@/components/DebugDialog/DebugShopSessionSection'
 import { DebugTextKeys } from '@/components/DebugDialog/DebugTextKeys'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { usePriceIntent } from './PriceIntentContext'
@@ -25,18 +25,18 @@ export function ProductPageDebugDialog() {
 
 function LinkToOfferSection() {
   const locale = useRoutingLocale()
-  const { shopSession } = useShopSession()
+  const shopSessionId = useShopSessionId()
   const [priceIntent] = usePriceIntent()
 
   const link = useMemo(() => {
-    if (!(shopSession && priceIntent)) return null
+    if (!(shopSessionId && priceIntent)) return null
 
     return PageLink.session({
       locale,
-      shopSessionId: shopSession.id,
+      shopSessionId,
       priceIntentId: priceIntent.id,
     }).toString()
-  }, [locale, shopSession, priceIntent])
+  }, [locale, shopSessionId, priceIntent])
 
   return <CopyToClipboard label="Share link to offer">{link ?? ''}</CopyToClipboard>
 }

--- a/apps/store/src/components/ProductPage/ProductPageViewTrack.tsx
+++ b/apps/store/src/components/ProductPage/ProductPageViewTrack.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect } from 'react'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { useTracking } from '@/services/Tracking/useTracking'
 
 // Optimization - since tracking depends on shopSession,
@@ -10,12 +10,12 @@ export const ProductPageViewTracker = () => {
   // TODO: Provide some tracking API to use with router.ready to check if current page
   //  is the first during window lifetime -> then replace effect with event subscriptions
   const { id, displayNameFull } = useProductData()
-  const { shopSession } = useShopSession()
+  const shopSessionId = useShopSessionId()
   const tracking = useTracking()
   useEffect(() => {
-    if (shopSession?.id != null) {
+    if (shopSessionId != null) {
       tracking.reportViewProductPage({ id, displayNameFull })
     }
-  }, [tracking, id, displayNameFull, shopSession?.id])
+  }, [tracking, id, displayNameFull, shopSessionId])
   return null
 }

--- a/apps/store/src/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam.ts
@@ -1,6 +1,6 @@
 import { useSearchParams } from 'next/navigation'
 import { useEffect, useRef } from 'react'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 
 export const OPEN_PRICE_CALCULATOR_QUERY_PARAM = 'openPriceCalculator'
 
@@ -11,17 +11,17 @@ type Params = {
 export const useOpenPriceCalculatorQueryParam = ({ onQueryParamDetected }: Params) => {
   const triggeredRef = useRef(false)
   const isPriceCalculatorExpanded = useIsPriceCalculatorExpanded()
-  const { shopSession } = useShopSession()
+  const shopSessionId = useShopSessionId()
 
   useEffect(() => {
-    if (isPriceCalculatorExpanded && shopSession?.id && !triggeredRef.current) {
+    if (isPriceCalculatorExpanded && shopSessionId != null && !triggeredRef.current) {
       // Guards against repeated triggers in case any other query param changes
       // GOTCHA: We've tried removing query param via shallow router.replace, but it triggers some weird
       // window.location change, and this problem only ever happens in production
       triggeredRef.current = true
       onQueryParamDetected()
     }
-  }, [onQueryParamDetected, isPriceCalculatorExpanded, shopSession?.id])
+  }, [onQueryParamDetected, isPriceCalculatorExpanded, shopSessionId])
 }
 
 export const useIsPriceCalculatorExpanded = () => {

--- a/apps/store/src/components/QuickAdd/useBonusOffer.ts
+++ b/apps/store/src/components/QuickAdd/useBonusOffer.ts
@@ -5,7 +5,7 @@ import {
   type ProductRecommendationsQuery,
   useProductRecommendationsQuery,
 } from '@/services/graphql/generated'
-import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 
 type OfferRecommendation = {
   offer: OfferRecommendationFragment
@@ -13,13 +13,13 @@ type OfferRecommendation = {
 }
 
 export const useBonusOffer = (customShopSessionId?: string): OfferRecommendation | null => {
-  const { shopSession } = useShopSession()
-  const shopSessionId = customShopSessionId ?? shopSession?.id
+  const currentShopSessionId = useShopSessionId()
+  const shopSessionId = customShopSessionId ?? currentShopSessionId
 
   const result = useProductRecommendationsQuery({
     fetchPolicy: 'cache-and-network',
     variables: shopSessionId ? { shopSessionId } : undefined,
-    skip: !shopSessionId,
+    skip: shopSessionId == null,
     onCompleted(data) {
       const offerRecommendations = getOfferRecommendations(data)
       if (offerRecommendations.length > 1) {

--- a/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
+++ b/apps/store/src/features/manyPets/ManyPetsMigrationPage/ManyPetsMigrationPage.tsx
@@ -83,7 +83,7 @@ export const ManyPetsMigrationPage = ({
   )
 
   return (
-    <TrackingProvider shopSession={migrationSessionQueryResult.data?.shopSession}>
+    <TrackingProvider shopSessionId={migrationSessionId}>
       {announcement}
       <main>
         {preOfferContent}

--- a/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/calculate-price.tsx
+++ b/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/calculate-price.tsx
@@ -99,7 +99,11 @@ const Page = ({ partner, ...rest }: Props) => {
       <Head>
         <title>{`Hedvig | ${t('CALCULATE_PRICE_PAGE_TITLE')}`}</title>
       </Head>
-      <TrackingProvider shopSession={shopSession} priceIntent={priceIntent} partner={partner}>
+      <TrackingProvider
+        shopSessionId={rest.shopSessionId}
+        priceIntent={priceIntent}
+        partner={partner}
+      >
         <CalculatePricePage {...rest} shopSession={shopSession} priceIntent={priceIntent} />
       </TrackingProvider>
     </>

--- a/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
+++ b/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
@@ -49,7 +49,7 @@ const NextWidgetSignPage = (props: Props) => {
         selectedTypeOfContract={props.initialSelectedTypeOfContract}
       >
         <TrackingProvider
-          shopSession={shopSession}
+          shopSessionId={props.shopSessionId}
           productData={props.productData}
           partner={props.partner}
         >

--- a/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/switch.tsx
+++ b/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/switch.tsx
@@ -86,7 +86,7 @@ const Page = (props: Props) => {
       <Head>
         <title>{`Hedvig | ${t('CALCULATE_PRICE_PAGE_TITLE')}`}</title>
       </Head>
-      <TrackingProvider shopSession={shopSession} priceIntent={priceIntent}>
+      <TrackingProvider shopSessionId={props.shopSessionId} priceIntent={priceIntent}>
         <SwitchPage {...props} shopSession={shopSession} priceIntent={priceIntent} />
       </TrackingProvider>
     </>

--- a/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/select.tsx
+++ b/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/select.tsx
@@ -12,7 +12,6 @@ import { SelectProductPage } from '@/features/widget/SelectProductPage'
 import { createPriceIntent, getWidgetPriceTemplate } from '@/features/widget/widget.helpers'
 import { initializeApolloServerSide } from '@/services/apollo/client'
 import { hideChatOnPage } from '@/services/CustomerFirst'
-import { useShopSessionQuery } from '@/services/graphql/generated'
 import type { Template } from '@/services/PriceCalculator/PriceCalculator.types'
 import { priceIntentServiceInitServerSide } from '@/services/priceIntent/PriceIntentService'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
@@ -107,14 +106,13 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
 
 const NextPage = ({ partner, ...rest }: Props) => {
   const { t } = useTranslation('widget')
-  const { data } = useShopSessionQuery({ variables: { shopSessionId: rest.shopSessionId } })
 
   return (
     <>
       <Head>
         <title>{`Hedvig | ${t('SELECT_PAGE_TITLE')}`}</title>
       </Head>
-      <TrackingProvider shopSession={data?.shopSession} partner={partner}>
+      <TrackingProvider shopSessionId={rest.shopSessionId} partner={partner}>
         <SelectProductPage {...rest} />
       </TrackingProvider>
     </>

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -24,7 +24,7 @@ import { useInitDatadogAfterInteractive } from '@/services/logger/client'
 import { PageTransitionProgressBar } from '@/services/nprogress/pageTransition'
 import { OneTrustStyles } from '@/services/OneTrust'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
-import { ShopSessionProvider, useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { ShopSessionProvider, useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { initStoryblok } from '@/services/storyblok/storyblok'
 import { Tracking } from '@/services/Tracking/Tracking'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
@@ -129,8 +129,8 @@ const ShopSessionTrackingProvider = (props: { children: ReactNode }) => {
   // Outermost component where we have tracking + shopSession
   useReportDeviceInfo()
 
-  const { shopSession } = useShopSession()
-  return <TrackingProvider shopSession={shopSession}>{props.children}</TrackingProvider>
+  const shopSessionId = useShopSessionId()
+  return <TrackingProvider shopSessionId={shopSessionId}>{props.children}</TrackingProvider>
 }
 
 export default appWithTranslation(MyApp)

--- a/apps/store/src/services/Tracking/TrackingContext.tsx
+++ b/apps/store/src/services/Tracking/TrackingContext.tsx
@@ -2,7 +2,6 @@
 import { type ReactNode, createContext, useMemo } from 'react'
 import { type ProductData } from '@/components/ProductData/ProductData.types'
 import { type PriceIntent } from '@/services/priceIntent/priceIntent.types'
-import { type ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useCurrentCountry } from '@/utils/l10n/useCurrentCountry'
 import { type Tracking } from './Tracking'
 
@@ -10,32 +9,32 @@ export const TrackingContext = createContext<Tracking['context']>({})
 
 type Props = {
   children: ReactNode
-  shopSession?: ShopSession
+  shopSessionId?: string | null
   priceIntent?: PriceIntent
   productData?: ProductData
   partner?: string
 }
 
-export const TrackingProvider = (props: Props) => {
+export const TrackingProvider = ({
+  children,
+  partner,
+  shopSessionId,
+  productData,
+  priceIntent,
+}: Props) => {
   const { countryCode } = useCurrentCountry()
 
   const data = useMemo<Tracking['context']>(() => {
     return {
-      shopSessionId: props.shopSession?.id,
-      ...parsePriceIntentData(props.priceIntent?.data ?? {}),
-      ...(props.productData && parseProductData(props.productData)),
-      partner: props.partner,
+      shopSessionId: shopSessionId ?? undefined,
+      ...parsePriceIntentData(priceIntent?.data ?? {}),
+      ...(productData && parseProductData(productData)),
+      partner,
       countryCode,
     }
-  }, [
-    props.shopSession?.id,
-    props.priceIntent?.data,
-    props.productData,
-    props.partner,
-    countryCode,
-  ])
+  }, [shopSessionId, priceIntent?.data, productData, partner, countryCode])
 
-  return <TrackingContext.Provider value={data}>{props.children}</TrackingContext.Provider>
+  return <TrackingContext.Provider value={data}>{children}</TrackingContext.Provider>
 }
 
 const parsePriceIntentData = (data: Record<string, unknown>): Tracking['context'] => {

--- a/apps/store/src/services/shopSession/ShopSessionContext.tsx
+++ b/apps/store/src/services/shopSession/ShopSessionContext.tsx
@@ -24,7 +24,13 @@ type Props = PropsWithChildren<{ shopSessionId?: string }>
 
 export const ShopSessionProvider = ({ children, shopSessionId: initialShopSessionId }: Props) => {
   const contextValue = useShopSessionContextValue(initialShopSessionId)
-  return <ShopSessionContext.Provider value={contextValue}>{children}</ShopSessionContext.Provider>
+  return (
+    <ShopSessionContext.Provider value={contextValue}>
+      <ShopSessionIdContext.Provider value={contextValue.shopSession?.id ?? null}>
+        {children}
+      </ShopSessionIdContext.Provider>
+    </ShopSessionContext.Provider>
+  )
 }
 
 export const useShopSession = (): ShopSessionResult => {
@@ -106,4 +112,12 @@ const useShopSessionContextValue = (initialShopSessionId?: string) => {
   queryResult.shopSession = shopSession?.countryCode === countryCode ? shopSession : undefined
 
   return queryResult
+}
+
+// Optimization: single-field context that allows consuming just sessionId
+// Unlike full ShopSessionContext, almost never triggers rerender since ID rarely changes
+export const ShopSessionIdContext = createContext<string | null>(null)
+
+export const useShopSessionId = (): string | null => {
+  return useContext(ShopSessionIdContext)
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Allow to consume just `shopSessionId` via separate context

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Step towards refactoring Purchase Form state management
- New hook makes code more readable
- Less re-rendering for components who just need an ID. Before they re-rendered when, for example, cart items changed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
