### PR TITLE
Extract PriceCalculator loading state into atom

### DIFF
--- a/apps/store/src/components/PriceCalculator/AutomaticField.tsx
+++ b/apps/store/src/components/PriceCalculator/AutomaticField.tsx
@@ -18,12 +18,11 @@ import { useTranslateFieldLabel } from './useTranslateFieldLabel'
 type Props = {
   field: InputFieldType
   onSubmit: (data: JSONData) => Promise<unknown>
-  loading: boolean
   autoFocus?: boolean
   priceIntent: PriceIntent
 }
 
-export const AutomaticField = ({ field, priceIntent, onSubmit, loading, autoFocus }: Props) => {
+export const AutomaticField = ({ field, priceIntent, onSubmit, autoFocus }: Props) => {
   const translateLabel = useTranslateFieldLabel()
 
   switch (field.type) {
@@ -134,7 +133,6 @@ export const AutomaticField = ({ field, priceIntent, onSubmit, loading, autoFocu
             name: buildingOption.label,
           }))}
           onSubmit={onSubmit}
-          loading={loading}
         />
       )
 
@@ -167,10 +165,10 @@ export const AutomaticField = ({ field, priceIntent, onSubmit, loading, autoFocu
       )
 
     case 'pet-cat-breeds':
-      return <PetCatBreedsField field={field} loading={loading} />
+      return <PetCatBreedsField field={field} />
 
     case 'pet-dog-breeds':
-      return <PetDogBreedsField field={field} loading={loading} />
+      return <PetDogBreedsField field={field} />
 
     default: {
       const badField: never = field

--- a/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
+++ b/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { useAtomValue } from 'jotai'
 import { useTranslation } from 'next-i18next'
 import type { FormEventHandler } from 'react'
 import { useState } from 'react'
@@ -14,6 +15,7 @@ import {
   CrossIconSmall,
 } from 'ui'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
+import { priceCalculatorLoadingAtom } from '@/components/PriceCalculator/priceCalculatorAtoms'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import { TextField } from '@/components/TextField/TextField'
 import type {
@@ -39,16 +41,15 @@ enum Field {
 type ExtraBuildingsFieldProps = {
   field: InputFieldExtraBuildings
   onSubmit: (data: JSONData) => Promise<unknown>
-  loading: boolean
   buildingOptions: Array<FieldOption>
 }
 
 export const ExtraBuildingsField = ({
   field,
   onSubmit,
-  loading,
   buildingOptions,
 }: ExtraBuildingsFieldProps) => {
+  const loading = useAtomValue(priceCalculatorLoadingAtom)
   const [isOpen, setIsOpen] = useState(false)
 
   const { t } = useTranslation('purchase-form')

--- a/apps/store/src/components/PriceCalculator/PetCatBreedsField.tsx
+++ b/apps/store/src/components/PriceCalculator/PetCatBreedsField.tsx
@@ -1,6 +1,8 @@
+import { useAtomValue } from 'jotai'
 import { useTranslation } from 'next-i18next'
 import { useMemo } from 'react'
 import { Combobox } from '@/components/Combobox/Combobox'
+import { priceCalculatorLoadingAtom } from '@/components/PriceCalculator/priceCalculatorAtoms'
 import { PriceIntentAnimal, usePriceIntentAvailableBreedsQuery } from '@/services/graphql/generated'
 import type {
   PetCatBreedsField as InputFieldPetBreed,
@@ -10,13 +12,13 @@ import { useTranslateFieldLabel } from './useTranslateFieldLabel'
 
 type Props = {
   field: InputFieldPetBreed
-  loading: boolean
 }
 
-export const PetCatBreedsField = ({ field, loading }: Props) => {
+export const PetCatBreedsField = ({ field }: Props) => {
   const translateLabel = useTranslateFieldLabel()
   const { t } = useTranslation('purchase-form')
   const { breeds } = usePetBreeds(PriceIntentAnimal.Cat)
+  const loading = useAtomValue(priceCalculatorLoadingAtom)
 
   let defaultSelectedBreed: Breed | null = null
   if (field.value) {

--- a/apps/store/src/components/PriceCalculator/PetDogBreedsField.tsx
+++ b/apps/store/src/components/PriceCalculator/PetDogBreedsField.tsx
@@ -1,8 +1,10 @@
 import { datadogLogs } from '@datadog/browser-logs'
+import { useAtomValue } from 'jotai'
 import { useTranslation } from 'next-i18next'
 import { useState, useMemo } from 'react'
 import { Space } from 'ui'
 import { Combobox } from '@/components/Combobox/Combobox'
+import { priceCalculatorLoadingAtom } from '@/components/PriceCalculator/priceCalculatorAtoms'
 import { PriceIntentAnimal, usePriceIntentAvailableBreedsQuery } from '@/services/graphql/generated'
 import type {
   PetDogBreedsField as InputFieldPetDogBreeds,
@@ -13,10 +15,10 @@ import { MixedBreedPicker } from './MixedBreedPicker/MixedBreedPicker'
 
 type Props = {
   field: InputFieldPetDogBreeds
-  loading: boolean
 }
 
-export const PetDogBreedsField = ({ field, loading }: Props) => {
+export const PetDogBreedsField = ({ field }: Props) => {
+  const loading = useAtomValue(priceCalculatorLoadingAtom)
   const [showMixedPicker, setShowMixedPicker] = useState(() => (field.value ?? []).length > 1)
   const { t } = useTranslation('purchase-form')
 

--- a/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
@@ -54,9 +54,7 @@ export const PriceCalculator = (props: Props) => {
 
   const showFetchInsurance = useShowFetchInsurance({ priceIntentId })
   const showPriceIntentWarning = useSetAtom(showPriceIntentWarningAtom)
-  const [handleSubmit, handleSubmitSection, isLoading] = useHandleSubmitPriceCalculator({
-    shopSession,
-    priceIntent,
+  const [handleSubmit, handleSubmitSection] = useHandleSubmitPriceCalculator({
     onSuccess({ priceIntent, customer }) {
       const form = setupForm({
         customer,
@@ -95,7 +93,6 @@ export const PriceCalculator = (props: Props) => {
           <PriceCalculatorSection
             section={section}
             onSubmit={handleSubmitSection}
-            loading={isLoading}
             last={sectionIndex === form.sections.length - 1}
           >
             <FormGrid items={section.items}>
@@ -103,7 +100,6 @@ export const PriceCalculator = (props: Props) => {
                 <AutomaticField
                   field={field}
                   onSubmit={handleSubmit}
-                  loading={isLoading}
                   priceIntent={priceIntent}
                   // We don't want to mess up focusing for the user by setting autoFocus on the
                   // first item in the form, since that would make it unintuitive to navigate our

--- a/apps/store/src/components/PriceCalculator/PriceCalculatorSection.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculatorSection.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled'
+import { useAtomValue } from 'jotai'
 import NextLink from 'next/link'
 import { useTranslation } from 'next-i18next'
 import { type FormEventHandler, type ReactNode } from 'react'
 import { Button, Space, Text } from 'ui'
+import { priceCalculatorLoadingAtom } from '@/components/PriceCalculator/priceCalculatorAtoms'
 import { linkStyles } from '@/components/RichText/RichText.styles'
 import { deserializeField } from '@/services/PriceCalculator/PriceCalculator.helpers'
 import { type FormSection, type JSONData } from '@/services/PriceCalculator/PriceCalculator.types'
@@ -12,16 +14,16 @@ import { useTranslateFieldLabel } from './useTranslateFieldLabel'
 
 type Props = {
   section: FormSection
-  loading: boolean
   onSubmit: (data: JSONData) => void
   last: boolean
   children: ReactNode
 }
 
-export const PriceCalculatorSection = ({ section, loading, onSubmit, last, children }: Props) => {
+export const PriceCalculatorSection = ({ section, onSubmit, last, children }: Props) => {
   const locale = useRoutingLocale()
   const { t } = useTranslation('purchase-form')
   const translateLabel = useTranslateFieldLabel()
+  const loading = useAtomValue(priceCalculatorLoadingAtom)
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault()
@@ -46,7 +48,7 @@ export const PriceCalculatorSection = ({ section, loading, onSubmit, last, child
         {children}
 
         <Space as="footer" y={0.25}>
-          <Button type="submit" disabled={loading} loading={loading} fullWidth={true}>
+          <Button type="submit" loading={loading} fullWidth={true}>
             {translateLabel(section.submitLabel)}
           </Button>
 

--- a/apps/store/src/components/PriceCalculator/priceCalculatorAtoms.ts
+++ b/apps/store/src/components/PriceCalculator/priceCalculatorAtoms.ts
@@ -111,3 +111,5 @@ export const useSyncPriceCalculatorState = (priceIntent: PriceIntentFragment): v
 export const useIsPriceCalculatorStateReady = (): boolean => {
   return !!useAtomValue(currentPriceIntentIdAtom)
 }
+
+export const priceCalculatorLoadingAtom = atom(false)

--- a/apps/store/src/components/PriceCalculator/useHandleSubmitPriceCalculator.ts
+++ b/apps/store/src/components/PriceCalculator/useHandleSubmitPriceCalculator.ts
@@ -1,85 +1,75 @@
 import { datadogLogs } from '@datadog/browser-logs'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { useTranslation } from 'next-i18next'
-import { startTransition, useCallback } from 'react'
+import { startTransition, useCallback, useEffect } from 'react'
+import {
+  currentPriceIntentIdAtom,
+  priceCalculatorLoadingAtom,
+} from '@/components/PriceCalculator/priceCalculatorAtoms'
 import { useAppErrorHandleContext } from '@/services/appErrors/AppErrorContext'
 import { usePriceIntentDataUpdateMutation } from '@/services/graphql/generated'
 import type { JSONData } from '@/services/PriceCalculator/PriceCalculator.types'
 import type { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import type { ShopSession } from '@/services/shopSession/ShopSession.types'
+import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 
 type Params = {
-  shopSession: ShopSession
-  priceIntent: PriceIntent
   onSuccess: (values: { priceIntent: PriceIntent; customer: ShopSession['customer'] }) => void
 }
 
 export const useHandleSubmitPriceCalculator = (params: Params) => {
-  const { t } = useTranslation('purchase-form')
-  const { showError } = useAppErrorHandleContext()
-  const [updateData, { loading }] = usePriceIntentDataUpdateMutation({
-    // priceIntent.suggestedData may be updated based on customer.ssn
-    refetchQueries: 'active',
-    awaitRefetchQueries: true,
-    onCompleted: (data) => {
-      const { priceIntent } = data.priceIntentDataUpdate
-      const { shopSession: updatedShopSession } = data.shopSessionCustomerUpdate
-      if (updatedShopSession && priceIntent) {
-        params.onSuccess({ priceIntent, customer: updatedShopSession.customer })
-      }
-    },
-    onError(error) {
-      window.console.log("Couldn't update price intent", error)
-      datadogLogs.logger.error("Couldn't update price intent", {
-        error,
-        shopSessionId: params.shopSession.id,
-        priceIntentId: params.priceIntent.id,
-      })
-      showError(new Error(t('GENERAL_ERROR_DIALOG_PROMPT')))
-    },
-  })
+  const shopSessionId = useShopSessionId()!
+  const priceIntentId = useAtomValue(currentPriceIntentIdAtom)!
+  const updatePriceIntent = useUpdatePriceIntent({ onSuccess: params.onSuccess })
 
   const handleSubmit = useCallback(
     async (data: JSONData) => {
       const [customerData, priceIntentData] = separateCustomerData(data)
       if (customerData) {
         datadogLogs.logger.warn("Submitting customer data out of section isn't supported", {
-          shopSessionId: params.shopSession.id,
-          priceIntentId: params.priceIntent.id,
+          shopSessionId,
+          priceIntentId,
         })
       }
-      return await updateData({
+      return await updatePriceIntent({
         variables: {
-          priceIntentId: params.priceIntent.id,
+          priceIntentId,
           data: priceIntentData,
-          customer: { shopSessionId: params.shopSession.id },
+          customer: { shopSessionId },
         },
       })
     },
-    [params.priceIntent.id, params.shopSession.id, updateData],
+    [priceIntentId, shopSessionId, updatePriceIntent],
   )
 
-  // NOTE: We probably want to refactor this in the future and stop editing priceIntent and customer data as a mix
-  // We should refactor this when current solution becomes a problem
+  // NOTE: We probably want to refactor this in the future
+  // and stop editing priceIntent and customer data as a mix.
+  // We should do this when current solution becomes a problem
   const handleSubmitSection = useCallback(
     (data: JSONData) => {
       const [customerData, priceIntentData] = separateCustomerData(data)
 
-      if (priceIntentData) {
-        startTransition(() => {
-          updateData({
-            variables: {
-              priceIntentId: params.priceIntent.id,
-              data: priceIntentData,
-              customer: { shopSessionId: params.shopSession.id, ...customerData },
-            },
-          })
-        })
+      if (priceIntentData == null) {
+        console.warn(
+          'handleSubmitSection called without priceIntentData, this is not intended usage. ' +
+            'Skipping priceIntentDataUpdate',
+        )
+        return
       }
+      startTransition(() => {
+        updatePriceIntent({
+          variables: {
+            priceIntentId,
+            data: priceIntentData,
+            customer: { shopSessionId, ...customerData },
+          },
+        })
+      })
     },
-    [params.priceIntent.id, params.shopSession.id, updateData],
+    [priceIntentId, shopSessionId, updatePriceIntent],
   )
 
-  return [handleSubmit, handleSubmitSection, loading] as const
+  return [handleSubmit, handleSubmitSection] as const
 }
 
 const CUSTOMER_FIELDS = ['ssn', 'email']
@@ -101,4 +91,40 @@ const separateCustomerData = (data: JSONData) => {
     customerDataIsEmpty ? null : customerData,
     priceIntentDataIsEmpty ? null : priceIntentData,
   ] as const
+}
+
+type UseUpdatePriceIntentOptions = {
+  onSuccess: (values: { priceIntent: PriceIntent; customer: ShopSession['customer'] }) => void
+}
+
+const useUpdatePriceIntent = ({ onSuccess }: UseUpdatePriceIntentOptions) => {
+  const { t } = useTranslation('purchase-form')
+  const { showError } = useAppErrorHandleContext()
+
+  const [updatePriceIntent, { loading }] = usePriceIntentDataUpdateMutation({
+    // priceIntent.suggestedData may be updated based on customer.ssn
+    refetchQueries: 'active',
+    awaitRefetchQueries: true,
+    onCompleted: (data) => {
+      const { priceIntent } = data.priceIntentDataUpdate
+      const { shopSession: updatedShopSession } = data.shopSessionCustomerUpdate
+      if (updatedShopSession && priceIntent) {
+        onSuccess({ priceIntent, customer: updatedShopSession.customer })
+      }
+    },
+    onError(error) {
+      window.console.log("Couldn't update price intent", error)
+      datadogLogs.logger.error("Couldn't update price intent", {
+        error,
+      })
+      showError(new Error(t('GENERAL_ERROR_DIALOG_PROMPT')))
+    },
+  })
+
+  const setIsPriceCalculatorLoading = useSetAtom(priceCalculatorLoadingAtom)
+  useEffect(() => {
+    setIsPriceCalculatorLoading(loading)
+  }, [loading, setIsPriceCalculatorLoading])
+
+  return updatePriceIntent
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

`isLoading` state of price calculator is now jotai atom

This allows us to call mutations from separate places (next PR), since we don't need single component to hold loading state anymore

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
