### PR TITLE
Prop-drill responsive variant of HeaderMenu to prevent rendering 'initial' then discarding it

### DIFF
--- a/apps/store/src/blocks/HeaderBlockNew/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlockNew/HeaderBlock.tsx
@@ -1,6 +1,5 @@
 import { storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
-import { NestedMenuBlock } from '@/blocks/HeaderBlockNew/NestedMenuBlock'
 import { Header } from '@/components/HeaderNew/Header'
 import { HeaderMenu } from '@/components/HeaderNew/HeaderMenu/HeaderMenu'
 import { ShoppingCartMenuItem } from '@/components/HeaderNew/ShoppingCartMenuItem/ShoppingCartMenuItem'
@@ -31,11 +30,7 @@ export const HeaderBlock = ({ blok }: HeaderBlockNewProps) => {
   return (
     <Header {...storyblokEditable(blok)}>
       {blok.headerMenu.length > 0 && (
-        <HeaderMenu defaultValue={productNavItem}>
-          {blok.headerMenu.map((item) => (
-            <NestedMenuBlock key={item._uid} blok={item} />
-          ))}
-        </HeaderMenu>
+        <HeaderMenu defaultValue={productNavItem} items={blok.headerMenu} />
       )}
 
       <ShoppingCartMenuItem />

--- a/apps/store/src/blocks/HeaderBlockNew/NestedMenuBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlockNew/NestedMenuBlock.tsx
@@ -7,14 +7,12 @@ import {
 } from '@/blocks/HeaderBlockNew/ProductMenuBlock'
 import { SubMenuBlock, type SubMenuBlockProps } from '@/blocks/HeaderBlockNew/SubMenuBlock'
 import { checkBlockType } from '@/services/storyblok/Storyblok.helpers'
-import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
 
 type NestedMenuBlockProps = {
   blok: HeaderBlockNewProps['blok']['headerMenu'][number]
+  variant: 'mobile' | 'desktop'
 }
-export const NestedMenuBlock = ({ blok }: NestedMenuBlockProps) => {
-  const variant = useResponsiveVariant('lg')
-
+export const NestedMenuBlock = ({ blok, variant }: NestedMenuBlockProps) => {
   const subMenu = checkBlockType<SubMenuBlockProps['blok']>(blok, SubMenuBlock.blockName)
   if (subMenu) {
     return <SubMenuBlock key={subMenu._uid} blok={subMenu} />
@@ -25,13 +23,7 @@ export const NestedMenuBlock = ({ blok }: NestedMenuBlockProps) => {
     ProductMenuBlock.blockName,
   )
   if (productMenu) {
-    return (
-      <ProductMenuBlock
-        key={productMenu._uid}
-        blok={productMenu}
-        variant={variant === 'mobile' ? 'mobile' : 'desktop'}
-      />
-    )
+    return <ProductMenuBlock key={productMenu._uid} blok={productMenu} variant={variant} />
   }
 
   const menuBlock = checkBlockType<MenuItemBlockProps['blok']>(blok, MenuItemBlock.blockName)

--- a/apps/store/src/components/HeaderNew/HeaderMenu/HeaderMenu.tsx
+++ b/apps/store/src/components/HeaderNew/HeaderMenu/HeaderMenu.tsx
@@ -1,20 +1,28 @@
 'use client'
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import { usePathname } from 'next/navigation'
-import { useState, useEffect, type ReactNode } from 'react'
+import { useState, useEffect, useMemo } from 'react'
+import { type HeaderMenuProps } from '@/blocks/HeaderBlockNew/HeaderBlock'
+import { NestedMenuBlock } from '@/blocks/HeaderBlockNew/NestedMenuBlock'
 import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
 import { navigationPrimaryList, HeaderMenuDesktop } from '../Header.css'
 import { HeaderMenuMobile } from '../HeaderMenuMobile/HeaderMenuMobile'
 
 export type HeaderMenuDesktopProps = {
-  children: ReactNode
+  items: HeaderMenuProps
   defaultValue?: string
 }
 
-export const HeaderMenu = ({ children, defaultValue }: HeaderMenuDesktopProps) => {
+export const HeaderMenu = ({ items, defaultValue }: HeaderMenuDesktopProps) => {
   const [activeItem, setActiveItem] = useState('')
   const pathname = usePathname()
   const variant = useResponsiveVariant('lg')
+
+  const content = useMemo(() => {
+    // Optimization: we don't want to assume default variant to avoid rendering twice on miss
+    if (variant === 'initial') return null
+    return items.map((item) => <NestedMenuBlock key={item._uid} blok={item} variant={variant} />)
+  }, [items, variant])
 
   useEffect(() => {
     setActiveItem('')
@@ -22,7 +30,7 @@ export const HeaderMenu = ({ children, defaultValue }: HeaderMenuDesktopProps) =
 
   return (
     <>
-      {/* 'Desktop' menu is always rendered for SEO reasons so navigation links becomes acessible */}
+      {/* 'Desktop' menu is always rendered for SEO reasons so navigation links becomes accessible */}
       {/* in the markup */}
       <NavigationMenuPrimitive.Root
         className={HeaderMenuDesktop}
@@ -30,12 +38,12 @@ export const HeaderMenu = ({ children, defaultValue }: HeaderMenuDesktopProps) =
         onValueChange={setActiveItem}
       >
         <NavigationMenuPrimitive.List className={navigationPrimaryList}>
-          {children}
+          {content}
         </NavigationMenuPrimitive.List>
       </NavigationMenuPrimitive.Root>
 
       {variant === 'mobile' && (
-        <HeaderMenuMobile defaultValue={defaultValue}>{children}</HeaderMenuMobile>
+        <HeaderMenuMobile defaultValue={defaultValue}>{content}</HeaderMenuMobile>
       )}
     </>
   )


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Small optimization for mobile menu
- pass down `variant` into mobile menu elements so that we don't get `initial` when opening the menu
- skip rendering elements when variant is still `initial` - this prevents double renders when we guess default variant and miss

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Original issue in React DevTools (variant changed, but why should it?)

![Screenshot 2024-07-05 at 16.07.24.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/873e8625-b808-4790-8d35-704429b11273.png)

Less scripting when opening the menu, saves 20-30%

Before

![Screenshot 2024-07-05 at 16.08.47.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/35693031-2ab5-4022-92b9-0d117e91c141.png)

After

![Screenshot 2024-07-05 at 16.08.03.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/0be8fb5c-40c4-4c1d-a092-d0d51c82d1af.png)


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
