### PR TITLE
GEN-2470 - styles(combobox): support size variants (small, medium, large)

### DIFF
--- a/apps/store/src/components/Combobox/Combobox.css.ts
+++ b/apps/store/src/components/Combobox/Combobox.css.ts
@@ -1,81 +1,94 @@
-import { style } from '@vanilla-extract/css'
+import { style, createVar, styleVariants } from '@vanilla-extract/css'
 import { tokens, hoverStyles } from 'ui'
 import { zIndexes } from '@/utils/zIndex'
 
-export const wrapper = style({
-  position: 'relative',
+const wrapperBase = style({
   isolation: 'isolate',
-  selectors: {
-    '&[data-expanded=true]': {
-      zIndex: zIndexes.header,
-      boxShadow: tokens.shadow.default,
-      borderTopLeftRadius: tokens.radius.sm,
-      borderTopRightRadius: tokens.radius.sm,
+})
+
+const inlinePadding = createVar('inputLateralPadding')
+export const wrapper = styleVariants({
+  small: [
+    wrapperBase,
+    {
+      vars: {
+        [inlinePadding]: '0.875rem',
+      },
+      fontSize: tokens.fontSizes.md,
     },
-  },
+  ],
+  medium: [
+    wrapperBase,
+    {
+      vars: {
+        [inlinePadding]: tokens.space.md,
+      },
+      fontSize: tokens.fontSizes.md,
+    },
+  ],
+  large: [
+    wrapperBase,
+    {
+      vars: {
+        [inlinePadding]: tokens.space.md,
+      },
+      fontSize: tokens.fontSizes.xl,
+    },
+  ],
+})
+
+export const wrapperExpanded = style({
+  zIndex: zIndexes.header,
 })
 
 export const inputWrapper = style({ position: 'relative' })
 
-export const inputBackground = style({
+const inputBase = style({
+  width: '100%',
+  paddingLeft: inlinePadding,
+  paddingRight: tokens.space.xxxl,
   borderRadius: tokens.radius.sm,
   backgroundColor: tokens.colors.translucent1,
-  selectors: {
-    '&[data-expanded=true]': {
-      borderBottomLeftRadius: 0,
-      borderBottomRightRadius: 0,
-    },
-
-    '&[data-warning=true]': {
-      borderBottomLeftRadius: tokens.radius.sm,
-      borderBottomRightRadius: tokens.radius.sm,
-    },
-  },
 })
 
-export const input = style({
-  width: '100%',
-  height: '2.5rem',
-  paddingLeft: tokens.space.md,
-  paddingRight: tokens.space.xxxl,
-  color: tokens.colors.textPrimary,
-  fontSize: tokens.fontSizes.lg,
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-  selectors: {
-    '&[data-size=large]': {
-      height: '3rem',
-      fontSize: tokens.fontSizes.xl,
-    },
-  },
+export const input = styleVariants({
+  small: [inputBase, { height: '3rem' }],
+  medium: [inputBase, { height: '4rem' }],
+  large: [inputBase, { height: '4rem' }],
+})
+
+export const inputExpanded = style({
+  borderBottomLeftRadius: 0,
+  borderBottomRightRadius: 0,
+})
+
+export const inputWarning = style({
+  borderBottomLeftRadius: tokens.radius.sm,
+  borderBottomRightRadius: tokens.radius.sm,
 })
 
 export const actionsWrapper = style({
   position: 'absolute',
+  right: inlinePadding,
+  // Vertically center button actions
   top: '50%',
-  right: '1.125rem',
+  transform: 'translateY(-50%)',
   display: 'flex',
   gap: tokens.space.xs,
   alignItems: 'center',
-  transform: 'translateY(-50%)',
 })
 
-export const toggleButton = style({
+export const toggleActionButton = style({
   cursor: 'pointer',
   transition: 'transform 200ms cubic-bezier(0.77,0,0.18,1)',
   selectors: {
     '&[aria-expanded=true]': {
       transform: 'rotate(180deg)',
     },
-
-    '&[data-warning=true]': {
-      transform: 'rotate(0)',
-    },
   },
 })
 
-export const deleteButton = style({
+export const deleteActionButton = style({
   cursor: 'pointer',
 })
 
@@ -86,19 +99,16 @@ export const separator = style({
 })
 
 export const list = style({
-  position: 'absolute',
   width: '100%',
   borderBottomLeftRadius: tokens.radius.sm,
   borderBottomRightRadius: tokens.radius.sm,
   backgroundColor: tokens.colors.opaque1,
-  boxShadow: tokens.shadow.default,
 })
 
 export const listItem = style({
-  minHeight: '2.5rem',
-  fontSize: tokens.fontSizes.lg,
   display: 'flex',
   alignItems: 'center',
+  minHeight: '2.5rem',
   paddingInline: tokens.space.md,
   paddingBlock: tokens.space.xs,
   ...hoverStyles({ backgroundColor: tokens.colors.gray300 }),
@@ -106,14 +116,8 @@ export const listItem = style({
     borderBottomLeftRadius: tokens.radius.sm,
     borderBottomRightRadius: tokens.radius.sm,
   },
-  selectors: {
-    '&[data-size=large]': {
-      minHeight: '3rem',
-      fontSize: tokens.fontSizes.xl,
-    },
+})
 
-    '&[data-highlighted=true]': {
-      backgroundColor: tokens.colors.gray200,
-    },
-  },
+export const listItemHighlighted = style({
+  backgroundColor: tokens.colors.gray200,
 })

--- a/apps/store/src/components/Combobox/Combobox.stories.tsx
+++ b/apps/store/src/components/Combobox/Combobox.stories.tsx
@@ -1,6 +1,7 @@
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
-import type { Meta, StoryFn } from '@storybook/react'
+import type { Meta, StoryObj, StoryFn } from '@storybook/react'
 import { useState } from 'react'
+import { yStack } from 'ui'
 import { Combobox } from './Combobox'
 
 export default {
@@ -33,16 +34,32 @@ const FRUIT = [
 
 type Fruit = (typeof FRUIT)[number]
 
-export const Default: StoryFn = () => {
+type Story = StoryObj<typeof Combobox<Fruit>>
+
+const Template: StoryFn<typeof Combobox<Fruit>> = (args) => {
+  const availableSizes = ['small', 'medium', 'large'] as const
   const [selectedItem, setSelectedItem] = useState<Fruit | null>(FRUIT[1])
 
   return (
-    <Combobox
-      placeholder="Search fruit..."
-      items={FRUIT}
-      selectedItem={selectedItem}
-      onSelectedItemChange={setSelectedItem}
-      displayValue={(fruit) => fruit.name}
-    />
+    <section className={yStack({ gap: 'lg' })}>
+      {availableSizes.map((size) => (
+        <div key={size} className={yStack({ gap: 'sm' })}>
+          <p>{size.toUpperCase()}</p>
+          <Combobox
+            {...args}
+            size={size}
+            placeholder="Search fruit..."
+            items={FRUIT}
+            selectedItem={selectedItem}
+            onSelectedItemChange={setSelectedItem}
+            displayValue={(fruit) => fruit.name}
+          />
+        </div>
+      ))}
+    </section>
   )
+}
+
+export const Default: Story = {
+  render: Template,
 }

--- a/apps/store/src/components/Combobox/Combobox.tsx
+++ b/apps/store/src/components/Combobox/Combobox.tsx
@@ -1,18 +1,22 @@
+import clsx from 'clsx'
 import { useCombobox } from 'downshift'
 import { Fragment, useState, useMemo, useDeferredValue } from 'react'
 import { ChevronIcon, CrossIconSmall, Text, xStack, theme, WarningTriangleIcon } from 'ui'
 import { useHighlightAnimation } from '@/utils/useHighlightAnimation'
 import {
   wrapper,
+  wrapperExpanded,
   inputWrapper,
-  inputBackground,
   input,
+  inputExpanded,
+  inputWarning,
   actionsWrapper,
-  toggleButton,
-  deleteButton,
+  toggleActionButton,
+  deleteActionButton,
   separator,
   list,
   listItem,
+  listItemHighlighted,
 } from './Combobox.css'
 
 const ITEMS_TO_SHOW = 5
@@ -30,7 +34,7 @@ type Props<Item> = {
   disabled?: boolean
   required?: boolean
   mutliSelect?: boolean
-  size?: 'large' | 'small'
+  size?: 'small' | 'medium' | 'large'
 }
 
 /**
@@ -51,7 +55,7 @@ export function Combobox<Item>({
   size = 'large',
   ...externalInputProps
 }: Props<Item>) {
-  const { highlight, animationProps } = useHighlightAnimation<HTMLDivElement>()
+  const { highlight, animationProps } = useHighlightAnimation<HTMLInputElement>()
 
   const [inputValue, setInputValue] = useState(() => {
     if (defaultSelectedItem) {
@@ -141,37 +145,32 @@ export function Combobox<Item>({
     openMenu()
   }
 
-  const isExanded = isOpen && !noOptions
+  const isExpanded = isOpen && !noOptions
 
   return (
-    <div data-expanded={isExanded} className={wrapper}>
+    <div className={clsx(wrapper[size], isExpanded && wrapperExpanded)}>
+      {/* We use a wrapper for the input here so we can position action buttons (toggle and delete) */}
+      {/* on the right side of the input. Doing it without a wrapper would required add those as children */}
+      {/* of the input, which is not valid HTML.*/}
       <div className={inputWrapper}>
-        <div
-          className={inputBackground}
-          {...animationProps}
-          data-expanded={isExanded}
-          data-warning={noOptions}
-        >
-          <input className={input} {...getInputProps()} {...externalInputProps} data-size={size} />
-        </div>
+        <input
+          className={clsx(input[size], isExpanded && inputExpanded, noOptions && inputWarning)}
+          {...getInputProps({ ref: animationProps.ref })}
+          {...externalInputProps}
+        />
         {internalSelectedItem && (
           <input type="hidden" name={name} value={getFormValue(internalSelectedItem)} />
         )}
         <div className={actionsWrapper}>
           <button
-            className={deleteButton}
+            className={deleteActionButton}
             type="button"
             onClick={handleClickDelete}
             hidden={inputValue.length === 0}
           >
             <CrossIconSmall />
           </button>
-          <button
-            className={toggleButton}
-            type="button"
-            {...getToggleButtonProps()}
-            data-warning={noOptions}
-          >
+          <button className={toggleActionButton} type="button" {...getToggleButtonProps()}>
             <ChevronIcon size="1rem" />
           </button>
         </div>
@@ -183,10 +182,8 @@ export function Combobox<Item>({
             <Fragment key={`${item}${index}`}>
               <hr className={separator} />
               <li
-                className={listItem}
+                className={clsx(listItem, highlightedIndex === index && listItemHighlighted)}
                 {...getItemProps({ item, index })}
-                data-highlighted={highlightedIndex === index}
-                data-size={size}
               >
                 {displayValue(item)}
               </li>


### PR DESCRIPTION
## Describe your changes

* Combobox: support size variants: 'small', 'medium' and 'large'

<img width="341" alt="image" src="https://github.com/user-attachments/assets/3af165c0-0b4a-487f-a4a1-ca7127df6f85">

With that change, Breed Selector now has the same sizing styles and other inputs on new Price Calculator pages:

<img width="847" alt="image" src="https://github.com/user-attachments/assets/6900813e-f384-421b-b58d-68e1afa1bc3d">


## Justify why they are needed

Some of the changes included in Breed Selector [redesign](https://www.figma.com/design/5kmmDdh6StpXzbEfr7WevV/Hedvig-UI-Kit?node-id=15404-12523).