### PR TITLE
New design for InputSelect

### DIFF
--- a/apps/store/public/locales/en/purchase-form.json
+++ b/apps/store/public/locales/en/purchase-form.json
@@ -82,6 +82,7 @@
   "FIELD_IS_SUBLETED_OPTION_YES": "Yes",
   "FIELD_LIVING_SPACE_LABEL": "Living space",
   "FIELD_MILEAGE_LABEL": "Annual mileage",
+  "FIELD_MILEAGE_PLACEHOLDER": "Select expected mileage",
   "FIELD_MIXED_BREEDS_LABEL": "Add the most prominent breeds",
   "FIELD_MIXED_BREEDS_PLACEHOLDER": "Search breed",
   "FIELD_NAME_PET_LABEL": "Name",

--- a/apps/store/public/locales/sv-se/purchase-form.json
+++ b/apps/store/public/locales/sv-se/purchase-form.json
@@ -82,6 +82,7 @@
   "FIELD_IS_SUBLETED_OPTION_YES": "Ja",
   "FIELD_LIVING_SPACE_LABEL": "Boyta",
   "FIELD_MILEAGE_LABEL": "Årlig körsträcka",
+  "FIELD_MILEAGE_PLACEHOLDER": "Välj förväntad körsträcka",
   "FIELD_MIXED_BREEDS_LABEL": "Lägg till de raser som är mest framträdande",
   "FIELD_MIXED_BREEDS_PLACEHOLDER": "Sök ras",
   "FIELD_NAME_PET_LABEL": "Namn",

--- a/apps/store/src/components/InputSelect/InputSelect.css.ts
+++ b/apps/store/src/components/InputSelect/InputSelect.css.ts
@@ -1,0 +1,116 @@
+import { createVar, globalStyle, style, styleVariants } from '@vanilla-extract/css'
+import { theme, tokens } from 'ui'
+
+// **InputSelect styling strategy**
+//
+// We want whole visible input to be clickable, therefore inner `select` has to have 100% width and height
+// Other elements like label and chevron are absolutely positioned on top of it
+// Visual centering is achieved by hand-picked paddings for select and `top` for label
+
+const paddingHorizontal = createVar('selectPaddingHorizontal')
+const paddingTop = createVar('selectPaddingTop')
+const labelTop = createVar('selectLabelTop')
+const labelHeight = createVar('selectLabelHeight')
+
+export const wrapperVariants = styleVariants({
+  base: {
+    position: 'relative',
+    width: '100%',
+    height: '4rem',
+    vars: {
+      [paddingHorizontal]: tokens.space.md,
+      [paddingTop]: tokens.space.md,
+      [labelHeight]: tokens.fontSizes.md,
+    },
+  },
+  small: {
+    height: '3.5rem',
+    fontSize: theme.fontSizes.md,
+  },
+  medium: {
+    fontSize: theme.fontSizes.md,
+    vars: {
+      [paddingTop]: '20px',
+    },
+  },
+  large: {
+    fontSize: theme.fontSizes.xl,
+  },
+})
+
+export const wrapperWithLabelVariants = styleVariants({
+  small: {
+    vars: {
+      [labelTop]: '7.5px',
+      [paddingTop]: `calc(${labelTop} + ${labelHeight})`,
+      [paddingHorizontal]: '14px',
+    },
+  },
+  medium: {
+    vars: {
+      [labelTop]: tokens.space.sm,
+      [paddingTop]: `calc(${labelTop} + ${labelHeight})`,
+    },
+  },
+  large: {
+    vars: {
+      [labelTop]: '10px',
+      [paddingTop]: `calc(${labelTop} + ${labelHeight} - 2px)`,
+    },
+  },
+})
+
+export const inputLabel = style({
+  position: 'absolute',
+  fontSize: tokens.fontSizes.xs,
+  color: tokens.colors.textTranslucentSecondary,
+  userSelect: 'none',
+  top: labelTop,
+  left: paddingHorizontal,
+})
+
+export const chevronIcon = style({
+  position: 'absolute',
+  top: '50%',
+  right: '1.125rem',
+  transform: 'translateY(-50%)',
+  pointerEvents: 'none',
+})
+
+export const select = style({
+  color: tokens.colors.textPrimary,
+  // Truncate if there's not enough space
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+
+  width: '100%',
+  height: '100%',
+
+  // Paddings:
+  // - no bottom padding to avoid clipping text descenders
+  // - right padding increased to avoid overlapping chevron
+  paddingTop: paddingTop,
+  paddingLeft: paddingHorizontal,
+  paddingRight: `calc(${paddingHorizontal} + 1.125rem)`,
+
+  backgroundColor: tokens.colors.translucent1,
+  borderRadius: tokens.radius.md,
+
+  cursor: 'pointer',
+
+  selectors: {
+    '&:invalid, &:disabled': {
+      color: theme.colors.textSecondary,
+    },
+
+    '&:disabled': {
+      cursor: 'not-allowed',
+    },
+  },
+})
+
+// Hack to target placeholder being selected
+// https://stackoverflow.com/questions/55085140/detecting-if-an-option-has-been-selected-in-select-using-css
+globalStyle(`${select}:has(option[value=""]:checked)`, {
+  color: theme.colors.textSecondary,
+})

