### PR TITLE
Add SE_ACCIDENT_V2 price template for new Price Calculator page

### DIFF
--- a/apps/store/public/locales/en/purchase-form.json
+++ b/apps/store/public/locales/en/purchase-form.json
@@ -130,7 +130,7 @@
   "PRICE_MATCH_BUBBLE_SUCCESS_TITLE": "You save {{amount}}",
   "QUICK_CHECKOUT_BUTTON_LABEL": "Go to checkout",
   "SECTION_SUBTITLE_YOUR_DOG": "Fill in additional information about your dog that you want to insure",
-  "SECTION_SUBTITLE_YOUR_INFORMATION": "Fill in additional information",
+  "SECTION_SUBTITLE_YOUR_INFORMATION": "Check your details and\nselect the number of insured persons",
   "SECTION_TITLE_BUILDING_DETAILS": "Building details",
   "SECTION_TITLE_PERSONAL_NUMBER": "Personal Number",
   "SECTION_TITLE_YOUR_ADDRESS": "Your address",

--- a/apps/store/public/locales/sv-se/purchase-form.json
+++ b/apps/store/public/locales/sv-se/purchase-form.json
@@ -130,7 +130,7 @@
   "PRICE_MATCH_BUBBLE_SUCCESS_TITLE": "Du sparar {{amount}}",
   "QUICK_CHECKOUT_BUTTON_LABEL": "Gå till kassan",
   "SECTION_SUBTITLE_YOUR_DOG": "Fyll i ytterligare uppgifter om din hund som du vill försäkra",
-  "SECTION_SUBTITLE_YOUR_INFORMATION": "Fyll i ytterligare uppgifter",
+  "SECTION_SUBTITLE_YOUR_INFORMATION": "Kontrollera dina uppgifter och \nvälj antal försäkrade personer",
   "SECTION_TITLE_BUILDING_DETAILS": "Byggnadsdetaljer",
   "SECTION_TITLE_PERSONAL_NUMBER": "Personnummer",
   "SECTION_TITLE_YOUR_ADDRESS": "Din adress",

--- a/apps/store/src/features/priceCalculator/priceTemplates/SE_ACCIDENT_V2.ts
+++ b/apps/store/src/features/priceCalculator/priceTemplates/SE_ACCIDENT_V2.ts
@@ -1,0 +1,47 @@
+import {
+  LAYOUT,
+  livingSpaceField,
+  ssnSeSection,
+  postalCodeField,
+  streetAddressField,
+  emailField,
+  householdSizeField,
+} from '@/services/PriceCalculator/formFragments'
+import { type TemplateV2 } from '@/services/PriceCalculator/PriceCalculator.types'
+import { setI18nNamespace, tKey } from '@/utils/i18n'
+
+setI18nNamespace('purchase-form')
+
+const template: TemplateV2 = {
+  name: 'SE_ACCIDENT_V2',
+  productName: 'SE_ACCIDENT',
+  sections: [
+    ssnSeSection,
+    {
+      id: 'your-information',
+      title: { key: tKey('SECTION_TITLE_YOUR_INFORMATION') },
+      subtitle: { key: tKey('SECTION_SUBTITLE_YOUR_INFORMATION') },
+      submitLabel: { key: tKey('SUBMIT_LABEL_FINISH') },
+      items: [
+        {
+          field: streetAddressField,
+          layout: LAYOUT.FULL_WIDTH,
+        },
+        {
+          field: postalCodeField,
+          layout: LAYOUT.HALF_WIDTH,
+        },
+        {
+          field: livingSpaceField,
+          layout: LAYOUT.HALF_WIDTH,
+        },
+        { field: householdSizeField, layout: LAYOUT.FULL_WIDTH },
+        { field: emailField, layout: LAYOUT.FULL_WIDTH },
+      ],
+      preview: {
+        fieldName: streetAddressField.name,
+      },
+    },
+  ],
+}
+export default template

--- a/apps/store/src/features/priceCalculator/priceTemplates/SE_PET_DOG_V2.ts
+++ b/apps/store/src/features/priceCalculator/priceTemplates/SE_PET_DOG_V2.ts
@@ -3,13 +3,14 @@ import {
   ssnSeSection,
   yourAddressSectionWithLivingSpaceV2,
 } from '@/services/PriceCalculator/formFragments'
-import type { Template } from '@/services/PriceCalculator/PriceCalculator.types'
+import type { TemplateV2 } from '@/services/PriceCalculator/PriceCalculator.types'
 import { setI18nNamespace, tKey } from '@/utils/i18n'
 
 setI18nNamespace('purchase-form')
 
-export const SE_PET_DOG_V2: Template = {
+const template: TemplateV2 = {
   name: 'SE_PET_DOG_V2',
+  productName: 'SE_PET_DOG',
   sections: [
     ssnSeSection,
     {
@@ -96,3 +97,4 @@ export const SE_PET_DOG_V2: Template = {
     yourAddressSectionWithLivingSpaceV2,
   ],
 }
+export default template

--- a/apps/store/src/services/PriceCalculator/PriceCalculator.types.ts
+++ b/apps/store/src/services/PriceCalculator/PriceCalculator.types.ts
@@ -29,6 +29,10 @@ export type Template = {
   sections: Array<TemplateSection>
 }
 
+export type TemplateV2 = Template & {
+  productName: string
+}
+
 export type TemplateSection = {
   id: string
   title: Label

--- a/apps/store/src/services/PriceCalculator/formFragments.ts
+++ b/apps/store/src/services/PriceCalculator/formFragments.ts
@@ -44,7 +44,7 @@ export const currentInsuranceField: InputField = {
   label: { key: tKey('FIELD_EXTERNAL_INSURER_LABEL') },
 }
 
-const householdSizeField: InputField = {
+export const householdSizeField: InputField = {
   type: 'stepper',
   name: 'numberCoInsured',
   label: { key: tKey('FIELD_HOUSEHOLD_SIZE_LABEL') },

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -152,9 +152,9 @@ export type WidgetFlowStory = ISbStoryData<{
   showBackButton?: boolean
 }>
 
-// TODO: Refine type
 export type PriceCalculatorPageStory = ISbStoryData<{
   component: 'priceCalculatorPage'
+  priceTemplate: string
   deductibleInfo?: Array<SbBlokData>
 }>
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add configuration for Accident Price Calculator page
- specify priceTemplate name in Storyblok and load that template in the code
- 2-section Accident configuration with address and coInsured + email combined into single section
- add `/se-en/insurances/accident/price-calculator` storyblok page

![Screenshot 2024-07-18 at 15.02.50.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/1a1edced-fec2-4d84-bac4-8cfa1db9079e.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
