### PR TITLE
Extract parts of PriceCalculator state into jotai

### DIFF
--- a/apps/store/src/components/PriceCalculator/priceCalculatorAtoms.ts
+++ b/apps/store/src/components/PriceCalculator/priceCalculatorAtoms.ts
@@ -1,0 +1,113 @@
+import { datadogLogs } from '@datadog/browser-logs'
+import { type Atom, atom, type Getter, useAtomValue, useStore } from 'jotai'
+import { atomFamily } from 'jotai/utils'
+import { useEffect } from 'react'
+import { priceTemplateAtom } from '@/components/ProductPage/PurchaseForm/priceTemplateAtom'
+import {
+  type PriceIntentFragment,
+  type ShopSessionCustomerFragment,
+} from '@/services/graphql/generated'
+import { setupForm } from '@/services/PriceCalculator/PriceCalculator.helpers'
+import { type Form } from '@/services/PriceCalculator/PriceCalculator.types'
+import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+
+export const currentPriceIntentIdAtom = atom<string | null>(null)
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const priceIntentAtomFamily = atomFamily((priceIntentId: unknown) =>
+  atom<PriceIntentFragment | null>(null),
+)
+
+export const priceIntentAtom = atom<PriceIntentFragment>((get) => {
+  const priceIntentId = getAtomValueOrThrow(get, currentPriceIntentIdAtom)
+  return getAtomValueOrThrow(get, priceIntentAtomFamily(priceIntentId))
+})
+
+export const shopSessionCustomerAtom = atom<ShopSessionCustomerFragment | null>(null)
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const priceCalculatorFormAtom = atom<Form>((get) => {
+  const priceIntent = get(priceIntentAtom)
+  const template = getAtomValueOrThrow(get, priceTemplateAtom)
+  return setupForm({
+    customer: get(shopSessionCustomerAtom),
+    priceIntent,
+    template,
+  })
+})
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const activeFormSectionIdAtomFamily = atomFamily((priceIntentId: unknown) =>
+  atom<string | null>(null),
+)
+
+export const activeFormSectionIdAtom = atom(
+  (get) => {
+    const priceIntentId = getAtomValueOrThrow(get, currentPriceIntentIdAtom)
+    const activeSectionId = get(activeFormSectionIdAtomFamily(priceIntentId))
+    if (activeSectionId != null) {
+      return activeSectionId
+    }
+    const form = get(priceCalculatorFormAtom)
+    const firstIncompleteSection = form.sections.find(({ state }) => state !== 'valid')
+    if (firstIncompleteSection) {
+      return firstIncompleteSection.id
+    }
+    return form.sections[form.sections.length - 1].id
+  },
+  (get, set, newValue: string | typeof GOTO_NEXT_SECTION) => {
+    const priceIntentId = getAtomValueOrThrow(get, currentPriceIntentIdAtom)
+    if (newValue === GOTO_NEXT_SECTION) {
+      const oldValue = get(activeFormSectionIdAtom)
+      const form = get(priceCalculatorFormAtom)
+      const currentSectionIndex = form.sections.findIndex(({ id }) => id === oldValue)
+
+      // If section has both customer and priceIntent fields, we'll get two onSuccess callbacks
+      // in unknown order. Making sure we only go forward when section fields are all filled
+      if (form.sections[currentSectionIndex].state !== 'valid') {
+        return
+      }
+      const nextSection = form.sections[currentSectionIndex + 1]
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (nextSection) {
+        set(activeFormSectionIdAtomFamily(priceIntentId), nextSection.id)
+        return
+      } else {
+        const templateName = get(priceTemplateAtom)?.name
+        datadogLogs.logger.error('Failed to find next section', {
+          oldValue,
+          templateName,
+          priceIntentId,
+        })
+      }
+    } else {
+      set(activeFormSectionIdAtomFamily(priceIntentId), newValue)
+    }
+  },
+)
+export const GOTO_NEXT_SECTION = Symbol('GOTO_NEXT_SECTION')
+
+// TODO: Consider moving to utils
+const getAtomValueOrThrow = <T>(get: Getter, atom: Atom<T>): NonNullable<T> => {
+  const value = get(atom)
+  if (value == null) {
+    throw new Error(`${atom} must have value`)
+  }
+  return value
+}
+
+export const useSyncPriceCalculatorState = (priceIntent: PriceIntentFragment): void => {
+  const shopSessionCustomer = useShopSession().shopSession?.customer
+  const store = useStore()
+  useEffect(() => {
+    store.set(currentPriceIntentIdAtom, priceIntent.id)
+    store.set(priceIntentAtomFamily(priceIntent.id), priceIntent)
+  }, [priceIntent, store])
+  useEffect(() => {
+    store.set(shopSessionCustomerAtom, shopSessionCustomer ?? null)
+  }, [shopSessionCustomer, store])
+}
+
+export const useIsPriceCalculatorStateReady = (): boolean => {
+  return !!useAtomValue(currentPriceIntentIdAtom)
+}

