### PR TITLE
Use Badge component instead of one-off substitutes in OfferPresenterV2

### DIFF
--- a/apps/store/src/features/priceCalculator/DeductibleSelectorV2.css.ts
+++ b/apps/store/src/features/priceCalculator/DeductibleSelectorV2.css.ts
@@ -1,10 +1,6 @@
 import { style } from '@vanilla-extract/css'
-import { tokens } from 'ui'
 import { labelBackground } from '@/features/priceCalculator/CardRadioGroup.css'
 
 export const priceLabel = style({
-  paddingBlock: tokens.space.xxs,
-  paddingInline: tokens.space.xs,
-  borderRadius: tokens.radius.xs,
   backgroundColor: labelBackground,
 })

--- a/apps/store/src/features/priceCalculator/DeductibleSelectorV2.tsx
+++ b/apps/store/src/features/priceCalculator/DeductibleSelectorV2.tsx
@@ -3,7 +3,7 @@ import { StoryblokComponent } from '@storyblok/react'
 import { useTranslation } from 'next-i18next'
 import { useMemo } from 'react'
 import { sprinkles } from 'ui/src/theme/sprinkles.css'
-import { Button, Heading, PlusIcon, Text, xStack, yStack } from 'ui'
+import { Badge, Button, Heading, PlusIcon, Text, xStack, yStack } from 'ui'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
 import { usePriceCalculatorDeductibleInfo } from '@/features/priceCalculator/priceCalculatorAtoms'
 import type { Money, ProductOfferFragment } from '@/services/graphql/generated'
