### PR TITLE
Revert "Remove link from sub and product menu main items"

### DIFF
--- a/apps/store/src/blocks/HeaderBlockNew/ProductMenuBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlockNew/ProductMenuBlock.tsx
@@ -4,7 +4,6 @@ import { storyblokEditable } from '@storyblok/react'
 import clsx from 'clsx'
 import { useTranslation } from 'next-i18next'
 import { sprinkles } from 'ui/src/theme/sprinkles.css'
-import { Button } from 'ui'
 import type { ButtonBlockProps } from '@/blocks/ButtonBlock'
 import { MenuItemBlock, type MenuItemBlockProps } from '@/blocks/HeaderBlockNew/MenuItemBlock'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
@@ -91,9 +90,9 @@ export const ProductMenuBlock = ({ blok, variant }: ProductMenuBlockProps) => {
         {...storyblokEditable(blok)}
       >
         <NavigationTrigger>
-          <Button size="medium" variant="secondary">
+          <ButtonNextLink size="medium" variant="secondary" href={PageLink.store({ locale })}>
             {blok.name}
-          </Button>
+          </ButtonNextLink>
         </NavigationTrigger>
         <NavigationContent>{content}</NavigationContent>
       </NavigationMenuPrimitive.Item>

--- a/apps/store/src/blocks/HeaderBlockNew/SubMenuBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlockNew/SubMenuBlock.tsx
@@ -1,8 +1,9 @@
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
 import { storyblokEditable } from '@storyblok/react'
 import clsx from 'clsx'
-import { Button, MinusIcon, PlusIcon } from 'ui'
+import { MinusIcon, PlusIcon } from 'ui'
 import { MenuItemBlock, type MenuItemBlockProps } from '@/blocks/HeaderBlockNew/MenuItemBlock'
+import { ButtonNextLink } from '@/components/ButtonNextLink'
 import {
   navigationItem,
   navigationItemSubMenu,
@@ -29,6 +30,8 @@ export const SubMenuBlock = ({ blok, variant }: SubMenuBlockProps) => {
     return null
   }
 
+  const firstMenuItem = filteredMenuItems[0]
+
   return (
     <NavigationMenuPrimitive.Item
       className={clsx(navigationItem, navigationItemSubMenu)}
@@ -49,9 +52,13 @@ export const SubMenuBlock = ({ blok, variant }: SubMenuBlockProps) => {
         </NavigationTrigger>
       ) : (
         <NavigationTrigger>
-          <Button size="medium" variant="secondary">
+          <ButtonNextLink
+            size="medium"
+            variant="secondary"
+            href={getLinkFieldURL(firstMenuItem.link, firstMenuItem.name)}
+          >
             {blok.name}
-          </Button>
+          </ButtonNextLink>
         </NavigationTrigger>
       )}
       <NavigationContent>


### PR DESCRIPTION
Reverts HedvigInsurance/racoon#4499

We tested and weren't satisfied with the functionality. Revert back to main items being linkable. Let's eavalute if we should change behaviour after vacations