--- a/apps/store/src/components/InputSelect/InputSelect.stories.tsx
+++ b/apps/store/src/components/InputSelect/InputSelect.stories.tsx
@@ -12,6 +12,18 @@ const meta: Meta<typeof InputSelect> = {
     },
     grid: { width: '1/3' },
   },
+  args: {
+    name: 'buildingType',
+    placeholder: 'Choose building type',
+    label: 'Building type',
+    options: [
+      { name: 'Garage', value: 'garage' },
+      { name: 'Attefallshus', value: 'attefallshus' },
+      { name: 'Greenhouse', value: 'greenhouse' },
+      { name: 'Very long building type so it gets clipped', value: 'longlong' },
+      { name: 'Other', value: 'other' },
+    ],
+  },
 }
 
 export default meta
@@ -20,20 +32,17 @@ type Story = StoryObj<typeof InputSelect>
 export const Small: Story = {
   args: {
     size: 'small',
-    placeholder: 'Byggnadstyp',
-    options: [
-      { name: 'Garage', value: 'garage' },
-      { name: 'Attefallshus', value: 'attefallshus' },
-      { name: 'Växthus', value: 'växthus' },
-      { name: 'Annan', value: 'annan' },
-    ],
-    name: 'Byggnadstyp',
+  },
+}
+
+export const Medium: Story = {
+  args: {
+    size: 'medium',
   },
 }
 
 export const Large: Story = {
   args: {
-    ...Small.args,
     size: 'large',
   },
 }

--- a/apps/store/src/components/InputSelect/InputSelect.tsx
+++ b/apps/store/src/components/InputSelect/InputSelect.tsx
@@ -1,10 +1,16 @@
 'use client'
 
-import isValidProp from '@emotion/is-prop-valid'
-import styled from '@emotion/styled'
-import { type ChangeEventHandler } from 'react'
-import { ChevronIcon, InputBase, type InputBaseProps, type UIColorKeys, theme, getColor } from 'ui'
+import { clsx } from 'clsx'
+import { type ChangeEventHandler, useId } from 'react'
+import { ChevronIcon, InputBase, type InputBaseProps, type UIColorKeys, getColor } from 'ui'
 import { useHighlightAnimation } from '@/utils/useHighlightAnimation'
