### PR TITLE
Edit cart item mode for Price Calculator page

### DIFF
--- a/apps/store/src/components/ProductItem/useEditProductOffer.ts
+++ b/apps/store/src/components/ProductItem/useEditProductOffer.ts
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import { useProductMetadata } from '@/components/LayoutWithMenu/productMetadataHooks'
 import { OPEN_PRICE_CALCULATOR_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam'
 import { PRELOADED_PRICE_INTENT_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/usePreloadedPriceIntentId'
+import { CART_ENTRY_TO_REPLACE_QUERY_PARAM } from '@/components/ProductPage/useCartEntryToReplace'
 import { useShowAppError } from '@/services/appErrors/appErrorAtom'
 import { getPriceTemplate } from '@/services/PriceCalculator/PriceCalculator.helpers'
 import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntentService'
@@ -63,7 +64,7 @@ export const useEditProductOffer = () => {
         pathname: product.pageLink,
         query: {
           [OPEN_PRICE_CALCULATOR_QUERY_PARAM]: 1,
-          replace: params.offerId,
+          [CART_ENTRY_TO_REPLACE_QUERY_PARAM]: params.offerId,
           [PRELOADED_PRICE_INTENT_QUERY_PARAM]: priceIntent.id,
         },
       })

--- a/apps/store/src/components/ProductPage/useCartEntryToReplace.tsx
+++ b/apps/store/src/components/ProductPage/useCartEntryToReplace.tsx
@@ -2,9 +2,11 @@ import { useSearchParams } from 'next/navigation'
 import { useMemo } from 'react'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 
+export const CART_ENTRY_TO_REPLACE_QUERY_PARAM = 'replace'
+
 export const useCartEntryToReplace = () => {
   const searchParams = useSearchParams()
-  const cartEntryId = searchParams?.get('replace') as string | undefined
+  const cartEntryId = searchParams?.get(CART_ENTRY_TO_REPLACE_QUERY_PARAM) as string | undefined
   const { shopSession } = useShopSession()
 
   return useMemo(

--- a/apps/store/src/features/priceCalculator/InsuranceDataForm.tsx
+++ b/apps/store/src/features/priceCalculator/InsuranceDataForm.tsx
@@ -2,7 +2,7 @@
 
 import { datadogRum } from '@datadog/browser-rum'
 import { clsx } from 'clsx'
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useSetAtom, useStore } from 'jotai'
 import { useTranslation } from 'next-i18next'
 import { type FormEventHandler, type ReactNode } from 'react'
 import { sprinkles } from 'ui/src/theme/sprinkles.css'
@@ -15,6 +15,7 @@ import { useHandleSubmitPriceCalculatorSection } from '@/components/PriceCalcula
 import { useTranslateFieldLabel } from '@/components/PriceCalculator/useTranslateFieldLabel'
 import {
   activeFormSectionIdAtom,
+  currentPriceIntentIdAtom,
   GOTO_NEXT_SECTION,
   priceCalculatorFormAtom,
 } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
@@ -38,20 +39,22 @@ import {
   type JSONData,
 } from '@/services/PriceCalculator/PriceCalculator.types'
 import type { PriceIntent } from '@/services/priceIntent/priceIntent.types'
-import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 
 export function InsuranceDataForm() {
-  const shopSessionId = useShopSessionId()
-  if (shopSessionId == null) {
-    throw new Error('shopSession must be ready')
-  }
   const locale = useRoutingLocale()
   const { t } = useTranslation('purchase-form')
-  const form = useAtomValue(priceCalculatorFormAtom)
-  const activeSectionId = useAtomValue(activeFormSectionIdAtom)
-  const step = useAtomValue(priceCalculatorStepAtom)
+  const store = useStore()
+
+  // Special case: navigating away from price calculator
+  if (store.get(currentPriceIntentIdAtom) == null) {
+    return null
+  }
+
+  const form = store.get(priceCalculatorFormAtom)
+  const activeSectionId = store.get(activeFormSectionIdAtom)
+  const step = store.get(priceCalculatorStepAtom)
   const sections = form.sections.map((section, index) => {
     if (step !== 'fillForm' || section.id !== activeSectionId) {
       // No preview needed for sections that are not yet touched

--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.tsx
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.tsx
@@ -11,6 +11,7 @@ import { PriceCalculatorStoryProvider } from '@/features/priceCalculator/PriceCa
 import { setupApolloClient } from '@/services/apollo/app-router/rscClient'
 import { type TemplateV2 } from '@/services/PriceCalculator/PriceCalculator.types'
 import type { PriceCalculatorPageStory } from '@/services/storyblok/storyblok'
+import { Features } from '@/utils/Features'
 import { type RoutingLocale } from '@/utils/l10n/types'
 import { PurchaseFormV2 } from './PurchaseFormV2'
 
@@ -24,7 +25,7 @@ const HEADER_HEIGHT = '80px'
 
 // TODO: Convert to vanilla styles when we get to look and feel part
 export async function PriceCalculatorCmsPage({ locale, story }: Props) {
-  if (process.env.FEATURE_PRICE_CALCULATOR_PAGE !== 'true') {
+  if (!Features.enabled('PRICE_CALCULATOR_PAGE')) {
     throw notFound()
   }
   const { productName } = await getPriceTemplate(story.content.priceTemplate)

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2.tsx
@@ -1,37 +1,36 @@
 'use client'
 
-import { useAtom, useStore } from 'jotai'
+import { useAtom } from 'jotai'
 import { useEffect } from 'react'
 import { yStack } from 'ui'
 import { PriceLoader } from '@/components/PriceLoader'
 import {
-  priceIntentAtom,
   useIsPriceIntentStateReady,
   useSyncPriceIntentState,
 } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
+import {
+  PRELOADED_PRICE_INTENT_QUERY_PARAM,
+  usePreloadedPriceIntentId,
+} from '@/components/ProductPage/PurchaseForm/usePreloadedPriceIntentId'
 import { Skeleton } from '@/components/Skeleton/Skeleton'
 import { OfferPresenterV2 } from '@/features/priceCalculator/OfferPresenterV2'
-import { priceCalculatorStepAtom } from '@/features/priceCalculator/priceCalculatorAtoms'
+import {
+  INITIAL_STEP_AFTER_NAVIGATION,
+  priceCalculatorStepAtom,
+} from '@/features/priceCalculator/priceCalculatorAtoms'
 import { InsuranceDataForm } from './InsuranceDataForm'
 
-// TODO:
-// - support preloaded priceIntentId
-// - handle errors
-// - proceed to cart
 export function PurchaseFormV2() {
-  useSyncPriceIntentState(undefined)
-  const store = useStore()
+  useSyncPriceIntentState()
+  useWarnOnPreloadedPriceIntentId()
+
   const isReady = useIsPriceIntentStateReady()
   const [step, setStep] = useAtom(priceCalculatorStepAtom)
   useEffect(() => {
-    if (!isReady) return
-    const priceIntent = store.get(priceIntentAtom)
-    if (priceIntent?.offers.length) {
-      setStep('viewOffers')
-    } else {
-      setStep('fillForm')
+    if (isReady) {
+      setStep(INITIAL_STEP_AFTER_NAVIGATION)
     }
-  }, [isReady, setStep, store])
+  }, [isReady, setStep])
 
   switch (step) {
     case 'loadingForm':
@@ -54,4 +53,15 @@ export function PurchaseFormV2() {
     default:
       throw new Error(`Unexpected step: ${step}`)
   }
+}
+
+const useWarnOnPreloadedPriceIntentId = () => {
+  const preloadedPriceIntentId = usePreloadedPriceIntentId()
+  useEffect(() => {
+    if (preloadedPriceIntentId != null) {
+      console.warn(
+        `preloadedPriceIntentId is not supported on PriceCalculatorPage, please find and update the code that sets ${PRELOADED_PRICE_INTENT_QUERY_PARAM} query param`,
+      )
+    }
+  }, [preloadedPriceIntentId])
 }

--- a/apps/store/src/features/priceCalculator/priceCalculatorAtoms.ts
+++ b/apps/store/src/features/priceCalculator/priceCalculatorAtoms.ts
@@ -3,7 +3,10 @@
 import { type SbBlokData } from '@storyblok/react'
 import { atom, useAtomValue } from 'jotai'
 import { atomFamily } from 'jotai/utils'
-import { currentPriceIntentIdAtom } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
+import {
+  currentPriceIntentIdAtom,
+  priceIntentAtom,
+} from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
 import { getAtomValueOrThrow } from '@/utils/jotaiUtils'
 
 type PriceCalculatorStep = 'loadingForm' | 'fillForm' | 'calculatingPrice' | 'viewOffers'
@@ -21,11 +24,22 @@ export const priceCalculatorStepAtom = atom(
     }
     return get(priceCalculatorStepAtomFamily(priceIntentId))
   },
-  (get, set, value: PriceCalculatorStep) => {
+  (get, set, value: PriceCalculatorStep | typeof INITIAL_STEP_AFTER_NAVIGATION) => {
     const priceIntentId = getAtomValueOrThrow(get, currentPriceIntentIdAtom)
-    set(priceCalculatorStepAtomFamily(priceIntentId), value)
+    const atom = priceCalculatorStepAtomFamily(priceIntentId)
+    if (value === INITIAL_STEP_AFTER_NAVIGATION) {
+      const priceIntent = get(priceIntentAtom)
+      if (priceIntent?.offers.length) {
+        set(atom, 'viewOffers')
+      } else {
+        set(atom, 'fillForm')
+      }
+    } else {
+      set(atom, value)
+    }
   },
 )
+export const INITIAL_STEP_AFTER_NAVIGATION = Symbol('INITIAL_STEP_AFTER_NAVIGATION')
 
 export const priceCalculatorDeductibleInfoAtom = atom<Array<SbBlokData> | null>(null)
 

--- a/apps/store/src/graphql/ProductOfferFragment.graphql
+++ b/apps/store/src/graphql/ProductOfferFragment.graphql
@@ -4,6 +4,7 @@ fragment ProductOffer on ProductOffer {
     id
     name
     pageLink
+    priceCalculatorPageLink
     displayNameFull
     pillowImage {
       id

--- a/apps/store/src/utils/Features.ts
+++ b/apps/store/src/utils/Features.ts
@@ -22,6 +22,7 @@ const config = {
     process.env.NEXT_PUBLIC_HIDE_REVIEWS_FROM_PRODUCT_AVERAGE_RATING === 'true',
   NEW_HEADER: process.env.NEXT_PUBLIC_FEATURE_NEW_HEADER === 'true',
   CHECKOUT_PAGE_MERGE: process.env.NEXT_PUBLIC_FEATURE_CHECKOUT_PAGE_MERGE === 'true',
+  PRICE_CALCULATOR_PAGE: process.env.NEXT_PUBLIC_FEATURE_PRICE_CALCULATOR_PAGE === 'true',
 } as const
 
 export type FeatureFlag = keyof typeof config


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Covert `FEATURE_PRICE_CALCULATOR_PAGE` env variable into feature flag since we need it on client side as well now
- Add 'Edit information' button to new checkout page, that goes either to product page (default) or price calculator page (feature flag enabled and page linked to product metadata)

Limitations
- no confirmation dialog (easy to add, let's wait for designers to be back to discuss)
- editing bonus offers not supported, redirect will crash if offer.priceIntentId is not defined

Edit button:
![Screenshot 2024-08-07 at 10.47.53.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/f61f3b79-669a-478e-9ada-6c7ef23e61fc.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
