### PR TITLE
Initial version of terms-hub debugger

### DIFF
--- a/apps/store/src/app/debugger/DebuggerMenu.tsx
+++ b/apps/store/src/app/debugger/DebuggerMenu.tsx
@@ -23,6 +23,10 @@ export function DebuggerMenu() {
         <NavigationMenuPrimitive.Item className={navigationItem}>
           <NavigationLink href="/debugger/car-trial">Car trial debugger</NavigationLink>
         </NavigationMenuPrimitive.Item>
+
+        <NavigationMenuPrimitive.Item className={navigationItem}>
+          <NavigationLink href="/debugger/terms">Terms viewer</NavigationLink>
+        </NavigationMenuPrimitive.Item>
       </NavigationMenuPrimitive.List>
     </NavigationMenuPrimitive.Root>
   )

--- a/apps/store/src/app/debugger/layout.tsx
+++ b/apps/store/src/app/debugger/layout.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react'
-import { DebuggerMenu } from '@/appComponents/DebuggerMenu/DebuggerMenu'
+import { DebuggerMenu } from '@/app/debugger/DebuggerMenu'
 import { RootLayout } from '@/appComponents/RootLayout/RootLayout'
 import { Header } from '@/components/Header/Header'
 import { contentWrapper } from './debugger.css'

