### PR TITLE
Don't show cart count until shopSession is loaded

### DIFF
--- a/apps/store/src/components/HeaderNew/ShoppingCartMenuItem/ShoppingBagIcon.tsx
+++ b/apps/store/src/components/HeaderNew/ShoppingCartMenuItem/ShoppingBagIcon.tsx
@@ -2,11 +2,11 @@ import { Text, tokens } from 'ui'
 import { cartCount, iconWrapper } from './ShoppingCartMenuItem.css'
 
 export type ShoppingBagIconProps = {
-  count: number
+  count?: number
 }
 
 export const ShoppingBagIcon = ({ count }: ShoppingBagIconProps) => {
-  const hasItemsInCart = count > 0
+  const hasItemsInCart = count && count > 0
 
   return (
     <>
@@ -20,7 +20,7 @@ export const ShoppingBagIcon = ({ count }: ShoppingBagIconProps) => {
       ) : (
         <div className={iconWrapper}>
           <ShoppingBagIconLight />
-          <Text className={cartCount} size="md">
+          <Text className={cartCount} as="span" size="md">
             {count}
           </Text>
         </div>

--- a/apps/store/src/components/HeaderNew/ShoppingCartMenuItem/ShoppingCartMenuItem.tsx
+++ b/apps/store/src/components/HeaderNew/ShoppingCartMenuItem/ShoppingCartMenuItem.tsx
@@ -8,7 +8,7 @@ import { cartLink, wrapper } from './ShoppingCartMenuItem.css'
 
 export const ShoppingCartMenuItem = () => {
   const { shopSession } = useShopSession()
-  const cartLineCount = shopSession?.cart.entries.length ?? 0
+  const cartLineCount = shopSession?.cart.entries.length
 
   const locale = useRoutingLocale()
   return (


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Don't show cart count until shopSession is loaded

https://github.com/HedvigInsurance/racoon/assets/6661511/f2d7d541-32d9-42a5-8c61-d3d787e147be


https://github.com/HedvigInsurance/racoon/assets/6661511/d20a2bf3-0623-4d79-8ce4-bc5a809bf655



<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Less UI shift, we don't want to show a 0 and then number of cart items once shopsession has loaded
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
