### PR TITLE
GEN-2405 - fix(update-translations): make sure action triggers CI workflow

### DIFF
--- a/.github/workflows/download-translations.yml
+++ b/.github/workflows/download-translations.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
+          # We can't rely on GITHUB_TOKEN here otherwise no other wofkflows will be triggered as a side effect of this one
+          token: ${{ secrets.UPDATE_TRANSLATIONS_TOKEN }}
           commit-message: |
             ci: update translations from Lokalise
           title: |


### PR DESCRIPTION
## Describe your changes

* Update `download-translations.yml` so PRs created by `peter-evans/create-pull-reques` proper trigger `ci.yml` workflow.

## Justify why they are needed

I've noticed CI GH action get stuck for PRs created by `download-translations.yml` workflow.

![image](https://github.com/HedvigInsurance/racoon/assets/19200662/a3ea6cc9-1a80-4df6-8332-c02400373e9a)

That's happening because events triggered by `GITHUB_TOKEN` will not trigger the creation of a new workflow, so even tho we have configured in our `ci.yml` workflow that it should run when a new PR is opened, that's not going to happen as a side effect of `download-translations.yml` execution. One workaround is to use a Personal Access Token instead of `GITHUB_TOKEN`. More info [here](GITHUB_TOKEN)

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.

[GitHub Actions: Triggering a workflow from a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)