--- a/apps/store/src/app/debugger/terms/[productName]/page.tsx
+++ b/apps/store/src/app/debugger/terms/[productName]/page.tsx
@@ -1,0 +1,152 @@
+import { type ReactNode } from 'react'
+import { Heading, tokens, yStack } from 'ui'
+import { InsurableLimitsBlock } from '@/blocks/InsurableLimitsBlock'
+import { PerilsBlock } from '@/blocks/PerilsBlock'
+import { ProductDocumentsBlock } from '@/blocks/ProductDocumentsBlock'
+import { fetchProductData } from '@/components/ProductData/fetchProductData'
+import { ProductDataProvider } from '@/components/ProductData/ProductDataProvider'
+import { setupApolloClient } from '@/services/apollo/app-router/rscClient'
+import { toRoutingLocale } from '@/utils/l10n/localeUtils'
+import { type IsoLocale } from '@/utils/l10n/types'
+
+type Props = {
+  params: { productName: string }
+}
+
+const LOCALES = ['sv-SE', 'en-SE'] as const
+
+async function ProductTermsPage({ params }: Props) {
+  const apolloClient = setupApolloClient({ locale: toRoutingLocale(LOCALES[0]) }).getApolloClient()
+  const { productName } = params
+  const defaultData = await fetchProductData({ apolloClient, productName })
+
+  return (
+    <main className={yStack({ gap: 'xl' })} style={{ maxWidth: '80rem', marginInline: 'auto' }}>
+      <Heading as="h1" align="center">
+        {getTitle(params.productName)}
+      </Heading>
+      {defaultData.variants.map((variant) => (
+        <VariantDetails
+          key={variant.typeOfContract}
+          productName={productName}
+          typeOfContract={variant.typeOfContract}
+        />
+      ))}
+    </main>
+  )
+}
+
+export function generateMetadata({ params }: Props) {
+  return {
+    title: getTitle(params.productName),
+  }
+}
+
+export default ProductTermsPage
+
+const getTitle = (productName: string) => `${productName} - Terms and conditions`
+
+const variantDetailsStyle = {
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+}
+
+function VariantDetails({
+  productName,
+  typeOfContract,
+}: {
+  productName: string
+  typeOfContract: string
+}) {
+  return (
+    <div className={yStack()}>
+      <Heading
+        as="h3"
+        variant="standard.32"
+        style={{ backgroundColor: tokens.colors.signalAmberFill, paddingBlock: '0.5rem' }}
+      >
+        {typeOfContract}
+      </Heading>
+      <div style={variantDetailsStyle} className={yStack({ gap: 'md' })}>
+        <SectionHeader>Perils</SectionHeader>
+        {LOCALES.map((locale) => (
+          <VariantDataProvider
+            key={locale + typeOfContract}
+            productName={productName}
+            typeOfContract={typeOfContract}
+            locale={locale}
+            keyPrefix="perils"
+          >
+            <PerilsBlock blok={{ heading: `Locale: ${locale}` }} />
+          </VariantDataProvider>
+        ))}
+        <SectionHeader>Insurable limits</SectionHeader>
+        {LOCALES.map((locale) => (
+          <VariantDataProvider
+            key={locale + typeOfContract}
+            productName={productName}
+            typeOfContract={typeOfContract}
+            locale={locale}
+            keyPrefix="limits"
+          >
+            <InsurableLimitsBlock />
+          </VariantDataProvider>
+        ))}
+        <SectionHeader>Documents</SectionHeader>
+        {LOCALES.map((locale) => (
+          <VariantDataProvider
+            key={locale + typeOfContract}
+            productName={productName}
+            typeOfContract={typeOfContract}
+            locale={locale}
+            keyPrefix="docs"
+          >
+            <ProductDocumentsBlock blok={{ heading: locale, description: '' }} />
+          </VariantDataProvider>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function SectionHeader({ children }: { children: ReactNode }) {
+  return (
+    <Heading
+      as="h4"
+      variant="standard.24"
+      style={{
+        gridColumn: '1 / span 2',
+        backgroundColor: tokens.colors.signalGreenFill,
+        paddingInline: '1rem',
+      }}
+    >
+      {children}
+    </Heading>
+  )
+}
+
+async function VariantDataProvider({
+  locale,
+  productName,
+  typeOfContract,
+  children,
+  keyPrefix,
+}: {
+  locale: IsoLocale
+  productName: string
+  typeOfContract: string
+  children: ReactNode
+  keyPrefix: string
+}) {
+  const apolloClient = setupApolloClient({ locale: toRoutingLocale(locale) }).getApolloClient()
+  const productData = await fetchProductData({ apolloClient, productName })
+  return (
+    <ProductDataProvider
+      productKey={[keyPrefix, locale, productName, typeOfContract].join(':')}
+      productData={productData}
+      selectedTypeOfContract={typeOfContract}
+    >
+      {children}
+    </ProductDataProvider>
+  )
+}

--- a/apps/store/src/app/debugger/terms/page.tsx
+++ b/apps/store/src/app/debugger/terms/page.tsx
@@ -1,0 +1,41 @@
+import { Suspense } from 'react'
+import { Heading, yStack } from 'ui'
+import { ButtonNextLink } from '@/components/ButtonNextLink'
+import { fetchGlobalProductMetadata } from '@/components/LayoutWithMenu/fetchProductMetadata'
+import { setupApolloClient } from '@/services/apollo/app-router/rscClient'
+import { locales } from '@/utils/l10n/locales'
+
+function TermsNavigationPage() {
+  return (
+    <main className={yStack({})} style={{ maxWidth: '40rem', marginInline: 'auto' }}>
+      <Heading as="h1" align="center">
+        Terms and conditions
+      </Heading>
+      <Suspense fallback={'Loading...'}>
+        <AvailableProductSelector />
+      </Suspense>
+    </main>
+  )
+}
+
+async function AvailableProductSelector() {
+  const availableProducts = await fetchGlobalProductMetadata({
+    apolloClient: setupApolloClient({ locale: locales['sv-SE'].routingLocale }).getApolloClient(),
+  })
+  return (
+    <div className={yStack({})}>
+      {availableProducts.map((product) => (
+        <ButtonNextLink
+          key={product.id}
+          variant="secondary-alt"
+          href={`/debugger/terms/${product.name}`}
+          prefetch={false}
+        >
+          {product.displayNameFull}
+        </ButtonNextLink>
+      ))}
+    </div>
+  )
+}
+
+export default TermsNavigationPage

--- a/apps/store/src/components/ProductData/ProductData.graphql
+++ b/apps/store/src/components/ProductData/ProductData.graphql
@@ -1,33 +1,41 @@
+fragment ProductVariant on ProductVariant {
+  typeOfContract
+  displayName
+  displayNameSubtype
+  perils {
+    ...Peril
+  }
+  insurableLimits {
+    type
+    label
+    limit
+    description
+  }
+  documents {
+    ...InsuranceDocument
+  }
+}
+
+fragment ProductDataFull on Product {
+  id
+  name
+  displayNameFull
+  displayNameShort
+  tagline
+  pageLink
+  priceCalculatorPageLink
+  pillowImage {
+    id
+    alt
+    src
+  }
+  variants {
+    ...ProductVariant
+  }
+}
+
 query ProductData($productName: String!, $partnerName: String) {
   product(productName: $productName, partnerName: $partnerName) {
-    id
-    name
-    displayNameFull
-    displayNameShort
-    tagline
-    pageLink
-    priceCalculatorPageLink
-    pillowImage {
-      id
-      alt
-      src
-    }
-    variants {
-      typeOfContract
-      displayName
-      displayNameSubtype
-      perils {
-        ...Peril
-      }
-      insurableLimits {
-        type
-        label
-        limit
-        description
-      }
-      documents {
-        ...InsuranceDocument
-      }
-    }
+    ...ProductDataFull
   }
 }

--- a/apps/store/src/components/ProductData/ProductDataProvider.tsx
+++ b/apps/store/src/components/ProductData/ProductDataProvider.tsx
@@ -22,6 +22,7 @@ type Props = {
   children: ReactNode
   productData: ProductData
   selectedTypeOfContract?: string
+  productKey?: string
 }
 
 const ProductKeyContext = createContext<string | null>(null)
@@ -29,7 +30,9 @@ const ProductKeyContext = createContext<string | null>(null)
 // NOTE: No cleanup on atomFamilies here - we don't have that many products, so it's easier to retain all data
 export const ProductDataProvider = (props: Props) => {
   const locale = useRoutingLocale()
-  const key = productKey(props.productData.id, locale)
+  // Custom key is only used in terms debugger page when we want to have several providers (one per variant)
+  // on the same page - different key makes them not clash
+  const key = props.productKey ?? productKey(props.productData.id, locale)
   useHydrateAtoms([
     [productDataAtomFamily(key), props.productData],
     [selectedTypeOfContractAtomFamily(key), props.selectedTypeOfContract ?? null],

--- a/apps/store/src/services/apollo/app-router/rscClient.ts
+++ b/apps/store/src/services/apollo/app-router/rscClient.ts
@@ -45,8 +45,14 @@ const logRequests = process.env.NODE_ENV === 'development'
 const requestLogger = new ApolloLink((operation, forward) => {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (logRequests) {
+    let locale: string | undefined
+    try {
+      locale = operation.getContext()['headers']['Hedvig-Language']
+    } catch (err) {
+      // ignore errors
+    }
     console.log(
-      `GraphQL operation ${operation.operationName}, variables=${JSON.stringify(operation.variables)}`,
+      `GraphQL operation ${operation.operationName}, variables=${JSON.stringify(operation.variables)}, locale=${locale}`,
     )
   }
   return forward(operation)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Prototype of internal tool for showing terms data in both languages side-by-side

![Screenshot 2024-08-14 at 14.01.11.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/6130813c-132b-4123-a8df-89fc914816c0.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Allows manual verification of imported PCMS data. We foresee some risks related to matching texts between languages. This representation should make it easier to check compared to viewing product pages in multiple tabs

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
