### PR TITLE
GEN-2432 - fix(checkoutv2): display product item form checkout/cart page

### DIFF
--- a/apps/store/src/app/[locale]/new/checkout/CartEntries.tsx
+++ b/apps/store/src/app/[locale]/new/checkout/CartEntries.tsx
@@ -1,68 +1,20 @@
 'use client'
 
-import { datadogLogs } from '@datadog/browser-logs'
 import { motion, AnimatePresence } from 'framer-motion'
-import { useRouter, useSearchParams } from 'next/navigation'
-import { ProductItem } from '@/components/ProductItemV2/ProductItem'
-import { OPEN_PRICE_CALCULATOR_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam'
-import { PRELOADED_PRICE_INTENT_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/usePreloadedPriceIntentId'
-import { CART_ENTRY_TO_REPLACE_QUERY_PARAM } from '@/components/ProductPage/useCartEntryToReplace'
+import { useSearchParams } from 'next/navigation'
+import { EditActionButton } from '@/components/ProductItem/EditActionButton'
+import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
+import { RemoveActionButton } from '@/components/ProductItem/RemoveActionButton'
 import { DiscountFieldContainer } from '@/components/ShopBreakdown/DiscountFieldContainer'
 import { Divider, ShopBreakdown } from '@/components/ShopBreakdown/ShopBreakdown'
 import { TotalAmountContainer } from '@/components/ShopBreakdown/TotalAmountContainer'
-import { useShowAppError } from '@/services/appErrors/appErrorAtom'
-import {
-  useCartEntryRemoveMutation,
-  type ProductOfferFragment,
-  type ShopSessionFragment,
-} from '@/services/graphql/generated'
-import { useTracking } from '@/services/Tracking/useTracking'
-import { Features } from '@/utils/Features'
+import { type ShopSessionFragment } from '@/services/graphql/generated'
 import { QueryParam } from './CheckoutPage.constants'
 
 type Props = { shopSession: ShopSessionFragment }
 
 export function CartEntries({ shopSession }: Props) {
-  const tracking = useTracking()
-  const showError = useShowAppError()
   const searchParams = useSearchParams()
-
-  const [removeCartItem] = useCartEntryRemoveMutation({
-    awaitRefetchQueries: true,
-    onError(error) {
-      datadogLogs.logger.error('Checkout Page | Failed to remove offer from cart', {
-        shopSessionId: shopSession.id,
-        error,
-      })
-      showError(error)
-    },
-  })
-
-  const handleRemoveCartItem = (offer: ProductOfferFragment) => {
-    tracking.reportDeleteFromCart(offer)
-    removeCartItem({ variables: { shopSessionId: shopSession.id, offerId: offer.id } })
-  }
-
-  const router = useRouter()
-  const handleEditCartItem = (offer: ProductOfferFragment) => {
-    let targetUrl = new URL(offer.product.pageLink, window.location.origin)
-    if (
-      Features.enabled('PRICE_CALCULATOR_PAGE') &&
-      offer.product.priceCalculatorPageLink != null
-    ) {
-      targetUrl = new URL(offer.product.priceCalculatorPageLink, window.location.origin)
-    } else {
-      targetUrl.searchParams.set(OPEN_PRICE_CALCULATOR_QUERY_PARAM, '1')
-      // NOTE: Temporary code path, no need to handle this after PriceCalculatorPage is used everywhere
-      if (offer.priceIntentId == null) {
-        throw new Error('Expected to have offer.priceIntentId')
-      }
-      targetUrl.searchParams.set(PRELOADED_PRICE_INTENT_QUERY_PARAM, offer.priceIntentId)
-    }
-    targetUrl.searchParams.set(CART_ENTRY_TO_REPLACE_QUERY_PARAM, offer.id)
-
-    router.push(targetUrl.toString())
-  }
 
   return (
     <>
@@ -76,12 +28,17 @@ export function CartEntries({ shopSession }: Props) {
               exit={{ opacity: 0, height: 0 }}
               style={{ position: 'relative' }}
             >
-              <ProductItem
-                selectedOffer={offer}
-                onDelete={() => handleRemoveCartItem(offer)}
-                onEdit={() => handleEditCartItem(offer)}
+              <ProductItemContainer
+                offer={offer}
                 defaultExpanded={searchParams?.get(QueryParam.ExpandCart) === '1'}
-              />
+              >
+                <EditActionButton offer={offer} />
+                <RemoveActionButton
+                  shopSessionId={shopSession.id}
+                  offer={offer}
+                  title={offer.product.displayNameFull}
+                />
+              </ProductItemContainer>
             </motion.div>
           ))}
         </AnimatePresence>

--- a/apps/store/src/app/[locale]/new/checkout/CheckoutForm.tsx
+++ b/apps/store/src/app/[locale]/new/checkout/CheckoutForm.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { useApolloClient } from '@apollo/client'
-import { useRouter } from 'next/navigation'
 import { useTranslation } from 'next-i18next'
-import { useCallback, useEffect, useRef, useState, useTransition } from 'react'
+import { useState } from 'react'
 import { Text, Button, BankIdIcon, yStack } from 'ui'
+import { useAsyncRouterPush } from '@/appComponents/useAsyncRouterPush'
 import { useHandleSubmitCheckout } from '@/components/CheckoutPage/useHandleSubmitCheckout'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
 import { PersonalNumberField } from '@/components/PersonalNumberField/PersonalNumberField'
@@ -69,9 +69,6 @@ export function CheckoutForm({
       resetShopSession()
 
       const nextCheckoutStep = getNextCheckoutStep(data.currentMember.paymentInformation.status)
-      // TODO: router from next/navigation has a different API so we can't wait for the router to be updated
-      // before we navigate to the next step. We probably gonna need to change how BankIdDialog works so
-      // we can have smooth transitions between sucess state and connect payment page.
       await push(getCheckoutStepLink({ locale, step: nextCheckoutStep, shopSessionId }))
     },
     onError() {
@@ -168,37 +165,4 @@ function getNextCheckoutStep(connectPaymentStatus: MemberPaymentConnectionStatus
   const nextCheckoutStep = checkoutSteps[1]
 
   return nextCheckoutStep
-}
-
-// Hacky solution to wait for the router to finish the transition as `router` from `next/navigation`
-// package doesn't have a promise based API to wait for the transition to finish. They don't expose
-// events either. They claim that all navigations in app router are built on React Transitions so
-// the way forward for knowing wherebouts of a navigation is to use `useTransition` hook from React.
-// More info https://github.com/vercel/next.js/discussions/41934#discussioncomment-8996669
-function useAsyncRouterPush() {
-  const router = useRouter()
-  // We assume no other transition will happening at the same time
-  const [isPending] = useTransition()
-  const promiseResolveFnRef = useRef<((value?: unknown) => void) | null>(null)
-
-  useEffect(() => {
-    if (!isPending) {
-      promiseResolveFnRef.current?.()
-    }
-  }, [isPending])
-
-  const push = useCallback(
-    (url: string) => {
-      return new Promise((resolve) => {
-        // Ideally we could attach the resolve function to a router event but they're not exposed
-        // by next/navigation router. So we're using a ref to store the resolve function and calling
-        // it when the transition is finished based on the `isPending` value.
-        promiseResolveFnRef.current = resolve
-        router.push(url)
-      })
-    },
-    [router],
-  )
-
-  return push
 }

--- a/apps/store/src/appComponents/useAsyncRouterPush.tsx
+++ b/apps/store/src/appComponents/useAsyncRouterPush.tsx
@@ -1,0 +1,35 @@
+import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useRef, useTransition } from 'react'
+
+// Hacky solution to wait for the router to finish the transition as `router` from `next/navigation`
+// package doesn't have a promise based API to wait for the transition to finish. They don't expose
+// events either. They claim that all navigations in app router are built on React Transitions so
+// the way forward for knowing wherebouts of a navigation is to use `useTransition` hook from React.
+// More info https://github.com/vercel/next.js/discussions/41934#discussioncomment-8996669
+export function useAsyncRouterPush() {
+  const router = useRouter()
+  // We assume no other transition will happening at the same time
+  const [isPending] = useTransition()
+  const promiseResolveFnRef = useRef<((value?: unknown) => void) | null>(null)
+
+  useEffect(() => {
+    if (!isPending) {
+      promiseResolveFnRef.current?.()
+    }
+  }, [isPending])
+
+  const push = useCallback(
+    (url: string) => {
+      return new Promise((resolve) => {
+        // Ideally we could attach the resolve function to a router event but they're not exposed
+        // by next/navigation router. So we're using a ref to store the resolve function and calling
+        // it when the transition is finished based on the `isPending` value.
+        promiseResolveFnRef.current = resolve
+        router.push(url)
+      })
+    },
+    [router],
+  )
+
+  return push
+}

--- a/apps/store/src/components/CartPage/CartPage.tsx
+++ b/apps/store/src/components/CartPage/CartPage.tsx
@@ -84,7 +84,7 @@ export const CartPage = () => {
                       offer={item}
                       defaultExpanded={router.query[QueryParam.ExpandCart] === '1'}
                     >
-                      <EditActionButton shopSessionId={shopSession.id} offer={item} />
+                      <EditActionButton offer={item} />
                       <RemoveActionButton
                         shopSessionId={shopSession.id}
                         offer={item}

--- a/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
+++ b/apps/store/src/components/CheckoutPage/CheckoutPage.tsx
@@ -86,7 +86,7 @@ const CheckoutPage = (props: CheckoutPageProps) => {
                       offer={item}
                       defaultExpanded={router.query[QueryParam.ExpandCart] === '1'}
                     >
-                      <EditActionButton shopSessionId={shopSession.id} offer={item} />
+                      <EditActionButton offer={item} />
                       <RemoveActionButton
                         shopSessionId={shopSession.id}
                         offer={item}

--- a/apps/store/src/components/ProductItem/EditActionButton.tsx
+++ b/apps/store/src/components/ProductItem/EditActionButton.tsx
@@ -3,33 +3,19 @@ import { useTranslation } from 'next-i18next'
 import Balancer from 'react-wrap-balancer'
 import { Button, Text } from 'ui'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
-import { useShowAppError } from '@/services/appErrors/appErrorAtom'
 import type { ProductOfferFragment } from '@/services/graphql/generated'
 import { ActionButton } from './ProductItem'
 import { useEditProductOffer } from './useEditProductOffer'
 
 type Props = {
-  shopSessionId: string
   offer: ProductOfferFragment
 }
 
-export const EditActionButton = (props: Props) => {
-  const showError = useShowAppError()
+export const EditActionButton = ({ offer }: Props) => {
   const { t } = useTranslation(['cart', 'common'])
   const [editProductOffer, state] = useEditProductOffer()
 
-  const handleConfirmEdit = () => {
-    try {
-      editProductOffer({
-        shopSessionId: props.shopSessionId,
-        offerId: props.offer.id,
-        productName: props.offer.product.name,
-        data: props.offer.priceIntentData,
-      })
-    } catch (error) {
-      showError(new Error(t('common:UNKNOWN_ERROR_MESSAGE')))
-    }
-  }
+  const handleConfirmEdit = () => editProductOffer({ offer })
 
   return (
     <FullscreenDialog.Root>

--- a/apps/store/src/components/ProductItem/useEditProductOffer.ts
+++ b/apps/store/src/components/ProductItem/useEditProductOffer.ts
@@ -1,79 +1,51 @@
-import { useApolloClient } from '@apollo/client'
 import { datadogLogs } from '@datadog/browser-logs'
-import { useRouter } from 'next/router'
 import { useState } from 'react'
-import { useProductMetadata } from '@/components/LayoutWithMenu/productMetadataHooks'
+import { useAsyncRouterPush } from '@/appComponents/useAsyncRouterPush'
 import { OPEN_PRICE_CALCULATOR_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/useOpenPriceCalculatorQueryParam'
 import { PRELOADED_PRICE_INTENT_QUERY_PARAM } from '@/components/ProductPage/PurchaseForm/usePreloadedPriceIntentId'
 import { CART_ENTRY_TO_REPLACE_QUERY_PARAM } from '@/components/ProductPage/useCartEntryToReplace'
 import { useShowAppError } from '@/services/appErrors/appErrorAtom'
-import { getPriceTemplate } from '@/services/PriceCalculator/PriceCalculator.helpers'
-import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntentService'
+import type { ProductOfferFragment } from '@/services/graphql/generated'
+import { Features } from '@/utils/Features'
 
 type State = 'idle' | 'loading' | 'error'
 
 type Params = {
-  shopSessionId: string
-  offerId: string
-  data: any
-  productName: string
+  offer: ProductOfferFragment
 }
 
 export const useEditProductOffer = () => {
   const [state, setState] = useState<State>('idle')
-  const apolloClient = useApolloClient()
-  const products = useProductMetadata()
-  const router = useRouter()
   const showError = useShowAppError()
+  const push = useAsyncRouterPush()
 
-  const editProductOffer = async (params: Params) => {
-    setState('loading')
-    // TODO: Check if product offer is connected to price intent -- if not, create new one
-
-    const product = products?.find((item) => item.name === params.productName)
-    if (!product) {
-      datadogLogs.logger.error('Edit Offer | Product not found', {
-        productName: params.productName,
-        productNames: products?.map((item) => item.name),
-        offerId: params.offerId,
-      })
-      throw new Error(`Edit Offer | Product not found: ${params.productName}`)
-    }
-
-    const priceIntentService = priceIntentServiceInitClientSide(apolloClient)
-    const priceTemplate = getPriceTemplate(params.productName)
-    if (!priceTemplate) {
-      setState('error')
-      datadogLogs.logger.error('Price template not found', { productName: params.productName })
-      return
-    }
-
+  const editProductOffer = async ({ offer }: Params) => {
     try {
-      const priceIntent = await priceIntentService.create({
-        shopSessionId: params.shopSessionId,
-        productName: params.productName,
-        priceTemplate,
-      })
-      await priceIntentService.update({
-        priceIntentId: priceIntent.id,
-        data: params.data,
-        customer: { shopSessionId: params.shopSessionId },
-      })
+      setState('loading')
 
-      await router.push({
-        pathname: product.pageLink,
-        query: {
-          [OPEN_PRICE_CALCULATOR_QUERY_PARAM]: 1,
-          [CART_ENTRY_TO_REPLACE_QUERY_PARAM]: params.offerId,
-          [PRELOADED_PRICE_INTENT_QUERY_PARAM]: priceIntent.id,
-        },
-      })
+      let targetUrl = new URL(offer.product.pageLink, window.location.origin)
+      if (
+        Features.enabled('PRICE_CALCULATOR_PAGE') &&
+        offer.product.priceCalculatorPageLink != null
+      ) {
+        targetUrl = new URL(offer.product.priceCalculatorPageLink, window.location.origin)
+      } else {
+        targetUrl.searchParams.set(OPEN_PRICE_CALCULATOR_QUERY_PARAM, '1')
+        // NOTE: Temporary code path, no need to handle this after PriceCalculatorPage is used everywhere
+        if (offer.priceIntentId == null) {
+          throw new Error('Expected to have offer.priceIntentId')
+        }
+        targetUrl.searchParams.set(PRELOADED_PRICE_INTENT_QUERY_PARAM, offer.priceIntentId)
+      }
+      targetUrl.searchParams.set(CART_ENTRY_TO_REPLACE_QUERY_PARAM, offer.id)
+      await push(targetUrl.toString())
+
       setState('idle')
     } catch (error) {
       setState('error')
       datadogLogs.logger.error('Error while editing product offer', {
         error,
-        offerId: params.offerId,
+        offerId: offer.id,
       })
       showError(error as Error)
     }


### PR DESCRIPTION
## Describe your changes

* New checkout page: render the same product item card we already use on checkout/cart pages today. With that we'll:
  * Include the confirmation dialog for deletion
  * Solves an issue where it's not possible to edit
  * Add exposure + start date information


## Justify why they are needed

Requested during a testing session.