### PR TITLE
Add focus border to redesigned inputs (text, select, stepper)

### DIFF
--- a/apps/store/src/components/InputSelect/InputSelect.css.ts
+++ b/apps/store/src/components/InputSelect/InputSelect.css.ts
@@ -106,6 +106,10 @@ export const select = style({
     '&:disabled': {
       cursor: 'not-allowed',
     },
+
+    '&:focus-within': {
+      border: `solid 1px ${tokens.colors.borderFocusedInput}`,
+    },
   },
 })
 

--- a/apps/store/src/components/StepperInput/StepperInput.css.ts
+++ b/apps/store/src/components/StepperInput/StepperInput.css.ts
@@ -13,6 +13,10 @@ export const outerWrapper = style({
     '&:has(label)': {
       paddingBlock: tokens.space.sm,
     },
+
+    '&:focus-within': {
+      border: `solid 1px ${tokens.colors.borderFocusedInput}`,
+    },
   },
 })
 

--- a/apps/store/src/components/TextField/TextField.css.ts
+++ b/apps/store/src/components/TextField/TextField.css.ts
@@ -39,6 +39,10 @@ export const baseWrapper = style({
     '&[data-warning=true]': {
       animation: `${warningAnimation} 1.5s cubic-bezier(0.2, -2, 0.8, 2) 1`,
     },
+
+    '&:focus-within': {
+      border: `solid 1px ${tokens.colors.borderFocusedInput}`,
+    },
   },
 })
 

--- a/packages/ui/src/theme/colors/colors.ts
+++ b/packages/ui/src/theme/colors/colors.ts
@@ -322,6 +322,7 @@ export const colors = {
   borderTranslucent3: grayTranslucent[700],
   borderOpaque4: gray[800],
   borderTranslucent4: grayTranslucent[800],
+  borderFocusedInput: grayTranslucent[300],
 
   // Fills
   opaque1: gray[100],


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Highlight currently focused input with gray border
- Add explicitly named design token for focused border color
- Applied to inputs that already have new design (select, text, stepper)

![Screenshot 2024-07-31 at 13.38.42.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/95efcd6a-870e-4026-967c-3f80f695ae6a.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

UX/Accessibility - focus highlight is essential for keyboard navigation

## Checklist before requesting a review

- [x] I have performed a self-review of my code
