### PR TITLE
Revert "styles(StoryblokLayout): make sure footer is always at the bottom of the page (#4594)"

### DIFF
--- a/apps/store/src/app/[locale]/StoryblokLayout.css.ts
+++ b/apps/store/src/app/[locale]/StoryblokLayout.css.ts
@@ -3,10 +3,6 @@ import { bodyBgColor, bodyTextColor, footerBgColor } from 'ui/src/theme/vars.css
 import { tokens } from 'ui'
 
 export const wrapper = style({
-  display: 'grid',
-  // 'Sticky' footer at the bottom of the page.
-  // Based on 'GlobalStory' type a 'header' and a 'footer' are always expected
-  gridTemplateRows: 'auto 1fr auto',
   minHeight: '100vh',
   isolation: 'isolate',
   selectors: {


### PR DESCRIPTION
## Describe your changes

Reverts "sticky at the bottom footer" styles since it causes other responsive issues
