### PR TITLE
Fix English -> Swedish locale change on home page

### DIFF
--- a/apps/store/public/mockServiceWorker.js
+++ b/apps/store/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.3.4'
+const PACKAGE_VERSION = '2.3.5'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/apps/store/src/middleware.ts
+++ b/apps/store/src/middleware.ts
@@ -1,4 +1,5 @@
 import { get as getFromConfig } from '@vercel/edge-config'
+import { type NextURL } from 'next/dist/server/web/next-url'
 import { removeTrailingSlash } from 'next/dist/shared/lib/router/utils/remove-trailing-slash'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
@@ -57,7 +58,7 @@ const localeMiddleware = (req: NextRequest): NextResponse | undefined => {
     }
 
     // Otherwise redirect to the targeted page
-    return NextResponse.redirect(targetURL, 308)
+    return redirectResponse(targetURL)
   }
 
   // Localized route
@@ -71,7 +72,7 @@ const localeMiddleware = (req: NextRequest): NextResponse | undefined => {
       // Redirect to the root fomain
       targetURL.pathname = '/'
 
-      return NextResponse.redirect(targetURL, 308)
+      return redirectResponse(targetURL)
     }
 
     // Otherwise serve original route
@@ -89,6 +90,13 @@ const localeMiddleware = (req: NextRequest): NextResponse | undefined => {
   const defaultLocale = locales[FALLBACK_LOCALE].routingLocale
   console.info(`Routing traffic to /${defaultLocale}`)
   return handleLocaleRouting(defaultLocale)
+}
+
+const redirectResponse = (targetURL: string | NextURL) => {
+  const response = NextResponse.redirect(targetURL, 308)
+  // Prevents client from using old cached redirect with new language
+  response.headers.set('Vary', 'cookie')
+  return response
 }
 
 type Redirect = {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix a bug where changing language from English to Swedish had no effect

Root cause: / -> /en-se redirect was cached on the client

This PR adds "Vary: cookie" header to redirect to prevent this from happening

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
