### PR TITLE
fix(widget): make sure widget load ssn when provided via URL

### DIFF
--- a/apps/store/src/services/shopSession/ShopSessionContext.tsx
+++ b/apps/store/src/services/shopSession/ShopSessionContext.tsx
@@ -47,14 +47,14 @@ export const useShopSession = (): ShopSessionResult => {
 const useShopSessionContextValue = (initialShopSessionId?: string) => {
   const { countryCode } = useCurrentCountry()
   const apolloClient = useApolloClient()
-  const shopSessionServiceClientSide = useMemo(
-    () => setupShopSessionServiceClientSide(apolloClient),
-    [apolloClient],
-  )
+  const shopSessionServiceClientSide = useMemo(() => {
+    const service = setupShopSessionServiceClientSide(apolloClient)
+    if (initialShopSessionId) service.saveId(initialShopSessionId)
 
-  const [shopSessionId, setShopSessionId] = useState(
-    shopSessionServiceClientSide.shopSessionId() ?? initialShopSessionId,
-  )
+    return service
+  }, [apolloClient, initialShopSessionId])
+
+  const [shopSessionId, setShopSessionId] = useState(shopSessionServiceClientSide.shopSessionId())
 
   const queryResult = useShopSessionQuery({
     variables: shopSessionId ? { shopSessionId } : undefined,


### PR DESCRIPTION
## Describe your changes

* Proper use `initialShopSessionId` when it's provided to `ShopSessionProvider`

## Justify why they are needed

I've found a bug with widget where ssn was not being loaded when provided via URL. Turns out the issue was with `ShopSessionContext`. Here's is why:
1. We create a "regular" shop session and store it in a cookie when the load a page in racoon. That happens for widget landing pages as well.
2. While triggering the flow we create a partner shopsession and redirect user to calculate price page. We include partner shop session id as long as any query params in the URL
3. We pass the partner shop session id as `initialShopSessionId` to `ShopSessionProvider` but it's internal logic used to retrieve the shop session client side takes shop session id stored in a cookie into account, when present. Previous implementation had a problem with that because the shop session that was updated with ssn (URL) is the partner shopsession while the one used by shop session context is the regular one.

The fix was about changing the persister to store the `initialShopSessionId` when provided.
