### PR TITLE
GEN-2421 - refact(confirmation-page): better split props dependencies between UI component and nextjs page

### DIFF
--- a/apps/store/src/app/[locale]/new/confirmation/[shopSessionId]/page.tsx
+++ b/apps/store/src/app/[locale]/new/confirmation/[shopSessionId]/page.tsx
@@ -1,0 +1,24 @@
+import { type Metadata } from 'next'
+import type { ConfirmationStory } from '@/services/storyblok/storyblok'
+import { getStoryBySlug } from '@/services/storyblok/storyblok'
+import type { RoutingLocale } from '@/utils/l10n/types'
+
+type Params = { locale: RoutingLocale; shopSessionId: string }
+
+type Props = { params: Params }
+
+export default function Page() {
+  return null
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const story = await fetchConfirmationStory(params.locale)
+
+  return { title: story.content.seoTitle }
+}
+
+function fetchConfirmationStory(locale: RoutingLocale): Promise<ConfirmationStory> {
+  const CONFIRMATION_PAGE_SLUG = 'confirmation'
+
+  return getStoryBySlug<ConfirmationStory>(CONFIRMATION_PAGE_SLUG, { locale })
+}

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.stories.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.stories.tsx
@@ -4,40 +4,6 @@ import { ShopSessionOutcomeDocument } from '@/services/graphql/generated'
 import type { ConfirmationStory } from '@/services/storyblok/storyblok'
 import { ConfirmationPage } from './ConfirmationPage'
 
-const meta: Meta<typeof ConfirmationPage> = {
-  title: 'Checkout / ConfirmationPage',
-  parameters: {
-    layout: 'fullscreen',
-  },
-}
-
-export default meta
-type Story = StoryObj<typeof ConfirmationPage>
-
-const Template: Story = {
-  render: (args) => <ConfirmationPage {...args} />,
-}
-
-const storyblokStory = {
-  id: 123,
-  alternates: [],
-  full_slug: 'confirmation-page',
-  created_at: '2021-03-02T10:00:00.000Z',
-  group_id: '123',
-  is_startpage: false,
-  name: 'Confirmation page',
-  parent_id: 123,
-  position: 0,
-  published_at: '2021-03-02T10:00:00.000Z',
-  first_published_at: '2021-03-02T10:00:00.000Z',
-  meta_data: {},
-  slug: 'confirmation-page',
-  lang: 'en',
-  uuid: '123',
-  sort_by_date: '2021-03-02T10:00:00.000Z',
-  tag_list: [],
-}
-
 const cart = {
   id: '123',
   cost: {
@@ -110,7 +76,23 @@ const cart = {
 
 // TODO: get this from some fixture module
 const story: ConfirmationStory = {
-  ...storyblokStory,
+  id: 123,
+  alternates: [],
+  full_slug: 'confirmation-page',
+  created_at: '2021-03-02T10:00:00.000Z',
+  group_id: '123',
+  is_startpage: false,
+  name: 'Confirmation page',
+  parent_id: 123,
+  position: 0,
+  published_at: '2021-03-02T10:00:00.000Z',
+  first_published_at: '2021-03-02T10:00:00.000Z',
+  meta_data: {},
+  slug: 'confirmation-page',
+  lang: 'en',
+  uuid: '123',
+  sort_by_date: '2021-03-02T10:00:00.000Z',
+  tag_list: [],
   content: {
     body: [],
     title: 'Your purchase is complete!',
@@ -123,37 +105,41 @@ const story: ConfirmationStory = {
       name: '',
       focus: '',
       title: '',
-      filename: 'https://a.storyblok.com/f/165473/2160x1549/7784154280/phone_heldnatural_en-1.png',
+      filename:
+        'https://a.storyblok.com/f/165473/3000x1750/2286e28041/mobil-i-handen-hedvig-3000.jpg',
       copyright: '',
       fieldtype: 'asset',
       is_external_url: false,
     },
     checklistTitle: 'What happens next?',
     checklistSubtitle: 'We will send you a confirmation via email.',
-    checklist: `Sign Hedvig
-          Connect payment method
-          Download the app`,
+    checklist: 'Sign Hedvig\nConnect payment method\nDownload the app',
     faqTitle: 'Frequently asked questions',
     faqSubtitle: 'Here are some answers to the most common questions.',
     seoTitle: 'Your purchase is complete | Hedvig',
   },
 }
 
+const meta: Meta<typeof ConfirmationPage> = {
+  title: 'Checkout / ConfirmationPage',
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof ConfirmationPage>
+
+const Template: Story = {
+  render: (args) => <ConfirmationPage {...args} />,
+}
+
 export const Default = {
   ...Template,
   args: {
-    globalStory: {
-      ...storyblokStory,
-      content: {
-        header: [],
-        footer: [],
-      },
-    },
-    shopSessionId: 'ecf94a27-9daa-460e-a272-48b60f2d74ec',
-    memberPartnerData: { sas: { eligible: true } },
     currency: 'SEK',
-    cart: cart,
-    story: story,
+    cart,
+    story,
   },
 }
 
@@ -215,5 +201,13 @@ export const WithSwitchingAssistant = {
         },
       ],
     },
+  },
+}
+
+export const WithSasPartnership = {
+  ...Template,
+  args: {
+    ...Default.args,
+    memberPartnerData: { sas: { eligible: true } },
   },
 }

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -6,17 +6,12 @@ import { ShopBreakdown } from '@/components/ShopBreakdown/ShopBreakdown'
 import { TotalAmountContainer } from '@/components/ShopBreakdown/TotalAmountContainer'
 import { ProductItemContractContainerCar } from '@/features/carDealership/ProductItemContractContainer'
 import { SasEurobonusSectionContainer } from '@/features/sas/SasEurobonusSection'
