### PR TITLE
Remove prop-drilling from FetchInsuranceContrainer

### DIFF
--- a/apps/store/src/components/PriceCalculator/FetchInsurance.tsx
+++ b/apps/store/src/components/PriceCalculator/FetchInsurance.tsx
@@ -14,7 +14,6 @@ import {
   INSURELY_IFRAME_MAX_HEIGHT,
   INSURELY_IFRAME_MAX_WIDTH,
 } from '@/services/Insurely/Insurely.constants'
-import type { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { Features } from '@/utils/Features'
 import { FetchInsuranceSuccess } from './FetchInsuranceSuccess'
 import {
@@ -29,7 +28,7 @@ const USE_NATIVE_SUCCESS = Features.enabled('INSURELY_NATIVE_SUCCESS')
 type OnCompleted = NonNullable<ComponentProps<typeof InsurelyIframe>['onCompleted']>
 
 type Props = {
-  shopSession: ShopSession
+  customerSsn?: string
   priceIntentId: string
   externalInsurer: ExternalInsurer
   insurely: { configName: string; partner: string }
@@ -58,7 +57,7 @@ export const FetchInsurance = (props: Props) => {
     fetchInsuranceCompare()
     setInsurelyConfig({
       company: props.externalInsurer.insurelyId ?? undefined,
-      ssn: props.shopSession.customer?.ssn ?? undefined,
+      ssn: props.customerSsn ?? undefined,
     })
   }
   const handleClickSkip = () => {

--- a/apps/store/src/components/PriceCalculator/FetchInsuranceContainer.tsx
+++ b/apps/store/src/components/PriceCalculator/FetchInsuranceContainer.tsx
@@ -1,24 +1,27 @@
-import type { ComponentProps } from 'react'
-import { type ReactNode } from 'react'
-import type { PriceIntent } from '@/services/priceIntent/priceIntent.types'
+import { useAtomValue } from 'jotai'
+import { FetchInsurance } from '@/components/PriceCalculator/FetchInsurance'
+import {
+  priceIntentAtom,
+  shopSessionCustomerAtom,
+} from '@/components/PriceCalculator/priceCalculatorAtoms'
 import { Features } from '@/utils/Features'
-import type { FetchInsurance } from './FetchInsurance'
 
-type ChildrenProps = Pick<ComponentProps<typeof FetchInsurance>, 'externalInsurer' | 'insurely'>
+export const FetchInsuranceContainer = () => {
+  const shopSessionCustomer = useAtomValue(shopSessionCustomerAtom)
+  const priceIntent = useAtomValue(priceIntentAtom)
 
-type Props = {
-  priceIntent: PriceIntent
-  children: (props: ChildrenProps) => ReactNode
-}
-
-export const FetchInsuranceContainer = (props: Props) => {
   if (!Features.enabled('INSURELY')) return null
-  if (props.priceIntent.product.name === 'SE_CAR' && !Features.enabled('INSURELY_CAR')) return null
-  if (!props.priceIntent.externalInsurer) return null
-  if (!props.priceIntent.insurely) return null
+  if (priceIntent.product.name === 'SE_CAR' && !Features.enabled('INSURELY_CAR')) return null
+  if (!priceIntent.externalInsurer) return null
+  if (!priceIntent.insurely) return null
 
-  return props.children({
-    externalInsurer: props.priceIntent.externalInsurer,
-    insurely: props.priceIntent.insurely,
-  })
+  return (
+    <FetchInsurance
+      priceIntentId={priceIntent.id}
+      customerSsn={shopSessionCustomer?.ssn ?? undefined}
+      externalInsurer={priceIntent.externalInsurer}
+      insurely={priceIntent.insurely}
+      productName={priceIntent.product.name}
+    />
+  )
 }

--- a/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
@@ -22,9 +22,8 @@ import {
 } from '@/services/PriceCalculator/PriceCalculator.helpers'
 import { type Form } from '@/services/PriceCalculator/PriceCalculator.types'
 import { type PriceIntent } from '@/services/priceIntent/priceIntent.types'
-import { useShopSession, useShopSessionId } from '@/services/shopSession/ShopSessionContext'
+import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import * as Accordion from './Accordion'
-import { FetchInsurance } from './FetchInsurance'
 import { FetchInsuranceContainer } from './FetchInsuranceContainer'
 import { FormGrid } from './FormGrid/FormGrid'
 import { PriceCalculatorSection } from './PriceCalculatorSection'
@@ -43,11 +42,10 @@ type CustomerData = {
 }
 
 export const PriceCalculator = (props: Props) => {
-  const { shopSession } = useShopSession()
-  if (shopSession == null) {
+  const shopSessionId = useShopSessionId()
+  if (shopSessionId == null) {
     throw new Error('shopSession must be ready')
   }
-  const shopSessionId = useShopSessionId()!
   const priceIntentId = useAtomValue(currentPriceIntentIdAtom)
   if (priceIntentId == null) {
     throw new Error('priceIntentId must be set')
@@ -194,17 +192,7 @@ export const PriceCalculator = (props: Props) => {
         <Warning priceIntentWarning={priceIntent.warning} onConfirm={goToNextSection} />
       )}
 
-      <FetchInsuranceContainer priceIntent={priceIntent}>
-        {({ externalInsurer, insurely }) => (
-          <FetchInsurance
-            shopSession={shopSession}
-            priceIntentId={priceIntent.id}
-            externalInsurer={externalInsurer}
-            insurely={insurely}
-            productName={priceIntent.product.name}
-          />
-        )}
-      </FetchInsuranceContainer>
+      <FetchInsuranceContainer />
     </>
   )
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Use atoms instead of prop-drilling for `FetchInsuranceContainer`
- Remove render child pattern

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

This was the last use of non-local data access in PriceCalculator

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
