### PR TITLE
Fix product variant selector backgroung being visible under rounded corners

### DIFF
--- a/apps/store/src/blocks/FooterBlock/LanguageSelectForm.tsx
+++ b/apps/store/src/blocks/FooterBlock/LanguageSelectForm.tsx
@@ -31,7 +31,6 @@ export function LanguageSelectForm() {
   }
   const { language: currentLanguage } = useCurrentLocale()
 
-  // TODO: Override background color via css vars when InputSelect supports it
   return (
     <div className={languageSelectForm}>
       <InputSelect
@@ -39,7 +38,7 @@ export function LanguageSelectForm() {
         onChange={handleChangeLanguage}
         defaultValue={currentLanguage}
         options={languageList}
-        backgroundColor={'gray300' as any}
+        backgroundColor="gray300"
       />
     </div>
   )

--- a/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
+++ b/apps/store/src/blocks/ProductVariantSelectorBlock.tsx
@@ -21,7 +21,7 @@ export const ProductVariantSelectorBlock = ({ nested }: ProductVariantSelectorBl
       condition={!nested}
       wrapWith={(children) => <VariantSelectorWrapper>{children}</VariantSelectorWrapper>}
     >
-      <StyledProductVariantSelector />
+      <ProductVariantSelector backgroundColor="signalGreenFill" />
     </ConditionalWrapper>
   )
 }
@@ -37,14 +37,5 @@ const VariantSelectorWrapper = styled.div({
   [mq.md]: {
     top: `calc(${NAVIGATION_LIST_HEIGHT} + 1.5rem)`,
     paddingInline: theme.space.lg,
-  },
-})
-
-const StyledProductVariantSelector = styled(ProductVariantSelector)({
-  backgroundColor: theme.colors.signalGreenFill,
-  boxShadow: theme.shadow.default,
-
-  ':hover, :focus-within': {
-    backgroundColor: theme.colors.signalGreenHighlight,
   },
 })

--- a/apps/store/src/components/InputSelect/InputSelect.css.ts
+++ b/apps/store/src/components/InputSelect/InputSelect.css.ts
@@ -12,6 +12,8 @@ const paddingTop = createVar('selectPaddingTop')
 const labelTop = createVar('selectLabelTop')
 const labelHeight = createVar('selectLabelHeight')
 
+export const selectBackgroundColor = createVar('selectBackgroundColor')
+
 export const wrapperVariants = styleVariants({
   base: {
     position: 'relative',
@@ -93,10 +95,14 @@ export const select = style({
   paddingLeft: paddingHorizontal,
   paddingRight: `calc(${paddingHorizontal} + 1.125rem)`,
 
-  backgroundColor: tokens.colors.translucent1,
+  backgroundColor: selectBackgroundColor,
   borderRadius: tokens.radius.md,
 
   cursor: 'pointer',
+
+  vars: {
+    [selectBackgroundColor]: tokens.colors.translucent1,
+  },
 
   selectors: {
     '&:invalid, &:disabled': {

--- a/apps/store/src/components/InputSelect/InputSelect.tsx
+++ b/apps/store/src/components/InputSelect/InputSelect.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { assignInlineVars } from '@vanilla-extract/dynamic'
 import { clsx } from 'clsx'
 import { type ChangeEventHandler, useId } from 'react'
 import { ChevronIcon, InputBase, type InputBaseProps, type UIColorKeys, getColor } from 'ui'
@@ -10,6 +11,7 @@ import {
   wrapperWithLabelVariants,
   select,
   wrapperVariants,
+  selectBackgroundColor,
 } from './InputSelect.css'
 
 export type InputSelectProps = InputBaseProps & {
@@ -24,7 +26,7 @@ export type InputSelectProps = InputBaseProps & {
   autoFocus?: boolean
   className?: string
   size?: 'small' | 'medium' | 'large'
-  backgroundColor?: Extract<UIColorKeys, 'backgroundStandard' | 'backgroundFrostedGlass'>
+  backgroundColor?: UIColorKeys
 }
 
 export const InputSelect = ({
@@ -74,8 +76,12 @@ export const InputSelect = ({
             onChange={handleChange}
             value={value}
             defaultValue={value ? undefined : (defaultValue ?? '')}
-            style={{ backgroundColor }}
-            className={clsx(select)}
+            style={
+              backgroundColor
+                ? assignInlineVars({ [selectBackgroundColor]: backgroundColor })
+                : undefined
+            }
+            className={select}
             {...animationProps}
             {...rest}
           >

--- a/apps/store/src/components/ProductVariantSelector/ProductVariantSelector.tsx
+++ b/apps/store/src/components/ProductVariantSelector/ProductVariantSelector.tsx
@@ -1,13 +1,13 @@
 import { type ChangeEventHandler, useMemo } from 'react'
-import { InputSelect } from '@/components/InputSelect/InputSelect'
+import { InputSelect, type InputSelectProps } from '@/components/InputSelect/InputSelect'
 import {
   useProductData,
   useSelectedTypeOfContract,
 } from '@/components/ProductData/ProductDataProvider'
 
-type Props = { className?: string }
+type Props = Pick<InputSelectProps, 'className' | 'backgroundColor'>
 
-export const ProductVariantSelector = ({ className }: Props) => {
+export const ProductVariantSelector = ({ className, backgroundColor }: Props) => {
   const productData = useProductData()
   const [selectedTypeOfContract, setSelectedTypeOfContract] = useSelectedTypeOfContract()
 
@@ -33,6 +33,7 @@ export const ProductVariantSelector = ({ className }: Props) => {
       options={variantOptions}
       onChange={handleChange}
       defaultValue={defaultValue}
+      backgroundColor={backgroundColor}
       size="small"
     />
   )


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Product variant selector had double backgrounds and outer one showed under rounded corners

Improved `backgroundColor` prop implementation in `InputSelect` and use it instead of custom styles to make it right

Rejected options:
- `contain: 'paint'` on outer container (only solves half)
- move background and border-radius to outer div (non-obvious API where `InputSelect` behaves as div in regard to styling)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

Before

![Screenshot 2024-08-13 at 08.47.05.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/32e05642-e9bf-4905-9b4e-8ca302311492.png)

After
![Screenshot 2024-08-13 at 09.09.05.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/02e9102a-a36f-4d01-97f0-53c28698ff9a.png)

## Justify why they are needed

## Checklist before requesting a review

- [x] I have performed a self-review of my code
