### PR TITLE
Show error when confirmPriceIntent fails

### DIFF
--- a/apps/store/src/components/AppErrorDialog.tsx
+++ b/apps/store/src/components/AppErrorDialog.tsx
@@ -32,9 +32,11 @@ export const AppErrorDialog = () => {
       >
         <Wrapper>
           <WarningTriangleIcon size="1em" color={theme.colors.amber600} />
-          <Text align="center" size={{ _: 'md', lg: 'lg' }}>
-            {t('GENERAL_ERROR_DIALOG_TITLE')}
-          </Text>
+          <FullscreenDialog.Title asChild={true}>
+            <Text align="center" size={{ _: 'md', lg: 'lg' }}>
+              {t('GENERAL_ERROR_DIALOG_TITLE')}
+            </Text>
+          </FullscreenDialog.Title>
         </Wrapper>
         <Text align="center" size={{ _: 'md', lg: 'lg' }} color="textSecondary" balance={true}>
           {errorMessage}

--- a/apps/store/src/features/priceCalculator/InsuranceDataForm.tsx
+++ b/apps/store/src/features/priceCalculator/InsuranceDataForm.tsx
@@ -128,15 +128,7 @@ function InsuranceDataSection({ section }: InsuranceDataSectionProps) {
   const priceTemplate = usePriceTemplate()
   const setStep = useSetAtom(priceCalculatorStepAtom)
 
-  const confirmPriceIntent = useConfirmPriceIntent({
-    onSuccess() {
-      setStep('viewOffers')
-    },
-    onError(message) {
-      console.log('TODO: show error', message)
-      window.alert('Something went wrong. TODO: show error')
-    },
-  })
+  const confirmPriceIntent = useConfirmPriceIntent()
 
   const showPriceIntentWarning = useSetAtom(showPriceIntentWarningAtom)
   const submitPriceCalculatorSection = useHandleSubmitPriceCalculatorSection({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Use default app error handler when we fail to confirm price intent in Price Calculator page. Since we don't need custom actions ('try again' kept price calculator open, 'close' closed it), we no longer need custom error dialog

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
