### PR TITLE
Separate priceTemplateAtom from ProductPageContext

### DIFF
--- a/apps/store/src/components/ProductPage/PriceIntentContext.tsx
+++ b/apps/store/src/components/ProductPage/PriceIntentContext.tsx
@@ -4,7 +4,7 @@ import { datadogLogs } from '@datadog/browser-logs'
 import { type PropsWithChildren, useRef } from 'react'
 import { createContext, useCallback, useContext, useEffect, useState } from 'react'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
-import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
+import { usePriceTemplate } from '@/components/ProductPage/PurchaseForm/priceTemplateAtom'
 import { useCartEntryToReplace } from '@/components/ProductPage/useCartEntryToReplace'
 import {
   type CartFragment,
@@ -34,7 +34,7 @@ export const PriceIntentContextProvider = ({ children }: Props) => {
 }
 
 const usePriceIntentContextValue = () => {
-  const { priceTemplate } = useProductPageContext()
+  const priceTemplate = usePriceTemplate()
   const productData = useProductData()
   const apolloClient = useApolloClient()
   const { onReady, shopSession } = useShopSession()

--- a/apps/store/src/components/ProductPage/ProductPageContext.tsx
+++ b/apps/store/src/components/ProductPage/ProductPageContext.tsx
@@ -1,10 +1,12 @@
 'use client'
+import { useHydrateAtoms } from 'jotai/utils'
 import type { PropsWithChildren } from 'react'
 import { createContext, useContext, useMemo } from 'react'
+import { priceTemplateAtom } from '@/components/ProductPage/PurchaseForm/priceTemplateAtom'
 import { useProductData } from '../ProductData/ProductDataProvider'
 import type { ProductPageProps } from './ProductPage.types'
 
-type ProductPageContextData = Pick<ProductPageProps, 'priceTemplate'> & {
+type ProductPageContextData = {
   content: {
     product: {
       name: string
@@ -19,10 +21,11 @@ const ProductPageContext = createContext<ProductPageContextData | null>(null)
 type Props = PropsWithChildren<Pick<ProductPageProps, 'priceTemplate' | 'story'>>
 
 export const ProductPageContextProvider = ({ children, story, priceTemplate }: Props) => {
+  useHydrateAtoms([[priceTemplateAtom, priceTemplate]])
+
   const productData = useProductData()
   const contextValue = useMemo(
     () => ({
-      priceTemplate,
       content: {
         product: {
           name: story.content.name || productData.displayNameShort,
@@ -31,7 +34,7 @@ export const ProductPageContextProvider = ({ children, story, priceTemplate }: P
         },
       },
     }),
-    [priceTemplate, productData, story.content],
+    [productData, story.content],
   )
   return <ProductPageContext.Provider value={contextValue}>{children}</ProductPageContext.Provider>
 }

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -24,6 +24,7 @@ import { PriceIntentTrackingProvider } from '@/components/ProductPage/PriceInten
 import { useProductPageContext } from '@/components/ProductPage/ProductPageContext'
 import { ProductPageDebugDialog } from '@/components/ProductPage/ProductPageDebugDialog'
 import { ProductPageViewTracker } from '@/components/ProductPage/ProductPageViewTrack'
+import { usePriceTemplate } from '@/components/ProductPage/PurchaseForm/priceTemplateAtom'
 import {
   purchaseFormHeroWrapper,
   purchaseFormPriceLoaderWrapper,
@@ -97,7 +98,7 @@ type PurchaseFormInnerProps = PurchaseFormProps & {
 }
 
 const PurchaseFormInner = (props: PurchaseFormInnerProps) => {
-  const { priceTemplate } = useProductPageContext()
+  const priceTemplate = usePriceTemplate()
   const productData = useProductData()
   const { shopSession } = useShopSession()
   const [priceIntent] = usePriceIntent()

--- a/apps/store/src/components/ProductPage/PurchaseForm/priceTemplateAtom.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/priceTemplateAtom.ts
@@ -1,0 +1,12 @@
+import { atom, useAtomValue } from 'jotai'
+import { type Template } from '@/services/PriceCalculator/PriceCalculator.types'
+
+export const priceTemplateAtom = atom<Template | null>(null)
+
+export const usePriceTemplate = () => {
+  const value = useAtomValue(priceTemplateAtom)
+  if (value == null) {
+    throw new Error('priceTemplateAtom must be set')
+  }
+  return value
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Subj.

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Small step in purchase form state management

In next PR we will want to have priceTemplate as atom in widget flow, where `ProductPageContext` makes no sense

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
