### PR TITLE
Fix rendering bundle discount with different start dates on Vercel

### DIFF
--- a/apps/store/src/features/bundleDiscount/BundleDiscountCartSummary.tsx
+++ b/apps/store/src/features/bundleDiscount/BundleDiscountCartSummary.tsx
@@ -38,7 +38,10 @@ export function BundleDiscountCartSummary({ cart }: Props) {
     })
   } else {
     // Safe to sort as strings, since API dates use ISO8601 format
-    const earliestStartDate = [...startDates.values()].toSorted()[0]
+    // GOTCHA: toSorted() not found when server side rendering on Vercel, hence `sort()`
+    const sortedStartDates = [...startDates.values()]
+    sortedStartDates.sort()
+    const earliestStartDate = sortedStartDates[0]
     content = t('BUNDLE_DISCOUNT_SUMMARY_WITHOUT_TOTAL', {
       percentage,
       startDate: formatter.dateFull(new Date(earliestStartDate), { abbreviateMonth: true }),


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Remove `Array.toSorted()` call that led to rendering errors

This fixes Vercel-only error where `toSorted()` is not available in server environment. Vercel still runs node 18

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
