### PR TITLE
Optimize responsive layout in Perils grid with ResizeObserver instead of window-based media queries

### DIFF
--- a/apps/store/src/utils/useElementSize.ts
+++ b/apps/store/src/utils/useElementSize.ts
@@ -1,0 +1,28 @@
+import { useIsomorphicLayoutEffect } from 'framer-motion'
+import { type RefObject, useCallback, useState } from 'react'
+
+// Heavily inspired by
+// https://github.com/juliencrn/usehooks-ts/blob/master/packages/usehooks-ts/src/useResizeObserver/useResizeObserver.ts
+export const useElementSize = <E extends HTMLElement>(elementRef: RefObject<E>) => {
+  const [size, setSize] = useState({ width: 0, height: 0 })
+  const handleResize: ResizeObserverCallback = useCallback((resizeEntry) => {
+    setSize((prevSize) => {
+      const width = resizeEntry[0].borderBoxSize[0].inlineSize
+      const height = resizeEntry[0].borderBoxSize[0].blockSize
+      // Prevent rerenders by returning old value if unchanged
+      if (width === prevSize.width && height === prevSize.height) {
+        return prevSize
+      } else {
+        return { width, height }
+      }
+    })
+  }, [])
+  useIsomorphicLayoutEffect(() => {
+    const observer = new ResizeObserver(handleResize)
+    if (elementRef.current != null) {
+      observer.observe(elementRef.current)
+    }
+    return () => observer.disconnect()
+  }, [elementRef, handleResize])
+  return size
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

- Refactor how `Perils` component implements responsive number of column
- Commented why current solution uses JS responsive logic instead of usual CSS solutions

New solution uses container size instead of window size. This works better in terms debugger where we have 2 perils blocks size by size and window-based size is way off

**Performance effect**
~5% reduction in product page scripting time

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
