### PR TITLE
Use atomFamily to keep product-specific atoms scoped

### DIFF
--- a/apps/store/src/components/ProductVariantSelector/ProductVariantSelector.tsx
+++ b/apps/store/src/components/ProductVariantSelector/ProductVariantSelector.tsx
@@ -1,15 +1,18 @@
+import { useAtom } from 'jotai'
 import { type ChangeEventHandler, useMemo } from 'react'
 import { InputSelect, type InputSelectProps } from '@/components/InputSelect/InputSelect'
 import {
   useProductData,
-  useSelectedTypeOfContract,
+  useSelectedTypeOfContractAtom,
 } from '@/components/ProductData/ProductDataProvider'
 
 type Props = Pick<InputSelectProps, 'className' | 'backgroundColor'>
 
 export const ProductVariantSelector = ({ className, backgroundColor }: Props) => {
   const productData = useProductData()
-  const [selectedTypeOfContract, setSelectedTypeOfContract] = useSelectedTypeOfContract()
+  const [selectedTypeOfContract, setSelectedTypeOfContract] = useAtom(
+    useSelectedTypeOfContractAtom(),
+  )
 
   const variantOptions = useMemo(
     () =>

--- a/apps/store/src/features/widget/ProductItemContainer.tsx
+++ b/apps/store/src/features/widget/ProductItemContainer.tsx
@@ -1,9 +1,10 @@
 import { datadogRum } from '@datadog/browser-rum'
+import { useSetAtom } from 'jotai'
 import { useTranslation } from 'next-i18next'
 import { useMemo, type ComponentProps } from 'react'
 import { Button, Space } from 'ui'
 import { CancellationForm } from '@/components/Cancellation/CancellationForm'
-import { useSelectedTypeOfContract } from '@/components/ProductData/ProductDataProvider'
+import { useSelectedTypeOfContractAtom } from '@/components/ProductData/ProductDataProvider'
 import { ProductItem } from '@/components/ProductItemV2/ProductItem'
 import type { Offer } from '@/components/ProductItemV2/ProductItem.types'
 import { ComparisonTableModal } from '@/components/ProductPage/PurchaseForm/ComparisonTableModal'
@@ -29,7 +30,7 @@ export function ProductItemContainer({
   ...delegated
 }: Props) {
   const { t } = useTranslation('purchase-form')
-  const [, setSelectedTypeOfContract] = useSelectedTypeOfContract()
+  const setSelectedTypeOfContract = useSetAtom(useSelectedTypeOfContractAtom())
   const { tiers, deductibles } = useTiersAndDeductibles({
     offers,
     selectedOffer,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Demo of 2nd alternative approach to scoping jotai atoms to React subtree. Original problem and 1st solution can be seen in https://github.com/HedvigInsurance/racoon/pull/4581

Used in next following PR to show multiple product variants next to each other

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
