### PR TITLE
Add block and component for the new header and menu

### DIFF
--- a/apps/store/src/app/[locale]/StoryblokLayout.tsx
+++ b/apps/store/src/app/[locale]/StoryblokLayout.tsx
@@ -2,8 +2,10 @@ import { clsx } from 'clsx'
 import type { ReactNode } from 'react'
 import { FooterBlock } from '@/blocks/FooterBlock/FooterBlock'
 import { HeaderBlock } from '@/blocks/HeaderBlock/HeaderBlock'
+import { HeaderBlock as HeaderBlockNew } from '@/blocks/HeaderBlockNew/HeaderBlock'
 import type { GlobalStory } from '@/services/storyblok/storyblok'
 import { filterByBlockType } from '@/services/storyblok/Storyblok.helpers'
+import { Features } from '@/utils/Features'
 import { wrapper } from './StoryblokLayout.css'
 
 export const StoryblokLayout = ({
@@ -20,9 +22,13 @@ export const StoryblokLayout = ({
 
   return (
     <div className={clsx(wrapper, className)}>
-      {headerBlock.map((nestedBlock) => (
-        <HeaderBlock key={nestedBlock._uid} blok={nestedBlock} />
-      ))}
+      {headerBlock.map((nestedBlock) =>
+        Features.enabled('NEW_HEADER') ? (
+          <HeaderBlockNew key={nestedBlock._uid} blok={nestedBlock} />
+        ) : (
+          <HeaderBlock key={nestedBlock._uid} blok={nestedBlock} />
+        ),
+      )}
       {children}
       {footerBlock.map((nestedBlock) => (
         <FooterBlock key={nestedBlock._uid} blok={nestedBlock} />

--- a/apps/store/src/blocks/HeaderBlock/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock/HeaderBlock.tsx
@@ -13,10 +13,12 @@ import {
   type ProductNavContainerBlockProps,
 } from './ProductNavContainerBlock'
 
+export type NavMenuContainerProps = ExpectedBlockType<
+  NestedNavContainerBlockProps | NavItemBlockProps | ProductNavContainerBlockProps
+>
+
 export type HeaderBlockProps = SbBaseBlockProps<{
-  navMenuContainer: ExpectedBlockType<
-    NestedNavContainerBlockProps | NavItemBlockProps | ProductNavContainerBlockProps
-  >
+  navMenuContainer: NavMenuContainerProps
 }>
 
 // Performance considerations

--- a/apps/store/src/blocks/HeaderBlockNew/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlockNew/HeaderBlock.tsx
@@ -1,0 +1,43 @@
+import { storyblokEditable } from '@storyblok/react'
+import { useMemo } from 'react'
+import { NestedMenuBlock } from '@/blocks/HeaderBlockNew/NestedMenuBlock'
+import { Header } from '@/components/HeaderNew/Header'
+import { HeaderMenu } from '@/components/HeaderNew/HeaderMenu/HeaderMenu'
+import { ShoppingCartMenuItem } from '@/components/HeaderNew/ShoppingCartMenuItem/ShoppingCartMenuItem'
+import type { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { checkBlockType } from '@/services/storyblok/Storyblok.helpers'
+import { type MenuItemBlockProps } from './MenuItemBlock'
+import { ProductMenuBlock, type ProductMenuBlockProps } from './ProductMenuBlock'
+import { type SubMenuBlockProps } from './SubMenuBlock'
+
+export type HeaderMenuProps = ExpectedBlockType<
+  SubMenuBlockProps | MenuItemBlockProps | ProductMenuBlockProps
+>
+
+export type HeaderBlockNewProps = SbBaseBlockProps<{
+  headerMenu: HeaderMenuProps
+}>
+
+// Performance considerations
+// - this block is important for site-wide INP since it's present on most pages and is used often
+export const HeaderBlock = ({ blok }: HeaderBlockNewProps) => {
+  const productNavItem = useMemo(
+    () =>
+      blok.headerMenu.find((item) =>
+        checkBlockType<ProductMenuBlockProps['blok']>(item, ProductMenuBlock.blockName),
+      )?.name,
+    [blok.headerMenu],
+  )
+  return (
+    <Header {...storyblokEditable(blok)}>
+      <HeaderMenu defaultValue={productNavItem}>
+        {blok.headerMenu.map((item) => (
+          <NestedMenuBlock key={item._uid} blok={item} />
+        ))}
+      </HeaderMenu>
+
+      <ShoppingCartMenuItem />
+    </Header>
+  )
+}
+HeaderBlock.blockName = 'header'

--- a/apps/store/src/blocks/HeaderBlockNew/MenuItemBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlockNew/MenuItemBlock.tsx
@@ -1,0 +1,26 @@
+'use client'
+import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
+import { storyblokEditable } from '@storyblok/react'
+import { navigationItem } from '@/components/HeaderNew/Header.css'
+import { NavigationLink } from '@/components/HeaderNew/NavigationLink/NavigationLink'
+import type { LinkField, SbBaseBlockProps, StoryblokAsset } from '@/services/storyblok/storyblok'
+import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
+
+export type MenuItemBlockProps = SbBaseBlockProps<{
+  name: string
+  link: LinkField
+  pillowImage?: StoryblokAsset
+  label?: string
+}>
+export const MenuItemBlock = ({ blok }: MenuItemBlockProps) => {
+  return (
+    <NavigationMenuPrimitive.Item
+      className={navigationItem}
+      value={blok.name}
+      {...storyblokEditable(blok)}
+    >
+      <NavigationLink href={getLinkFieldURL(blok.link, blok.name)}>{blok.name}</NavigationLink>
+    </NavigationMenuPrimitive.Item>
+  )
+}
+MenuItemBlock.blockName = 'menuItem'

--- a/apps/store/src/blocks/HeaderBlockNew/NestedMenuBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlockNew/NestedMenuBlock.tsx
@@ -1,0 +1,41 @@
+'use client'
+import { type HeaderBlockNewProps } from '@/blocks/HeaderBlockNew/HeaderBlock'
+import { MenuItemBlock, type MenuItemBlockProps } from '@/blocks/HeaderBlockNew/MenuItemBlock'
+import {
+  ProductMenuBlock,
+  type ProductMenuBlockProps,
+} from '@/blocks/HeaderBlockNew/ProductMenuBlock'
+import { SubMenuBlock, type SubMenuBlockProps } from '@/blocks/HeaderBlockNew/SubMenuBlock'
+import { checkBlockType } from '@/services/storyblok/Storyblok.helpers'
+import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
+
+type NestedMenuBlockProps = {
+  blok: HeaderBlockNewProps['blok']['headerMenu'][number]
+}
+export const NestedMenuBlock = ({ blok }: NestedMenuBlockProps) => {
+  const variant = useResponsiveVariant('lg')
+
+  const subMenu = checkBlockType<SubMenuBlockProps['blok']>(blok, SubMenuBlock.blockName)
+  if (subMenu) {
+    return <SubMenuBlock key={subMenu._uid} blok={subMenu} />
+  }
+
+  const productMenu = checkBlockType<ProductMenuBlockProps['blok']>(
+    blok,
+    ProductMenuBlock.blockName,
+  )
+  if (productMenu) {
+    return (
+      <ProductMenuBlock
+        key={productMenu._uid}
+        blok={productMenu}
+        variant={variant === 'mobile' ? 'mobile' : 'desktop'}
+      />
+    )
+  }
+
+  const menuBlock = checkBlockType<MenuItemBlockProps['blok']>(blok, MenuItemBlock.blockName)
+  if (menuBlock) return <MenuItemBlock key={menuBlock._uid} blok={menuBlock} />
+
+  return null
+}

--- a/apps/store/src/blocks/HeaderBlockNew/ProductMenuBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlockNew/ProductMenuBlock.tsx
@@ -1,0 +1,97 @@
+'use client'
+import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
+import { storyblokEditable } from '@storyblok/react'
+import { useTranslation } from 'next-i18next'
+import type { ButtonBlockProps } from '@/blocks/ButtonBlock'
+import { MenuItemBlock, type MenuItemBlockProps } from '@/blocks/HeaderBlockNew/MenuItemBlock'
+import { ButtonNextLink } from '@/components/ButtonNextLink'
+import {
+  navigationItem,
+  navigationMenuWrapper,
+  navigationProductList,
+} from '@/components/HeaderNew/Header.css'
+import { NavigationContent } from '@/components/HeaderNew/NavigationContent'
+import { ProductNavigationLink } from '@/components/HeaderNew/NavigationLink/NavigationLink'
+import { NavigationTrigger } from '@/components/HeaderNew/NavigationTrigger'
+import { useProductMetadata } from '@/components/LayoutWithMenu/productMetadataHooks'
+import type { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { filterByBlockType, getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
+import { PageLink } from '@/utils/PageLink'
+import { mobileWrapper } from './ProductNavContainerBlock.css'
+
+export type ProductMenuBlockProps = SbBaseBlockProps<{
+  name: string
+  menuItems: ExpectedBlockType<MenuItemBlockProps>
+  buttons: ExpectedBlockType<ButtonBlockProps>
+  currentActiveItem?: string
+}> & { variant: 'mobile' | 'desktop' }
+type ProductMenuItem = { name: string; url: string; image?: string; label?: string }
+export const ProductMenuBlock = ({ blok, variant }: ProductMenuBlockProps) => {
+  const locale = useRoutingLocale()
+  const { t } = useTranslation()
+  const productMetadata = useProductMetadata()
+  const filteredMenuItems = filterByBlockType(blok.menuItems, MenuItemBlock.blockName)
+
+  const productMenuItems: Array<ProductMenuItem> = []
+  filteredMenuItems.forEach((item) => {
+    const product = productMetadata?.find((product) => product.name === item.name)
+    let menuItem
+    if (product) {
+      menuItem = {
+        name: product.displayNameShort,
+        url: product.pageLink,
+        image: product.pillowImage.src,
+        label: item.label,
+      }
+    } else {
+      menuItem = {
+        name: item.name,
+        url: getLinkFieldURL(item.link, item.name),
+        image: item.pillowImage?.filename,
+        label: item.label,
+      }
+    }
+    productMenuItems.push(menuItem)
+  })
+
+  const content = (
+    <div className={navigationMenuWrapper}>
+      <NavigationMenuPrimitive.Sub defaultValue={blok.name}>
+        <NavigationMenuPrimitive.List className={navigationProductList}>
+          {productMenuItems.map((item) => (
+            <NavigationMenuPrimitive.Item key={item.name} value={item.name}>
+              <ProductNavigationLink href={item.url} pillowImageSrc={item.image} label={item.label}>
+                {item.name}
+              </ProductNavigationLink>
+            </NavigationMenuPrimitive.Item>
+          ))}
+        </NavigationMenuPrimitive.List>
+      </NavigationMenuPrimitive.Sub>
+      <ButtonNextLink
+        href={PageLink.store({ locale })}
+        variant="secondary"
+        size="medium"
+        fullWidth={true}
+      >
+        {t('NAVIGATION_STORE_LINK')}
+      </ButtonNextLink>
+    </div>
+  )
+
+  if (variant === 'mobile') {
+    return <div className={mobileWrapper}>{content}</div>
+  } else {
+    return (
+      <NavigationMenuPrimitive.Item
+        className={navigationItem}
+        value={blok.name}
+        {...storyblokEditable(blok)}
+      >
+        <NavigationTrigger href={PageLink.store({ locale })}>{blok.name}</NavigationTrigger>
+        <NavigationContent>{content}</NavigationContent>
+      </NavigationMenuPrimitive.Item>
+    )
+  }
+}
+ProductMenuBlock.blockName = 'productMenu'

--- a/apps/store/src/blocks/HeaderBlockNew/ProductNavContainerBlock.css.ts
+++ b/apps/store/src/blocks/HeaderBlockNew/ProductNavContainerBlock.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css'
+import { tokens } from 'ui/src/theme'
+
+export const mobileWrapper = style({
+  paddingTop: tokens.space.md,
+  borderBottom: `1px solid ${tokens.colors.borderOpaque1}`,
+})

--- a/apps/store/src/blocks/HeaderBlockNew/SubMenuBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlockNew/SubMenuBlock.tsx
@@ -1,0 +1,65 @@
+'use client'
+import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
+import { storyblokEditable } from '@storyblok/react'
+import { MenuItemBlock, type MenuItemBlockProps } from '@/blocks/HeaderBlockNew/MenuItemBlock'
+import {
+  navigationItem,
+  navigationMenuWrapper,
+  navigationSecondaryItem,
+  navigationSecondaryList,
+} from '@/components/HeaderNew/Header.css'
+import { NavigationContent } from '@/components/HeaderNew/NavigationContent'
+import { SecondaryNavigationLink } from '@/components/HeaderNew/NavigationLink/NavigationLink'
+import { NavigationTrigger } from '@/components/HeaderNew/NavigationTrigger'
+import type { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { filterByBlockType, getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
+
+export type SubMenuBlockProps = SbBaseBlockProps<{
+  name: string
+  menuItems: ExpectedBlockType<MenuItemBlockProps>
+  currentActiveItem?: string
+}>
+export const SubMenuBlock = ({ blok }: SubMenuBlockProps) => {
+  const filteredMenuItems = filterByBlockType(blok.menuItems, MenuItemBlock.blockName)
+
+  if (filteredMenuItems.length === 0) {
+    return null
+  }
+
+  const firstMenuItem = filteredMenuItems[0]
+
+  return (
+    <NavigationMenuPrimitive.Item
+      className={navigationItem}
+      value={blok.name}
+      {...storyblokEditable(blok)}
+    >
+      <NavigationTrigger href={getLinkFieldURL(firstMenuItem.link, firstMenuItem.name)}>
+        {blok.name}
+      </NavigationTrigger>
+      <NavigationContent>
+        <div className={navigationMenuWrapper}>
+          <NavigationMenuPrimitive.Sub defaultValue={blok.name}>
+            <NavigationMenuPrimitive.List className={navigationSecondaryList}>
+              {filteredMenuItems.map((nestedBlock) => (
+                <NavigationMenuPrimitive.Item
+                  key={nestedBlock._uid}
+                  className={navigationSecondaryItem}
+                  value={nestedBlock.name}
+                  {...storyblokEditable(nestedBlock)}
+                >
+                  <SecondaryNavigationLink
+                    href={getLinkFieldURL(nestedBlock.link, nestedBlock.name)}
+                  >
+                    {nestedBlock.name}
+                  </SecondaryNavigationLink>
+                </NavigationMenuPrimitive.Item>
+              ))}
+            </NavigationMenuPrimitive.List>
+          </NavigationMenuPrimitive.Sub>
+        </div>
+      </NavigationContent>
+    </NavigationMenuPrimitive.Item>
+  )
+}
+SubMenuBlock.blockName = 'subMenu'

--- a/apps/store/src/components/HeaderNew/Header.constants.ts
+++ b/apps/store/src/components/HeaderNew/Header.constants.ts
@@ -1,0 +1,9 @@
+import { theme } from 'ui'
+
+export const MENU_BAR_HEIGHT_MOBILE = '3.5rem'
+export const MENU_BAR_HEIGHT_DESKTOP = '4rem'
+export const MENU_BAR_HEIGHT_PX = 64
+export const MENU_TRIGGER_MOBILE_SIZE = '2.5rem'
+
+export const HEADER_HEIGHT_MOBILE = `calc(${MENU_BAR_HEIGHT_MOBILE} + ${theme.space.xs})`
+export const HEADER_HEIGHT_DESKTOP = `calc(${MENU_BAR_HEIGHT_DESKTOP} + ${theme.space.xs})`

--- a/apps/store/src/components/HeaderNew/Header.css.ts
+++ b/apps/store/src/components/HeaderNew/Header.css.ts
@@ -1,0 +1,266 @@
+import { createVar, style } from '@vanilla-extract/css'
+import { minWidth, tokens, yStack } from 'ui'
+import { zIndexes } from '@/utils/zIndex'
+import { MAX_WIDTH } from '../GridLayout/GridLayout.constants'
+import {
+  HEADER_HEIGHT_DESKTOP,
+  HEADER_HEIGHT_MOBILE,
+  MENU_BAR_HEIGHT_DESKTOP,
+  MENU_BAR_HEIGHT_MOBILE,
+} from './Header.constants'
+
+export const focusableStyles = style({
+  cursor: 'pointer',
+
+  ':focus-visible': {
+    outline: `2px solid ${tokens.colors.gray900}`,
+  },
+})
+
+const ghostWrapperHeight = createVar()
+
+export const ghostWrapper = style({
+  vars: {
+    [ghostWrapperHeight]: HEADER_HEIGHT_MOBILE,
+  },
+
+  position: 'relative',
+  height: ghostWrapperHeight,
+
+  zIndex: zIndexes.header,
+
+  '@media': {
+    [minWidth.lg]: {
+      vars: {
+        [ghostWrapperHeight]: HEADER_HEIGHT_DESKTOP,
+      },
+    },
+  },
+
+  selectors: {
+    'body:has(main[data-overlay-menu=true]) &': {
+      // Using negative margin to pull page's content bellow the menu causing the desired
+      // 'menu overlay' behaviour. Before that was being implemented by removing the header
+      // from doc's flow with absolute positioning. However, that solution doesn't play well
+      // if we have banners/announcements on the screen.
+      marginBottom: `calc(-1 * ${ghostWrapperHeight})`,
+    },
+  },
+})
+
+export const wrapper = style({
+  top: 0,
+  zIndex: zIndexes.header,
+  width: '100%',
+})
+
+export const contentWrapper = style({
+  position: 'relative',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  maxWidth: MAX_WIDTH,
+  marginInline: 'auto',
+  paddingInline: tokens.space.md,
+  height: MENU_BAR_HEIGHT_MOBILE,
+
+  '@media': {
+    [minWidth.lg]: {
+      height: MENU_BAR_HEIGHT_DESKTOP,
+
+      paddingInline: tokens.space.lg,
+    },
+  },
+})
+
+export const logoWrapper = style({
+  position: 'absolute',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  // Fix to make sure line-height doesn't affect wrapper height
+  fontSize: 0,
+  flex: 1,
+})
+
+export const menuWrapper = style({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  flex: 1,
+  gap: tokens.space.xs,
+})
+
+export const navigation = style({
+  fontSize: tokens.fontSizes.xl,
+
+  '@media': {
+    [minWidth.lg]: {
+      fontSize: tokens.fontSizes.md,
+      top: 0,
+    },
+  },
+})
+
+export const HeaderMenuDesktop = style([
+  navigation,
+  {
+    // Visually hide menu on mobile. It still needs to be present in the DOM for SEO purposes
+    display: 'none',
+
+    '@media': {
+      [minWidth.lg]: {
+        display: 'revert',
+        // Ensure menu is left-aligned while cart item is right-aligned
+        flexGrow: 1,
+      },
+    },
+  },
+])
+
+export const navigationItem = style({
+  selectors: {
+    '&:not(:last-child)': {
+      borderBottom: `1px solid ${tokens.colors.borderOpaque1}`,
+    },
+  },
+
+  '@media': {
+    [minWidth.lg]: {
+      selectors: {
+        '&&': { borderBottom: 'unset' },
+      },
+    },
+  },
+})
+
+export const navigationTriggerLink = style([
+  focusableStyles,
+  {
+    paddingBlock: tokens.space.lg,
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.space.xxxl,
+    whiteSpace: 'nowrap',
+
+    '@media': {
+      [minWidth.lg]: {
+        paddingBlock: tokens.space.xs,
+        paddingInline: tokens.space.md,
+
+        borderRadius: tokens.radius.sm,
+
+        ':hover': {
+          backgroundColor: tokens.colors.grayTranslucent100,
+        },
+
+        selectors: {
+          '&[data-state="open"]': {
+            backgroundColor: tokens.colors.grayTranslucent100,
+          },
+        },
+      },
+    },
+  },
+])
+
+export const navigationSecondaryItem = style({
+  padding: tokens.space.md,
+  marginLeft: tokens.space.md,
+  color: tokens.colors.textPrimary,
+
+  '@media': {
+    [minWidth.lg]: {
+      padding: `${tokens.space.xs} ${tokens.space.sm}`,
+      margin: 0,
+      borderRadius: tokens.radius.sm,
+
+      ':hover': {
+        backgroundColor: tokens.colors.grayTranslucent100,
+      },
+    },
+  },
+})
+
+export const navigationContent = style({
+  // For SEO reasons, navigation content get's always mounted and it's appearance is toggled via CSS
+  selectors: {
+    '&[data-state="open"]': {
+      display: 'block',
+    },
+    '&[data-state="closed"]': {
+      display: 'none',
+    },
+  },
+  '@media': {
+    [minWidth.lg]: {
+      position: 'absolute',
+      paddingTop: `calc(${tokens.space.sm} + ${tokens.space.xs})`,
+    },
+  },
+})
+
+// Same component reused between mobile and desktop menus
+export const navigationMenuWrapper = style({
+  paddingBottom: tokens.space.xl,
+  rowGap: tokens.space.lg,
+
+  '@media': {
+    [minWidth.lg]: {
+      backgroundColor: tokens.colors.light,
+      boxShadow: tokens.shadow.default,
+      borderRadius: tokens.radius.sm,
+      padding: tokens.space.md,
+      rowGap: tokens.space.md,
+    },
+  },
+})
+
+export const navigationPrimaryList = style({
+  all: 'unset',
+  listStyle: 'none',
+  position: 'fixed',
+  inset: `${MENU_BAR_HEIGHT_MOBILE} 0 0 0`,
+  display: 'flex',
+  flexDirection: 'column',
+  paddingInline: tokens.space.md,
+  paddingBottom: tokens.space.xl,
+  overflowY: 'auto',
+
+  '@media': {
+    [minWidth.lg]: {
+      position: 'static',
+      flexDirection: 'row',
+      alignItems: 'center',
+      height: MENU_BAR_HEIGHT_DESKTOP,
+      padding: tokens.space.none,
+      gap: tokens.space.xxs,
+    },
+  },
+})
+
+export const navigationSecondaryList = style({
+  display: 'block',
+
+  '@media': {
+    [minWidth.lg]: {
+      padding: 0,
+    },
+  },
+})
+
+export const navigationProductList = style([
+  yStack({ gap: 'xs' }),
+  {
+    marginBottom: tokens.space.lg,
+    fontSize: tokens.fontSizes.md,
+    color: tokens.colors.textPrimary,
+
+    '@media': {
+      [minWidth.lg]: {
+        minWidth: '16rem',
+        marginBottom: tokens.space.md,
+      },
+    },
+  },
+])

--- a/apps/store/src/components/HeaderNew/Header.tsx
+++ b/apps/store/src/components/HeaderNew/Header.tsx
@@ -1,0 +1,78 @@
+'use client'
+import type { Transition } from 'framer-motion'
+import { motion } from 'framer-motion'
+import type { PropsWithChildren } from 'react'
+import { bodyBgColor } from 'ui/src/theme/vars.css'
+import { LogoHomeLink } from '@/components/LogoHomeLink'
+import { isBrowser } from '@/utils/env'
+import { useScrollState } from '@/utils/useScrollState'
+import { MENU_BAR_HEIGHT_PX } from './Header.constants'
+import { menuWrapper, ghostWrapper, logoWrapper, wrapper, contentWrapper } from './Header.css'
+
+const ANIMATION_VARIANTS = {
+  SLIDE_IN: {
+    y: 0,
+    position: 'fixed',
+    backgroundColor: bodyBgColor,
+    boxShadow: 'rgba(0, 0, 0, 0.06) 0px 2px 12px',
+  },
+  SLIDE_OUT: {
+    position: 'fixed',
+    y: '-150%',
+  },
+  HIDE: {
+    y: '-150%',
+    transition: { duration: 0 },
+  },
+} as const
+
+// Source: https://easings.co · easeInOutCubic
+const TRANSITION: Transition = { ease: [0.65, 0.05, 0.36, 1] }
+
+type AnimationVariant = keyof typeof ANIMATION_VARIANTS | undefined
+
+export const Header = (props: PropsWithChildren<unknown>) => {
+  const { children } = props
+  const scrollState = useScrollState({ threshold: MENU_BAR_HEIGHT_PX * 2 })
+
+  const initialStyles = {
+    backgroundColor: bodyBgColor,
+  }
+
+  let animate: AnimationVariant = undefined
+  if (
+    isBrowser() &&
+    window.document.querySelector('main[data-supports-sticky-header=true]') != null
+  ) {
+    switch (scrollState) {
+      case 'SCROLL_UP':
+        animate = 'SLIDE_IN'
+        break
+      case 'SCROLL_DOWN':
+        animate = 'SLIDE_OUT'
+        break
+      case 'BELOW':
+        animate = 'HIDE'
+        break
+    }
+  }
+
+  return (
+    <div className={ghostWrapper}>
+      <motion.header
+        className={wrapper}
+        initial={initialStyles}
+        variants={ANIMATION_VARIANTS}
+        animate={animate}
+        transition={TRANSITION}
+      >
+        <div className={contentWrapper}>
+          {children ? <div className={menuWrapper}>{children}</div> : null}
+          <div className={logoWrapper}>
+            <LogoHomeLink />
+          </div>
+        </div>
+      </motion.header>
+    </div>
+  )
+}

--- a/apps/store/src/components/HeaderNew/HeaderMenu/HeaderMenu.tsx
+++ b/apps/store/src/components/HeaderNew/HeaderMenu/HeaderMenu.tsx
@@ -1,0 +1,42 @@
+'use client'
+import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
+import { usePathname } from 'next/navigation'
+import { useState, useEffect, type ReactNode } from 'react'
+import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
+import { navigationPrimaryList, HeaderMenuDesktop } from '../Header.css'
+import { HeaderMenuMobile } from '../HeaderMenuMobile/HeaderMenuMobile'
+
+export type HeaderMenuDesktopProps = {
+  children: ReactNode
+  defaultValue?: string
+}
+
+export const HeaderMenu = ({ children, defaultValue }: HeaderMenuDesktopProps) => {
+  const [activeItem, setActiveItem] = useState('')
+  const pathname = usePathname()
+  const variant = useResponsiveVariant('lg')
+
+  useEffect(() => {
+    setActiveItem('')
+  }, [pathname])
+
+  return (
+    <>
+      {/* 'Desktop' menu is always rendered for SEO reasons so navigation links becomes acessible */}
+      {/* in the markup */}
+      <NavigationMenuPrimitive.Root
+        className={HeaderMenuDesktop}
+        value={activeItem}
+        onValueChange={setActiveItem}
+      >
+        <NavigationMenuPrimitive.List className={navigationPrimaryList}>
+          {children}
+        </NavigationMenuPrimitive.List>
+      </NavigationMenuPrimitive.Root>
+
+      {variant === 'mobile' && (
+        <HeaderMenuMobile defaultValue={defaultValue}>{children}</HeaderMenuMobile>
+      )}
+    </>
+  )
+}

--- a/apps/store/src/components/HeaderNew/HeaderMenuMobile/HeaderMenuMobile.css.ts
+++ b/apps/store/src/components/HeaderNew/HeaderMenuMobile/HeaderMenuMobile.css.ts
@@ -1,0 +1,49 @@
+import { style } from '@vanilla-extract/css'
+import { tokens } from 'ui'
+import {
+  MENU_BAR_HEIGHT_MOBILE,
+  MENU_TRIGGER_MOBILE_SIZE,
+} from '@/components/HeaderNew/Header.constants'
+
+export const contentWrapper = style({
+  position: 'fixed',
+  top: 0,
+  width: '100%',
+  color: tokens.colors.textPrimary,
+})
+
+export const buttonWrapper = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  columnGap: tokens.space.xs,
+  paddingTop: tokens.space.lg,
+})
+
+export const buttonTrigger = style({
+  width: MENU_TRIGGER_MOBILE_SIZE,
+  height: MENU_TRIGGER_MOBILE_SIZE,
+  // Avoid flickering background-color on button when toggling menu on non-hover devices
+  '@media': {
+    '(hover: none)': {
+      ':active': {
+        backgroundColor: 'transparent',
+      },
+    },
+  },
+})
+
+export const HeaderMenuHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  height: MENU_BAR_HEIGHT_MOBILE,
+  paddingInline: tokens.space.md,
+  gap: tokens.space.xs,
+})
+
+export const dialogOverlay = style({
+  position: 'fixed',
+  inset: 0,
+  top: 0,
+  backgroundColor: tokens.colors.light,
+})

--- a/apps/store/src/components/HeaderNew/HeaderMenuMobile/HeaderMenuMobile.tsx
+++ b/apps/store/src/components/HeaderNew/HeaderMenuMobile/HeaderMenuMobile.tsx
@@ -1,0 +1,171 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
+import { usePathname } from 'next/navigation'
+import { useTranslation } from 'next-i18next'
+import type { ReactNode } from 'react'
+import { startTransition, useEffect, useState } from 'react'
+import { AndroidIcon, AppleIcon, Button, tokens } from 'ui'
+import { LogoHomeLink } from '@/components/LogoHomeLink'
+import { SpaceFlex } from '@/components/SpaceFlex/SpaceFlex'
+import { getAppStoreLink } from '@/utils/appStoreLinks'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
+import { logoWrapper, navigation, navigationPrimaryList } from '../Header.css'
+import { ShoppingCartMenuItem } from '../ShoppingCartMenuItem/ShoppingCartMenuItem'
+import {
+  buttonTrigger,
+  buttonWrapper,
+  contentWrapper,
+  dialogOverlay,
+  HeaderMenuHeader,
+} from './HeaderMenuMobile.css'
+
+type Props = {
+  defaultValue?: string
+  children: ReactNode
+}
+
+export function HeaderMenuMobile(props: Props) {
+  const pathname = usePathname()
+  const [isOpen, setIsOpen] = useState(false)
+  const [isContentVisible, setIsContentVisible] = useState(false)
+
+  // Close on navigation
+  useEffect(() => {
+    setIsOpen(false)
+  }, [pathname])
+
+  // Poor man's useDeferredValue that waits for the next UI frame
+  // Waiting for next render loop is too early since major part of rendering work happens
+  // in `Presence` inner component after dialog content is rendered
+  useEffect(() => {
+    const timeoutId = setTimeout(() => setIsContentVisible(isOpen))
+    return () => clearTimeout(timeoutId)
+  }, [isOpen])
+
+  const { children, defaultValue } = props
+  const { t } = useTranslation('common')
+  const locale = useRoutingLocale()
+
+  return (
+    <DialogPrimitive.Root
+      defaultOpen={false}
+      open={isOpen}
+      onOpenChange={(newValue: boolean) => startTransition(() => setIsOpen(newValue))}
+    >
+      <DialogPrimitive.Trigger asChild={true}>
+        <Button
+          className={buttonTrigger}
+          variant="ghost"
+          size="medium"
+          aria-label={t('NAV_MENU_DIALOG_OPEN')}
+        >
+          <MobileMenuOpenIcon />
+        </Button>
+      </DialogPrimitive.Trigger>
+      <DialogContent>
+        <div className={contentWrapper}>
+          <div className={HeaderMenuHeader}>
+            <div className={logoWrapper}>
+              <LogoHomeLink />
+            </div>
+            <DialogPrimitive.Close asChild={true}>
+              <Button
+                className={buttonTrigger}
+                variant="ghost"
+                size="medium"
+                aria-label={t('NAV_MENU_DIALOG_CLOSE')}
+              >
+                <MobileMenuCloseIcon />
+              </Button>
+            </DialogPrimitive.Close>
+            <ShoppingCartMenuItem />
+          </div>
+          {isContentVisible && (
+            <NavigationMenuPrimitive.Root className={navigation} defaultValue={defaultValue}>
+              <NavigationMenuPrimitive.List className={navigationPrimaryList}>
+                <div>{children}</div>
+                <div className={buttonWrapper}>
+                  <Button
+                    as="a"
+                    href={getAppStoreLink('apple', locale).toString()}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    variant="secondary"
+                    size="medium"
+                  >
+                    <SpaceFlex space={0.5} align="center">
+                      <AppleIcon />
+                      App Store
+                    </SpaceFlex>
+                  </Button>
+                  <Button
+                    as="a"
+                    href={getAppStoreLink('google', locale).toString()}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    variant="secondary"
+                    size="medium"
+                  >
+                    <SpaceFlex space={0.5} align="center">
+                      <AndroidIcon />
+                      Google Play
+                    </SpaceFlex>
+                  </Button>
+                </div>
+              </NavigationMenuPrimitive.List>
+            </NavigationMenuPrimitive.Root>
+          )}
+        </div>
+      </DialogContent>
+    </DialogPrimitive.Root>
+  )
+}
+
+function DialogContent(props: DialogPrimitive.DialogContentProps) {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className={dialogOverlay} />
+      <DialogPrimitive.Content {...props} />
+    </DialogPrimitive.Portal>
+  )
+}
+
+const MobileMenuOpenIcon = () => {
+  return (
+    <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M0 16C0 10.3995 0 7.59921 1.08993 5.46009C2.04867 3.57847 3.57847 2.04867 5.46009 1.08993C7.59921 0 10.3995 0 16 0H24C29.6005 0 32.4008 0 34.5399 1.08993C36.4215 2.04867 37.9513 3.57847 38.9101 5.46009C40 7.59921 40 10.3995 40 16V24C40 29.6005 40 32.4008 38.9101 34.5399C37.9513 36.4215 36.4215 37.9513 34.5399 38.9101C32.4008 40 29.6005 40 24 40H16C10.3995 40 7.59921 40 5.46009 38.9101C3.57847 37.9513 2.04867 36.4215 1.08993 34.5399C0 32.4008 0 29.6005 0 24V16Z"
+        fill={tokens.colors.grayTranslucent200}
+      />
+      <path
+        d="M14 16L26 16"
+        stroke={tokens.colors.gray1000}
+        stroke-width="1.5"
+        stroke-linecap="round"
+      />
+      <path
+        d="M14 24L26 24"
+        stroke={tokens.colors.gray1000}
+        stroke-width="1.5"
+        stroke-linecap="round"
+      />
+    </svg>
+  )
+}
+
+const MobileMenuCloseIcon = () => {
+  return (
+    <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M0 16C0 10.3995 0 7.59921 1.08993 5.46009C2.04867 3.57847 3.57847 2.04867 5.46009 1.08993C7.59921 0 10.3995 0 16 0H24C29.6005 0 32.4008 0 34.5399 1.08993C36.4215 2.04867 37.9513 3.57847 38.9101 5.46009C40 7.59921 40 10.3995 40 16V24C40 29.6005 40 32.4008 38.9101 34.5399C37.9513 36.4215 36.4215 37.9513 34.5399 38.9101C32.4008 40 29.6005 40 24 40H16C10.3995 40 7.59921 40 5.46009 38.9101C3.57847 37.9513 2.04867 36.4215 1.08993 34.5399C0 32.4008 0 29.6005 0 24V16Z"
+        fill={tokens.colors.grayTranslucent200}
+      />
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M14.8735 13.8128C14.5806 13.5199 14.1057 13.5199 13.8128 13.8128C13.5199 14.1057 13.5199 14.5805 13.8128 14.8734L18.9393 19.9999L13.8128 25.1265C13.5199 25.4194 13.52 25.8943 13.8128 26.1871C14.1057 26.48 14.5806 26.48 14.8735 26.1871L20 21.0606L25.1265 26.1871C25.4194 26.48 25.8943 26.48 26.1872 26.1871C26.4801 25.8942 26.4801 25.4194 26.1872 25.1265L21.0606 19.9999L26.1871 14.8733C26.48 14.5804 26.48 14.1056 26.1871 13.8127C25.8942 13.5198 25.4193 13.5198 25.1265 13.8127L20 18.9393L14.8735 13.8128Z"
+        fill={tokens.colors.gray1000}
+      />
+    </svg>
+  )
+}

--- a/apps/store/src/components/HeaderNew/NavigationContent.tsx
+++ b/apps/store/src/components/HeaderNew/NavigationContent.tsx
@@ -1,0 +1,23 @@
+import {
+  Content as NavigationMenuContent,
+  type NavigationMenuContentProps,
+} from '@radix-ui/react-navigation-menu'
+import clsx from 'clsx'
+import { navigationContent } from './Header.css'
+
+export function NavigationContent({ className, ...forwardedProps }: NavigationMenuContentProps) {
+  return (
+    <NavigationMenuContent
+      className={clsx(navigationContent, className)}
+      {...forwardedProps}
+      // For SEO reasons, we want to force the content to be mounted so navigation links are
+      // accessible to search engines.
+      forceMount={true}
+      // Gotcha: For some reason when 'forceMount' is enable for navigation content, radix
+      // considers clicks inside the content as outside clicks. This is a workaround to
+      // prevent the behavior of closing the navigation menu when clicking on a link inside
+      // the navigation content.
+      onPointerDownOutside={(event) => event.preventDefault()}
+    />
+  )
+}

--- a/apps/store/src/components/HeaderNew/NavigationLink/NavigationLink.css.ts
+++ b/apps/store/src/components/HeaderNew/NavigationLink/NavigationLink.css.ts
@@ -1,0 +1,65 @@
+import { style } from '@vanilla-extract/css'
+import { tokens, minWidth } from 'ui'
+import { focusableStyles } from '../Header.css'
+
+export const navigationLink = style([
+  focusableStyles,
+  {
+    display: 'block',
+    paddingBlock: tokens.space.lg,
+
+    '@media': {
+      [minWidth.lg]: {
+        paddingBlock: tokens.space.xs,
+        paddingInline: tokens.space.md,
+        borderRadius: tokens.radius.sm,
+
+        ':hover': {
+          backgroundColor: tokens.colors.grayTranslucent100,
+        },
+      },
+    },
+  },
+])
+
+export const productNavigationLinkCard = style([
+  focusableStyles,
+  {
+    display: 'flex',
+    columnGap: tokens.space.sm,
+    placeItems: 'center',
+    flexShrink: 0,
+    paddingBlock: tokens.space.xs,
+    position: 'relative',
+
+    '@media': {
+      [minWidth.lg]: {
+        columnGap: tokens.space.xs,
+        paddingInline: tokens.space.xs,
+        borderRadius: tokens.radius.sm,
+
+        ':hover': {
+          backgroundColor: tokens.colors.grayTranslucent100,
+        },
+      },
+    },
+  },
+])
+
+export const secondaryNavigationLink = style([
+  focusableStyles,
+  {
+    alignSelf: 'center',
+    textDecoration: 'none',
+    whiteSpace: 'nowrap',
+  },
+])
+
+export const expandingLink = style({
+  // Make the whole card clickable - CallToAction height
+  '::after': {
+    content: '""',
+    position: 'absolute',
+    inset: 0,
+  },
+})

--- a/apps/store/src/components/HeaderNew/NavigationLink/NavigationLink.tsx
+++ b/apps/store/src/components/HeaderNew/NavigationLink/NavigationLink.tsx
@@ -1,0 +1,81 @@
+import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
+import clsx from 'clsx'
+import Link from 'next/link'
+import { Badge, Space, Text } from 'ui'
+import { Pillow } from '@/components/Pillow/Pillow'
+import {
+  navigationLink,
+  productNavigationLinkCard,
+  expandingLink,
+  secondaryNavigationLink,
+} from './NavigationLink.css'
+
+export type NavigationLinkProps = Pick<HTMLAnchorElement, 'href'> &
+  Omit<NavigationMenuPrimitive.NavigationMenuLinkProps, 'href'> & {
+    pillowImageSrc?: string
+    label?: string
+    absoluteUrl?: boolean
+  }
+
+export const NavigationLink = ({ href, className, children, ...rest }: NavigationLinkProps) => {
+  // Render a regular <a> tag for manual URLs containing https://. Thats because when linking between locales (/no -> /se),
+  // you end up on /no/se with using Next internal routing. This will also work for external links.
+  const isExternalLink = href.match(/^(https?:)?\/\//)
+  if (isExternalLink) {
+    return (
+      <NavigationMenuPrimitive.Link
+        href={href}
+        className={clsx(navigationLink, className)}
+        {...rest}
+      >
+        {children}
+      </NavigationMenuPrimitive.Link>
+    )
+  }
+
+  return (
+    <Link href={href} passHref legacyBehavior>
+      <NavigationMenuPrimitive.Link className={clsx(navigationLink, className)} {...rest}>
+        {children}
+      </NavigationMenuPrimitive.Link>
+    </Link>
+  )
+}
+
+export const ProductNavigationLink = ({
+  href,
+  children,
+  pillowImageSrc,
+  label,
+}: NavigationLinkProps) => {
+  return (
+    <Space className={productNavigationLinkCard}>
+      <Pillow size="xsmall" src={pillowImageSrc} />
+      <Link href={href} className={expandingLink}>
+        <Text as="span" size={{ _: 'xl', lg: 'md' }}>
+          {children}
+        </Text>
+      </Link>
+      {label && (
+        <Badge size="responsive" as="span" color="green50">
+          {label}
+        </Badge>
+      )}
+    </Space>
+  )
+}
+
+export const SecondaryNavigationLink = ({
+  href,
+  className,
+  children,
+  ...rest
+}: NavigationLinkProps) => {
+  return (
+    <Link href={href} passHref legacyBehavior>
+      <NavigationMenuPrimitive.Link className={clsx(secondaryNavigationLink, className)} {...rest}>
+        {children}
+      </NavigationMenuPrimitive.Link>
+    </Link>
+  )
+}

--- a/apps/store/src/components/HeaderNew/NavigationTrigger.tsx
+++ b/apps/store/src/components/HeaderNew/NavigationTrigger.tsx
@@ -1,0 +1,12 @@
+import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
+import type { LinkProps } from 'next/link'
+import Link from 'next/link'
+import { navigationTriggerLink } from './Header.css'
+
+export const NavigationTrigger = (props: LinkProps & { children: string }) => {
+  return (
+    <NavigationMenuPrimitive.Trigger asChild>
+      <Link className={navigationTriggerLink} {...props} />
+    </NavigationMenuPrimitive.Trigger>
+  )
+}

--- a/apps/store/src/components/HeaderNew/ShoppingCartMenuItem/ShoppingBagIcon.tsx
+++ b/apps/store/src/components/HeaderNew/ShoppingCartMenuItem/ShoppingBagIcon.tsx
@@ -1,0 +1,52 @@
+import { Text, tokens } from 'ui'
+import { cartCount, iconWrapper } from './ShoppingCartMenuItem.css'
+
+export type ShoppingBagIconProps = {
+  count: number
+}
+
+export const ShoppingBagIcon = ({ count }: ShoppingBagIconProps) => {
+  const hasItemsInCart = count > 0
+
+  return (
+    <>
+      {hasItemsInCart ? (
+        <div className={iconWrapper}>
+          <ShoppingBagIconGreen />
+          <Text className={cartCount} as="span" size="md">
+            {count}
+          </Text>
+        </div>
+      ) : (
+        <div className={iconWrapper}>
+          <ShoppingBagIconLight />
+          <Text className={cartCount} size="md">
+            {count}
+          </Text>
+        </div>
+      )}
+    </>
+  )
+}
+
+const ShoppingBagIconLight = () => {
+  return (
+    <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M0 16C0 10.3995 0 7.59921 1.08993 5.46009C2.04867 3.57847 3.57847 2.04867 5.46009 1.08993C7.59921 0 10.3995 0 16 0H24C29.6005 0 32.4008 0 34.5399 1.08993C36.4215 2.04867 37.9513 3.57847 38.9101 5.46009C40 7.59921 40 10.3995 40 16V24C40 29.6005 40 32.4008 38.9101 34.5399C37.9513 36.4215 36.4215 37.9513 34.5399 38.9101C32.4008 40 29.6005 40 24 40H16C10.3995 40 7.59921 40 5.46009 38.9101C3.57847 37.9513 2.04867 36.4215 1.08993 34.5399C0 32.4008 0 29.6005 0 24V16Z"
+        fill={tokens.colors.grayTranslucent200}
+      />
+    </svg>
+  )
+}
+
+const ShoppingBagIconGreen = () => {
+  return (
+    <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M0 16C0 10.3995 0 7.59921 1.08993 5.46009C2.04867 3.57847 3.57847 2.04867 5.46009 1.08993C7.59921 0 10.3995 0 16 0H24C29.6005 0 32.4008 0 34.5399 1.08993C36.4215 2.04867 37.9513 3.57847 38.9101 5.46009C40 7.59921 40 10.3995 40 16V24C40 29.6005 40 32.4008 38.9101 34.5399C37.9513 36.4215 36.4215 37.9513 34.5399 38.9101C32.4008 40 29.6005 40 24 40H16C10.3995 40 7.59921 40 5.46009 38.9101C3.57847 37.9513 2.04867 36.4215 1.08993 34.5399C0 32.4008 0 29.6005 0 24V16Z"
+        fill={tokens.colors.green100}
+      />
+    </svg>
+  )
+}

--- a/apps/store/src/components/HeaderNew/ShoppingCartMenuItem/ShoppingCartMenuItem.css.ts
+++ b/apps/store/src/components/HeaderNew/ShoppingCartMenuItem/ShoppingCartMenuItem.css.ts
@@ -1,0 +1,28 @@
+import { style } from '@vanilla-extract/css'
+import { tokens } from 'ui'
+
+export const wrapper = style({
+  // Align to the right in the header
+  marginLeft: 'auto',
+  lineHeight: 0,
+})
+
+export const cartLink = style({
+  display: 'inline-block',
+  ':focus-visible': {
+    outline: `2px solid ${tokens.colors.gray900}`,
+  },
+})
+
+export const iconWrapper = style({
+  position: 'relative',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+})
+
+export const cartCount = style({
+  position: 'absolute',
+  // Center vertically
+  marginTop: -1,
+})

--- a/apps/store/src/components/HeaderNew/ShoppingCartMenuItem/ShoppingCartMenuItem.tsx
+++ b/apps/store/src/components/HeaderNew/ShoppingCartMenuItem/ShoppingCartMenuItem.tsx
@@ -1,0 +1,25 @@
+'use client'
+import Link from 'next/link'
+import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
+import { PageLink } from '@/utils/PageLink'
+import { ShoppingBagIcon } from './ShoppingBagIcon'
+import { cartLink, wrapper } from './ShoppingCartMenuItem.css'
+
+export const ShoppingCartMenuItem = () => {
+  const { shopSession } = useShopSession()
+  const cartLineCount = shopSession?.cart.entries.length ?? 0
+
+  const locale = useRoutingLocale()
+  return (
+    <div className={wrapper}>
+      <Link
+        className={cartLink}
+        href={PageLink.cart({ locale }).pathname}
+        aria-label="shopping cart"
+      >
+        <ShoppingBagIcon count={cartLineCount} />
+      </Link>
+    </div>
+  )
+}

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -2,7 +2,8 @@ import * as process from 'process'
 import type { ISbStoriesParams, ISbStoryData, SbBlokData, StoryblokClient } from '@storyblok/react'
 import { apiPlugin, getStoryblokApi, storyblokInit } from '@storyblok/react'
 import type { FooterBlockProps } from '@/blocks/FooterBlock/FooterBlock'
-import type { HeaderBlockProps } from '@/blocks/HeaderBlock/HeaderBlock'
+import { type NavMenuContainerProps } from '@/blocks/HeaderBlock/HeaderBlock'
+import { type HeaderMenuProps } from '@/blocks/HeaderBlockNew/HeaderBlock'
 import type { ReusableBlockReferenceProps } from '@/blocks/ReusableBlockReference'
 import { type ContentAlignment, type ContentWidth } from '@/components/GridLayout/GridLayout.helper'
 import type { BreadcrumbListItem } from '@/components/PageBreadcrumbs/PageBreadcrumbs'
@@ -151,9 +152,14 @@ export type WidgetFlowStory = ISbStoryData<{
   showBackButton?: boolean
 }>
 
+type HeaderProps = SbBaseBlockProps<{
+  navMenuContainer: NavMenuContainerProps
+  headerMenu: HeaderMenuProps
+}>
+
 export type GlobalStory = ISbStoryData & {
   content: ISbStoryData['content'] & {
-    header: ExpectedBlockType<HeaderBlockProps>
+    header: ExpectedBlockType<HeaderProps>
     footer: ExpectedBlockType<FooterBlockProps>
   }
 }

--- a/apps/store/src/utils/Features.ts
+++ b/apps/store/src/utils/Features.ts
@@ -20,6 +20,7 @@ const config = {
   CROSS_SELL_CARD_V2: process.env.NEXT_PUBLIC_CROSS_SELL_CARD_V2 === 'true',
   HIDE_REVIEWS_FROM_PRODUCT_AVERAGE_RATING:
     process.env.NEXT_PUBLIC_HIDE_REVIEWS_FROM_PRODUCT_AVERAGE_RATING === 'true',
+  NEW_HEADER: process.env.NEXT_PUBLIC_FEATURE_NEW_HEADER === 'true',
 } as const
 
 export type FeatureFlag = keyof typeof config


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
First step of the new header and menu

To simplify replacing the menu, I made a copy of the current `HeaderBlock` and `Header` and started modifying them. I'll summarise the updates since some parts of the code is still the same.

- Update schema in Storyblock with new blocks with more logical names `headerMenu` with new child blocks `productMenu`, `subMenu` and `menuItem`
- Add feature flag for the new HeaderBlock
- Change layout in Header and put the logo in the center
- Update `ShoppingCartMenuItem` with new design
- Update mobile menu trigger with new design

https://github.com/HedvigInsurance/racoon/assets/6661511/b63474a2-db73-4810-a5a6-ae68d91e8941

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
New header and menu for Hedvig.com

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
