### PR TITLE
GEN-2432-feat(checkout-v2): enable CMS content for connect payment page

### DIFF
--- a/apps/store/src/blocks/ConnectPaymentBlock.tsx
+++ b/apps/store/src/blocks/ConnectPaymentBlock.tsx
@@ -1,0 +1,17 @@
+import type { SbBlokData } from '@storyblok/react'
+import { storyblokEditable, StoryblokComponent } from '@storyblok/react'
+import type { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+
+type ConnectPaymentBlockProps = SbBaseBlockProps<{
+  body?: Array<SbBlokData>
+}>
+
+export function ConnectPaymentBlock({ blok }: ConnectPaymentBlockProps) {
+  return (
+    <div {...storyblokEditable(blok)}>
+      {blok.body?.map((nestedBlock) => (
+        <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />
+      ))}
+    </div>
+  )
+}

--- a/apps/store/src/services/storyblok/commonStoryblokComponents.ts
+++ b/apps/store/src/services/storyblok/commonStoryblokComponents.ts
@@ -8,6 +8,7 @@ import { CardLinkListBlock } from '@/blocks/CardLinkListBlock'
 import { CheckListBlock } from '@/blocks/CheckListBlock'
 import { ComparisonTableBlock } from '@/blocks/ComparisonTableBlock'
 import { ConfirmationPageBlock } from '@/blocks/ConfirmationPageBlock'
+import { ConnectPaymentBlock } from '@/blocks/ConnectPaymentBlock'
 import { ContactSupportBlock } from '@/blocks/ContactSupportBlock'
 import { ContentBlock } from '@/blocks/ContentBlock'
 import { CookieListBlock } from '@/blocks/CookieListBlock'
@@ -66,6 +67,7 @@ export const commonStoryblokComponents = {
   checkList: CheckListBlock,
   comparisonTable: ComparisonTableBlock,
   confirmation: ConfirmationPageBlock,
+  connectPayment: ConnectPaymentBlock,
   contactSupport: ContactSupportBlock,
   content: ContentBlock,
   cookieList: CookieListBlock,

--- a/apps/store/src/services/storyblok/storyblok.ts
+++ b/apps/store/src/services/storyblok/storyblok.ts
@@ -210,6 +210,12 @@ export type ConfirmationStory = ISbStoryData & {
   }
 }
 
+export type ConnectPaymentStory = ISbStoryData & {
+  content: ISbStoryData['content'] & {
+    body?: Array<SbBlokData>
+  }
+}
+
 export const initStoryblok = () => {
   // https://github.com/storyblok/storyblok-react/issues/156#issuecomment-1197764828
   let shouldUseBridge = false


### PR DESCRIPTION
## Describe your changes

* Enable the addition of CMS content for the _Connect Payment_ page.

<img width="1101" alt="Screenshot 2024-07-30 at 13 54 02" src="https://github.com/user-attachments/assets/ebce78ac-ce63-422b-ad07-0285e946c894">

How it works:

* I have added a new content type: `Connect Payment`
* Connect payment page reads from that (when present) and renders the content bellow the _insurely_ iframe.

## Justify why they are needed

As requested for new Checkout+Cart page [designs](https://www.figma.com/design/p1TEzLLVqJB9gKDNTDVGU4/Hedvig.com?node-id=470-2211&t=0VO3PWzvNqc6CqL7-4).
