### PR TITLE
Make secondary nav items area fully clickable

### DIFF
--- a/apps/store/src/components/HeaderNew/Header.css.ts
+++ b/apps/store/src/components/HeaderNew/Header.css.ts
@@ -167,14 +167,10 @@ export const navigationItemGeneralMenu = style({
 })
 
 export const navigationSecondaryItem = style({
-  paddingBlock: tokens.space.xxs,
-  paddingLeft: tokens.space.lg,
-  paddingRight: tokens.space.md,
   color: tokens.colors.textSecondaryOnGray,
 
   '@media': {
     [minWidth.lg]: {
-      padding: `${tokens.space.sm} ${tokens.space.sm}`,
       borderRadius: tokens.radius.md,
       color: tokens.colors.textPrimary,
 

--- a/apps/store/src/components/HeaderNew/NavigationLink/NavigationLink.css.ts
+++ b/apps/store/src/components/HeaderNew/NavigationLink/NavigationLink.css.ts
@@ -48,9 +48,20 @@ export const productNavigationLinkCard = style([
 export const secondaryNavigationLink = style([
   focusableStyles,
   {
+    display: 'block',
     alignSelf: 'center',
     textDecoration: 'none',
     whiteSpace: 'nowrap',
+    width: '100%',
+    paddingBlock: tokens.space.xxs,
+    paddingLeft: tokens.space.lg,
+    paddingRight: tokens.space.md,
+
+    '@media': {
+      [minWidth.lg]: {
+        padding: tokens.space.sm,
+      },
+    },
   },
 ])
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
The secondary nav item links where not full height and width of the the nav item. Put he padding and size properties on link instead of the item
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
