### PR TITLE
Add new forms for SE_APARTMENT_RENT and _BRF

### DIFF
--- a/apps/store/public/locales/en/purchase-form.json
+++ b/apps/store/public/locales/en/purchase-form.json
@@ -130,6 +130,7 @@
   "PRICE_MATCH_BUBBLE_SUCCESS_TITLE": "You save {{amount}}",
   "QUICK_CHECKOUT_BUTTON_LABEL": "Go to checkout",
   "SECTION_SUBTITLE_YOUR_DOG": "Fill in additional information about your dog that you want to insure",
+  "SECTION_SUBTITLE_YOUR_HOME": "Fill in additional information about the home you want to insure",
   "SECTION_SUBTITLE_YOUR_INFORMATION": "Check your details and\nselect the number of insured persons",
   "SECTION_TITLE_BUILDING_DETAILS": "Building details",
   "SECTION_TITLE_PERSONAL_NUMBER": "Personal Number",

--- a/apps/store/public/locales/sv-se/purchase-form.json
+++ b/apps/store/public/locales/sv-se/purchase-form.json
@@ -130,6 +130,7 @@
   "PRICE_MATCH_BUBBLE_SUCCESS_TITLE": "Du sparar {{amount}}",
   "QUICK_CHECKOUT_BUTTON_LABEL": "Gå till kassan",
   "SECTION_SUBTITLE_YOUR_DOG": "Fyll i ytterligare uppgifter om din hund som du vill försäkra",
+  "SECTION_SUBTITLE_YOUR_HOME": "Fyll i ytterligare uppgifter om bostaden du vill försäkra",
   "SECTION_SUBTITLE_YOUR_INFORMATION": "Kontrollera dina uppgifter och \nvälj antal försäkrade personer",
   "SECTION_TITLE_BUILDING_DETAILS": "Byggnadsdetaljer",
   "SECTION_TITLE_PERSONAL_NUMBER": "Personnummer",

--- a/apps/store/public/mockServiceWorker.js
+++ b/apps/store/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.3.1'
+const PACKAGE_VERSION = '2.3.2'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/apps/store/src/features/priceCalculator/priceTemplates/SE_APARTMENT_BRF_V2.ts
+++ b/apps/store/src/features/priceCalculator/priceTemplates/SE_APARTMENT_BRF_V2.ts
@@ -1,0 +1,9 @@
+import { apartmentSectionV2, ssnSeSection } from '@/services/PriceCalculator/formFragments'
+import { type TemplateV2 } from '@/services/PriceCalculator/PriceCalculator.types'
+
+const SE_APARTMENT_BRF_V2: TemplateV2 = {
+  name: 'SE_APARTMENT_BRF_V2',
+  productName: 'SE_APARTMENT_BRF',
+  sections: [ssnSeSection, apartmentSectionV2],
+}
+export default SE_APARTMENT_BRF_V2

--- a/apps/store/src/features/priceCalculator/priceTemplates/SE_APARTMENT_RENT_V2.ts
+++ b/apps/store/src/features/priceCalculator/priceTemplates/SE_APARTMENT_RENT_V2.ts
@@ -1,0 +1,9 @@
+import { apartmentSectionV2, ssnSeSection } from '@/services/PriceCalculator/formFragments'
+import { type TemplateV2 } from '@/services/PriceCalculator/PriceCalculator.types'
+
+const SE_APARTMENT_RENT_V2: TemplateV2 = {
+  name: 'SE_APARTMENT_RENT_V2',
+  productName: 'SE_APARTMENT_RENT',
+  sections: [ssnSeSection, apartmentSectionV2],
+}
+export default SE_APARTMENT_RENT_V2

--- a/apps/store/src/services/PriceCalculator/formFragments.ts
+++ b/apps/store/src/services/PriceCalculator/formFragments.ts
@@ -220,3 +220,21 @@ export const yourAddressSectionWithLivingSpaceV2: TemplateSection = {
     fieldName: streetAddressField.name,
   },
 }
+
+export const apartmentSectionV2: TemplateSection = {
+  id: 'your-apartment',
+  title: { key: tKey('SECTION_TITLE_YOUR_HOME') },
+  subtitle: { key: tKey('SECTION_SUBTITLE_YOUR_HOME') },
+  submitLabel: { key: tKey('SUBMIT_LABEL_FINISH') },
+  items: [
+    { field: streetAddressField, layout: LAYOUT.FULL_WIDTH },
+    { field: postalCodeField, layout: LAYOUT.HALF_WIDTH },
+    { field: livingSpaceField, layout: LAYOUT.HALF_WIDTH },
+    { field: householdSizeField, layout: LAYOUT.FULL_WIDTH },
+    { field: emailField, layout: LAYOUT.FULL_WIDTH },
+    { field: currentInsuranceField, layout: LAYOUT.FULL_WIDTH },
+  ],
+  preview: {
+    fieldName: streetAddressField.name,
+  },
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add Price Calculator pages for SE_APARTMENT_RENT and SE_APARTMENT_BRF

Apartment and co-insured info grouped into single form section

![Screenshot 2024-07-19 at 12.18.28.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/a14a7671-e282-4f48-b384-8105ccc4350a.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

To be followed by PR for "use your registration address?" field

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
