### PR TITLE
Fix few accessibilty warnings from radix dialogs

### DIFF
--- a/apps/store/src/components/ChangeSsnWarningDialog/ChangeSsnWarningDialog.tsx
+++ b/apps/store/src/components/ChangeSsnWarningDialog/ChangeSsnWarningDialog.tsx
@@ -45,10 +45,12 @@ export const ChangeSsnWarningDialog = ({ open, onAccept, onDecline }: Props) => 
           </>
         }
       >
-        <Text className={title}>
-          <WarningTriangleIcon size="1em" color={theme.colors.amber600} />
-          {t('CHANGE_SSN_TITLE')}
-        </Text>
+        <FullscreenDialog.Title>
+          <Text className={title}>
+            <WarningTriangleIcon size="1em" color={theme.colors.amber600} />
+            {t('CHANGE_SSN_TITLE')}
+          </Text>
+        </FullscreenDialog.Title>
         <Text color="textSecondary" align="center">
           {t('CHANGE_SSN_DESCRIPTION')}
         </Text>

--- a/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
+++ b/apps/store/src/components/FullscreenDialog/FullscreenDialog.tsx
@@ -64,6 +64,7 @@ export function AnimateContentWrapper({ children }: { children: ReactNode }) {
 export const Root = Dialog.Root
 export const Close = Dialog.Close
 export const Trigger = Dialog.Trigger
+export const Title = Dialog.Title
 
 const ANIMATE_TRANSITION: Transition = {
   duration: 0.5,

--- a/apps/store/src/components/ProductPage/PurchaseForm/PriceCalculatorDialog.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PriceCalculatorDialog.tsx
@@ -35,7 +35,7 @@ export const PriceCalculatorDialog = ({ children, header, isOpen, toggleDialog }
   )
 }
 
-const HeaderWrapper = styled.div({
+const HeaderWrapper = styled(Dialog.Title)({
   paddingTop: theme.space.xxxl,
 })
 

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -24,6 +24,9 @@ export const Content = (props: ContentProps) => {
           className={props.className}
           onEscapeKeyDown={handleClose}
           onInteractOutside={(e) => e.preventDefault()}
+          // Prevents accessibility warning from radix
+          // Adding non-visible descriptions everywhere is not a priority right now
+          aria-describedby={undefined}
         >
           {props.children}
         </DialogPrimitive.Content>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix accessibility warnings from radix dialogs.  Looks like they came with recent update

- Add Dialog.Title to 2 dialogs. We should continue doing this in other places where we see this warning
- Export FullscreenDialog.Title to keep everything accessible via same component bag
- Explicitly state we're not providing dialog descriptions for screen readers

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Developer experience, remove warnings

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
