### PR TITLE
Fix global 404 page crash by wrapping into RootLayout

### DIFF
--- a/apps/store/src/app/[locale]/[[...slug]]/page.tsx
+++ b/apps/store/src/app/[locale]/[[...slug]]/page.tsx
@@ -36,8 +36,12 @@ type Props = {
 // NOTE: Since we're using catch-all routing segment, we have to do our own dispatching
 // to specific components based on story content type
 // Any type-specific data fetching should happen in child components
-export default async function CmsPage(props: Props) {
-  const story = await fetchStory(props.params.locale, props.params.slug?.join('/'))
+export default async function CmsPage({ params }: Props) {
+  if (!isRoutingLocale(params.locale)) {
+    console.log(`Invalid locale: ${params.locale}`)
+    throw notFound()
+  }
+  const story = await fetchStory(params.locale, params.slug?.join('/'))
 
   const { hideBreadcrumbs, hideChat } = story.content
   let chat: ReactNode = null
@@ -47,24 +51,24 @@ export default async function CmsPage(props: Props) {
   if (isProductStory(story)) {
     return (
       <>
-        <ProductCmsPage locale={props.params.locale} story={story} />
-        <StoryBreadcrumbs params={props.params} currentPageTitle={story.name} />
+        <ProductCmsPage locale={params.locale} story={story} />
+        <StoryBreadcrumbs params={params} currentPageTitle={story.name} />
         {chat}
       </>
     )
   } else if (isPriceCalculatorPageStory(story)) {
     return (
       <>
-        <PriceCalculatorCmsPage locale={props.params.locale} story={story} />
-        <StoryBreadcrumbs params={props.params} currentPageTitle={story.name} />
+        <PriceCalculatorCmsPage locale={params.locale} story={story} />
+        <StoryBreadcrumbs params={params} currentPageTitle={story.name} />
       </>
     )
   }
 
   return (
     <>
-      <ContentCmsPage locale={props.params.locale} story={story} />
-      {!hideBreadcrumbs && <StoryBreadcrumbs params={props.params} currentPageTitle={story.name} />}
+      <ContentCmsPage locale={params.locale} story={story} />
+      {!hideBreadcrumbs && <StoryBreadcrumbs params={params} currentPageTitle={story.name} />}
       {chat}
       <DefaultDebugDialog />
     </>
@@ -72,6 +76,9 @@ export default async function CmsPage(props: Props) {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  if (!isRoutingLocale(params.locale)) {
+    throw notFound()
+  }
   const story = await fetchStory(params.locale, params.slug?.join('/'))
   const pageUrl = normalizePageUrl([params.locale, ...(params.slug ?? [])].join('/'))
 

--- a/apps/store/src/app/not-found.tsx
+++ b/apps/store/src/app/not-found.tsx
@@ -1,6 +1,7 @@
 import { initTranslations } from '@/app/i18n'
 import { TranslationsProvider } from '@/appComponents/providers/TranslationsProvider'
 import { NotFoundPageContent } from '@/appComponents/RootLayout/NotFoundPageContent'
+import { RootLayout } from '@/appComponents/RootLayout/RootLayout'
 import { FALLBACK_LOCALE } from '@/utils/l10n/locales' // Fallback to se/not-found
 import { toRoutingLocale } from '@/utils/l10n/localeUtils'
 
@@ -12,8 +13,10 @@ export default async function RootNotFoundPage() {
   // Only loading common namespace since this page's React tree is added to every normal page - size matters
   const { resources } = await initTranslations(locale, { ns: ['common'] })
   return (
-    <TranslationsProvider locale={locale} resources={resources}>
-      <NotFoundPageContent />
-    </TranslationsProvider>
+    <RootLayout locale={locale}>
+      <TranslationsProvider locale={locale} resources={resources}>
+        <NotFoundPageContent />
+      </TranslationsProvider>
+    </RootLayout>
   )
 }

--- a/apps/store/src/components/ProductPage/PurchaseForm/ProductHero/ProductHero.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/ProductHero/ProductHero.tsx
@@ -1,15 +1,16 @@
+'use client'
 import { Heading, Text, yStack } from 'ui'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { pillow } from './ProductHero.css'
 
 type Props = {
   name: string
-  description: string
-  pillow: { src: string; alt?: string }
+  description?: string
+  pillow: { src: string; alt?: string | null }
   size: 'small' | 'large'
 }
 
-export const ProductHero = (props: Props) => {
+export function ProductHero(props: Props) {
   return (
     <div className={yStack({ gap: 'md' })}>
       <Pillow
@@ -23,9 +24,11 @@ export const ProductHero = (props: Props) => {
         <Heading as="h1" variant="standard.24" align="center">
           {props.name}
         </Heading>
-        <Text size="xs" color="textSecondary" align="center">
-          {props.description}
-        </Text>
+        {props.description && (
+          <Text size="xs" color="textSecondary" align="center">
+            {props.description}
+          </Text>
+        )}
       </div>
     </div>
   )

--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.tsx
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.tsx
@@ -1,10 +1,11 @@
 import { notFound } from 'next/navigation'
 import { type ReactNode, Suspense } from 'react'
-import { xStack } from 'ui'
+import { tokens, xStack, yStack } from 'ui'
 import { fetchProductData } from '@/components/ProductData/fetchProductData'
 import { ProductDataProvider } from '@/components/ProductData/ProductDataProvider'
 import { ProductPageDataProvider } from '@/components/ProductPage/ProductPageDataProvider'
 import { ProductPageDebugDialog } from '@/components/ProductPage/ProductPageDebugDialog'
+import { ProductHero } from '@/components/ProductPage/PurchaseForm/ProductHero/ProductHero'
 import { Skeleton } from '@/components/Skeleton/Skeleton'
 import { PriceCalculatorStoryProvider } from '@/features/priceCalculator/PriceCalculatorStoryProvider'
 import { getApolloClient } from '@/services/apollo/app-router/rscClient'
@@ -17,47 +18,89 @@ type Props = {
   locale: RoutingLocale
   story: PriceCalculatorPageStory
 }
+
+// TODO: Make it responsive or stop using it. It should probably be a CSS var
+const HEADER_HEIGHT = '80px'
+
 // TODO: Convert to vanilla styles when we get to look and feel part
 export function PriceCalculatorCmsPage({ locale, story }: Props) {
   if (process.env.FEATURE_PRICE_CALCULATOR_PAGE !== 'true') {
     throw notFound()
   }
+  // TODO: Take from story
+  const productName = 'SE_PET_DOG'
   return (
-    <div className={xStack({})} style={{ backgroundColor: 'white', gap: 'initial' }}>
+    <div
+      className={xStack({ gap: 'none' })}
+      style={{ backgroundColor: tokens.colors.backgroundStandard }}
+    >
       <div
         style={{
-          backgroundColor: 'lightblue',
           position: 'sticky',
           top: 0,
           width: '50%',
+          height: `calc(100vh - ${HEADER_HEIGHT})`,
+        }}
+        className={yStack({ justifyContent: 'center', alignItems: 'center' })}
+      >
+        <Suspense>
+          <ProductHeroContainer locale={locale} productName={productName} />
+        </Suspense>
+      </div>
+      <div
+        style={{
+          width: '50%',
+          flexGrow: 1,
+          padding: '1rem',
+          minHeight: '100vh',
+          backgroundColor: tokens.colors.white,
         }}
       >
-        TODO: background media
-      </div>
-      <div style={{ minHeight: '300vh', width: '50%', flexGrow: 1, padding: '1rem' }}>
         <Suspense fallback={<Skeleton style={{ height: '75vh' }} />}>
-          <PriceCalculatorProviders locale={locale} story={story}>
-            <PurchaseFormV2 />
-          </PriceCalculatorProviders>
+          <div style={{ height: '200vh' }}>
+            <PriceCalculatorProviders productName={productName} locale={locale} story={story}>
+              <PurchaseFormV2 />
+            </PriceCalculatorProviders>
+          </div>
         </Suspense>
       </div>
     </div>
   )
 }
 
+type ProductHeroContainerProps = {
+  locale: RoutingLocale
+  productName: string
+}
+
+async function ProductHeroContainer({ locale, productName }: ProductHeroContainerProps) {
+  const apolloClient = getApolloClient({ locale })
+  const productData = await fetchProductData({
+    apolloClient,
+    productName,
+  })
+  return (
+    <ProductHero
+      name={productData.displayNameFull}
+      pillow={productData.pillowImage}
+      size={'large'}
+    />
+  )
+}
+
 type PriceCalculatorProvidersProps = {
   locale: RoutingLocale
   story: PriceCalculatorPageStory
+  productName: string
   children: ReactNode
 }
 async function PriceCalculatorProviders({
   locale,
   story,
+  productName,
   children,
 }: PriceCalculatorProvidersProps) {
   const apolloClient = getApolloClient({ locale })
-  // TODO: Take from story
-  const productName = 'SE_PET_DOG'
   const productData = await fetchProductData({
     apolloClient,
     productName,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Properly return 404 instead of crashing on invalid locale

Trying to access something like `/admin.php` which site scanners routinely try to do led to HTTP 500 and an error in datadog. Now it's 404 and regular message (see below)

1.
![Screenshot 2024-07-16 at 16.27.33.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/5ddc7445-62b5-4a9c-bbf6-8671a615577d.png)


2.
![Screenshot 2024-07-16 at 16.26.22.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/bb12d94f-bee9-49d8-be80-4764ce19f1e1.png)


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Should reduce number of error alerts from Datadog

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