+import {
+  chevronIcon,
+  inputLabel,
+  wrapperWithLabelVariants,
+  select,
+  wrapperVariants,
+} from './InputSelect.css'
 
 export type InputSelectProps = InputBaseProps & {
   name: string
@@ -17,7 +23,7 @@ export type InputSelectProps = InputBaseProps & {
   placeholder?: string
   autoFocus?: boolean
   className?: string
-  size?: 'large' | 'small'
+  size?: 'small' | 'medium' | 'large'
   backgroundColor?: Extract<UIColorKeys, 'backgroundStandard' | 'backgroundFrostedGlass'>
 }
 
@@ -29,7 +35,8 @@ export const InputSelect = ({
   defaultValue,
   placeholder,
   label,
-  size = 'large',
+  size = 'medium',
+  className,
   backgroundColor: _backgroundColor,
   ...rest
 }: InputSelectProps) => {
@@ -42,25 +49,39 @@ export const InputSelect = ({
     highlight()
   }
 
-  const labelText = label || placeholder
+  const labelId = useId()
+  const selectId = useId()
 
   return (
     <InputBase {...rest}>
       {() => (
-        <Wrapper>
-          <StyledSelect
+        <div
+          className={clsx(
+            wrapperVariants.base,
+            wrapperVariants[size],
+            label && wrapperWithLabelVariants[size],
+            className,
+          )}
+        >
+          {label && (
+            <label id={labelId} htmlFor={selectId} className={inputLabel}>
+              {label}
+            </label>
+          )}
+          <select
+            id={selectId}
             name={name}
             onChange={handleChange}
             value={value}
-            defaultValue={value ? undefined : defaultValue ?? ''}
-            variantSize={size}
+            defaultValue={value ? undefined : (defaultValue ?? '')}
             style={{ backgroundColor }}
+            className={clsx(select)}
             {...animationProps}
             {...rest}
           >
-            {labelText && (
+            {placeholder && (
               <option value="" disabled>
-                {labelText}
+                {placeholder}
               </option>
             )}
             {options.map(({ name, value, disabled }) => (
@@ -68,61 +89,11 @@ export const InputSelect = ({
                 {name}
               </option>
             ))}
-          </StyledSelect>
+          </select>
 
-          <StyledChevronIcon size="1rem" />
-        </Wrapper>
+          <ChevronIcon size="1rem" className={chevronIcon} />
+        </div>
       )}
     </InputBase>
   )
 }
-
-const Wrapper = styled.div({ position: 'relative' })
-
-const StyledChevronIcon = styled(ChevronIcon)({
-  position: 'absolute',
-  top: '50%',
-  right: '1.125rem',
-  transform: 'translateY(-50%)',
-  pointerEvents: 'none',
-})
-
-type SelectProps = { variantSize: Required<InputSelectProps['size']> }
-
-const elementConfig = { shouldForwardProp: isValidProp }
-const StyledSelect = styled(
-  'select',
-  elementConfig,
-)<SelectProps>(({ variantSize }) => ({
-  color: theme.colors.textPrimary,
-  width: '100%',
-  display: 'flex',
-  alignItems: 'center',
-  paddingLeft: theme.space.md,
-  paddingRight: theme.space.xxl,
-  cursor: 'pointer',
-  backgroundColor: theme.colors.translucent1,
-  // Truncate if there's not enough space
-  whiteSpace: 'nowrap',
-  textOverflow: 'ellipsis',
-
-  ...(variantSize === 'small' && {
-    height: '2.5rem',
-    fontSize: theme.fontSizes.md,
-    borderRadius: theme.radius.xs,
-  }),
-
-  ...(variantSize === 'large' && {
-    height: '3.5rem',
-    fontSize: theme.fontSizes.xl,
-    borderRadius: theme.radius.sm,
-  }),
-
-  '&:invalid, &:disabled': {
-    color: theme.colors.textSecondary,
-  },
-
-  '&:disabled': {
-    cursor: 'not-allowed',
-  },
-}))

--- a/apps/store/src/components/PriceCalculator/CarMileageField.tsx
+++ b/apps/store/src/components/PriceCalculator/CarMileageField.tsx
@@ -21,10 +21,13 @@ const options = [
 export const CarMileageField = ({ field, autoFocus, backgroundColor }: Props) => {
   const { t } = useTranslation('purchase-form')
 
+  // TODO: Use size=medium when text input styles are updated
   return (
     <InputSelect
       name={field.name}
-      placeholder={t(field.label.key, { defaultValue: t('FIELD_MILEAGE_LABEL') })}
+      label={t('FIELD_MILEAGE_LABEL')}
+      placeholder={t('FIELD_MILEAGE_PLACEHOLDER')}
+      size="large"
       required={field.required}
       defaultValue={field.value ?? field.defaultValue}
       options={options.map((option) => ({

--- a/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
+++ b/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
@@ -167,7 +167,8 @@ export const ExtraBuildingsField = ({ field, buildingOptions }: ExtraBuildingsFi
                 <Space y={0.25}>
                   <InputSelect
                     name={Field.Type}
-                    placeholder={t('FIELD_EXTRA_BUILDINGS_TYPE_LABEL')}
+                    label={t('FIELD_EXTRA_BUILDINGS_TYPE_LABEL')}
+                    size="large"
                     options={buildingOptionsInput}
                     required={true}
                   />


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Apply new design for select input. It's used in
- Car Mileage field
- Extract building dialog (type field)
- Product Variant Selector CMS block

What has changed
- Field supports label
- 3 size variants (small/medium/large) instead of small/large before
- It's possible to use `placeholder=""` if you want empty default option, but don't have good display text for it
- Placeholder text uses secondary color (other options still use primary)

Styling implementation is cruel and unusual, extensively commented how it works and why it's so complicated

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

Screenshots:

1.
![Screenshot 2024-07-25 at 12.42.00.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/a39583ca-c85d-4ea2-9c59-d3362b9a40c9.png)

2. 
![Screenshot 2024-07-25 at 13.02.37.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/eeb787fe-42a6-4a83-b2d6-7d27946205a5.png)

3.
![Screenshot 2024-07-25 at 13.00.36.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/917aa5af-b77b-497e-88b8-35d4f8be20ad.png)

## Justify why they are needed

Step towards upgrading all input designs. Looks somewhat inconsistent due to smaller height, but close enough. It's probably easier to merge such PRs one by one instead of waiting until we're fully done

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
