### PR TITLE
Fix unsafe shopSession access in Widget / CalculatePricePage

### DIFF
--- a/apps/store/src/components/PriceCalculator/Warning/WarningPrompt/WarningPrompt.tsx
+++ b/apps/store/src/components/PriceCalculator/Warning/WarningPrompt/WarningPrompt.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { Button, InfoIcon, Space, Text, theme } from 'ui'
+import { Button, InfoIcon, Space, Text, theme, Dialog } from 'ui'
 import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
 import type { PriceIntentWarning } from '@/services/graphql/generated'
 
@@ -18,7 +18,9 @@ export const WarningPrompt = ({ header, message, onClickConfirm, onClickEdit }: 
         <SpaceFlex space={1} direction="vertical" align="center">
           <InfoIcon size="1.5rem" color={theme.colors.signalBlueElement} />
           <div>
-            <Text balance={true}>{header}</Text>
+            <Dialog.Title asChild={true}>
+              <Text balance={true}>{header}</Text>
+            </Dialog.Title>
             <Text color="textSecondary" balance={true}>
               {message}
             </Text>

--- a/apps/store/src/features/widget/CalculatePricePage.tsx
+++ b/apps/store/src/features/widget/CalculatePricePage.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/services/graphql/generated'
 import { type Template } from '@/services/PriceCalculator/PriceCalculator.types'
 import { type ShopSession } from '@/services/shopSession/ShopSession.types'
+import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { useTracking } from '@/services/Tracking/useTracking'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
@@ -124,8 +125,9 @@ export const CalculatePricePage = (props: Props) => {
   useSyncPriceTemplate(props.priceTemplate)
   useSyncPriceCalculatorState(props.priceIntent)
 
+  const shopSessionId = useShopSessionId()
   const isReady = useIsPriceCalculatorStateReady()
-  if (!isReady) {
+  if (shopSessionId == null || !isReady) {
     return null
   }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix error when PriceCalculator is used before shopSession is ready in widget flow

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
