### PR TITLE
GEN-2421 - feat(app router confirmation page): handle story and cart data

### DIFF
--- a/apps/store/src/app/[locale]/new/confirmation/[shopSessionId]/page.tsx
+++ b/apps/store/src/app/[locale]/new/confirmation/[shopSessionId]/page.tsx
@@ -1,4 +1,7 @@
 import { type Metadata } from 'next'
+import { ConfirmationPage } from '@/components/ConfirmationPage/ConfirmationPage'
+import { getApolloClient } from '@/services/apollo/app-router/rscClient'
+import { setupShopSession } from '@/services/shopSession/app-router/ShopSession.utils'
 import type { ConfirmationStory } from '@/services/storyblok/storyblok'
 import { getStoryBySlug } from '@/services/storyblok/storyblok'
 import type { RoutingLocale } from '@/utils/l10n/types'
@@ -7,8 +10,18 @@ type Params = { locale: RoutingLocale; shopSessionId: string }
 
 type Props = { params: Params }
 
-export default function Page() {
-  return null
+export default async function Page({ params }: Props) {
+  const confirmationStory = await fetchConfirmationStory(params.locale)
+
+  // TODO: enable fetching switching data. In order to do that we first need
+  // to be able to initialize apollo client with auth headers for rsc
+  const apolloClient = getApolloClient(params.locale)
+  const shopSessionService = setupShopSession(apolloClient)
+  const [shopSession] = await Promise.all([shopSessionService.fetchById(params.shopSessionId)])
+
+  return (
+    <ConfirmationPage story={confirmationStory} cart={shopSession.cart} memberPartnerData={null} />
+  )
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -22,3 +35,8 @@ function fetchConfirmationStory(locale: RoutingLocale): Promise<ConfirmationStor
 
   return getStoryBySlug<ConfirmationStory>(CONFIRMATION_PAGE_SLUG, { locale })
 }
+
+// Make sure this route always gets generated using dynamic rendering.
+// This provides a simple migration path between SSR pages into it's app router based counterpart.
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#options
+export const dynamic = 'force-dynamic'

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { Heading, mq, Space, theme } from 'ui'
 import * as GridLayout from '@/components/GridLayout/GridLayout'

--- a/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/fetchSwitchingData.ts
+++ b/apps/store/src/components/ConfirmationPage/SwitchingAssistantSection/fetchSwitchingData.ts
@@ -3,9 +3,9 @@ import type { SwitchingAssistantData } from './SwitchingAssistantSection.types'
 
 export async function fetchSwitchingData(
   shopSessionService: ShopSessionService,
-  shopSessionOutcomeId: string,
+  shopSessionId: string,
 ): Promise<SwitchingAssistantData | null> {
-  const outcome = await fetchOutcomeData(shopSessionService, shopSessionOutcomeId)
+  const outcome = await fetchOutcomeData(shopSessionService, shopSessionId)
   if (!outcome) return null
 
   const switchingContract = outcome.createdContracts.find(

--- a/apps/store/src/components/ConfirmationPage/fetchMemberPartnerData.ts
+++ b/apps/store/src/components/ConfirmationPage/fetchMemberPartnerData.ts
@@ -1,0 +1,26 @@
+import { type ApolloClient, isApolloError } from '@apollo/client'
+import {
+  CurrentMemberDocument,
+  type CurrentMemberQuery,
+  type CurrentMemberQueryVariables,
+} from '@/services/graphql/generated'
+import { Features } from '@/utils/Features'
+
+export async function fetchMemberPartnerData(apolloClient: ApolloClient<unknown>) {
+  if (!Features.enabled('SAS_PARTNERSHIP')) {
+    return null
+  }
+  try {
+    const { data } = await apolloClient.query<CurrentMemberQuery, CurrentMemberQueryVariables>({
+      query: CurrentMemberDocument,
+    })
+    return data.currentMember.partnerData ?? null
+  } catch (err) {
+    if (err instanceof Error && isApolloError(err)) {
+      console.info('Failed to fetch currentMember', err)
+      return null
+    } else {
+      throw err
+    }
+  }
+}

--- a/apps/store/src/graphql/ShopSessionOutcomeId.graphql
+++ b/apps/store/src/graphql/ShopSessionOutcomeId.graphql
@@ -1,5 +1,6 @@
 query ShopSessionOutcomeId($shopSessionId: UUID!) {
   shopSession(id: $shopSessionId) {
+    id
     outcome {
       id
     }

--- a/apps/store/src/pages/[locale]/confirmation/[shopSessionId].tsx
+++ b/apps/store/src/pages/[locale]/confirmation/[shopSessionId].tsx
@@ -1,23 +1,17 @@
-import { type ApolloClient, isApolloError } from '@apollo/client'
 import type { GetServerSideProps, NextPageWithLayout } from 'next'
 import Head from 'next/head'
 import { ConfirmationPage } from '@/components/ConfirmationPage/ConfirmationPage'
 import { type ConfirmationPageProps } from '@/components/ConfirmationPage/ConfirmationPage.types'
 import { fetchConfirmationStory } from '@/components/ConfirmationPage/fetchConfirmationStory'
+import { fetchMemberPartnerData } from '@/components/ConfirmationPage/fetchMemberPartnerData'
 import { SuccessAnimation } from '@/components/ConfirmationPage/SuccessAnimation/SuccessAnimation'
 import { fetchSwitchingData } from '@/components/ConfirmationPage/SwitchingAssistantSection/fetchSwitchingData'
 import { getLayoutWithMenuProps } from '@/components/LayoutWithMenu/getLayoutWithMenuProps'
 import { LayoutWithMenu } from '@/components/LayoutWithMenu/LayoutWithMenu'
 import { addApolloState, initializeApolloServerSide } from '@/services/apollo/client'
-import {
-  CurrentMemberDocument,
-  type CurrentMemberQuery,
-  type CurrentMemberQueryVariables,
-} from '@/services/graphql/generated'
 import { SHOP_SESSION_PROP_NAME } from '@/services/shopSession/ShopSession.constants'
 import { setupShopSessionServiceServerSide } from '@/services/shopSession/ShopSession.helpers'
 import { type StoryblokPageProps } from '@/services/storyblok/storyblok'
-import { Features } from '@/utils/Features'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { patchNextI18nContext } from '@/utils/patchNextI18nContext'
 
@@ -86,22 +80,3 @@ const CheckoutConfirmationPage: NextPageWithLayout<Props> = (props) => {
 CheckoutConfirmationPage.getLayout = (children) => <LayoutWithMenu>{children}</LayoutWithMenu>
 
 export default CheckoutConfirmationPage
-
-const fetchMemberPartnerData = async (apolloClient: ApolloClient<unknown>) => {
-  if (!Features.enabled('SAS_PARTNERSHIP')) {
-    return null
-  }
-  try {
-    const { data } = await apolloClient.query<CurrentMemberQuery, CurrentMemberQueryVariables>({
-      query: CurrentMemberDocument,
-    })
-    return data.currentMember.partnerData ?? null
-  } catch (err) {
-    if (err instanceof Error && isApolloError(err)) {
-      console.info('Failed to fetch currentMember', err)
-      return null
-    } else {
-      throw err
-    }
-  }
-}


### PR DESCRIPTION
## Describe your changes

Renders `ConfirmationPage` UI inside app router's new confirmation page. Right now I'm only supporting fetching `shopSession`. Switching and member partner data will be handle in the future as we'd need to make changes on apollo client instance used by RSC (next PR).

## Justify why they are needed

The idea is to get my hands dirty with Nextjs app router migration by migrating _ConfirmationPage_: `pages/[locale]/confirmation/[shopSessionId]` --> `app/[locale]/new/confirmation/[shopSessionId]` (`page.tsx` file)
