### PR TITLE
GEN-2382 - feat: added support for content structured data

### DIFF
--- a/apps/store/src/app/[locale]/[[...slug]]/ContentCmsPage.tsx
+++ b/apps/store/src/app/[locale]/[[...slug]]/ContentCmsPage.tsx
@@ -1,0 +1,22 @@
+import { StoryblokStory } from '@storyblok/react/rsc'
+import { storyblokBridgeOptions } from '@/appComponents/storyblokBridgeOptions'
+import { type PageStory } from '@/services/storyblok/storyblok'
+import { type RoutingLocale } from '@/utils/l10n/types'
+import { BlogStoryContainer } from './BlogStoryContainer'
+import { ContentTypeStructuredData } from './ContentTypeStructuredData'
+
+type Props = {
+  locale: RoutingLocale
+  story: PageStory
+}
+
+export function ContentCmsPage({ locale, story }: Props) {
+  return (
+    <>
+      <BlogStoryContainer locale={locale} story={story}>
+        <StoryblokStory story={story} bridgeOptions={storyblokBridgeOptions} />
+      </BlogStoryContainer>
+      <ContentTypeStructuredData story={story} />
+    </>
+  )
+}

--- a/apps/store/src/app/[locale]/[[...slug]]/ContentTypeStructuredData.tsx
+++ b/apps/store/src/app/[locale]/[[...slug]]/ContentTypeStructuredData.tsx
@@ -1,0 +1,82 @@
+import { formatISO } from 'date-fns'
+import { type PageStory } from '@/services/storyblok/storyblok'
+
+export function ContentTypeStructuredData({ story }: { story: PageStory }) {
+  const { type } = story.content
+
+  if (!type) return null
+
+  // Just being extra careful here and covering the case where we get a uncodversed type
+  // for whatever reason.
+  switch (type) {
+    case 'Article':
+    case 'NewsArticle':
+    case 'BlogPosting':
+      return <ArticleStructuredData story={story} />
+    case 'ProfilePage':
+      return <ProfilePageStructuredData story={story} />
+    default:
+      console.log('Stuctured data: Unsupported content type:', type)
+      return null
+  }
+}
+
+function ArticleStructuredData({ story }: { story: PageStory }) {
+  const { type, image, headline, datePublished, dateModified, authorType, authorName, authorLink } =
+    story.content
+
+  return (
+    <script
+      key="article-structured-data"
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': type,
+          ...(headline && { headline }),
+          ...(image && { image: image.filename }),
+          ...(datePublished && { datePublished: formatDate(datePublished) }),
+          ...(dateModified && { dateModified: formatDate(dateModified) }),
+          ...(authorType && {
+            author: { '@type': authorType, name: authorName, url: authorLink?.url },
+          }),
+        }),
+      }}
+    />
+  )
+}
+
+function ProfilePageStructuredData({ story }: { story: PageStory }) {
+  const { image, datePublished, dateModified, authorName } = story.content
+
+  const mainEntity =
+    authorName || image
+      ? {
+          '@type': 'Person',
+          name: authorName,
+          image: image?.filename,
+        }
+      : undefined
+
+  return (
+    <script
+      key="article-structured-data"
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'ProfilePage',
+          ...(datePublished && { dateCreated: formatDate(datePublished) }),
+          ...(dateModified && { dateModified: formatDate(dateModified) }),
+          mainEntity,
+        }),
+      }}
+    />
+  )
+}
+
+function formatDate(date: string) {
+  // Storyblok return dates in a yyyy-mm-dd hh:00 GMT+0 format.
+  // Google expect them in ISO 8601 format.
+  return formatISO(new Date(date))
+}

--- a/apps/store/src/app/[locale]/[[...slug]]/page.tsx
+++ b/apps/store/src/app/[locale]/[[...slug]]/page.tsx
@@ -1,9 +1,7 @@
-import { StoryblokStory } from '@storyblok/react/rsc'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import type { ReactNode } from 'react'
 import { cache } from 'react'
-import { storyblokBridgeOptions } from '@/appComponents/storyblokBridgeOptions'
 import { ContactUs } from '@/components/ContactUs/ContactUs'
 import { DefaultDebugDialog } from '@/components/DebugDialog/DefaultDebugDialog'
 import { CustomerFirstScript } from '@/services/CustomerFirst'
@@ -21,7 +19,7 @@ import {
 } from '@/utils/l10n/localeUtils'
 import type { IsoLocale, RoutingLocale } from '@/utils/l10n/types'
 import { removeTrailingSlash } from '@/utils/PageLink'
-import { BlogStoryContainer } from './BlogStoryContainer'
+import { ContentCmsPage } from './ContentCmsPage'
 import { ProductCmsPage } from './ProductCmsPage'
 import { StoryBreadcrumbs } from './StoryBreadcrumbs'
 
@@ -49,9 +47,7 @@ export default async function CmsPage(props: Props) {
   }
   return (
     <>
-      <BlogStoryContainer locale={props.params.locale} story={story}>
-        <StoryblokStory story={story} bridgeOptions={storyblokBridgeOptions} />
-      </BlogStoryContainer>
+      <ContentCmsPage locale={props.params.locale} story={story} />
       {!hideBreadcrumbs && <StoryBreadcrumbs params={props.params} currentPageTitle={story.name} />}
       {chat}
       <DefaultDebugDialog />

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -98,6 +98,14 @@ export type SEOData = {
   seoMetaOgImage?: StoryblokAsset
   abTestOrigin?: PageStory
   canonicalUrl?: string
+  type?: 'Article' | 'NewsArticle' | 'BlogPosting' | 'ProfilePage'
+  image?: StoryblokAsset
+  headline?: string
+  datePublished?: string
+  dateModified?: string
+  authorType?: 'Person' | 'Organization'
+  authorName?: string
+  authorLink?: LinkField
 }
 
 export type PageStory = ISbStoryData<


### PR DESCRIPTION
## Describe your changes

* Added support for content structured data (Article, NewsArticle, BlogPosting and ProfilePage).

<img width="352" alt="image" src="https://github.com/HedvigInsurance/racoon/assets/19200662/770b27aa-b5b4-4a21-8c84-cdeb8853514e">

## Justify why they are needed

Requested by Peter