### PR TITLE
fix(checkout): hydration error

### DIFF
--- a/apps/store/src/services/shopSession/ShopSessionContext.tsx
+++ b/apps/store/src/services/shopSession/ShopSessionContext.tsx
@@ -54,7 +54,9 @@ const useShopSessionContextValue = (initialShopSessionId?: string) => {
     return service
   }, [apolloClient, initialShopSessionId])
 
-  const [shopSessionId, setShopSessionId] = useState(shopSessionServiceClientSide.shopSessionId())
+  const [shopSessionId, setShopSessionId] = useState(
+    shopSessionServiceClientSide.shopSessionId() ?? initialShopSessionId,
+  )
 
   const queryResult = useShopSessionQuery({
     variables: shopSessionId ? { shopSessionId } : undefined,


### PR DESCRIPTION
## Describe your changes

It was introduced [here](https://github.com/HedvigInsurance/racoon/commit/6b81a429d2a0a1160fbc9f7acc128469c24eaf98)

`shopSessionId` state get's initialize with a an id server side but with `null` client side, which causes the hydration issue.

## Justify why they are needed

I've noticed a hydration error started to occur in the checkout page.