### PR TITLE
fix: add campaign code button was too wide

### DIFF
--- a/apps/store/src/components/ShopBreakdown/AddCampaignForm/AddCampaignForm.css.ts
+++ b/apps/store/src/components/ShopBreakdown/AddCampaignForm/AddCampaignForm.css.ts
@@ -6,3 +6,7 @@ export const wrapper = style({
   gridTemplateColumns: '1fr minmax(33%, min-content)',
   gap: tokens.space.xs,
 })
+
+export const button = style({
+  minWidth: 'auto',
+})

--- a/apps/store/src/components/ShopBreakdown/AddCampaignForm/AddCampaignForm.tsx
+++ b/apps/store/src/components/ShopBreakdown/AddCampaignForm/AddCampaignForm.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'next-i18next'
 import type { FormEventHandler } from 'react'
 import { Button } from 'ui'
 import { TextField } from '@/components/TextField/TextField'
-import { wrapper } from './AddCampaignForm.css'
+import { button, wrapper } from './AddCampaignForm.css'
 
 const FORM_CAMPAIGN_CODE = 'campaignCode'
 
@@ -36,7 +36,7 @@ export const AddCampaignForm = (props: Props) => {
           required={true}
           upperCaseInput={true}
         />
-        <Button type="submit" variant="primary-alt" loading={props.loading} fullWidth={true}>
+        <Button className={button} type="submit" variant="primary-alt" loading={props.loading}>
           {t('CHECKOUT_ADD_DISCOUNT_BUTTON')}
         </Button>
       </div>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
fix: add campaign code button was too wide

Need to talk with William and see how we want the large button to behave. We want a min-width on it when it's used on a page by itself but a few cases we us it inline and shouldn't have a min-width.

Will update the button large variant when we reach a conclusion 

### Before
![image (8)](https://github.com/HedvigInsurance/racoon/assets/6661511/e7024b66-9b2c-4966-bb83-32f60bd49a4f)

### After
<img width="656" alt="Screenshot 2024-06-27 at 10 28 28" src="https://github.com/HedvigInsurance/racoon/assets/6661511/3e2dea77-49e0-4f78-b498-c2a173b91e29">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
