### PR TITLE
Fix accessibility warning in cart item action dialogs (edit and remove confirmations)

### DIFF
--- a/apps/store/src/components/ProductItem/EditActionButton.tsx
+++ b/apps/store/src/components/ProductItem/EditActionButton.tsx
@@ -52,9 +52,11 @@ export const EditActionButton = (props: Props) => {
           </>
         }
       >
-        <CappedText size={{ _: 'md', lg: 'xl' }} align="center">
-          <Balancer>{t('EDIT_CONFIRMATION_MODAL_PROMPT')}</Balancer>
-        </CappedText>
+        <FullscreenDialog.Title asChild={true}>
+          <CappedText size={{ _: 'md', lg: 'xl' }} align="center">
+            <Balancer>{t('EDIT_CONFIRMATION_MODAL_PROMPT')}</Balancer>
+          </CappedText>
+        </FullscreenDialog.Title>
       </FullscreenDialog.Modal>
     </FullscreenDialog.Root>
   )

--- a/apps/store/src/components/ProductItem/RemoveActionButton.tsx
+++ b/apps/store/src/components/ProductItem/RemoveActionButton.tsx
@@ -71,9 +71,11 @@ export const RemoveActionButton = (props: Props) => {
           </>
         }
       >
-        <Text size={{ _: 'md', lg: 'xl' }} align="center">
-          {t('REMOVE_ENTRY_MODAL_PROMPT', { name: props.title })}
-        </Text>
+        <FullscreenDialog.Title asChild={true}>
+          <Text size={{ _: 'md', lg: 'xl' }} align="center">
+            {t('REMOVE_ENTRY_MODAL_PROMPT', { name: props.title })}
+          </Text>
+        </FullscreenDialog.Title>
       </FullscreenDialog.Modal>
     </FullscreenDialog.Root>
   )


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Subj. We had accessibility warnings in confirmation dialogs on cart item

Would be nice to get standard confirmation dialogs in new design. Currently we're using `FullscreenDialog`, which might be too low-level abstraction

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
