### PR TITLE
Replace most usages of priceIntentAtom with usePriceIntent hook

### DIFF
--- a/apps/store/src/components/PriceCalculator/CurrentInsuranceField/CurrentInsuranceField.tsx
+++ b/apps/store/src/components/PriceCalculator/CurrentInsuranceField/CurrentInsuranceField.tsx
@@ -1,6 +1,5 @@
 import { datadogLogs } from '@datadog/browser-logs'
-import { useAtomValue } from 'jotai'
-import { priceIntentAtom } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
+import { usePriceIntent } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
 import {
   useExternalInsurersQuery,
   useExternalInsurerUpdateMutation,
@@ -14,7 +13,7 @@ type Props = {
 }
 
 export const CurrentInsuranceField = ({ label }: Props) => {
-  const priceIntent = useAtomValue(priceIntentAtom)
+  const priceIntent = usePriceIntent()
   const priceIntentId = priceIntent.id
 
   const showFetchInsurance = useShowFetchInsurance({ priceIntentId })

--- a/apps/store/src/components/PriceCalculator/FetchInsuranceContainer.tsx
+++ b/apps/store/src/components/PriceCalculator/FetchInsuranceContainer.tsx
@@ -1,14 +1,14 @@
 import { useAtomValue } from 'jotai'
 import { FetchInsurance } from '@/components/PriceCalculator/FetchInsurance'
 import {
-  priceIntentAtom,
   shopSessionCustomerAtom,
+  usePriceIntent,
 } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
 import { Features } from '@/utils/Features'
 
 export const FetchInsuranceContainer = () => {
   const shopSessionCustomer = useAtomValue(shopSessionCustomerAtom)
-  const priceIntent = useAtomValue(priceIntentAtom)
+  const priceIntent = usePriceIntent()
 
   if (!Features.enabled('INSURELY')) return null
   if (priceIntent.product.name === 'SE_CAR' && !Features.enabled('INSURELY_CAR')) return null

--- a/apps/store/src/components/PriceCalculator/PriceIntentWarningDialog/PriceIntentWarningDialog.tsx
+++ b/apps/store/src/components/PriceCalculator/PriceIntentWarningDialog/PriceIntentWarningDialog.tsx
@@ -1,6 +1,6 @@
-import { useAtom, useAtomValue } from 'jotai'
+import { useAtom } from 'jotai'
 import { Dialog } from 'ui'
-import { priceIntentAtom } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
+import { usePriceIntent } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
 import { dialogContent, dialogWindow } from './PriceIntentWarningDialog.css'
 import { showPriceIntentWarningAtom } from './showPriceIntentWarningAtom'
 import { WarningPrompt } from './WarningPrompt'
@@ -10,7 +10,7 @@ type Props = {
 }
 
 export function PriceIntentWarningDialog({ onConfirm }: Props) {
-  const priceIntentWarning = useAtomValue(priceIntentAtom).warning
+  const priceIntentWarning = usePriceIntent().warning
   const [isOpen, setIsOpen] = useAtom(showPriceIntentWarningAtom)
 
   const handleClickConfirm = () => {

--- a/apps/store/src/components/ProductPage/PriceIntentTrackingProvider.tsx
+++ b/apps/store/src/components/ProductPage/PriceIntentTrackingProvider.tsx
@@ -1,31 +1,21 @@
 'use client'
-import { useStore } from 'jotai'
-import { type ReactNode, useRef } from 'react'
+import { useAtomValue } from 'jotai'
+import { type ReactNode } from 'react'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
-import {
-  currentPriceIntentIdAtom,
-  priceIntentAtom,
-} from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
-import { type PriceIntentFragment } from '@/services/graphql/generated'
+import { priceIntentAtom } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
 import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { TrackingProvider } from '@/services/Tracking/TrackingContext'
 
 export const PriceIntentTrackingProvider = (props: { children: ReactNode }) => {
   const shopSessionId = useShopSessionId()
-  const priceIntentRef = useRef<PriceIntentFragment | null>(null)
-  const store = useStore()
-  const priceIntentId = store.get(currentPriceIntentIdAtom)
-  if (priceIntentId !== null) {
-    // NOTE: `useAtomValue` won't work here since we need to read conditionally
-    // Tying to read before `currentPriceIntentIdAtom` is set will lead to an error
-    priceIntentRef.current = store.get(priceIntentAtom)
-  }
+  // NOTE: Can be null unlike `usePriceIntent()` which will crash if not loaded yet
+  const priceIntent = useAtomValue(priceIntentAtom)
   const productData = useProductData()
 
   return (
     <TrackingProvider
       shopSessionId={shopSessionId}
-      priceIntent={priceIntentRef.current}
+      priceIntent={priceIntent}
       productData={productData}
     >
       {props.children}

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -2,7 +2,6 @@ import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
 import styled from '@emotion/styled'
 import { useInView } from 'framer-motion'
-import { useAtomValue } from 'jotai'
 import { useRouter } from 'next/navigation'
 import { useTranslation } from 'next-i18next'
 import { memo, type MouseEventHandler, type ReactNode, type RefObject } from 'react'
@@ -28,7 +27,7 @@ import { useFormatter } from '@/utils/useFormatter'
 import { ComparisonTableModal } from './ComparisonTableModal'
 import { DeductibleSelector } from './DeductibleSelector'
 import { DiscountTooltip } from './DiscountTooltip/DiscountTooltip'
-import { priceIntentAtom, useResetPriceIntent } from './priceIntentAtoms'
+import { usePriceIntent, useResetPriceIntent } from './priceIntentAtoms'
 import { ProductTierSelector } from './ProductTierSelector'
 import { useSelectedOffer } from './useSelectedOffer'
 import { useTiersAndDeductibles } from './useTiersAndDeductibles'
@@ -49,7 +48,7 @@ export const OfferPresenter = memo((props: Props) => {
   if (shopSession == null) {
     throw new Error('shopSession must be defined')
   }
-  const priceIntent = useAtomValue(priceIntentAtom)
+  const priceIntent = usePriceIntent()
   const [selectedOffer, setSelectedOffer] = useSelectedOffer()
   if (selectedOffer == null) {
     throw new Error('selectedOffer must be defined')

--- a/apps/store/src/components/ProductPage/PurchaseForm/priceIntentAtoms.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/priceIntentAtoms.ts
@@ -29,16 +29,25 @@ const priceIntentAtomFamily = atomFamily((priceIntentId: unknown) =>
   atom<PriceIntentFragment | null>(null),
 )
 
-export const priceIntentAtom = atom<PriceIntentFragment>((get) => {
-  const priceIntentId = getAtomValueOrThrow(get, currentPriceIntentIdAtom)
-  return getAtomValueOrThrow(get, priceIntentAtomFamily(priceIntentId))
+export const priceIntentAtom = atom<PriceIntentFragment | null>((get) => {
+  const priceIntentId = get(currentPriceIntentIdAtom)
+  if (priceIntentId == null) return null
+  return get(priceIntentAtomFamily(priceIntentId)) ?? null
 })
+
+export const usePriceIntent = () => {
+  const atomValue = useAtomValue(priceIntentAtom)
+  if (atomValue == null) {
+    throw new Error('priceIntent must be defined')
+  }
+  return atomValue
+}
 
 export const shopSessionCustomerAtom = atom<ShopSessionCustomerFragment | null>(null)
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const priceCalculatorFormAtom = atom<Form>((get) => {
-  const priceIntent = get(priceIntentAtom)
+  const priceIntent = getAtomValueOrThrow(get, priceIntentAtom)
   const template = getAtomValueOrThrow(get, priceTemplateAtom)
   return setupForm({
     customer: get(shopSessionCustomerAtom),


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Made `priceIntentAtom` null-unsafe and moved definitely-non-null assertion to new `usePriceIntent()` hook

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

- Better developer experience for common case
- Easier to check for null priceIntent in one use case we had (tracking)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
