### PR TITLE
refact(yStack/xStack): make arguments optional

### DIFF
--- a/apps/store/src/components/BankIdDialog/BankIdDialog.tsx
+++ b/apps/store/src/components/BankIdDialog/BankIdDialog.tsx
@@ -111,7 +111,7 @@ export function BankIdDialog() {
         )
         Footer =
           !isMobile && currentOperation.autoStartToken ? (
-            <div className={yStack({ alignItems: 'center', gap: 'none' })}>
+            <div className={yStack({ alignItems: 'center' })}>
               <Text>{t('NO_MOBILE_BANKID_TITLE')}</Text>
               <Link
                 className={link}

--- a/apps/store/src/components/StepperInput/StepperInput.tsx
+++ b/apps/store/src/components/StepperInput/StepperInput.tsx
@@ -72,7 +72,7 @@ export const StepperInput = (props: StepperInputProps) => {
 
   return (
     <div className={clsx(outerWrapper, className)} {...animationProps}>
-      <div className={yStack({ gap: 'none', flexGrow: 1 })}>
+      <div className={yStack({ flexGrow: 1 })}>
         {label && (
           <label id={labelId} className={inputLabel} htmlFor={selectId}>
             {label}

--- a/apps/store/src/features/priceCalculator/OfferPresenterV2.tsx
+++ b/apps/store/src/features/priceCalculator/OfferPresenterV2.tsx
@@ -89,7 +89,7 @@ export const OfferPresenterV2 = memo(() => {
   }, [tiers, selectedOffer])
 
   return (
-    <div className={yStack({})}>
+    <div className={yStack({ gap: 'md' })}>
       {tiers.length > 1 && (
         <div className={yStack({ alignItems: 'stretch' })}>
           <ProductTierSelectorV2

--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.tsx
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.tsx
@@ -30,10 +30,7 @@ export async function PriceCalculatorCmsPage({ locale, story }: Props) {
   }
   const { productName } = await getPriceTemplate(story.content.priceTemplate)
   return (
-    <div
-      className={xStack({ gap: 'none' })}
-      style={{ backgroundColor: tokens.colors.backgroundStandard }}
-    >
+    <div className={xStack()} style={{ backgroundColor: tokens.colors.backgroundStandard }}>
       <div
         style={{
           position: 'sticky',

--- a/apps/store/src/features/priceCalculator/ProductCardSmall.tsx
+++ b/apps/store/src/features/priceCalculator/ProductCardSmall.tsx
@@ -17,7 +17,7 @@ export function ProductCardSmall({ children, productData, subtitle }: Props) {
     <div className={card}>
       <div className={xStack({ alignItems: 'center', gap: 'sm' })}>
         <Pillow src={productData.pillowImage.src} size="small" />
-        <div className={yStack({ gap: 'none' })}>
+        <div className={yStack()}>
           <Text as="span" size="lg">
             {productData.displayNameFull}
           </Text>

--- a/apps/store/src/features/priceCalculator/ProductTierSelectorV2.tsx
+++ b/apps/store/src/features/priceCalculator/ProductTierSelectorV2.tsx
@@ -29,7 +29,7 @@ export function ProductTierSelectorV2({ offers, selectedOffer, onValueChange }: 
       <CardRadioGroup.Root value={selectedOffer.id} onValueChange={onValueChange}>
         {offers.map((offer) => (
           <CardRadioGroup.Item key={offer.id} value={offer.id} style={{ padding: tokens.space.lg }}>
-            <div className={yStack({ gap: 'none' })}>
+            <div className={yStack()}>
               <div className={xStack({ justifyContent: 'space-between', alignItems: 'center' })}>
                 <Heading as="h2" variant="standard.24">
                   {offer.variant.displayNameSubtype || offer.variant.displayName}

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2.tsx
@@ -45,7 +45,7 @@ export function PurchaseFormV2() {
       )
     case 'viewOffers':
       return (
-        <div className={yStack({})} style={{ gap: '2.75rem' }}>
+        <div className={yStack({ gap: 'md' })} style={{ gap: '2.75rem' }}>
           <InsuranceDataForm />
           <OfferPresenterV2 />
         </div>

--- a/packages/ui/src/patterns/stack.ts
+++ b/packages/ui/src/patterns/stack.ts
@@ -5,16 +5,16 @@ type StackPatternParams = {
   direction?: 'row' | 'column'
 } & Omit<Sprinkles, 'display' | 'flexDirection'>
 
-export const stack = ({ direction = 'column', gap = 'md', ...params }: StackPatternParams) => {
-  return sprinkles({ display: 'flex', flexDirection: direction, gap, ...params })
+const stack = ({ direction = 'column', ...params }: StackPatternParams) => {
+  return sprinkles({ display: 'flex', flexDirection: direction, ...params })
 }
 
 type DirectedStackPatternParams = Omit<StackPatternParams, 'direction'>
 
-export const xStack = (params: DirectedStackPatternParams) => {
+export const xStack = (params?: DirectedStackPatternParams) => {
   return stack({ direction: 'row', ...params })
 }
 
-export const yStack = (params: DirectedStackPatternParams) => {
+export const yStack = (params?: DirectedStackPatternParams) => {
   return stack({ direction: 'column', ...params })
 }

--- a/packages/ui/src/theme/sprinkles.css.ts
+++ b/packages/ui/src/theme/sprinkles.css.ts
@@ -38,7 +38,7 @@ const unresponsiveProperties = defineProperties({
     display: ['flex', 'grid', 'none'],
     flexDirection: ['row', 'column'],
     flexGrow: [1],
-    gap: { ...spaceTokensSubset, none: 0 },
+    gap: { ...spaceTokensSubset },
     marginInline: spaceTokensSubset,
     marginTop: spaceTokensSubset,
     marginBottom: spaceTokensSubset,


### PR DESCRIPTION
## Describe your changes

* Update xStack/yStack apis so parameters became optional. Then `yStack()` would mean the same as `yStack({})` without the necessity of an empty object.
* Make `gap` opt in to `stack` by removing default `gap`. Then `yStack()` would be the same gapwise as `yStack({gap:'none'})`

## Justify why they are needed

Subjective. I think that API is easier to work with. Let me know what you think.