@@ -58,9 +58,9 @@ export function DeductibleSelectorV2({ offers, selectedOffer, onValueChange }: P
                   <Heading as="h2" variant="standard.24">
                     {item.title}
                   </Heading>
-                  <Text as="div" size="xs" color="textPrimary" className={priceLabel}>
+                  <Badge size="small" className={priceLabel}>
                     {formatter.monthlyPrice(item.price)}
-                  </Text>
+                  </Badge>
                 </div>
                 <Text size="xs" color="textSecondary">
                   {item.description}

--- a/apps/store/src/features/priceCalculator/OfferPriceDetails.tsx
+++ b/apps/store/src/features/priceCalculator/OfferPriceDetails.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'next-i18next'
 import type { ReactNode } from 'react'
-import { Text, tokens, xStack, yStack } from 'ui'
+import { Badge, sprinkles, Text, tokens, xStack, yStack } from 'ui'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { useSelectedOfferValueOrThrow } from '@/components/ProductPage/PurchaseForm/useSelectedOffer'
 import { CampaignDiscountType, type ProductOfferFragment } from '@/services/graphql/generated'
@@ -28,19 +28,10 @@ export function OfferPriceDetails() {
           <PriceBreakdownItem value={selectedOffer.cost.gross}>
             {selectedOffer.product.displayNameFull}
             {hasTiers && (
-              <Text
-                as="span"
-                color="textPrimary"
-                size="xxs"
-                style={{
-                  paddingInline: tokens.space.xs,
-                  paddingBlock: tokens.space.xxs,
-                  borderRadius: tokens.radius.xxs,
-                  backgroundColor: tokens.colors.pink300,
-                }}
-              >
+              // NOTE: display: flex fixes auto height calculation
+              <Badge size="tiny" color="pinkFill3" className={sprinkles({ display: 'flex' })}>
                 {selectedOffer.variant.displayNameSubtype}
-              </Text>
+              </Badge>
             )}
           </PriceBreakdownItem>
           <PriceBreakdownItem

--- a/apps/store/src/features/priceCalculator/ProductTierSelectorV2.tsx
+++ b/apps/store/src/features/priceCalculator/ProductTierSelectorV2.tsx
@@ -1,7 +1,9 @@
+import { assignInlineVars } from '@vanilla-extract/dynamic'
 import { useTranslation } from 'next-i18next'
 import { useRef } from 'react'
+import { badgeFontColor } from 'ui/src/components/Badge/Badge.css'
 import { sprinkles } from 'ui/src/theme/sprinkles.css'
-import { Button, Heading, PlusIcon, Text, tokens, xStack, yStack } from 'ui'
+import { Badge, Button, Heading, PlusIcon, Text, tokens, xStack, yStack } from 'ui'
 import { ComparisonTableModal } from '@/components/ProductPage/PurchaseForm/ComparisonTableModal'
 import type { ProductOfferFragment } from '@/services/graphql/generated'
 import { useFormatter } from '@/utils/useFormatter'
@@ -32,7 +34,15 @@ export function ProductTierSelectorV2({ offers, selectedOffer, onValueChange }: 
                 <Heading as="h2" variant="standard.24">
                   {offer.variant.displayNameSubtype || offer.variant.displayName}
                 </Heading>
-                {isDefaultTier(offer) && <DefaultTierLabel />}
+                {isDefaultTier(offer) && (
+                  <Badge
+                    size="small"
+                    color="pinkFill3"
+                    style={assignInlineVars({ [badgeFontColor]: tokens.colors.gray1000 })}
+                  >
+                    {t('DEFAULT_TIER_LABEL')}
+                  </Badge>
+                )}
               </div>
               <Heading as="h3" variant="standard.24" color="textSecondary">
                 {formatter.monthlyPrice(offer.cost.net)}
@@ -66,24 +76,6 @@ export function ProductTierSelectorV2({ offers, selectedOffer, onValueChange }: 
         </Button>
       </ComparisonTableModal>
     </>
-  )
-}
-
-function DefaultTierLabel() {
-  const { t } = useTranslation('purchase-form')
-  return (
-    <Text
-      as="div"
-      size="xs"
-      style={{
-        paddingInline: tokens.space.xs,
-        paddingBlock: tokens.space.xxs,
-        borderRadius: tokens.radius.xxs,
-        backgroundColor: tokens.colors.pink300,
-      }}
-    >
-      {t('DEFAULT_TIER_LABEL')}
-    </Text>
   )
 }
 

--- a/packages/ui/src/components/Badge/Badge.css.ts
+++ b/packages/ui/src/components/Badge/Badge.css.ts
@@ -2,7 +2,8 @@ import { createVar } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
 import { tokens, minWidth } from 'ui'
 
-export const badgeBgColorVar = createVar()
+export const badgeBgColor = createVar('badgeBgColor')
+export const badgeFontColor = createVar('badgeFontColor')
 
 const smallVariant = {
   paddingBlock: tokens.space.xxs,
@@ -18,14 +19,23 @@ const bigVariant = {
 export const badge = recipe({
   base: {
     display: 'inline-block',
-    color: tokens.colors.dark,
-    backgroundColor: badgeBgColorVar,
+    color: badgeFontColor,
+    backgroundColor: badgeBgColor,
     borderRadius: tokens.radius.xxs,
+    vars: {
+      [badgeFontColor]: tokens.colors.textPrimary,
+    },
   },
   variants: {
     size: {
+      tiny: {
+        paddingBlock: '3px',
+        paddingInline: '6px',
+        fontSize: tokens.fontSizes.xxs,
+      },
       small: smallVariant,
       big: bigVariant,
+
       responsive: {
         ...smallVariant,
         '@media': {

--- a/packages/ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/ui/src/components/Badge/Badge.stories.tsx
@@ -22,6 +22,7 @@ export const Default: Story = {
     <Space x={1}>
       <Badge size="big" {...args} />
       <Badge size="small" {...args} />
+      <Badge size="tiny" {...args} />
       <Badge size="responsive" {...args} />
     </Space>
   ),

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -1,7 +1,8 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 import { clsx } from 'clsx'
+import { type CSSProperties, type ReactNode } from 'react'
 import { getColor, type UIColors } from '../../theme'
-import { badge, badgeBgColorVar } from './Badge.css'
+import { badge, badgeBgColor } from './Badge.css'
 
 type BadgeColors = Pick<
   UIColors,
@@ -12,26 +13,37 @@ type BadgeColors = Pick<
   | 'signalAmberHighlight'
   | 'signalGreenFill'
   | 'pinkFill1'
+  | 'pinkFill3'
 >
 
 export type BadgeProps = {
-  children: React.ReactNode
-  as?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span'
+  children: ReactNode
+  as?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span' | 'div'
   className?: string
   color?: keyof BadgeColors
-  size?: 'small' | 'big' | 'responsive'
+  size?: 'tiny' | 'small' | 'big' | 'responsive'
+  style?: CSSProperties
 }
 
-export const Badge = ({ as, className, children, color, size = 'small', ...rest }: BadgeProps) => {
-  const Component = as ?? 'div'
+export function Badge({
+  as = 'div',
+  className,
+  children,
+  color = 'blueFill1',
+  size = 'small',
+  style,
+}: BadgeProps) {
+  const Component = as
 
   return (
     <Component
       className={clsx(badge({ size }), className)}
-      style={assignInlineVars({
-        [badgeBgColorVar]: getColor(color ?? 'blueFill1'),
-      })}
-      {...rest}
+      style={{
+        ...assignInlineVars({
+          [badgeBgColor]: getColor(color),
+        }),
+        ...style,
+      }}
     >
       {children}
     </Component>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Use Badge component in OfferPresenterV2
- Add CSS var for badge font color
- Allow overriding style on badge
- Add tiny badge variant as seen in price breakdown

All changed badges can be seen on screenshot below
![Screenshot 2024-08-05 at 16.38.58.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/76fb6160-9f95-4700-a58b-d9e9e240363b.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
