### PR TITLE
GEN-2463 - refact(InputRadio): update API - receive options via props

### DIFF
--- a/apps/store/src/app/debugger/car-trial/CarTrialDebuggerForm.tsx
+++ b/apps/store/src/app/debugger/car-trial/CarTrialDebuggerForm.tsx
@@ -5,7 +5,7 @@ import { Text, Space } from 'ui'
 import { SubmitButton } from '@/appComponents/SubmitButton'
 import { ErrorMessages } from '@/components/FormErrors/ErrorMessages'
 import { InputCarRegistrationNumber } from '@/components/InputCarRegistrationNumber/InputCarRegistrationNumber'
-import * as InputRadio from '@/components/InputRadio/InputRadio'
+import { InputRadio } from '@/components/InputRadio/InputRadio'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
 import { PersonalNumberField } from '@/components/PersonalNumberField/PersonalNumberField'
 import { Field } from '@/features/carDealership/DebuggerCarTrial/debuggerCarTrial.types'
@@ -47,20 +47,12 @@ export const CarTrialDebuggerForm = () => {
             options={TIER_OPTIONS}
           />
 
-          <InputRadio.Root
+          <InputRadio
             name={Field.Product}
             label="Product"
             defaultValue={state?.fields?.[Field.Product]}
-          >
-            {PRODUCT_OPTIONS.map((option) => (
-              <InputRadio.Item
-                key={option.value}
-                id={`Product-${option.value}`}
-                label={option.name}
-                value={option.value}
-              />
-            ))}
-          </InputRadio.Root>
+            options={PRODUCT_OPTIONS.map((option) => ({ label: option.name, value: option.value }))}
+          />
 
           <Space y={0.5}>
             <SubmitButton>Create car trial</SubmitButton>

--- a/apps/store/src/app/debugger/trial/components/TrialContractForm.tsx
+++ b/apps/store/src/app/debugger/trial/components/TrialContractForm.tsx
@@ -5,7 +5,7 @@ import { Space } from 'ui'
 import { Field } from '@/app/debugger/trial/debuggerTrial.types'
 import { SubmitButton } from '@/appComponents/SubmitButton'
 import { ErrorMessages } from '@/components/FormErrors/ErrorMessages'
-import * as InputRadio from '@/components/InputRadio/InputRadio'
+import { HorizontalInputRadio } from '@/components/InputRadio/InputRadio'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
 import { PersonalNumberField } from '@/components/PersonalNumberField/PersonalNumberField'
 import { TextField } from '@/components/TextField/TextField'
@@ -18,6 +18,16 @@ const partnerOptions = [
   { name: 'Byggvesta', value: 'BYGGVESTA' },
   { name: 'Samtrygg', value: 'SAMTRYGG' },
   { name: 'Hedvig', value: 'HEDVIG' },
+]
+
+const subtypeOptions = [
+  { label: 'Rent', value: 'RENT' },
+  { label: 'Own', value: 'BRF' },
+]
+
+const isStudentOptions = [
+  { label: 'Student', value: 'true' },
+  { label: 'Not student', value: 'false' },
 ]
 
 export function TrialContractForm() {
@@ -81,15 +91,13 @@ export function TrialContractForm() {
             pattern="\d{3} \d{2}"
             defaultValue={state?.fields?.[Field.zipCode]}
           />
-          <InputRadio.HorizontalRoot
+          <HorizontalInputRadio
             name={Field.subType}
             label="Sub Type"
             required={true}
             defaultValue={state?.fields?.[Field.subType]}
-          >
-            <InputRadio.HorizontalItem label="Rent" value="RENT" />
-            <InputRadio.HorizontalItem label="Own" value="BRF" />
-          </InputRadio.HorizontalRoot>
+            options={subtypeOptions}
+          />
 
           <TextField
             type="email"
@@ -111,10 +119,11 @@ export function TrialContractForm() {
             autoComplete="off"
             label="Living space (m²)"
           />
-          <InputRadio.HorizontalRoot name={Field.isStudent} label="Student?">
-            <InputRadio.HorizontalItem label="Student" value="true" />
-            <InputRadio.HorizontalItem label="Not student" value="false" />
-          </InputRadio.HorizontalRoot>
+          <HorizontalInputRadio
+            name={Field.isStudent}
+            label="Student?"
+            options={isStudentOptions}
+          />
 
           <SubmitButton>Create trial contract</SubmitButton>
         </Space>

--- a/apps/store/src/app/debugger/trial/components/TrialContractForm.tsx
+++ b/apps/store/src/app/debugger/trial/components/TrialContractForm.tsx
@@ -5,7 +5,7 @@ import { Space } from 'ui'
 import { Field } from '@/app/debugger/trial/debuggerTrial.types'
 import { SubmitButton } from '@/appComponents/SubmitButton'
 import { ErrorMessages } from '@/components/FormErrors/ErrorMessages'
-import { HorizontalInputRadio } from '@/components/InputRadio/InputRadio'
+import { InputRadio } from '@/components/InputRadio/InputRadio'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
 import { PersonalNumberField } from '@/components/PersonalNumberField/PersonalNumberField'
 import { TextField } from '@/components/TextField/TextField'
@@ -91,7 +91,7 @@ export function TrialContractForm() {
             pattern="\d{3} \d{2}"
             defaultValue={state?.fields?.[Field.zipCode]}
           />
-          <HorizontalInputRadio
+          <InputRadio
             name={Field.subType}
             label="Sub Type"
             required={true}
@@ -119,11 +119,7 @@ export function TrialContractForm() {
             autoComplete="off"
             label="Living space (m²)"
           />
-          <HorizontalInputRadio
-            name={Field.isStudent}
-            label="Student?"
-            options={isStudentOptions}
-          />
+          <InputRadio name={Field.isStudent} label="Student?" options={isStudentOptions} />
 
           <SubmitButton>Create trial contract</SubmitButton>
         </Space>

--- a/apps/store/src/components/InputRadio/InputRadio.css.ts
+++ b/apps/store/src/components/InputRadio/InputRadio.css.ts
@@ -1,5 +1,18 @@
-import { style } from '@vanilla-extract/css'
+import { style, styleVariants } from '@vanilla-extract/css'
 import { tokens, yStack, xStack } from 'ui'
+
+export const horizontalRadioGroup = styleVariants({
+  withLabel: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.space.md,
+  },
+  withoutLabel: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: tokens.space.xxs,
+  },
+})
 
 export const card = style([
   yStack({ gap: 'xs' }),
@@ -11,37 +24,24 @@ export const card = style([
   },
 ])
 
-export const option = style([
-  xStack({ gap: 'xs', alignItems: 'center' }),
-  {
-    cursor: 'pointer',
-  },
-])
-
-export const item = style({
-  width: '1.5rem',
-  aspectRatio: '1 / 1',
+export const radioButton = style({
   borderRadius: '50%',
   cursor: 'pointer',
   selectors: {
-    '&[data-state=checked]': {
-      borderColor: tokens.colors.gray1000,
-    },
-
     '&:focus-visible': {
       boxShadow: tokens.shadow.focusAlt,
     },
   },
 })
 
-export const horizontalRoot = style({
-  display: 'grid',
-  gridTemplateColumns: '1fr 1fr',
-  gap: tokens.space.xxs,
-})
+export const item = style([
+  xStack({ gap: 'xs', alignItems: 'center' }),
+  {
+    cursor: 'pointer',
+  },
+])
 
-export const horizontalItem = style({
-  cursor: 'pointer',
+export const paddedItem = style({
   padding: `${tokens.space.sm} ${tokens.space.md}`,
   borderRadius: tokens.radius.sm,
   backgroundColor: tokens.colors.translucent1,

--- a/apps/store/src/components/InputRadio/InputRadio.stories.tsx
+++ b/apps/store/src/components/InputRadio/InputRadio.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta } from '@storybook/react'
-import { InputRadio, HorizontalInputRadio } from './InputRadio'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react'
+import { InputRadio } from './InputRadio'
 
 export default {
   title: 'Inputs / Radio',
@@ -12,22 +12,31 @@ export default {
   ],
 } as Meta<typeof InputRadio>
 
-export const HorizontalWithLabel = () => (
+type Story = StoryObj<typeof InputRadio>
+
+const Template: StoryFn<typeof InputRadio> = (args) => (
   <InputRadio
+    {...args}
     label="Label"
     options={[
-      { label: 'Option 1', value: '1' },
-      { label: 'Option 2', value: '2' },
+      { label: 'Yes', value: 'yes' },
+      { label: 'No', value: 'no' },
     ]}
   />
 )
 
-export const HorizontalWithoutLabel = () => (
-  <HorizontalInputRadio
-    label="Horizontal"
-    options={[
-      { label: 'Option 1', value: '1' },
-      { label: 'Option 2', value: '2' },
-    ]}
-  />
-)
+export const HorizontalWithLabel: Story = {
+  render: Template,
+  args: {
+    orientation: 'horizontal',
+    displayLabel: true,
+  },
+}
+
+export const HorizontalWithoutLabel: Story = {
+  render: Template,
+  args: {
+    orientation: 'horizontal',
+    displayLabel: false,
+  },
+}

--- a/apps/store/src/components/InputRadio/InputRadio.stories.tsx
+++ b/apps/store/src/components/InputRadio/InputRadio.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from '@storybook/react'
-import * as InputRadio from './InputRadio'
+import { InputRadio, HorizontalInputRadio } from './InputRadio'
 
 export default {
   title: 'Inputs / Radio',
@@ -12,16 +12,22 @@ export default {
   ],
 } as Meta<typeof InputRadio>
 
-export const Horizontal = () => (
-  <InputRadio.HorizontalRoot label="Horizontal">
-    <InputRadio.HorizontalItem value="1" label="Option 1" />
-    <InputRadio.HorizontalItem value="2" label="Option 2" />
-  </InputRadio.HorizontalRoot>
+export const HorizontalWithLabel = () => (
+  <InputRadio
+    label="Label"
+    options={[
+      { label: 'Option 1', value: '1' },
+      { label: 'Option 2', value: '2' },
+    ]}
+  />
 )
 
-export const Vertical = () => (
-  <InputRadio.Root label="Vertical">
-    <InputRadio.Item value="1" label="Option 1" />
-    <InputRadio.Item value="2" label="Option 2" />
-  </InputRadio.Root>
+export const HorizontalWithoutLabel = () => (
+  <HorizontalInputRadio
+    label="Horizontal"
+    options={[
+      { label: 'Option 1', value: '1' },
+      { label: 'Option 2', value: '2' },
+    ]}
+  />
 )

--- a/apps/store/src/components/InputRadio/InputRadio.tsx
+++ b/apps/store/src/components/InputRadio/InputRadio.tsx
@@ -2,42 +2,54 @@
 
 import * as RadioGroup from '@radix-ui/react-radio-group'
 import clsx from 'clsx'
-import { type ComponentPropsWithoutRef, type MouseEventHandler } from 'react'
+import {
+  useId,
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type MouseEventHandler,
+} from 'react'
 import { Text, xStack } from 'ui'
 import { RadioIndicatorIcon } from '@/features/priceCalculator/RadioIndicatorIcon'
 import { useHighlightAnimation } from '@/utils/useHighlightAnimation'
 import { card, option, item, horizontalRoot, horizontalItem } from './InputRadio.css'
 
-type RootProps = {
-  label: string
-  children: React.ReactNode
-  value?: string
-  onValueChange?: (value: string) => void
-  required?: boolean
-  defaultValue?: string
-  name?: string
-}
+type Option = { label: string; value: string; autoFocus?: boolean }
 
-export const Root = ({ children, label, onValueChange, ...props }: RootProps) => {
+type RootProps = { label: string; options: Array<Option> } & Omit<
+  ComponentProps<typeof RadioGroup.Root>,
+  'children'
+>
+
+export function InputRadio({ label, options, orientation = 'horizontal', ...props }: RootProps) {
   const { highlight, animationProps } = useHighlightAnimation<HTMLDivElement>()
 
   const handleValueChange = (value: string) => {
     highlight()
-    onValueChange?.(value)
+    props.onValueChange?.(value)
   }
 
+  if (orientation === 'vertical') {
+    // TODO: add support for vertical orientation layout
+    return null
+  }
+
+  // TODO: this is horizontal layout with label. Horizontal layout without label
+  // can be achieved by using HorizontalRoot at the moment, but in the future I'll
+  // be merging both and deciding between them based on the present of the label prop.
   return (
     <div className={card} {...animationProps}>
       <Text as="span" size="xs" color="textSecondary">
         {label}
       </Text>
       <RadioGroup.Root
-        className={xStack({ gap: 'md', alignItems: 'center' })}
-        onValueChange={handleValueChange}
-        aria-label={label}
         {...props}
+        className={xStack({ gap: 'md', alignItems: 'center' })}
+        aria-label={label}
+        onValueChange={handleValueChange}
       >
-        {children}
+        {options.map((option) => {
+          return <Item key={option.value} {...option} />
+        })}
       </RadioGroup.Root>
     </div>
   )
@@ -48,8 +60,8 @@ type ItemProps = {
   value: string
 } & Omit<ComponentPropsWithoutRef<'button'>, 'value'>
 
-export const Item = ({ value, label, id, className, ...itemProps }: ItemProps) => {
-  const identifier = id ?? `radio-${value}`
+function Item({ value, label, className, ...itemProps }: ItemProps) {
+  const identifier = useId()
 
   return (
     <label className={clsx(option, className)} htmlFor={identifier}>
@@ -65,15 +77,17 @@ export const Item = ({ value, label, id, className, ...itemProps }: ItemProps) =
   )
 }
 
-export const HorizontalRoot = ({ label, children, ...rootProps }: RootProps) => {
+export function HorizontalInputRadio({ label, options, ...rootProps }: RootProps) {
   return (
     <RadioGroup.Root className={horizontalRoot} aria-label={label} {...rootProps}>
-      {children}
+      {options.map((option) => (
+        <HorizontalItem key={option.value} {...option} />
+      ))}
     </RadioGroup.Root>
   )
 }
 
-export const HorizontalItem = ({ onClick, ...props }: ItemProps) => {
+function HorizontalItem({ onClick, ...props }: ItemProps) {
   const { highlight, animationProps } = useHighlightAnimation<HTMLDivElement>()
 
   const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {

--- a/apps/store/src/components/PriceCalculator/AutomaticField.tsx
+++ b/apps/store/src/components/PriceCalculator/AutomaticField.tsx
@@ -1,4 +1,4 @@
-import { InputRadio, HorizontalInputRadio } from '@/components/InputRadio/InputRadio'
+import { InputRadio } from '@/components/InputRadio/InputRadio'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
 import { UseRegistrationAddressField } from '@/components/PriceCalculator/UseRegistrationAddressField'
 import { StepperInput } from '@/components/StepperInput/StepperInput'
@@ -71,14 +71,14 @@ export const AutomaticField = ({ field, autoFocus }: Props) => {
       )
 
     case 'radio': {
-      const RadioComponent = field.stacking === 'horizontal' ? HorizontalInputRadio : InputRadio
-
       return (
-        <RadioComponent
+        <InputRadio
           name={field.name}
           label={translateLabel(field.label)}
+          displayLabel={field.displayLabel}
           required={field.required}
           defaultValue={field.value ?? field.defaultValue}
+          orientation={field.stacking}
           options={field.options.map((option, index) => ({
             label: translateLabel(option.label),
             value: option.value,

--- a/apps/store/src/components/PriceCalculator/AutomaticField.tsx
+++ b/apps/store/src/components/PriceCalculator/AutomaticField.tsx
@@ -1,4 +1,4 @@
-import * as InputRadio from '@/components/InputRadio/InputRadio'
+import { InputRadio, HorizontalInputRadio } from '@/components/InputRadio/InputRadio'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
 import { UseRegistrationAddressField } from '@/components/PriceCalculator/UseRegistrationAddressField'
 import { StepperInput } from '@/components/StepperInput/StepperInput'
@@ -70,42 +70,23 @@ export const AutomaticField = ({ field, autoFocus }: Props) => {
         />
       )
 
-    case 'radio':
-      return field.stacking === 'horizontal' ? (
-        <InputRadio.HorizontalRoot
+    case 'radio': {
+      const RadioComponent = field.stacking === 'horizontal' ? HorizontalInputRadio : InputRadio
+
+      return (
+        <RadioComponent
           name={field.name}
           label={translateLabel(field.label)}
           required={field.required}
           defaultValue={field.value ?? field.defaultValue}
-        >
-          {field.options.map((option, index) => (
-            <InputRadio.HorizontalItem
-              key={option.value}
-              id={`${field.name}-${option.value}`}
-              label={translateLabel(option.label)}
-              value={option.value}
-              autoFocus={autoFocus && index === 0}
-            />
-          ))}
-        </InputRadio.HorizontalRoot>
-      ) : (
-        <InputRadio.Root
-          name={field.name}
-          label={translateLabel(field.label)}
-          required={field.required}
-          defaultValue={field.value ?? field.defaultValue}
-        >
-          {field.options.map((option, index) => (
-            <InputRadio.Item
-              key={option.value}
-              id={`${field.name}-${option.value}`}
-              label={translateLabel(option.label)}
-              value={option.value}
-              autoFocus={autoFocus && index === 0}
-            />
-          ))}
-        </InputRadio.Root>
+          options={field.options.map((option, index) => ({
+            label: translateLabel(option.label),
+            value: option.value,
+            autoFocus: autoFocus && index === 0,
+          }))}
+        />
       )
+    }
 
     case 'select':
       return (

--- a/apps/store/src/components/PriceCalculator/CurrentInsuranceField/InputCurrentInsurance.tsx
+++ b/apps/store/src/components/PriceCalculator/CurrentInsuranceField/InputCurrentInsurance.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'next-i18next'
 import type { ChangeEventHandler } from 'react'
 import { useState } from 'react'
 import { Space } from 'ui'
-import * as InputRadio from '@/components/InputRadio/InputRadio'
+import { InputRadio } from '@/components/InputRadio/InputRadio'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
 
 export type SelectOptions = ReadonlyArray<{ name: string; value: string }>
@@ -40,14 +40,15 @@ export const InputCurrentInsurance = (props: InputCurrentInsuranceProps) => {
 
   return (
     <Space y={0.25}>
-      <InputRadio.Root
+      <InputRadio
         label={label}
         value={hasInsurance ? RadioOption.YES : RadioOption.NO}
         onValueChange={handleRadioValueChange}
-      >
-        <InputRadio.Item label={t('LABEL_YES')} value={RadioOption.YES} />
-        <InputRadio.Item label={t('LABEL_NO')} value={RadioOption.NO} />
-      </InputRadio.Root>
+        options={[
+          { label: t('LABEL_YES'), value: RadioOption.YES },
+          { label: t('LABEL_NO'), value: RadioOption.NO },
+        ]}
+      />
 
       {hasInsurance && (
         <InputSelect

--- a/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
+++ b/apps/store/src/components/PriceCalculator/ExtraBuildingsField.tsx
@@ -14,7 +14,7 @@ import {
   CrossIcon,
   CrossIconSmall,
 } from 'ui'
-import * as InputRadio from '@/components/InputRadio/InputRadio'
+import { InputRadio } from '@/components/InputRadio/InputRadio'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
 import { useUpdatePriceIntent } from '@/components/PriceCalculator/useUpdatePriceIntent'
 import {
@@ -183,13 +183,14 @@ export const ExtraBuildingsField = ({ field, buildingOptions }: ExtraBuildingsFi
                     suffix="m²"
                     required
                   />
-                  <InputRadio.Root
+                  <InputRadio
                     name={Field.HasWaterConnected}
                     label={t('FIELD_HAS_WATER_CONNECTED_LABEL')}
-                  >
-                    <InputRadio.Item label={t('LABEL_NO')} value={RadioOption.NO} />
-                    <InputRadio.Item label={t('LABEL_YES')} value={RadioOption.YES} />
-                  </InputRadio.Root>
+                    options={[
+                      { label: t('LABEL_NO'), value: RadioOption.NO },
+                      { label: t('LABEL_YES'), value: RadioOption.YES },
+                    ]}
+                  />
                 </Space>
 
                 <Button

--- a/apps/store/src/components/PriceCalculator/UseRegistrationAddressField.tsx
+++ b/apps/store/src/components/PriceCalculator/UseRegistrationAddressField.tsx
@@ -1,6 +1,6 @@
 import { useAtom, useAtomValue } from 'jotai'
 import { useTranslation } from 'next-i18next'
-import * as InputRadio from '@/components/InputRadio/InputRadio'
+import { InputRadio } from '@/components/InputRadio/InputRadio'
 import {
   currentPriceIntentIdAtom,
   useRegistrationAddressAtomFamily,
@@ -20,15 +20,16 @@ export function UseRegistrationAddressField({ field }: Props) {
     setValue(newValue === 'true')
   }
   return (
-    <InputRadio.Root
+    <InputRadio
       name={field.name}
       label={t('FIELD_USE_REGISTRATION_ADDRESS_LABEL')}
       required={true}
       defaultValue={String(value)}
       onValueChange={handleChange}
-    >
-      <InputRadio.Item key={`${field.name}-true`} label={t('LABEL_YES')} value="true" />
-      <InputRadio.Item key={`${field.name}-false`} label={t('LABEL_NO')} value="false" />
-    </InputRadio.Root>
+      options={[
+        { label: t('LABEL_YES'), value: 'true' },
+        { label: t('LABEL_NO'), value: 'false' },
+      ]}
+    />
   )
 }

--- a/apps/store/src/services/PriceCalculator/Field.types.ts
+++ b/apps/store/src/services/PriceCalculator/Field.types.ts
@@ -36,7 +36,10 @@ export type DateField = BaseField<string> & {
 type RadioField = BaseField<string> & {
   type: 'radio'
   options: Array<FieldOption>
-  stacking?: 'horizontal'
+  // Defaults to 'horizontal'
+  stacking?: 'horizontal' | 'vertical'
+  // Defaults to 'true'
+  displayLabel?: boolean
 }
 
 export type FieldOption = {

--- a/apps/store/src/services/PriceCalculator/data/SE_PET_CAT.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_PET_CAT.ts
@@ -29,6 +29,7 @@ export const SE_PET_CAT: Template = {
             stacking: 'horizontal',
             name: 'gender',
             label: { key: tKey('FIELD_GENDER_LABEL') },
+            displayLabel: false,
             required: true,
             options: [
               {

--- a/apps/store/src/services/PriceCalculator/data/SE_PET_DOG.ts
+++ b/apps/store/src/services/PriceCalculator/data/SE_PET_DOG.ts
@@ -32,6 +32,7 @@ export const SE_PET_DOG: Template = {
             stacking: 'horizontal',
             name: 'gender',
             label: { key: tKey('FIELD_GENDER_LABEL') },
+            displayLabel: false,
             options: [
               { label: { key: tKey('FIELD_GENDER_OPTION_MALE_DOG') }, value: 'MALE' },
               { label: { key: tKey('FIELD_GENDER_OPTION_FEMALE_DOG') }, value: 'FEMALE' },


### PR DESCRIPTION
## Describe your changes

* Refact: Update `InputRadio` API so it receives options as props.

## Justify why they are needed

It's subjective. I think it's easier to work with that way and will ease the addition of vertical layout in the future:

![image](https://github.com/user-attachments/assets/9c4e2480-81cf-4a32-b3c6-73247660a96f)

With that's said this is not required. We can drop it if we think it's not worth it. 