### PR TITLE
GEN-2421 - feat(app router confirmation page): support swiching and member partner data

### DIFF
--- a/apps/store/src/app/[locale]/[[...slug]]/ProductCmsPage.tsx
+++ b/apps/store/src/app/[locale]/[[...slug]]/ProductCmsPage.tsx
@@ -25,7 +25,7 @@ export const ProductCmsPage = async ({ locale, story }: ProductCmsPageProps) => 
     throw new Error(`Unknown price template: ${story.content.priceFormTemplateId}`)
   }
 
-  const apolloClient = getApolloClient(locale)
+  const apolloClient = getApolloClient({ locale })
   const productName = story.content.productId
   const [productData, productReviewsMetadata] = await Promise.all([
     fetchProductData({

--- a/apps/store/src/app/[locale]/test/page.tsx
+++ b/apps/store/src/app/[locale]/test/page.tsx
@@ -13,7 +13,7 @@ type Props = {
 const Page = async (props: Props) => {
   const { t } = await initTranslations(props.params.locale)
   // Same graphql request as in layout, only one network request gets executed thanks to Apollo SSR cache
-  const apolloClient = getApolloClient(props.params.locale)
+  const apolloClient = getApolloClient({ locale: props.params.locale })
   const productMetadata = await fetchGlobalProductMetadata({ apolloClient })
 
   return (

--- a/apps/store/src/app/debugger/actions.ts
+++ b/apps/store/src/app/debugger/actions.ts
@@ -48,7 +48,7 @@ export const createCustomerSession = async (
       }
     }
 
-    const apolloClient = getApolloClient(DEFAULT_LOCALE)
+    const apolloClient = getApolloClient({ locale: DEFAULT_LOCALE })
     const shopSessionService = setupShopSession(apolloClient)
     const shopSession = await shopSessionService.create({ countryCode: DEFAULT_COUNTRY_CODE })
     console.log(`Created new ShopSession: ${shopSession.id}`)

--- a/apps/store/src/app/switcher/[id]/page.tsx
+++ b/apps/store/src/app/switcher/[id]/page.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 const DEFAULT_LOCALE: RoutingLocale = locales['sv-SE'].routingLocale
 
-const apolloClient = getApolloClient(DEFAULT_LOCALE)
+const apolloClient = getApolloClient({ locale: DEFAULT_LOCALE })
 
 export default async function InsuranceSwitchExpirationDate({ params }: Props) {
   const {

--- a/apps/store/src/app/switcher/[id]/submitSwitchConfirmation.ts
+++ b/apps/store/src/app/switcher/[id]/submitSwitchConfirmation.ts
@@ -32,7 +32,7 @@ export const submitSwitchConfirmation = async (
     }
   }
 
-  const apolloClient = getApolloClient(DEFAULT_LOCALE)
+  const apolloClient = getApolloClient({ locale: DEFAULT_LOCALE })
 
   const messages: Array<Message> = []
   const errors: Array<string> = []

--- a/apps/store/src/appComponents/StoreLayout.tsx
+++ b/apps/store/src/appComponents/StoreLayout.tsx
@@ -25,7 +25,7 @@ type StoreLayoutProps = {
 
 // Does not use routing params directly, so can be used outside of app/[locale] if needed - just pass locale explicitly
 export async function StoreLayout({ locale, children }: StoreLayoutProps) {
-  const apolloClient = getApolloClient(locale)
+  const apolloClient = getApolloClient({ locale })
   const [companyReviewsMetadata, productMetadata, globalStory] = await Promise.all([
     fetchCompanyReviewsMetadata(),
     fetchGlobalProductMetadata({ apolloClient }),

--- a/apps/store/src/components/ConfirmationPage/SuccessAnimation/SuccessAnimation.tsx
+++ b/apps/store/src/components/ConfirmationPage/SuccessAnimation/SuccessAnimation.tsx
@@ -1,3 +1,4 @@
+'use client'
 import styled from '@emotion/styled'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useTranslation } from 'next-i18next'

--- a/apps/store/src/services/apollo/app-router/serverDynamicHeadersLink.ts
+++ b/apps/store/src/services/apollo/app-router/serverDynamicHeadersLink.ts
@@ -1,0 +1,52 @@
+import { setContext } from '@apollo/client/link/context'
+import { jwtDecode, type JwtPayload } from 'jwt-decode'
+import {
+  getAccessToken,
+  getRefreshToken,
+  resetAuthTokens,
+  saveAuthTokens,
+} from '@/services/authApi/app-router/persist'
+import { refreshAccessToken } from '@/services/authApi/oauth'
+import { getShopSessionId } from '@/services/shopSession/app-router/ShopSession.utils'
+import type { NextCookiesStore } from '@/utils/types'
+
+type Header = Record<string, string>
+
+export function serverDynamicHeadersLink({ cookies }: { cookies: NextCookiesStore }) {
+  return setContext(async (_, prevContext) => {
+    return {
+      ...prevContext,
+      headers: {
+        ...prevContext.headers,
+        ...(await getAuthorizationHeader(cookies)),
+        ...getShopSessionHeader(cookies),
+      },
+    }
+  })
+}
+
+function getShopSessionHeader(cookies: NextCookiesStore): Header | undefined {
+  const shopSessionId = getShopSessionId(cookies)
+  return shopSessionId ? { 'Hedvig-ShopSessionID': shopSessionId } : undefined
+}
+
+async function getAuthorizationHeader(cookies: NextCookiesStore): Promise<Header | undefined> {
+  const currentAccessToken = getAccessToken(cookies)
+  if (!currentAccessToken) return
+
+  const { exp: expiryInSeconds } = jwtDecode<JwtPayload>(currentAccessToken)
+  const hasExpired = expiryInSeconds && Date.now() >= expiryInSeconds * 1000
+  if (!hasExpired) return { authorization: `Bearer ${currentAccessToken}` }
+
+  const currentRefreshToken = getRefreshToken(cookies)
+
+  if (!currentRefreshToken) {
+    console.warn('Token refresh: no refresh token found')
+    resetAuthTokens(cookies)
+    return
+  }
+
+  const { accessToken, refreshToken } = await refreshAccessToken(currentRefreshToken)
+  saveAuthTokens({ accessToken, refreshToken, cookies })
+  return { Authorization: `Bearer ${accessToken}` }
+}

--- a/apps/store/src/services/authApi/app-router/persist.ts
+++ b/apps/store/src/services/authApi/app-router/persist.ts
@@ -1,6 +1,5 @@
 import { type OptionsType } from 'cookies-next/lib/types'
-import { cookies } from 'next/headers'
-import { type CookieParams } from '@/utils/types'
+import type { NextCookiesStore } from '@/utils/types'
 
 const COOKIE_KEY = '_hvsession'
 const REFRESH_TOKEN_COOKIE_KEY = '_hvrefresh'
@@ -15,36 +14,33 @@ const OPTIONS: OptionsType = {
   }),
 }
 
-type SaveAuthTokensParams = CookieParams & {
+type SaveAuthTokensParams = {
   accessToken: string
   refreshToken: string
+  cookies: NextCookiesStore
 }
 
-export const saveAuthTokens = (params: SaveAuthTokensParams) => {
-  const { accessToken, refreshToken, ...cookieParams } = params
-  const cookieStore = cookies()
-
-  cookieStore.set(COOKIE_KEY, serialize(accessToken), { ...cookieParams, ...OPTIONS })
-  cookieStore.set(REFRESH_TOKEN_COOKIE_KEY, refreshToken, { ...cookieParams, ...OPTIONS })
+export const saveAuthTokens = ({ accessToken, refreshToken, cookies }: SaveAuthTokensParams) => {
+  cookies.set(COOKIE_KEY, serialize(accessToken), OPTIONS)
+  cookies.set(REFRESH_TOKEN_COOKIE_KEY, refreshToken, OPTIONS)
 }
 
-export const resetAuthTokens = () => {
-  const cookieStore = cookies()
-  cookieStore.delete(COOKIE_KEY)
-  cookieStore.delete(REFRESH_TOKEN_COOKIE_KEY)
+export const resetAuthTokens = (cookies: NextCookiesStore) => {
+  cookies.delete(COOKIE_KEY)
+  cookies.delete(REFRESH_TOKEN_COOKIE_KEY)
 }
 
-export const getRefreshToken = (): string | undefined => {
-  return cookies().get(REFRESH_TOKEN_COOKIE_KEY)?.value
+export const getRefreshToken = (cookies: NextCookiesStore): string | undefined => {
+  return cookies.get(REFRESH_TOKEN_COOKIE_KEY)?.value
 }
 
-export const getAccessToken = (): string | undefined => {
-  const cookieValue = cookies().get(COOKIE_KEY)?.value
+export const getAccessToken = (cookies: NextCookiesStore): string | undefined => {
+  const cookieValue = cookies.get(COOKIE_KEY)?.value
   return cookieValue ? deserialize(cookieValue) : undefined
 }
 
-export const getAuthHeaders = (): Record<string, string> => {
-  const accessToken = getAccessToken()
+export const getAuthHeaders = (cookies: NextCookiesStore): Record<string, string> => {
+  const accessToken = getAccessToken(cookies)
   return accessToken ? { Authorization: `Bearer ${accessToken}` } : {}
 }
 

--- a/apps/store/src/services/authApi/fetchJson.ts
+++ b/apps/store/src/services/authApi/fetchJson.ts
@@ -1,18 +1,18 @@
-import { i18n } from 'next-i18next'
-import { getLocaleOrFallback, toIsoLocale } from '@/utils/l10n/localeUtils'
-import type { UiLocale } from '@/utils/l10n/types'
+import { FALLBACK_LOCALE } from '@/utils/l10n/locales'
+import { toIsoLocale } from '@/utils/l10n/localeUtils'
+import type { RoutingLocale } from '@/utils/l10n/types'
 
 export const fetchJson = async <T extends object>(
   url: string,
-  options?: Partial<RequestInit>,
+  options?: { locale?: RoutingLocale } & Partial<RequestInit>,
 ): Promise<T> => {
-  const locale = getLocaleOrFallback(i18n?.language as UiLocale).routingLocale
+  const { locale, ...requestOptions } = options ?? {}
 
   const resp = await fetch(url, {
-    ...options,
+    ...requestOptions,
     headers: {
       'Content-type': 'application/json',
-      'Hedvig-Language': toIsoLocale(locale),
+      'Hedvig-Language': toIsoLocale(locale ?? FALLBACK_LOCALE),
       ...options?.headers,
     },
   })

--- a/apps/store/src/services/bankId/useBankIdLogin.ts
+++ b/apps/store/src/services/bankId/useBankIdLogin.ts
@@ -4,6 +4,7 @@ import type { Subscription } from 'zen-observable-ts'
 import { loginMemberSeBankId } from '@/services/authApi/login'
 import { exchangeAuthorizationCode } from '@/services/authApi/oauth'
 import { saveAuthTokens } from '@/services/authApi/persist'
+import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import type { BankIdLoginOptions, LoginPromptOptions, StartLoginOptions } from './bankId.types'
 import { apiStatusToBankIdState, bankIdLogger } from './bankId.utils'
 import type { BankIdDispatch } from './bankIdReducer'
@@ -62,13 +63,14 @@ export const useBankIdLogin = ({ dispatch }: HookOptions) => {
 }
 
 export const useBankIdLoginApi = ({ dispatch }: HookOptions) => {
+  const locale = useRoutingLocale()
   const subscriptionRef = useRef<Subscription | null>(null)
   const startLogin = useCallback(
     ({ ssn, onSuccess }: BankIdLoginOptions) => {
       bankIdLogger.info('Starting BankId login')
       // Future ideas
       // - try Observable.from().forEach to await final result and Promise.finally to clean up ref
-      subscriptionRef.current = loginMemberSeBankId(ssn).subscribe({
+      subscriptionRef.current = loginMemberSeBankId(ssn, locale).subscribe({
         async next(statusResponse) {
           dispatch({
             type: 'operationStateChange',
@@ -102,7 +104,7 @@ export const useBankIdLoginApi = ({ dispatch }: HookOptions) => {
         },
       })
     },
-    [dispatch],
+    [dispatch, locale],
   )
   const cancelLogin = useCallback(() => {
     subscriptionRef.current?.unsubscribe()

--- a/apps/store/src/services/shopSession/app-router/ShopSession.utils.ts
+++ b/apps/store/src/services/shopSession/app-router/ShopSession.utils.ts
@@ -1,6 +1,6 @@
 import type { ApolloClient } from '@apollo/client'
-import { cookies } from 'next/headers'
 import { AppRouterCookiePersister } from '@/services/persister/app-router/AppRouterCookiePersister'
+import type { NextCookiesStore } from '@/utils/types'
 import { SHOP_SESSION_COOKIE_NAME } from '../ShopSession.constants'
 import { ShopSessionService } from '../ShopSessionService'
 
@@ -11,7 +11,6 @@ export const setupShopSession = (apolloClient: ApolloClient<unknown>) => {
   )
 }
 
-export const getShopSessionId = () => {
-  const cookieStore = cookies()
-  return cookieStore.get(SHOP_SESSION_COOKIE_NAME)?.value
+export const getShopSessionId = (cookies: NextCookiesStore) => {
+  return cookies.get(SHOP_SESSION_COOKIE_NAME)?.value
 }

--- a/apps/store/src/utils/types.ts
+++ b/apps/store/src/utils/types.ts
@@ -1,3 +1,7 @@
 import { type DefaultOptions } from 'cookies-next/lib/types'
+import { type cookies } from 'next/headers'
 
 export type CookieParams = Pick<DefaultOptions, 'req' | 'res'>
+
+// This sucks but next/headers doesn't expose the type 🤷
+export type NextCookiesStore = ReturnType<typeof cookies>


### PR DESCRIPTION
## Describe your changes

Seems like a lot of changes but a bunch of them are just small updates due API changes. Here is what changed:

* Update `getApolloClient` function. Now server components can instantiate apollo client with `cookies()`. That will be used by adding links that handle shop session id and authorization headers (serverDynamicHeadersLink). Observe that I had to update `app-router/persit.ts` - before nextjs `cookies()` were being imported and used directly there. The issue with it is that we don't want those dynamic functions for every instance. Adding them for CMS pages, for example, makes the app break as we have a we don't want CMS pages being rendered dynamically and by using dynamic functions during their rendering process (headers() or cookies()) we'd end up making the whole route be rendered dynamically.
* Had update `fetchJson` function. Now it can receive a locale instead of trying to figure it out by itself. Old implementation breaks when using RSC because those don't have access to i18n.
* Update app router migration page so it also fetches switching and member partner data as it's page router counter part do.
  
## Justify why they are needed

The idea is to get my hands dirty with Nextjs app router migration by migrating _ConfirmationPage_: `pages/[locale]/confirmation/[shopSessionId]` --> `app/[locale]/new/confirmation/[shopSessionId]` (`page.tsx` file)
