### PR TITLE
fix(checkout-v2): enable empty cart state when customer data is not provided

### DIFF
--- a/apps/store/src/app/[locale]/new/checkout/page.tsx
+++ b/apps/store/src/app/[locale]/new/checkout/page.tsx
@@ -1,8 +1,7 @@
-import { notFound, redirect } from 'next/navigation'
+import { notFound } from 'next/navigation'
 import { setupApolloClient } from '@/services/apollo/app-router/rscClient'
 import { setupShopSession } from '@/services/shopSession/app-router/ShopSession.utils'
 import type { RoutingLocale } from '@/utils/l10n/types'
-import { PageLink } from '@/utils/PageLink'
 import { CheckoutPage } from './CheckoutPage'
 
 type Params = { locale: RoutingLocale }
@@ -10,8 +9,6 @@ type Params = { locale: RoutingLocale }
 type Props = { params: Params }
 
 export default async function Page({ params }: Props) {
-  const fallbackRedirectUrl = PageLink.home({ locale: params.locale }).toString()
-
   const { getApolloClient } = setupApolloClient({ locale: params.locale })
   const apolloClient = getApolloClient()
   const shopSessionService = setupShopSession(apolloClient)
@@ -20,17 +17,6 @@ export default async function Page({ params }: Props) {
   if (!shopSession) {
     console.warn('Checkout | Unable to fetch shop session')
     notFound()
-  }
-
-  const customer = shopSession.customer
-  if (!customer) {
-    console.warn('Checkout | No customer in shop session', shopSession.id)
-    return redirect(fallbackRedirectUrl)
-  }
-
-  if (!customer.ssn) {
-    console.warn('Checkout | No SSN in shop session', shopSession.id)
-    return redirect(fallbackRedirectUrl)
   }
 
   return <CheckoutPage locale={params.locale} shopSessionId={shopSession.id} />


### PR DESCRIPTION
## Describe your changes

- Display "Empty Cart" UI when `customer` info is not present (meaning user hasn't insert any data yet)

## Justify why they are needed

On such cases we still want to show "Empty Cart" UI for _Checkout Page_.
