### PR TITLE
GEN-2432 - styles(StoryblokLayout): make sure footer is always at the bottom of the page

### DIFF
--- a/apps/store/src/app/[locale]/StoryblokLayout.css.ts
+++ b/apps/store/src/app/[locale]/StoryblokLayout.css.ts
@@ -3,6 +3,10 @@ import { bodyBgColor, bodyTextColor, footerBgColor } from 'ui/src/theme/vars.css
 import { tokens } from 'ui'
 
 export const wrapper = style({
+  display: 'grid',
+  // 'Sticky' footer at the bottom of the page.
+  // Based on 'GlobalStory' type a 'header' and a 'footer' are always expected
+  gridTemplateRows: 'auto 1fr auto',
   minHeight: '100vh',
   isolation: 'isolate',
   selectors: {


### PR DESCRIPTION
## Describe your changes

* make sure footer is always at the bottom of the page

## Justify why they are needed

For large screens, footer might not be at very bottom of the page as expected, depending on the size of the content.

![Screenshot 2024-08-14 at 09 53 31](https://github.com/user-attachments/assets/1d512e3f-7540-418c-8a25-e5917e830823)