-import type { ConfirmationStory } from '@/services/storyblok/storyblok'
 import { Features } from '@/utils/Features'
 import type { ConfirmationPageProps } from './ConfirmationPage.types'
 import { StaticContent } from './StaticContent'
 import { SwitchingAssistantSection } from './SwitchingAssistantSection/SwitchingAssistantSection'
 
-type Props = ConfirmationPageProps & {
-  story: ConfirmationStory
-}
-
-export const ConfirmationPage = (props: Props) => {
+export const ConfirmationPage = (props: ConfirmationPageProps) => {
   const cartTotalCost = props.cart.cost.gross.amount
 
   return (

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
@@ -3,12 +3,11 @@ import type {
   CurrentMemberQuery,
   CartFragment,
 } from '@/services/graphql/generated'
-import type { StoryblokPageProps } from '@/services/storyblok/storyblok'
+import type { ConfirmationStory } from '@/services/storyblok/storyblok'
 
 export type MemberPartnerData = CurrentMemberQuery['currentMember']['partnerData']
 
-export type ConfirmationPageProps = Pick<StoryblokPageProps, 'globalStory'> & {
-  shopSessionId: string
+export type ConfirmationPageProps = {
   cart: CartFragment
   memberPartnerData: MemberPartnerData | null
   switching?: {
@@ -16,4 +15,5 @@ export type ConfirmationPageProps = Pick<StoryblokPageProps, 'globalStory'> & {
     companyDisplayName: string
   }
   carTrialContract?: TrialContractFragment
+  story: ConfirmationStory
 }

--- a/apps/store/src/features/sas/SasEurobonusSection.stories.tsx
+++ b/apps/store/src/features/sas/SasEurobonusSection.stories.tsx
@@ -1,9 +1,10 @@
 import type { StoryObj } from '@storybook/react'
 import { type Meta } from '@storybook/react'
-import type { SasEurobonusSection } from './SasEurobonusSection'
+import { SasEurobonusSection } from './SasEurobonusSection'
 
 const meta: Meta<typeof SasEurobonusSection> = {
-  title: 'Checkout / SAS Eurobonus Section',
+  title: 'Checkout / ConfirmationPage / SAS Eurobonus Section',
+  component: SasEurobonusSection,
   args: {
     state: 'idle',
     eurobonusNumber: '',

--- a/apps/store/src/pages/[locale]/car-buyer/confirmation/[contractId].tsx
+++ b/apps/store/src/pages/[locale]/car-buyer/confirmation/[contractId].tsx
@@ -1,7 +1,6 @@
 import type { ApolloClient } from '@apollo/client'
 import type { GetServerSideProps } from 'next'
-import type { ComponentPropsWithoutRef } from 'react'
-import type { ConfirmationPage } from '@/components/ConfirmationPage/ConfirmationPage'
+import { type ConfirmationPageProps } from '@/components/ConfirmationPage/ConfirmationPage.types'
 import { getLayoutWithMenuProps } from '@/components/LayoutWithMenu/getLayoutWithMenuProps'
 import { STORYBLOK_CAR_DEALERSHIP_FOLDER_SLUG } from '@/features/carDealership/carDearlership.constants'
 import { addApolloState, initializeApolloServerSide } from '@/services/apollo/client'
@@ -10,12 +9,16 @@ import type {
   CarTrialExtensionQueryVariables,
 } from '@/services/graphql/generated'
 import { CarTrialExtensionDocument } from '@/services/graphql/generated'
-import type { ConfirmationStory } from '@/services/storyblok/storyblok'
+import { type ConfirmationStory, type StoryblokPageProps } from '@/services/storyblok/storyblok'
 import { getStoryBySlug } from '@/services/storyblok/storyblok'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { patchNextI18nContext } from '@/utils/patchNextI18nContext'
 
-type Props = ComponentPropsWithoutRef<typeof ConfirmationPage>
+// globalStory is used by page's layout
+type Props = ConfirmationPageProps & { shopSessionId: string } & Pick<
+    StoryblokPageProps,
+    'globalStory'
+  >
 
 type Params = { contractId: string }
 

--- a/apps/store/src/pages/[locale]/confirmation/[shopSessionId].tsx
+++ b/apps/store/src/pages/[locale]/confirmation/[shopSessionId].tsx
@@ -16,16 +16,19 @@ import {
 } from '@/services/graphql/generated'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
-import { type ConfirmationStory } from '@/services/storyblok/storyblok'
+import { type StoryblokPageProps } from '@/services/storyblok/storyblok'
 import { Features } from '@/utils/Features'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { patchNextI18nContext } from '@/utils/patchNextI18nContext'
 
 type Params = { shopSessionId: string }
 
-export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Params> = async (
-  context,
-) => {
+type Props = ConfirmationPageProps & { shopSessionId: string } & Pick<
+    StoryblokPageProps,
+    'globalStory'
+  >
+
+export const getServerSideProps: GetServerSideProps<Props, Params> = async (context) => {
   patchNextI18nContext(context)
   const { req, res, locale, params } = context
 
@@ -67,9 +70,7 @@ export const getServerSideProps: GetServerSideProps<ConfirmationPageProps, Param
   }
 }
 
-const CheckoutConfirmationPage: NextPageWithLayout<
-  ConfirmationPageProps & { story: ConfirmationStory }
-> = (props) => {
+const CheckoutConfirmationPage: NextPageWithLayout<Props> = (props) => {
   return (
     <>
       <Head>


### PR DESCRIPTION
## Describe your changes

Foundation changes for migrating _Confirmation_ page into _app router_:
* Create the _app router_ counterpart page. Right now it just handles metadata (page's title).
* Update `ConfirmationPage` API. Before it was depending on `globalStory` which was being used by nextjs page component. By removing that dependency I can use the same component for the _app router_ counterpart.
* Code scout changes on storybook file.

## Justify why they are needed

The idea is to get my hands dirty with Nextjs app router migration by migrating _ConfirmationPage_: `pages/[locale]/confirmation/[shopSessionId]` --> `app/[locale]/new/confirmation/[shopSessionId]` (`page.tsx` file)