### PR TITLE
fix(widget): form auto completion with suggested data

### DIFF
--- a/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/calculate-price.tsx
+++ b/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/calculate-price.tsx
@@ -81,7 +81,7 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
         ...translations,
         ...context.params,
         showBackButton: story.content.showBackButton ?? false,
-        [SHOP_SESSION_PROP_NAME]: context.params.shopSessionId,
+        [SHOP_SESSION_PROP_NAME]: shopSession.id,
       },
     })
   } catch (error) {


### PR DESCRIPTION
## Describe your changes

Ok, we were having an issue before where widget's price calcuator page was not pre-populating 'your address' form section. It was solved by this [PR](https://github.com/HedvigInsurance/racoon/pull/4435), which introduced another couple of issues:

1. When completing a purchase in Hedvig-dot-com, one could still see the number of items you have purchased in the header
2. When completing a purchase in widget and opening a tab with hedvig-dot-com, one would have it loaded with widget's shop session

This is the second attempt, which solves all of them. Here's the reasoning behind it:

We have two possible sources for shop session id in our app (and while debugging I think it makes sense to have 2): the URL and/or a cookie. The cookie option is the fallback one. If provided in the URL we should use it despite what we have in a cookie. `ShopSessionContext` is responsible to provide us the shop session and therefore should be initialised following the same criteria.

The issue we were having before was that even though shop session id was present for widget URLs,`ShopSessionContext` was using what we have as a cookie. Therefore, when entering your ssn in the widget we were updating the wrong shop session. My first attempt was to synchronyze both: make sure the cookie always have the same what we have in the URL, when provided. But as mentioned that causes other issues.
