### PR TITLE
Fix regex warning on PersonalNumberField

### DIFF
--- a/apps/store/src/components/PersonalNumberField/PersonalNumberField.tsx
+++ b/apps/store/src/components/PersonalNumberField/PersonalNumberField.tsx
@@ -52,7 +52,7 @@ export const PersonalNumberField = memo((props: Props) => {
           minLength={10}
           maxLength={13}
           // https://github.com/personnummer/js
-          pattern="^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([+-]?)((?!000)\d{3})(\d)$"
+          pattern="^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([+\-]?)((?!000)\d{3})(\d)$"
           onValueChange={handleValueChange}
           onClear={onClear}
           warning={warning}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix annoying warning about regex in personal number field.  Turns out `[+-]` is valid way to match dash or plus in default regex, but becomes invalid in Unicode mode which is used by browser for pattern on inputs. The safe way is to always escape dash within character classes

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
