### PR TITLE
Fix layout shift in ProductGrid caused by Space component

### DIFF
--- a/apps/store/src/components/ProductCard/ProductCard.css.ts
+++ b/apps/store/src/components/ProductCard/ProductCard.css.ts
@@ -1,0 +1,4 @@
+import { style } from '@vanilla-extract/css'
+import { yStack } from 'ui'
+
+export const card = style([yStack({ gap: 'md' }), { position: 'relative' }])

--- a/apps/store/src/components/ProductCard/ProductCard.tsx
+++ b/apps/store/src/components/ProductCard/ProductCard.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useTranslation } from 'next-i18next'
 import { useState } from 'react'
-import { Button, mq, Space, theme } from 'ui'
+import { Button, mq, theme } from 'ui'
 import type { ImageSize } from '@/blocks/ProductCardBlock'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
@@ -14,6 +14,7 @@ import { OPEN_PRICE_CALCULATOR_QUERY_PARAM } from '@/components/ProductPage/Purc
 import { SelectInsuranceGrid } from '@/components/SelectInsuranceGrid/SelectInsuranceGrid'
 import { getParameterizedLink } from '@/utils/getParameterizedLink'
 import { isSameLink } from '@/utils/url'
+import { card } from './ProductCard.css'
 
 type ImageProps = {
   src: string
@@ -45,7 +46,7 @@ export const ProductCard = ({
   const router = useRouter()
 
   return (
-    <Container y={1}>
+    <div className={card}>
       <ImageWrapper aspectRatio={aspectRatio}>
         <Image {...imageProps} alt={alt} fill sizes="20rem" />
       </ImageWrapper>
@@ -67,7 +68,7 @@ export const ProductCard = ({
           {link.type === 'category' && <CategoryCTA link={link} />}
         </CallToAction>
       </ContentWrapper>
-    </Container>
+    </div>
   )
 }
 
@@ -135,10 +136,6 @@ const CategoryCTA = ({ link }: Pick<ProductCardProps, 'link'>) => {
 }
 
 const CALL_TO_ACTION_HEIGHT = '2.5rem'
-
-const Container = styled(Space)({
-  position: 'relative',
-})
 
 const ImageWrapper = styled.div<ImageSize>(({ aspectRatio }) => ({
   display: 'block',


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

Background:
Google reported 0.32 layout shift (CLS) on https://www.hedvig.com/se/forsakringar/djurforsakring page

One obvious thing I've found is that product grid jumps when page is loaded. This was caused by dreaded `Space` component. Replacing with div+yStack fixes the issue

To be followed by full conversion to vanilla-extract

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
