### PR TITLE
Add offer details to Price Calculator page

### DIFF
--- a/apps/store/src/components/ProductItem/ProductItemContainer.tsx
+++ b/apps/store/src/components/ProductItem/ProductItemContainer.tsx
@@ -1,6 +1,5 @@
-import { useTranslation } from 'next-i18next'
-import type { ComponentProps } from 'react'
-import { useMemo, type ReactNode } from 'react'
+import { type ComponentProps, type ReactNode } from 'react'
+import { useOfferDetails } from '@/components/ProductItem/useOfferDetails'
 import { type ProductOfferFragment } from '@/services/graphql/generated'
 import { getOfferPrice } from '@/utils/getOfferPrice'
 import { ProductItem } from './ProductItem'
@@ -26,7 +25,6 @@ type Props = {
 }
 
 export const ProductItemContainer = (props: Props) => {
-  const { t } = useTranslation('cart')
   const getStartDateProps = useGetStartDateProps()
 
   const price = getOfferPrice(props.offer.cost)
@@ -36,21 +34,7 @@ export const ProductItemContainer = (props: Props) => {
     startDate: props.offer.startDate,
   })
 
-  const productDetails = useMemo(() => {
-    const items = props.offer.displayItems.map((item) => ({
-      title: item.displayTitle,
-      value: item.displayValue,
-    }))
-    const tierLevelDisplayName = getTierLevelDisplayName(props.offer)
-    if (tierLevelDisplayName) {
-      items.push({ title: t('DATA_TABLE_TIER_LABEL'), value: tierLevelDisplayName })
-    }
-    const deductibleDisplayName = props.offer.deductible?.displayName
-    if (deductibleDisplayName) {
-      items.push({ title: t('DATA_TABLE_DEDUCTIBLE_LABEL'), value: deductibleDisplayName })
-    }
-    return items
-  }, [props.offer, t])
+  const productDetails = useOfferDetails(props.offer)
 
   const productDocuments = props.offer.variant.documents.map((item) => ({
     title: item.displayName,
@@ -72,11 +56,4 @@ export const ProductItemContainer = (props: Props) => {
       {props.children}
     </ProductItem>
   )
-}
-
-const getTierLevelDisplayName = (item: Pick<ProductOfferFragment, 'variant' | 'product'>) => {
-  // TODO: small hack, move logic to API
-  return item.variant.displayName !== item.product.displayNameFull
-    ? item.variant.displayName
-    : undefined
 }

--- a/apps/store/src/components/ProductItem/useOfferDetails.ts
+++ b/apps/store/src/components/ProductItem/useOfferDetails.ts
@@ -1,0 +1,31 @@
+import { useTranslation } from 'next-i18next'
+import { useMemo } from 'react'
+import type { ProductOfferFragment } from '@/services/graphql/generated'
+
+type Offer = Pick<ProductOfferFragment, 'displayItems' | 'deductible' | 'variant' | 'product'>
+
+export const useOfferDetails = (offer: Offer): Array<{ title: string; value: string }> => {
+  const { t } = useTranslation('cart')
+  return useMemo(() => {
+    const items = offer.displayItems.map((item) => ({
+      title: item.displayTitle,
+      value: item.displayValue,
+    }))
+    const tierLevelDisplayName = getTierLevelDisplayName(offer)
+    if (tierLevelDisplayName) {
+      items.push({ title: t('DATA_TABLE_TIER_LABEL'), value: tierLevelDisplayName })
+    }
+    const deductibleDisplayName = offer.deductible?.displayName
+    if (deductibleDisplayName) {
+      items.push({ title: t('DATA_TABLE_DEDUCTIBLE_LABEL'), value: deductibleDisplayName })
+    }
+    return items
+  }, [offer, t])
+}
+
+const getTierLevelDisplayName = (item: Pick<ProductOfferFragment, 'variant' | 'product'>) => {
+  // TODO: small hack, move logic to API
+  return item.variant.displayName !== item.product.displayNameFull
+    ? item.variant.displayName
+    : undefined
+}

--- a/apps/store/src/components/ProductItemV2/ProductDetails.tsx
+++ b/apps/store/src/components/ProductItemV2/ProductDetails.tsx
@@ -1,5 +1,6 @@
 import { clsx } from 'clsx'
 import { useTranslation } from 'next-i18next'
+import { type ReactNode } from 'react'
 import { Heading, Text } from 'ui'
 import { PDFViewer } from '@/components/PDFViewer'
 import { useIsEmbedded } from '@/utils/useIsEmbedded'
@@ -9,9 +10,16 @@ type Props = {
   items: Array<{ title: string; value: string }>
   documents: Array<{ title: string; url: string }>
   className?: string
+  afterDetailsSection?: ReactNode
 }
 
-export function ProductDetails({ items, documents, className, ...props }: Props) {
+export function ProductDetails({
+  items,
+  documents,
+  className,
+  afterDetailsSection = null,
+  ...props
+}: Props) {
   const { t } = useTranslation('cart')
   const isEmbedded = useIsEmbedded()
 
@@ -34,6 +42,8 @@ export function ProductDetails({ items, documents, className, ...props }: Props)
           ))}
         </ul>
       </section>
+
+      {afterDetailsSection}
 
       <section>
         <Heading as="h4" variant="standard.18" color="textTranslucentPrimary">

--- a/apps/store/src/components/ProductPage/PurchaseForm/useSelectedOffer.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/useSelectedOffer.ts
@@ -1,5 +1,5 @@
 import { datadogLogs } from '@datadog/browser-logs'
-import type { SetStateAction } from 'jotai'
+import { type SetStateAction, useAtomValue } from 'jotai'
 import { atom, useAtom } from 'jotai'
 import { useCallback } from 'react'
 import type { ProductOfferFragment } from '@/services/graphql/generated'
@@ -37,4 +37,12 @@ export const useSelectedOffer = () => {
   )
 
   return [selectedOffer, setSelectedOffer] as const
+}
+
+export const useSelectedOfferValueOrThrow = (): ProductOfferFragment => {
+  const value = useAtomValue(selectedOfferAtom)
+  if (value == null) {
+    throw new Error('selectedOfferAtom must have value')
+  }
+  return value
 }