--- a/apps/store/src/components/PriceCalculator/useHandleSubmitPriceCalculator.ts
+++ b/apps/store/src/components/PriceCalculator/useHandleSubmitPriceCalculator.ts
@@ -28,6 +28,7 @@ export const useHandleSubmitPriceCalculator = (params: Params) => {
       }
     },
     onError(error) {
+      window.console.log("Couldn't update price intent", error)
       datadogLogs.logger.error("Couldn't update price intent", {
         error,
         shopSessionId: params.shopSession.id,

--- a/apps/store/src/components/ProductPage/ProductPageContext.tsx
+++ b/apps/store/src/components/ProductPage/ProductPageContext.tsx
@@ -1,8 +1,7 @@
 'use client'
-import { useHydrateAtoms } from 'jotai/utils'
 import type { PropsWithChildren } from 'react'
 import { createContext, useContext, useMemo } from 'react'
-import { priceTemplateAtom } from '@/components/ProductPage/PurchaseForm/priceTemplateAtom'
+import { useSyncPriceTemplate } from '@/components/ProductPage/PurchaseForm/priceTemplateAtom'
 import { useProductData } from '../ProductData/ProductDataProvider'
 import type { ProductPageProps } from './ProductPage.types'
 
@@ -21,7 +20,7 @@ const ProductPageContext = createContext<ProductPageContextData | null>(null)
 type Props = PropsWithChildren<Pick<ProductPageProps, 'priceTemplate' | 'story'>>
 
 export const ProductPageContextProvider = ({ children, story, priceTemplate }: Props) => {
-  useHydrateAtoms([[priceTemplateAtom, priceTemplate]])
+  useSyncPriceTemplate(priceTemplate)
 
   const productData = useProductData()
   const contextValue = useMemo(

--- a/apps/store/src/components/ProductPage/PurchaseForm/priceTemplateAtom.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/priceTemplateAtom.ts
@@ -1,4 +1,6 @@
-import { atom, useAtomValue } from 'jotai'
+import { atom, useAtomValue, useSetAtom } from 'jotai'
+import { useHydrateAtoms } from 'jotai/utils'
+import { useEffect } from 'react'
 import { type Template } from '@/services/PriceCalculator/PriceCalculator.types'
 
 export const priceTemplateAtom = atom<Template | null>(null)
@@ -9,4 +11,12 @@ export const usePriceTemplate = () => {
     throw new Error('priceTemplateAtom must be set')
   }
   return value
+}
+
+export const useSyncPriceTemplate = (template: Template) => {
+  useHydrateAtoms([[priceTemplateAtom, template]])
+  const setTemplate = useSetAtom(priceTemplateAtom)
+  useEffect(() => {
+    setTemplate(template)
+  }, [setTemplate, template])
 }

--- a/apps/store/src/features/widget/CalculatePricePage.tsx
+++ b/apps/store/src/features/widget/CalculatePricePage.tsx
@@ -7,8 +7,13 @@ import { Heading, mq, Space, theme } from 'ui'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
 import * as GridLayout from '@/components/GridLayout/GridLayout'
 import { Pillow } from '@/components/Pillow/Pillow'
+import {
+  useIsPriceCalculatorStateReady,
+  useSyncPriceCalculatorState,
+} from '@/components/PriceCalculator/priceCalculatorAtoms'
 import { PriceCalculatorDynamic } from '@/components/PriceCalculator/PriceCalculatorDynamic'
 import { completePriceLoader, PriceLoader } from '@/components/PriceLoader'
+import { useSyncPriceTemplate } from '@/components/ProductPage/PurchaseForm/priceTemplateAtom'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { useAppErrorHandleContext } from '@/services/appErrors/AppErrorContext'
 import {
@@ -116,6 +121,14 @@ export const CalculatePricePage = (props: Props) => {
     priceLoaderPromise.current = completePriceLoader()
   }
 
+  useSyncPriceTemplate(props.priceTemplate)
+  useSyncPriceCalculatorState(props.priceIntent)
+
+  const isReady = useIsPriceCalculatorStateReady()
+  if (!isReady) {
+    return null
+  }
+
   return (
     <Wrapper y={3}>
       <Header step="YOUR_INFO" showBackButton={props.showBackButton} />
@@ -130,12 +143,7 @@ export const CalculatePricePage = (props: Props) => {
 
         <GridLayout.Root>
           <GridLayout.Content width="1/3" align="center">
-            <PriceCalculatorDynamic
-              shopSession={props.shopSession}
-              priceIntent={props.priceIntent}
-              priceTemplate={props.priceTemplate}
-              onConfirm={handleConfirm}
-            />
+            <PriceCalculatorDynamic onConfirm={handleConfirm} />
           </GridLayout.Content>
         </GridLayout.Root>
       </Space>

--- a/apps/store/src/services/shopSession/ShopSessionContext.tsx
+++ b/apps/store/src/services/shopSession/ShopSessionContext.tsx
@@ -19,6 +19,7 @@ type ShopSessionResult = ShopSessionQueryResult & {
 }
 
 export const ShopSessionContext = createContext<ShopSessionResult | null>(null)
+ShopSessionContext.displayName = 'ShopSessionContext'
 
 type Props = PropsWithChildren<{ shopSessionId?: string }>
 
@@ -117,6 +118,7 @@ const useShopSessionContextValue = (initialShopSessionId?: string) => {
 // Optimization: single-field context that allows consuming just sessionId
 // Unlike full ShopSessionContext, almost never triggers rerender since ID rarely changes
 export const ShopSessionIdContext = createContext<string | null>(null)
+ShopSessionIdContext.displayName = 'ShopSessionIdContext'
 
 export const useShopSessionId = (): string | null => {
   return useContext(ShopSessionIdContext)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Moved most of `PriceCalculator` global state into atoms
- Started using existing contexts for shopSession / shopSessionId instead of prod drilling
- Use atoms instead of prop-drilling in `PriceCalculatorAccordion`. Deeper components will have separate PR(s)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Part of purchase form state rework

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
