### PR TITLE
fix: bug where links for folder pages have trailing slash

### DIFF
--- a/apps/store/src/services/storyblok/Storyblok.helpers.test.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@jest/globals'
+import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
+import { ORIGIN_URL } from '@/utils/url'
+
+const link = {
+  id: '9c9cfdce-075c-426a-b0c8-9053c59dd40e',
+  url: '',
+  linktype: 'story' as const,
+  fieldtype: 'multilink',
+  cached_url: 'se-en/insurances/home-insurance/',
+  story: {
+    name: 'Home Insurance',
+    id: 293342693,
+    uuid: '9c9cfdce-075c-426a-b0c8-9053c59dd40e',
+    slug: 'home-insurance',
+    url: 'se-en/insurances/home-insurance/',
+    full_slug: 'se-en/insurances/home-insurance/',
+    _stopResolving: true,
+  },
+}
+
+test('getLinkFieldURL should return the full URL without trailing slash when given a link object', () => {
+  const result = getLinkFieldURL(link, 'Home Insurance')
+
+  const expectedUrl = `${ORIGIN_URL}/se-en/insurances/home-insurance`
+
+  expect(result).toBe(expectedUrl)
+})

--- a/apps/store/src/services/storyblok/Storyblok.helpers.ts
+++ b/apps/store/src/services/storyblok/Storyblok.helpers.ts
@@ -1,6 +1,6 @@
 import { type ISbStoryData, type SbBlokData } from '@storyblok/react'
 import type { RoutingLocale } from '@/utils/l10n/types'
-import { makeAbsolute, appendAnchor } from '@/utils/url'
+import { makeAbsolute, appendAnchor, removeTrailingSlash } from '@/utils/url'
 import type {
   LinkField,
   PriceCalculatorPageStory,
@@ -36,9 +36,11 @@ export const checkBlockType = <BlockData extends SbBlokData>(
 
 const MISSING_LINKS = new Set()
 export const getLinkFieldURL = (link: LinkField, linkText?: string) => {
-  if (link.story) return makeAbsolute(appendAnchor(link.story.url, link.anchor))
+  if (link.story)
+    return removeTrailingSlash(makeAbsolute(appendAnchor(link.story.url, link.anchor)))
 
-  if (link.linktype === 'url') return makeAbsolute(appendAnchor(link.url, link.anchor))
+  if (link.linktype === 'url')
+    return removeTrailingSlash(makeAbsolute(appendAnchor(link.url, link.anchor)))
 
   // Warn about CMS links without target. This could be either reference to something not yet created or misconfiguration
   if (!MISSING_LINKS.has(link.id)) {
@@ -46,7 +48,7 @@ export const getLinkFieldURL = (link: LinkField, linkText?: string) => {
     console.log('Did not see story field in link, returning empty URL.', linkText, link)
   }
 
-  return makeAbsolute(appendAnchor(link.cached_url, link.anchor))
+  return removeTrailingSlash(makeAbsolute(appendAnchor(link.cached_url, link.anchor)))
 }
 
 export const isProductStory = (story: ISbStoryData): story is ProductStory => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Fix issue with trailing slash for links to root folder pages is back that causes redirects.
- Add a test since this bug has been coming back

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Bug reported by Peter https://hedviginsurance.slack.com/archives/C041SD67G82/p1720447038841489

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
