### PR TITLE
Fix PriceIntentWarningDialog -> Edit not keeping previous form section active

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/priceIntentAtoms.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/priceIntentAtoms.ts
@@ -85,6 +85,13 @@ export const activeFormSectionIdAtom = atom(
     const priceIntentId = getAtomValueOrThrow(get, currentPriceIntentIdAtom)
     if (newValue === GOTO_NEXT_SECTION) {
       const oldValue = get(activeFormSectionIdAtom)
+      // Special case - write current calculated value if we had null before.
+      // No need to update it in this case, calculation already returned the result we want.
+      if (get(activeFormSectionIdAtomFamily(priceIntentId)) == null) {
+        set(activeFormSectionIdAtomFamily(priceIntentId), oldValue)
+        return
+      }
+
       const form = get(priceCalculatorFormAtom)
       const currentSectionIndex = form.sections.findIndex(({ id }) => id === oldValue)
 

--- a/apps/store/src/features/priceCalculator/InsuranceDataForm.tsx
+++ b/apps/store/src/features/priceCalculator/InsuranceDataForm.tsx
@@ -131,6 +131,8 @@ function InsuranceDataSection({ section }: InsuranceDataSectionProps) {
   const confirmPriceIntent = useConfirmPriceIntent()
 
   const showPriceIntentWarning = useSetAtom(showPriceIntentWarningAtom)
+  const setActiveSectionId = useSetAtom(activeFormSectionIdAtom)
+
   const submitPriceCalculatorSection = useHandleSubmitPriceCalculatorSection({
     onSuccess({ priceIntent, customer }) {
       const form = setupForm({
@@ -156,21 +158,11 @@ function InsuranceDataSection({ section }: InsuranceDataSectionProps) {
         showPriceIntentWarning(true)
         datadogRum.addAction('Show PriceIntent Warning')
       } else {
-        goToNextSection()
-      }
-
-      if (priceIntent.externalInsurer) {
-        // FIXME: restore Insurely support
-        // NOTE: We're still going to the next section underneath Insurely prompt
-        // showFetchInsurance()
+        setActiveSectionId(GOTO_NEXT_SECTION)
       }
     },
   })
 
-  const setActiveSectionId = useSetAtom(activeFormSectionIdAtom)
-  const goToNextSection = () => {
-    setActiveSectionId(GOTO_NEXT_SECTION)
-  }
   const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault()
     const jsonData = formDataToJson(new FormData(event.currentTarget), section.items)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix a bug when "Edit" button on price intent warning dialog did not prevent form switching to the next section

This was caused by never explicitly setting underlying atom on default forward transitions. Fixed this for SSN section. Tested in both new and old price calculators

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
