### PR TITLE
Use explicit WidgetFlowType to create partner session the right way (only pass externalMemberId to trial extensions)

### DIFF
--- a/apps/store/src/features/widget/StartFlow.helpers.ts
+++ b/apps/store/src/features/widget/StartFlow.helpers.ts
@@ -4,6 +4,7 @@ import {
   type PageStory,
   type WidgetFlowStory,
   getStoryBySlug,
+  type WidgetFlowType,
 } from '@/services/storyblok/storyblok'
 import { isWidgetFlowStory } from '@/services/storyblok/Storyblok.helpers'
 import type { RoutingLocale } from '@/utils/l10n/types'
@@ -25,7 +26,12 @@ type FetchFlowMetadataParams = {
   draftMode?: boolean
 }
 
-type FlowMetadata = { flow: string; partnerName: string; campaignCode?: string }
+type FlowMetadata = {
+  flow: string
+  flowType: WidgetFlowType
+  partnerName: string
+  campaignCode?: string
+}
 
 export const fetchFlowMetadata = async (
   params: FetchFlowMetadataParams,
@@ -39,6 +45,7 @@ export const fetchFlowMetadata = async (
   if (isWidgetFlowStory(story)) {
     return {
       flow: String(story.id),
+      flowType: story.content.flowType,
       partnerName: story.content.partner,
       campaignCode: story.content.campaignCode,
     }

--- a/apps/store/src/pages/[locale]/widget/flows/[...slug].tsx
+++ b/apps/store/src/pages/[locale]/widget/flows/[...slug].tsx
@@ -40,9 +40,8 @@ export const getServerSideProps: GetServerSideProps<any, Params> = async (contex
   const [shopSessionId, searchParams] = await createPartnerShopSession({
     apolloClient,
     countryCode: getCountryByLocale(context.locale).countryCode,
-    partnerName: flowMetadata.partnerName,
-    campaignCode: flowMetadata.campaignCode,
     searchParams: url.searchParams,
+    ...flowMetadata,
   })
 
   console.info(`Widget | Created Shop Session: ${shopSessionId}`)

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -156,8 +156,14 @@ export type ProductPageStory = ISbStoryData<
   } & SEOData
 >
 
+export enum WidgetFlowType {
+  Regular = 'Regular',
+  HomeTrialExtension = 'HomeTrialExtension',
+}
+
 export type WidgetFlowStory = ISbStoryData<{
   partner: string
+  flowType: WidgetFlowType
   products?: Array<string>
   backToAppButtonLabel?: string
   campaignCode?: string


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Make widget flow type explicit. Options are `Regular` and `HomeTrialExtension`.  Only send `externalMemberId` to `shopSessionCreatePartner` for trial extension flow type

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Avy is sending `externalMemberId` to us if person ever had a trial or is a returning members. We expected to only get it for extension flow and failed in other cases

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
