### PR TITLE
Ignore Datadog browser SDK multiload warnins in server-side code

### DIFF
--- a/apps/store/next.config.mjs
+++ b/apps/store/next.config.mjs
@@ -4,6 +4,9 @@ import experimentJson from './experiment.json' assert { type: 'json' }
 import { createVanillaExtractPlugin } from '@vanilla-extract/next-plugin'
 
 import { SiteCsp, StoryblokCsp } from './next-csp.config.mjs'
+import { patchServerConsole } from './src/utils/patchServerConsole.mjs'
+
+patchServerConsole()
 
 /** @type {import('next').NextConfig} */
 const config = {

--- a/apps/store/src/utils/patchServerConsole.mjs
+++ b/apps/store/src/utils/patchServerConsole.mjs
@@ -1,0 +1,22 @@
+const consolePatched = Symbol('consolePatched')
+
+const ignoredWarnings = new Set([
+  // Nothing we can do about it, nextjs loads datadog SDK multiple times when doing server-side code splitting
+  // Source of warning: https://github.com/DataDog/browser-sdk/blob/92d7ab9426b5e4e2bcf7e8dcd5852c8ab635cbb4/packages/core/src/boot/init.ts#L53
+  'Datadog Browser SDK: SDK is loaded more than once. This is unsupported and might have unexpected behavior.',
+])
+
+export const patchServerConsole = () => {
+  if (typeof window !== 'undefined') return
+  if (console[consolePatched] != null) return
+
+  console[consolePatched] = true
+
+  const origWarn = console.warn
+  console.warn = (...args) => {
+    if (ignoredWarnings.has(args.join(' '))) {
+      return
+    }
+    origWarn(...args)
+  }
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Ignore warnings from Datadog SDK that turn into server-side errors in monitoring

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Less monitoring noise, this error is non-actionable and we cannot fix it

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
