### PR TITLE
GEN-2432 - fix(checkout-v2): invalidate router cache for checkout page

### DIFF
--- a/apps/store/src/app/[locale]/new/checkout/BonusOffer.tsx
+++ b/apps/store/src/app/[locale]/new/checkout/BonusOffer.tsx
@@ -2,10 +2,9 @@
 
 import { QuickAddOfferContainer } from '@/components/QuickAdd/QuickAddOfferContainer'
 import { useBonusOffer } from '@/components/QuickAdd/useBonusOffer'
-import { useShopSessionSuspense } from '@/services/shopSession/app-router/useShopSessionSuspense'
+import { type ShopSessionFragment } from '@/services/graphql/generated'
 
-export function BonusOffer({ shopSessionId }: { shopSessionId: string }) {
-  const shopSession = useShopSessionSuspense({ shopSessionId })
+export function BonusOffer({ shopSession }: { shopSession: ShopSessionFragment }) {
   const offerRecommendation = useBonusOffer()
 
   if (!offerRecommendation) {
@@ -14,7 +13,7 @@ export function BonusOffer({ shopSessionId }: { shopSessionId: string }) {
 
   return (
     <QuickAddOfferContainer
-      shopSessionId={shopSessionId}
+      shopSessionId={shopSession.id}
       cart={shopSession.cart}
       {...offerRecommendation}
     />

--- a/apps/store/src/app/[locale]/new/checkout/CartEntries.tsx
+++ b/apps/store/src/app/[locale]/new/checkout/CartEntries.tsx
@@ -8,15 +8,17 @@ import { DiscountFieldContainer } from '@/components/ShopBreakdown/DiscountField
 import { Divider, ShopBreakdown } from '@/components/ShopBreakdown/ShopBreakdown'
 import { TotalAmountContainer } from '@/components/ShopBreakdown/TotalAmountContainer'
 import { useShowAppError } from '@/services/appErrors/appErrorAtom'
-import { type ProductOfferFragment, useCartEntryRemoveMutation } from '@/services/graphql/generated'
-import { useShopSessionSuspense } from '@/services/shopSession/app-router/useShopSessionSuspense'
+import {
+  useCartEntryRemoveMutation,
+  type ProductOfferFragment,
+  type ShopSessionFragment,
+} from '@/services/graphql/generated'
 import { useTracking } from '@/services/Tracking/useTracking'
 import { QueryParam } from './CheckoutPage.constants'
 
-type Props = { shopSessionId: string }
+type Props = { shopSession: ShopSessionFragment }
 
-export function CartEntries({ shopSessionId }: Props) {
-  const shopSession = useShopSessionSuspense({ shopSessionId })
+export function CartEntries({ shopSession }: Props) {
   const tracking = useTracking()
   const showError = useShowAppError()
   const searchParams = useSearchParams()

--- a/apps/store/src/app/[locale]/new/checkout/CheckoutPage.tsx
+++ b/apps/store/src/app/[locale]/new/checkout/CheckoutPage.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { yStack } from 'ui'
+import { BankIdDialog } from '@/components/BankIdDialog/BankIdDialog'
+import { type GlobalProductMetadata } from '@/components/LayoutWithMenu/fetchProductMetadata'
+import { useProductMetadata } from '@/components/LayoutWithMenu/productMetadataHooks'
+import { BankIdContextProvider } from '@/services/bankId/BankIdContext'
+import { useShopSessionSuspense } from '@/services/shopSession/app-router/useShopSessionSuspense'
+import { getShouldCollectEmail, getShouldCollectName } from '@/utils/customer'
+import type { RoutingLocale } from '@/utils/l10n/types'
+import { BonusOffer } from './BonusOffer'
+import { CartEntries } from './CartEntries'
+import { CheckoutForm } from './CheckoutForm'
+import { layout, content } from './CheckoutPage.css'
+import { EmptyCart, type Product } from './EmptyCart'
+
+export function CheckoutPage({
+  locale,
+  shopSessionId,
+}: {
+  locale: RoutingLocale
+  shopSessionId: string
+}) {
+  const shopSession = useShopSessionSuspense({
+    shopSessionId,
+    options: {
+      context: { fetchOptions: 'no-store' },
+    },
+  })
+  const productMetadata = useProductMetadata()
+
+  const isCartEmpty = shopSession.cart.entries.length === 0
+  if (isCartEmpty) {
+    const products = getAvailableProducts(productMetadata ?? [])
+
+    return <EmptyCart locale={locale} products={products} />
+  }
+
+  if (!shopSession.customer) {
+    throw new Error(`Checkout | No customer in shop session ${shopSession.id}`)
+  }
+  if (!shopSession.customer.ssn) {
+    throw new Error(`Checkout | No SSN in shop session ${shopSession.id}`)
+  }
+
+  return (
+    <main className={layout}>
+      <div className={content}>
+        <section className={yStack({ gap: 'md' })}>
+          <CartEntries shopSession={shopSession} />
+        </section>
+
+        <section className={yStack({ gap: 'xl' })}>
+          <BonusOffer shopSession={shopSession} />
+
+          <BankIdContextProvider>
+            <CheckoutForm
+              shopSessionId={shopSession.id}
+              ssn={shopSession.customer.ssn}
+              cart={shopSession.cart}
+              shouldCollectName={getShouldCollectName(shopSession.customer)}
+              shouldCollectEmail={getShouldCollectEmail(shopSession.customer)}
+            />
+            <BankIdDialog />
+          </BankIdContextProvider>
+        </section>
+      </div>
+    </main>
+  )
+}
+
+function getAvailableProducts(productMetadata: GlobalProductMetadata): Array<Product> {
+  const products = productMetadata.map(
+    ({ id, displayNameShort, tagline, pageLink, pillowImage }) => ({
+      id,
+      displayName: displayNameShort,
+      tagline,
+      pageLink,
+      pillowImage: {
+        src: pillowImage.src,
+        alt: pillowImage.alt ?? undefined,
+      },
+    }),
+  )
+
+  return products
+}

--- a/apps/store/src/app/[locale]/new/checkout/loading.tsx
+++ b/apps/store/src/app/[locale]/new/checkout/loading.tsx
@@ -1,0 +1,21 @@
+import { yStack } from 'ui'
+import { Skeleton } from '@/components/Skeleton/Skeleton'
+import { layout, content } from './CheckoutPage.css'
+
+export default function Loading() {
+  return (
+    <main className={layout}>
+      <div className={content}>
+        <section className={yStack({ gap: 'md' })}>
+          <Skeleton style={{ height: 200 }} />
+          <Skeleton style={{ height: 200 }} />
+        </section>
+
+        <section className={yStack({ gap: 'xl' })}>
+          <Skeleton style={{ height: 500 }} />
+          <Skeleton style={{ height: 180 }} />
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -106,6 +106,7 @@ export const OfferPresenter = memo((props: Props) => {
           datadogRum.addAction(BankSigneringEvent.Requested)
         }
       }
+
       onSuccessRef.current(addedProductOffer)
     },
   })

--- a/apps/store/src/services/shopSession/app-router/useShopSessionSuspense.ts
+++ b/apps/store/src/services/shopSession/app-router/useShopSessionSuspense.ts
@@ -1,11 +1,19 @@
 import { useShopSessionSuspenseQuery } from '@/services/graphql/generated'
 
-export function useShopSessionSuspense({ shopSessionId }: { shopSessionId: string }) {
+type Options = Omit<NonNullable<Parameters<typeof useShopSessionSuspenseQuery>[0]>, 'variables'>
+
+export function useShopSessionSuspense({
+  shopSessionId,
+  options,
+}: {
+  shopSessionId: string
+  options?: Options
+}) {
   // TODO: ideally we want to continue to use `useShopSession` from `ShopSessionContext` here but first we need
   // to change it so it uses React Suspense.
   const {
     data: { shopSession },
-  } = useShopSessionSuspenseQuery({ variables: { shopSessionId } })
+  } = useShopSessionSuspenseQuery({ variables: { shopSessionId }, ...options })
 
   return shopSession
 }


### PR DESCRIPTION
## Describe your changes

* Restructure how _Checkout_ page v2 is rendered so we don't have issues with caching

**The issues**

We have a couple of caching issues that comes from how _CheckoutPage_ is being rendered until now.

1. Recently added offers might not get shown in the _Checkout Page_

https://github.com/user-attachments/assets/b5c59f40-b53d-4421-9cbe-38f1536182f7

2. Checkout page _empty cart_ UI doesn't get shown when removing the last item from the cart

https://github.com/user-attachments/assets/39c59dff-3078-4ba0-9839-a3a8eabb4fe0

**Why they happen**

Current implementation of _CheckoutPage V2_ decides at the server level (via RSC) if we should show the _Empty cart UI_ or the _Shop breakdown_ based on the size of the cart entries. That works fine when browser navigating to checkout page but since Nextjs caches routes (even dynamic ones) at the client level the following can happen:

1. You visit checkout page and get's the _Empty cart_ UI. At this point Nextjs caches RSC payload for that route at client level (Router cache) for a certain amount of time (30 seconds if I'm mistaken)
2. You add a offer to the cart a client side navigate to checkout page. Cached RSC payload will be used which only includes the _Empty Cart UI_.

Additionally by keeping the logic between showing the _Empty Cart UI_ of the _Shop breakdown_ at the server level will cause the problem of not showing the _Empty Cart UI_ when removing the last offer because for that to happen we'd need to request the checkout page again. Since we keep mutations at the client side it makes sense to keep such decisions at the client side. In any case we're dealing with a highly dynamic and interactive page.

**The solution**

I've changed how _Checkout Page_ gets rendered by moving the decision between UI to the client via client components. Since everything is done the client side we'll not have caching issues as well because even if Nexjts caches RSC payload for the checkout page, that payload always refer to the that same client component that handle mutations and the decision between _Empty UI_ or _Shop breakdown_

[Oficial docs](https://nextjs.org/docs/app/building-your-application/caching#invalidation-1)
