### PR TITLE
Disable Renovate for major version updates of NodeJs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,6 +46,15 @@
       // By default, renovate does not group them and most updates break because of this
       "matchPackagePatterns": ["^@storyblok"],
       groupName: "storyblok packages",
+    },
+    {
+      // See https://vercel.com/docs/functions/runtimes/node-js/node-js-versions for available options
+      "description": "Ignore nodejs major versions, we want to use the same version as Vercel uses",
+      "matchPackageNames": ["node"],
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   // Rate limits

--- a/apps/store/public/mockServiceWorker.js
+++ b/apps/store/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.3.2'
+const PACKAGE_VERSION = '2.3.4'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Revert `toSorted()` removal since we're using node 20.x on vercel right now
- Configure Renovate to not auto-update NodeJs to major versions, we should do it manually when vercel support them

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
