### PR TITLE
Use priceCalculatorAtoms in OfferPresenter

### DIFF
--- a/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
+++ b/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
@@ -16,8 +16,8 @@ import {
 } from 'ui'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
 import {
-  currentPriceIntentIdAtom,
   priceCalculatorLoadingAtom,
+  usePriceIntentId,
 } from '@/components/PriceCalculator/priceCalculatorAtoms'
 import { useUpdatePriceIntent } from '@/components/PriceCalculator/useUpdatePriceIntent'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
@@ -50,7 +50,7 @@ type ExtraBuildingsFieldProps = {
 export const ExtraBuildingsField = ({ field, buildingOptions }: ExtraBuildingsFieldProps) => {
   const loading = useAtomValue(priceCalculatorLoadingAtom)
   const [isOpen, setIsOpen] = useState(false)
-  const priceIntentId = useAtomValue(currentPriceIntentIdAtom)!
+  const priceIntentId = usePriceIntentId()
   const shopSessionId = useShopSessionId()!
 
   const { t } = useTranslation('purchase-form')

--- a/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceCalculator.tsx
@@ -6,11 +6,11 @@ import { ChangeSsnWarningDialog } from '@/components/ChangeSsnWarningDialog/Chan
 import { PriceCalculatorAccordionSection } from '@/components/PriceCalculator/PriceCalculatorAccordionSection'
 import {
   activeFormSectionIdAtom,
-  currentPriceIntentIdAtom,
   GOTO_NEXT_SECTION,
   priceCalculatorFormAtom,
   priceIntentAtom,
   shopSessionCustomerAtom,
+  usePriceIntentId,
 } from '@/components/PriceCalculator/priceCalculatorAtoms'
 import { SSN_SE_SECTION_ID, SsnSeSection } from '@/components/PriceCalculator/SsnSeSection'
 import { usePriceTemplate } from '@/components/ProductPage/PurchaseForm/priceTemplateAtom'
@@ -46,10 +46,7 @@ export const PriceCalculator = (props: Props) => {
   if (shopSessionId == null) {
     throw new Error('shopSession must be ready')
   }
-  const priceIntentId = useAtomValue(currentPriceIntentIdAtom)
-  if (priceIntentId == null) {
-    throw new Error('priceIntentId must be set')
-  }
+  const priceIntentId = usePriceIntentId()
   const priceTemplate = usePriceTemplate()
   const form = useAtomValue(priceCalculatorFormAtom)
   const priceIntent = useAtomValue(priceIntentAtom)

--- a/apps/store/src/components/PriceCalculator/priceCalculatorAtoms.ts
+++ b/apps/store/src/components/PriceCalculator/priceCalculatorAtoms.ts
@@ -96,12 +96,14 @@ const getAtomValueOrThrow = <T>(get: Getter, atom: Atom<T>): NonNullable<T> => {
   return value
 }
 
-export const useSyncPriceCalculatorState = (priceIntent: PriceIntentFragment): void => {
+export const useSyncPriceCalculatorState = (priceIntent?: PriceIntentFragment): void => {
   const shopSessionCustomer = useShopSession().shopSession?.customer
   const store = useStore()
   useEffect(() => {
-    store.set(currentPriceIntentIdAtom, priceIntent.id)
-    store.set(priceIntentAtomFamily(priceIntent.id), priceIntent)
+    if (priceIntent != null) {
+      store.set(currentPriceIntentIdAtom, priceIntent.id)
+      store.set(priceIntentAtomFamily(priceIntent.id), priceIntent)
+    }
   }, [priceIntent, store])
   useEffect(() => {
     store.set(shopSessionCustomerAtom, shopSessionCustomer ?? null)
@@ -113,3 +115,11 @@ export const useIsPriceCalculatorStateReady = (): boolean => {
 }
 
 export const priceCalculatorLoadingAtom = atom(false)
+
+export const usePriceIntentId = (): string => {
+  const priceIntentId = useAtomValue(currentPriceIntentIdAtom)
+  if (priceIntentId == null) {
+    throw new Error('priceIntentId must be defined')
+  }
+  return priceIntentId
+}

--- a/apps/store/src/components/PriceCalculator/useHandleSubmitPriceCalculatorSection.ts
+++ b/apps/store/src/components/PriceCalculator/useHandleSubmitPriceCalculatorSection.ts
@@ -1,6 +1,5 @@
-import { useAtomValue } from 'jotai'
 import { startTransition, useCallback } from 'react'
-import { currentPriceIntentIdAtom } from '@/components/PriceCalculator/priceCalculatorAtoms'
+import { usePriceIntentId } from '@/components/PriceCalculator/priceCalculatorAtoms'
 import { useUpdatePriceIntent } from '@/components/PriceCalculator/useUpdatePriceIntent'
 import type { JSONData } from '@/services/PriceCalculator/PriceCalculator.types'
 import type { PriceIntent } from '@/services/priceIntent/priceIntent.types'
@@ -13,7 +12,7 @@ type Params = {
 
 export const useHandleSubmitPriceCalculatorSection = (params: Params) => {
   const shopSessionId = useShopSessionId()!
-  const priceIntentId = useAtomValue(currentPriceIntentIdAtom)!
+  const priceIntentId = usePriceIntentId()
   const updatePriceIntent = useUpdatePriceIntent({ onSuccess: params.onSuccess })
 
   // NOTE: We probably want to refactor this in the future


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Use `priceCalculatorAtoms` in `OfferPresenter` instead of prop-drilling
- Move sync state hook higher into `PurchaseForm` since now we have 2 purchase form states that consume these atoms

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
