### PR TITLE
Optimize image sizes in ProductGrid

### DIFF
--- a/apps/store/src/blocks/ProductGridBlock.tsx
+++ b/apps/store/src/blocks/ProductGridBlock.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { storyblokEditable } from '@storyblok/react'
-import { useMemo } from 'react'
 import type { ProductCardBlockProps } from '@/blocks/ProductCardBlock'
 import { ProductCardBlock } from '@/blocks/ProductCardBlock'
 import { ProductGrid } from '@/components/ProductGrid/ProductGrid'
@@ -13,13 +12,11 @@ type ProductGridBlockProps = SbBaseBlockProps<{
 }>
 
 export const ProductGridBlock = ({ blok }: ProductGridBlockProps) => {
-  const items = useMemo(
-    () => blok.items.map((item) => ({ key: item._uid || item.title, ...item })),
-    [blok.items],
-  )
   return (
-    <ProductGrid title={blok.title} items={items} {...storyblokEditable(blok)}>
-      {(nestedBlock) => <ProductCardBlock key={nestedBlock.key} blok={nestedBlock} />}
+    <ProductGrid title={blok.title} {...storyblokEditable(blok)}>
+      {blok.items.map((nestedBlock) => (
+        <ProductCardBlock key={nestedBlock._uid || nestedBlock.title} blok={nestedBlock} />
+      ))}
     </ProductGrid>
   )
 }

--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -47,7 +47,7 @@ export const ProductCard = ({
   return (
     <Container y={1}>
       <ImageWrapper aspectRatio={aspectRatio}>
-        <Image {...imageProps} alt={alt} fill sizes="100vw" />
+        <Image {...imageProps} alt={alt} fill sizes="20rem" />
       </ImageWrapper>
       <ContentWrapper>
         <MainLink href={link.url}>{title}</MainLink>

--- a/apps/store/src/components/ProductGrid/ProductGrid.stories.tsx
+++ b/apps/store/src/components/ProductGrid/ProductGrid.stories.tsx
@@ -16,10 +16,16 @@ const meta: Meta<typeof ProductGrid> = {
 
 export default meta
 
-type ProductItem = ProductCardProps & { key: string }
+type ProductItem = ProductCardProps
 
-const Template: StoryFn<ProductGridProps<ProductItem>> = (props) => {
-  return <ProductGrid {...props}>{(itemProps) => <ProductCard {...itemProps} />}</ProductGrid>
+const Template: StoryFn<ProductGridProps & { items: Array<ProductItem> }> = (props) => {
+  return (
+    <ProductGrid {...props}>
+      {props.items.map((itemProps) => (
+        <ProductCard key={itemProps.title} {...itemProps} />
+      ))}
+    </ProductGrid>
+  )
 }
 
 export const Default = {
@@ -28,35 +34,30 @@ export const Default = {
     title: 'Popular insurances',
     items: [
       {
-        key: '1',
         title: 'Hedvig Home',
         subtitle: 'Flexible and simple, for both renters and owners.',
         image: { src: 'https://via.placeholder.com/336x400' },
         link: { url: '/', type: 'product' },
       },
       {
-        key: '2',
         title: 'Hedvig House',
         subtitle: 'Lörem ipsum dålor, nufs plufs glufs och gruls.',
         image: { src: 'https://via.placeholder.com/336x400' },
         link: { url: '/', type: 'product' },
       },
       {
-        key: '3',
         title: 'Hedvig Car',
         subtitle: 'Lörem ipsum dålor, nufs plufs glufs och gruls.',
         image: { src: 'https://via.placeholder.com/336x400' },
         link: { url: '/', type: 'product' },
       },
       {
-        key: '4',
         title: 'Hedvig Student',
         subtitle: 'Lörem ipsum dålor, nufs plufs glufs och gruls.',
         image: { src: 'https://via.placeholder.com/336x400' },
         link: { url: '/', type: 'product' },
       },
       {
-        key: '3',
         title: 'Hedvig Accident',
         subtitle: 'Lörem ipsum dålor, nufs plufs glufs och gruls.',
         image: { src: 'https://via.placeholder.com/336x400' },

--- a/apps/store/src/components/ProductGrid/ProductGrid.tsx
+++ b/apps/store/src/components/ProductGrid/ProductGrid.tsx
@@ -1,30 +1,28 @@
-import { Fragment } from 'react'
-import { Space, Text } from 'ui'
+import { type ReactNode } from 'react'
+import { sprinkles } from 'ui/src/theme/sprinkles.css'
+import { Text } from 'ui'
 import { productGrid } from './ProductGrid.css'
 
-export type ProductGridProps<Item> = {
+export type ProductGridProps = {
   title?: string
-  items: Array<Item>
-  children: (item: Item) => React.ReactNode
+  children: ReactNode
 }
 
-export const ProductGrid = <ItemType extends { key: string }>({
-  title,
-  items,
-  children,
-}: ProductGridProps<ItemType>) => {
+export function ProductGrid({ title, children }: ProductGridProps) {
   return (
-    <Space y={1.5}>
+    <div>
       {title && (
-        <Text align="center" color="textSecondary" size="xs" uppercase={true}>
+        <Text
+          align="center"
+          color="textSecondary"
+          size="xs"
+          uppercase={true}
+          className={sprinkles({ marginTop: 'lg' })}
+        >
           {title}
         </Text>
       )}
-      <div className={productGrid}>
-        {items.map((item) => (
-          <Fragment key={item.key}>{children(item)}</Fragment>
-        ))}
-      </div>
-    </Space>
+      <div className={productGrid}>{children}</div>
+    </div>
   )
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

1. Fix warnings like 
```
warn-once.js:16 Image with src "https://assets.hedvig.com/f/165473/1500x1500/f9fb8e014a/bil-bmw-hedvig-1500.jpg" has "fill" prop and "sizes" prop of "100vw", but image is not rendered at full viewport width. Please adjust "sizes" to improve page performance. Read more: https://nextjs.org/docs/api-reference/next/image#sizes
```
originating from `ProductGrid` component

2. Stop using render child pattern in ProductGrid and just pass children instead

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Reduces total  size of images on home page from ~1300 KB to ~1000 KB compressed (opened with cache disabled in 920px wide window and scrolled to footer)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
