### PR TITLE
Remove link from sub and product menu main items

### DIFF
--- a/apps/store/src/blocks/HeaderBlockNew/ProductMenuBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlockNew/ProductMenuBlock.tsx
@@ -4,6 +4,7 @@ import { storyblokEditable } from '@storyblok/react'
 import clsx from 'clsx'
 import { useTranslation } from 'next-i18next'
 import { sprinkles } from 'ui/src/theme/sprinkles.css'
+import { Button } from 'ui'
 import type { ButtonBlockProps } from '@/blocks/ButtonBlock'
 import { MenuItemBlock, type MenuItemBlockProps } from '@/blocks/HeaderBlockNew/MenuItemBlock'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
@@ -90,9 +91,9 @@ export const ProductMenuBlock = ({ blok, variant }: ProductMenuBlockProps) => {
         {...storyblokEditable(blok)}
       >
         <NavigationTrigger>
-          <ButtonNextLink size="medium" variant="secondary" href={PageLink.store({ locale })}>
+          <Button size="medium" variant="secondary">
             {blok.name}
-          </ButtonNextLink>
+          </Button>
         </NavigationTrigger>
         <NavigationContent>{content}</NavigationContent>
       </NavigationMenuPrimitive.Item>

--- a/apps/store/src/blocks/HeaderBlockNew/SubMenuBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlockNew/SubMenuBlock.tsx
@@ -1,9 +1,8 @@
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import { storyblokEditable } from '@storyblok/react'
 import clsx from 'clsx'
-import { MinusIcon, PlusIcon } from 'ui'
+import { Button, MinusIcon, PlusIcon } from 'ui'
 import { MenuItemBlock, type MenuItemBlockProps } from '@/blocks/HeaderBlockNew/MenuItemBlock'
-import { ButtonNextLink } from '@/components/ButtonNextLink'
 import {
   navigationItem,
   navigationItemSubMenu,
@@ -30,8 +29,6 @@ export const SubMenuBlock = ({ blok, variant }: SubMenuBlockProps) => {
     return null
   }
 
-  const firstMenuItem = filteredMenuItems[0]
-
   return (
     <NavigationMenuPrimitive.Item
       className={clsx(navigationItem, navigationItemSubMenu)}
@@ -52,13 +49,9 @@ export const SubMenuBlock = ({ blok, variant }: SubMenuBlockProps) => {
         </NavigationTrigger>
       ) : (
         <NavigationTrigger>
-          <ButtonNextLink
-            size="medium"
-            variant="secondary"
-            href={getLinkFieldURL(firstMenuItem.link, firstMenuItem.name)}
-          >
+          <Button size="medium" variant="secondary">
             {blok.name}
-          </ButtonNextLink>
+          </Button>
         </NavigationTrigger>
       )}
       <NavigationContent>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Remove link from sub and product menu main items
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
We decided to test removing the main menu items to be a link. The hypothesis being that users might accidentally navigate when they want to open the submenu

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