--- a/apps/store/src/features/priceCalculator/OfferPresenterV2.tsx
+++ b/apps/store/src/features/priceCalculator/OfferPresenterV2.tsx
@@ -1,21 +1,43 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
 import { useInView } from 'framer-motion'
+import { useStore } from 'jotai'
 import { useRouter } from 'next/navigation'
 import { useTranslation } from 'next-i18next'
-import { memo, type MouseEventHandler, type ReactNode, useEffect, useMemo, useRef } from 'react'
+import {
+  memo,
+  type MouseEventHandler,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { sprinkles } from 'ui/src/theme/sprinkles.css'
 import { Button, Text, yStack } from 'ui'
 import { CancellationForm } from '@/components/Cancellation/CancellationForm'
+import Collapsible from '@/components/Collapsible/Collapsible'
+import { SSN_SE_SECTION_ID } from '@/components/PriceCalculator/SsnSeSection'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
+import { useOfferDetails } from '@/components/ProductItem/useOfferDetails'
+import { ProductDetails } from '@/components/ProductItemV2/ProductDetails'
 import { DiscountTooltip } from '@/components/ProductPage/PurchaseForm/DiscountTooltip/DiscountTooltip'
 import { useDiscountTooltipProps } from '@/components/ProductPage/PurchaseForm/DiscountTooltip/useDiscountTooltipProps'
-import { usePriceIntent } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
-import { useSelectedOffer } from '@/components/ProductPage/PurchaseForm/useSelectedOffer'
+import {
+  activeFormSectionIdAtom,
+  priceCalculatorFormAtom,
+  usePriceIntent,
+} from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
+import {
+  useSelectedOffer,
+  useSelectedOfferValueOrThrow,
+} from '@/components/ProductPage/PurchaseForm/useSelectedOffer'
 import { useTiersAndDeductibles } from '@/components/ProductPage/PurchaseForm/useTiersAndDeductibles'
 import { useCartEntryToReplace } from '@/components/ProductPage/useCartEntryToReplace'
 import { BUNDLE_DISCOUNT_ELIGIBLE_PRODUCT_IDS } from '@/features/bundleDiscount/bundleDiscount'
 import { BundleDiscountOfferTooltip } from '@/features/bundleDiscount/BundleDiscountOfferTooltip'
 import { DeductibleSelectorV2 } from '@/features/priceCalculator/DeductibleSelectorV2'
+import { priceCalculatorStepAtom } from '@/features/priceCalculator/priceCalculatorAtoms'
 import { ProductCardSmall } from '@/features/priceCalculator/ProductCardSmall'
 import { ProductTierSelectorV2 } from '@/features/priceCalculator/ProductTierSelectorV2'
 import { BankSigneringEvent } from '@/services/bankSignering'
@@ -111,10 +133,7 @@ function OfferSummary() {
   if (shopSession == null) {
     throw new Error('shopSession must be defined')
   }
-  const [selectedOffer] = useSelectedOffer()
-  if (selectedOffer == null) {
-    throw new Error('selectedOffer must be defined')
-  }
+  const selectedOffer = useSelectedOfferValueOrThrow()
   const { t } = useTranslation('purchase-form')
   const formatter = useFormatter()
   const priceIntent = usePriceIntent()
@@ -175,13 +194,7 @@ function OfferSummary() {
 
   return (
     <ProductCardSmall productData={productData} subtitle={selectedOffer.exposure.displayNameShort}>
-      <Button
-        variant="secondary-alt"
-        onClick={() => window.alert('TODO: Show details')}
-        fullWidth={true}
-      >
-        {t('SHOW_DETAILS_BUTTON_LABEL', { ns: 'cart' })}
-      </Button>
+      <OfferDetails />
 
       {discountTooltip}
       <Text as="p" align="center" size="xl">
@@ -199,5 +212,59 @@ function OfferSummary() {
         {t('ADD_TO_CART_BUTTON_LABEL')}
       </Button>
     </ProductCardSmall>
+  )
+}
+
+function OfferDetails() {
+  const [expanded, setExpanded] = useState(false)
+  const { t } = useTranslation('cart')
+  const selectedOffer = useSelectedOfferValueOrThrow()
+  const productDetails = useOfferDetails(selectedOffer)
+
+  // const productDocuments = selectedOffer.variant.documents.map((item) => ({
+  //   title: item.displayName,
+  //   url: item.url,
+  // }))
+  // TODO: Replace with commented code above when terms-hub starts returning something
+  const productDocuments = [
+    {
+      title: 'TODO: Terms and conditions',
+      url: 'about:blank',
+    },
+    {
+      title: 'TODO: One-pager',
+      url: 'about:blank',
+    },
+  ]
+
+  const store = useStore()
+  const handleEditClick = () => {
+    const form = store.get(priceCalculatorFormAtom)
+    const targetSectionId = form.sections.find((section) => section.id !== SSN_SE_SECTION_ID)!.id
+    store.set(activeFormSectionIdAtom, targetSectionId)
+    store.set(priceCalculatorStepAtom, 'fillForm')
+    // TODO: Scroll to form section top when opening to edit (atom effect?)
+  }
+
+  return (
+    <Collapsible.Root open={expanded} onOpenChange={setExpanded}>
+      <Collapsible.Trigger asChild>
+        <Button variant="secondary-alt" size="medium" fullWidth={true}>
+          {expanded ? t('HIDE_DETAILS_BUTTON_LABEL') : t('SHOW_DETAILS_BUTTON_LABEL')}
+        </Button>
+      </Collapsible.Trigger>
+      <Collapsible.Content>
+        <ProductDetails
+          items={productDetails}
+          documents={productDocuments}
+          className={sprinkles({ marginTop: 'md' })}
+          afterDetailsSection={
+            <Button variant="secondary" size="medium" fullWidth={true} onClick={handleEditClick}>
+              {t('EDIT_INFORMATION_BUTTON_LABEL')}
+            </Button>
+          }
+        />
+      </Collapsible.Content>
+    </Collapsible.Root>
   )
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Add details section (display items and documents) to Offer Summary
- Extract `useOfferDetails` hook to avoid duplicating that code
- Provide fake documents as a temp placeholder until terms-hub is ready to return real data in staging

![Screenshot 2024-08-02 at 10.26.29.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/6b783f86-57f3-40c5-a848-de67a3146410.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
