### PR TITLE
Support going back to specific InsuranceForm section from offers

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/priceIntentAtoms.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/priceIntentAtoms.ts
@@ -1,6 +1,6 @@
 import { useApolloClient } from '@apollo/client'
 import { datadogLogs } from '@datadog/browser-logs'
-import { type Atom, atom, type Getter, useAtomValue, useSetAtom, useStore } from 'jotai'
+import { atom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import { atomFamily } from 'jotai/utils'
 import { useCallback, useEffect, useState } from 'react'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
@@ -21,6 +21,7 @@ import { type Form } from '@/services/PriceCalculator/PriceCalculator.types'
 import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntentService'
 import { useShopSession, useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { getOffersByPrice } from '@/utils/getOffersByPrice'
+import { getAtomValueOrThrow } from '@/utils/jotaiUtils'
 
 export const currentPriceIntentIdAtom = atom<string | null>(null)
 
@@ -106,15 +107,6 @@ export const activeFormSectionIdAtom = atom(
   },
 )
 export const GOTO_NEXT_SECTION = Symbol('GOTO_NEXT_SECTION')
-
-// TODO: Consider moving to utils
-const getAtomValueOrThrow = <T>(get: Getter, atom: Atom<T>): NonNullable<T> => {
-  const value = get(atom)
-  if (value == null) {
-    throw new Error(`${atom} must have value`)
-  }
-  return value
-}
 
 export const useSyncPriceIntentState = (preloadedPriceIntentId?: string): void => {
   const priceTemplate = useAtomValue(priceTemplateAtom)

--- a/apps/store/src/features/priceCalculator/SectionPreview.tsx
+++ b/apps/store/src/features/priceCalculator/SectionPreview.tsx
@@ -5,6 +5,7 @@ import { sprinkles } from 'ui/src/theme/sprinkles.css'
 import { Button, Text, tokens, xStack } from 'ui'
 import { useTranslateFieldLabel } from '@/components/PriceCalculator/useTranslateFieldLabel'
 import { activeFormSectionIdAtom } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
+import { priceCalculatorStepAtom } from '@/features/priceCalculator/priceCalculatorAtoms'
 import { type FormSection } from '@/services/PriceCalculator/PriceCalculator.types'
 import { useAutoFormat } from '@/utils/useFormatter'
 
@@ -12,13 +13,16 @@ export function SectionPreview({ section }: { section: FormSection }) {
   const autoFormat = useAutoFormat()
   const translateLabel = useTranslateFieldLabel()
   const { t } = useTranslation('purchase-form')
-  const setActiveSectionId = useSetAtom(activeFormSectionIdAtom)
   const previewText = useMemo(() => {
-    if (!section.preview?.fieldName) return
+    if (!section.preview?.fieldName) {
+      return
+    }
 
     const item = section.items.find((item) => item.field.name === section.preview?.fieldName)
     const value = item?.field.value
-    if (value === undefined) return
+    if (value === undefined) {
+      return
+    }
 
     if (section.preview.label) {
       return translateLabel(section.preview.label, parseTranslateOptions(value))
@@ -27,7 +31,12 @@ export function SectionPreview({ section }: { section: FormSection }) {
     return autoFormat(section.preview.fieldName, value)
   }, [section, autoFormat, translateLabel])
 
-  const handleEdit = () => setActiveSectionId(section.id)
+  const setActiveSectionId = useSetAtom(activeFormSectionIdAtom)
+  const setStep = useSetAtom(priceCalculatorStepAtom)
+  const handleEdit = () => {
+    setActiveSectionId(section.id)
+    setStep('fillForm')
+  }
 
   return (
     <div
@@ -42,7 +51,7 @@ export function SectionPreview({ section }: { section: FormSection }) {
       </div>
       <Button
         variant="secondary"
-        size={'small'}
+        size="medium"
         style={{ backgroundColor: tokens.colors.white }}
         onClick={handleEdit}
       >

--- a/apps/store/src/features/priceCalculator/priceCalculatorAtoms.ts
+++ b/apps/store/src/features/priceCalculator/priceCalculatorAtoms.ts
@@ -1,0 +1,27 @@
+// State atoms exclusive for new Price Calculator. Reusable atoms are located in priceIntentAtoms
+
+import { atom } from 'jotai'
+import { atomFamily } from 'jotai/utils'
+import { currentPriceIntentIdAtom } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
+import { getAtomValueOrThrow } from '@/utils/jotaiUtils'
+
+type PriceCalculatorStep = 'loadingForm' | 'fillForm' | 'calculatingPrice' | 'viewOffers'
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const priceCalculatorStepAtomFamily = atomFamily((priceIntentId: string) =>
+  atom<PriceCalculatorStep>('loadingForm'),
+)
+
+export const priceCalculatorStepAtom = atom(
+  (get) => {
+    const priceIntentId = get(currentPriceIntentIdAtom)
+    if (priceIntentId == null) {
+      return 'loadingForm'
+    }
+    return get(priceCalculatorStepAtomFamily(priceIntentId))
+  },
+  (get, set, value: PriceCalculatorStep) => {
+    const priceIntentId = getAtomValueOrThrow(get, currentPriceIntentIdAtom)
+    set(priceCalculatorStepAtomFamily(priceIntentId), value)
+  },
+)

--- a/apps/store/src/utils/jotaiUtils.ts
+++ b/apps/store/src/utils/jotaiUtils.ts
@@ -1,0 +1,9 @@
+import { type Atom, type Getter } from 'jotai'
+
+export const getAtomValueOrThrow = <T>(get: Getter, atom: Atom<T>): NonNullable<T> => {
+  const value = get(atom)
+  if (value == null) {
+    throw new Error(`${atom} must have value`)
+  }
+  return value
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Convert Price Calculator step into jotai atom to simplify using from components nested several levels deep.  For example, confirming price intent is now fully done inside `InsuranceDataSetion`
- Show preview of every form section in `viewOffers` and allow getting back to it with "Edit" button
- Extract `getAtomValueOrThrow` to `utils/jotaiUtils`

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
