### PR TITLE
GEN-2432 - refact(TrustlyIframe): migrate to vanilla extract css

### DIFF
--- a/apps/store/src/app/[locale]/new/checkout/[shopSessionId]/payment/trustly/CheckoutPaymentTrustlyPage.css.ts
+++ b/apps/store/src/app/[locale]/new/checkout/[shopSessionId]/payment/trustly/CheckoutPaymentTrustlyPage.css.ts
@@ -15,3 +15,8 @@ export const successState = style([
 export const content = style({
   paddingBlock: tokens.space.xxl,
 })
+
+export const trustlyIframe = style({
+  width: 'min(29rem, 100%)',
+  height: 'min(32rem, 60vh)',
+})

--- a/apps/store/src/app/[locale]/new/checkout/[shopSessionId]/payment/trustly/CheckoutPaymentTrustlyPage.tsx
+++ b/apps/store/src/app/[locale]/new/checkout/[shopSessionId]/payment/trustly/CheckoutPaymentTrustlyPage.tsx
@@ -8,7 +8,7 @@ import { Text, yStack, theme } from 'ui'
 import { CheckIcon } from '@/components/ComparisonTable/ComparisonTable'
 import * as GridLayout from '@/components/GridLayout/GridLayout'
 import { TrustlyIframe } from '@/services/trustly/TrustlyIframe'
-import { successState, content } from './CheckoutPaymentTrustlyPage.css'
+import { successState, content, trustlyIframe } from './CheckoutPaymentTrustlyPage.css'
 
 const datadogLogger = datadogLogs.createLogger('trustly')
 
@@ -49,7 +49,7 @@ export function CheckoutPaymentTrustlyPage({ shopSessionId, trustlyUrl, nextUrl 
       <GridLayout.Content className={content} width="1/3" align="center">
         <div className={yStack({ gap: 'lg' })}>
           <TrustlyIframe
-            style={{ width: 'min(29rem, 100%)', height: 'min(32rem, 60vh)' }}
+            className={trustlyIframe}
             url={trustlyUrl}
             onSuccess={handleSuccess}
             onFail={handleFail}

--- a/apps/store/src/components/PaymentConnectPage/IdleState.tsx
+++ b/apps/store/src/components/PaymentConnectPage/IdleState.tsx
@@ -9,7 +9,7 @@ import { Button, Space, Text, theme } from 'ui'
 import { exchangeAuthorizationCode } from '@/services/authApi/oauth'
 import { getAccessToken, saveAuthTokens } from '@/services/authApi/persist'
 import { createTrustlyUrl } from '@/services/trustly/createTrustlyUrl'
-import { trustlyIframeStyles } from '@/services/trustly/TrustlyIframe'
+import { trustlyIframeBaseStyles } from '@/services/trustly/TrustlyIframe.css'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { Layout } from './Layout'
 
@@ -53,7 +53,7 @@ export const IdleState = (props: Props) => {
     <Layout>
       <Space y={0.75}>
         <form onSubmit={handleSubmit}>
-          <IframePlaceholder data-state={state}>
+          <IframePlaceholder className={trustlyIframeBaseStyles} data-state={state}>
             <WideSpace y={0.5}>
               <Button loading={state === 'LOADING'} disabled={state === 'ERROR'}>
                 {t('FLOW_ACTIVATION_BUTTON')}
@@ -72,7 +72,7 @@ export const IdleState = (props: Props) => {
   )
 }
 
-export const IframePlaceholder = styled.div(trustlyIframeStyles, {
+export const IframePlaceholder = styled.div({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'stretch',

--- a/apps/store/src/pages/[locale]/payment/connect/start.tsx
+++ b/apps/store/src/pages/[locale]/payment/connect/start.tsx
@@ -8,7 +8,7 @@ import { type FormEventHandler, useState } from 'react'
 import { Button, Space, Text, theme } from 'ui'
 import { Layout } from '@/components/PaymentConnectPage/Layout'
 import { getAccessToken } from '@/services/authApi/persist'
-import { trustlyIframeStyles } from '@/services/trustly/TrustlyIframe'
+import { trustlyIframeBaseStyles } from '@/services/trustly/TrustlyIframe.css'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
@@ -45,7 +45,7 @@ const Page = () => {
     <Layout>
       <Space y={0.75}>
         <form onSubmit={handleSubmit}>
-          <IframePlaceholder>
+          <IframePlaceholder className={trustlyIframeBaseStyles}>
             <WideSpace y={0.5}>
               <Button loading={loading} fullWidth={true}>
                 {t('FLOW_ACTIVATION_BUTTON')}
@@ -61,7 +61,7 @@ const Page = () => {
   )
 }
 
-const IframePlaceholder = styled.div(trustlyIframeStyles, {
+const IframePlaceholder = styled.div({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'stretch',

--- a/apps/store/src/pages/[locale]/payment/connect/success.tsx
+++ b/apps/store/src/pages/[locale]/payment/connect/success.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { CheckIcon, Space, Text, theme } from 'ui'
 import { Layout } from '@/components/PaymentConnectPage/Layout'
-import { trustlyIframeStyles } from '@/services/trustly/TrustlyIframe'
+import { trustlyIframeBaseStyles } from '@/services/trustly/TrustlyIframe.css'
 import { isRoutingLocale } from '@/utils/l10n/localeUtils'
 import { patchNextI18nContext } from '@/utils/patchNextI18nContext'
 import { staticPathsPerSwedenLocale } from '@/utils/staticPaths'
@@ -21,7 +21,7 @@ const Page = () => {
   return (
     <Layout>
       <Space y={0.75}>
-        <IframePlaceholder>
+        <IframePlaceholder className={trustlyIframeBaseStyles}>
           <CheckIcon color={theme.colors.signalGreenElement} />
           <Text size={{ _: 'md', lg: 'lg' }}>{t('PAYMENT_CONNECT_SUCCESS')}</Text>
         </IframePlaceholder>
@@ -33,7 +33,7 @@ const Page = () => {
   )
 }
 
-const IframePlaceholder = styled.div(trustlyIframeStyles, {
+const IframePlaceholder = styled.div({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',

--- a/apps/store/src/services/trustly/TrustlyIframe.css.ts
+++ b/apps/store/src/services/trustly/TrustlyIframe.css.ts
@@ -1,0 +1,39 @@
+import { style, keyframes } from '@vanilla-extract/css'
+import { tokens } from 'ui'
+
+export const TRUSTLY_IFRAME_MAX_WIDTH = 600
+const TRUSTLY_IFRAME_MIN_HEIGHT = 500
+export const TRUSTLY_IFRAME_MAX_HEIGHT = 800
+
+const pulseAnimation = keyframes({
+  '0%': { opacity: 1 },
+  '50%': { opacity: 0.5 },
+  '100%': { opacity: 1 },
+})
+
+export const trustlyIframeBaseStyles = style({
+  width: '100%',
+  maxWidth: TRUSTLY_IFRAME_MAX_WIDTH,
+  minHeight: TRUSTLY_IFRAME_MIN_HEIGHT,
+  height: '100%',
+  maxHeight: TRUSTLY_IFRAME_MAX_HEIGHT,
+  borderRadius: 16,
+  boxShadow: tokens.shadow.default,
+  marginInline: 'auto',
+  backgroundColor: tokens.colors.white,
+})
+
+export const trustlyIframe = style([
+  trustlyIframeBaseStyles,
+  {
+    display: 'block',
+    border: 'none',
+    selectors: {
+      '&[data-loading=true]': {
+        backgroundColor: tokens.colors.gray200,
+        animation: `${pulseAnimation} 2s`,
+        animationIterationCount: 3,
+      },
+    },
+  },
+])

--- a/apps/store/src/services/trustly/TrustlyIframe.tsx
+++ b/apps/store/src/services/trustly/TrustlyIframe.tsx
@@ -1,9 +1,9 @@
-import { css, keyframes } from '@emotion/react'
-import styled from '@emotion/styled'
 import { type ComponentPropsWithoutRef, type ReactEventHandler, useEffect, useState } from 'react'
-import { theme } from 'ui'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
+import { trustlyIframe } from './TrustlyIframe.css'
+
+export { TRUSTLY_IFRAME_MAX_WIDTH, TRUSTLY_IFRAME_MAX_HEIGHT } from './TrustlyIframe.css'
 
 type Props = Omit<ComponentPropsWithoutRef<'iframe'>, 'src'> & {
   url: string
@@ -46,40 +46,13 @@ export const TrustlyIframe = ({ url, onSuccess, onFail, ...others }: Props) => {
     setLoading(false)
   }
 
-  return <Iframe src={url} onLoad={handleLoad} data-loading={loading} {...others} />
+  return (
+    <iframe
+      className={trustlyIframe}
+      src={url}
+      onLoad={handleLoad}
+      data-loading={loading}
+      {...others}
+    />
+  )
 }
-
-export const TRUSTLY_IFRAME_MAX_WIDTH = 600
-const TRUSTLY_IFRAME_MIN_HEIGHT = 500
-export const TRUSTLY_IFRAME_MAX_HEIGHT = 800
-
-export const trustlyIframeStyles = css({
-  width: '100%',
-  maxWidth: TRUSTLY_IFRAME_MAX_WIDTH,
-
-  minHeight: TRUSTLY_IFRAME_MIN_HEIGHT,
-  height: '100%',
-  maxHeight: TRUSTLY_IFRAME_MAX_HEIGHT,
-
-  borderRadius: 16,
-  boxShadow: theme.shadow.default,
-  marginInline: 'auto',
-  backgroundColor: theme.colors.white,
-})
-
-const pulseAnimation = keyframes({
-  '0%': { opacity: 1 },
-  '50%': { opacity: 0.5 },
-  '100%': { opacity: 1 },
-})
-
-const Iframe = styled.iframe(trustlyIframeStyles, {
-  display: 'block',
-  border: 'none',
-
-  '&[data-loading=true]': {
-    backgroundColor: theme.colors.gray200,
-    animation: `${pulseAnimation} 2s`,
-    animationIterationCount: 3,
-  },
-})


### PR DESCRIPTION
## Describe your changes

* chore(TrustlyIframe): migrate to vanilla extract css
* refact(CheckoutPaymentTrustlyPage): update Trustly iframe styles via CSS class instead of style object

## Justify why they are needed

Subj.