### PR TITLE
Fix purchase form sometimes not showing suggested data

### DIFF
--- a/apps/store/src/components/PriceCalculator/FormGrid/FormGrid.tsx
+++ b/apps/store/src/components/PriceCalculator/FormGrid/FormGrid.tsx
@@ -19,7 +19,13 @@ export const FormGrid = ({ items, autofocusFirst }: FormSectionProps) => {
             [columnSpan]: `${item.layout.columnSpan}`,
           })}
         >
-          <AutomaticField field={item.field} autoFocus={autofocusFirst && index === 0} />
+          <AutomaticField
+            // NOTE: We want to remount the field when default changes from empty (could be any f
+            // But not when default changes from one value to another - this risks loosing user input
+            key={`${item.field.name}_${item.field.defaultValue == null || item.field.defaultValue === ''}`}
+            field={item.field}
+            autoFocus={autofocusFirst && index === 0}
+          />
         </div>
       ))}
     </div>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Make sure we reliably update purchase form fields when we get non-empty suggested data

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

There was a race condition between price intent and customer update and we sometimes rendered empty fields in "your home" section

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
