### PR TITLE
Add active state to ProductMenuItems

### DIFF
--- a/apps/store/src/components/HeaderNew/Header.css.ts
+++ b/apps/store/src/components/HeaderNew/Header.css.ts
@@ -259,14 +259,13 @@ export const navigationSecondaryList = style({
 export const navigationProductList = style([
   yStack({ gap: 'xs' }),
   {
-    marginBottom: tokens.space.lg,
+    marginBottom: tokens.space.md,
     fontSize: tokens.fontSizes.md,
     color: tokens.colors.textPrimary,
 
     '@media': {
       [minWidth.lg]: {
         minWidth: '16rem',
-        marginBottom: tokens.space.md,
       },
     },
   },

--- a/apps/store/src/components/HeaderNew/NavigationLink/NavigationLink.css.ts
+++ b/apps/store/src/components/HeaderNew/NavigationLink/NavigationLink.css.ts
@@ -28,18 +28,28 @@ export const productNavigationLinkCard = style([
   {
     position: 'relative',
     flexShrink: 0,
+    // Make the pillow align with the rest of the menu items
+    // but make the clickable area and background bigger
+    marginInline: `calc(-1 * ${tokens.space.xxs})`,
     paddingBlock: tokens.space.xs,
-    paddingInline: tokens.space.xxs,
+    paddingInline: tokens.space.xs,
+    borderRadius: tokens.radius.sm,
 
     '@media': {
-      [minWidth.lg]: {
-        columnGap: tokens.space.xs,
-        paddingInline: tokens.space.xs,
-        borderRadius: tokens.radius.sm,
-
+      '(hover: none)': {
+        ':active': {
+          backgroundColor: tokens.colors.grayTranslucent100,
+        },
+      },
+      '(hover: hover)': {
         ':hover': {
           backgroundColor: tokens.colors.grayTranslucent100,
         },
+      },
+      [minWidth.lg]: {
+        columnGap: tokens.space.xs,
+        marginInline: 0,
+        paddingInline: tokens.space.xs,
       },
     },
   },

--- a/apps/store/src/components/Pillow/Pillow.tsx
+++ b/apps/store/src/components/Pillow/Pillow.tsx
@@ -54,7 +54,7 @@ const getSize = (size: PillowProps['size']) => {
     case 'xxsmall':
       return { width: '1.75rem', height: '1.75rem' }
     case 'xsmall':
-      return { width: '2.25rem', height: '2.25rem' }
+      return { width: '2rem', height: '2rem' }
     case 'small':
       return { width: '3rem', height: '3rem' }
     case 'medium':


### PR DESCRIPTION


<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add active state to ProductMenuItems

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/nv8d5VeBPARA7ezh3Od3/99138941-fea2-42d0-bab3-818b5c15b3c0.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/nv8d5VeBPARA7ezh3Od3/99138941-fea2-42d0-bab3-818b5c15b3c0.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/nv8d5VeBPARA7ezh3Od3/99138941-fea2-42d0-bab3-818b5c15b3c0.mov">Screen Recording 2024-07-17 at 14.54.03.mov</video>
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Mobile menu feedback

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
