### PR TITLE
GEN-2432 - fix(checkoutv2): added bundle offers

### DIFF
--- a/apps/store/src/app/[locale]/new/checkout/CartEntries.tsx
+++ b/apps/store/src/app/[locale]/new/checkout/CartEntries.tsx
@@ -1,20 +1,55 @@
 'use client'
 
 import { motion, AnimatePresence } from 'framer-motion'
+import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
+import { useTranslation } from 'next-i18next'
+import { useEffect } from 'react'
+import { Text, yStack } from 'ui'
 import { EditActionButton } from '@/components/ProductItem/EditActionButton'
 import { ProductItemContainer } from '@/components/ProductItem/ProductItemContainer'
 import { RemoveActionButton } from '@/components/ProductItem/RemoveActionButton'
 import { DiscountFieldContainer } from '@/components/ShopBreakdown/DiscountFieldContainer'
 import { Divider, ShopBreakdown } from '@/components/ShopBreakdown/ShopBreakdown'
 import { TotalAmountContainer } from '@/components/ShopBreakdown/TotalAmountContainer'
+import {
+  BUNDLE_DISCOUNT_PERCENTAGE,
+  BUNDLE_DISCOUNT_PROMO_PAGE_PATH,
+  hasBundleDiscount,
+  hasCartItemsEligibleForBundleDiscount,
+} from '@/features/bundleDiscount/bundleDiscount'
+import { BundleDiscountExtraProductLinks } from '@/features/bundleDiscount/BundleDiscountExtraProductLinks'
+import { readMoreLink } from '@/features/bundleDiscount/BundleDiscountSummary.css'
 import { type ShopSessionFragment } from '@/services/graphql/generated'
+import { useTracking } from '@/services/Tracking/useTracking'
 import { QueryParam } from './CheckoutPage.constants'
 
 type Props = { shopSession: ShopSessionFragment }
 
 export function CartEntries({ shopSession }: Props) {
+  const { t } = useTranslation('cart')
+  const tracking = useTracking()
   const searchParams = useSearchParams()
+
+  // - Do not show if only accident is in the cart (confusing)
+  // - Do not show if there's a discount already (mostly not relevant anymore)
+  const shouldShowBundleDiscountProducts =
+    hasCartItemsEligibleForBundleDiscount(shopSession) && !hasBundleDiscount(shopSession)
+
+  const lastItem = shopSession.cart.entries.at(-1)
+  // GOTCHA: useInView did not work on initial navigation for some reason, so let's just report as effect
+  useEffect(() => {
+    if (shouldShowBundleDiscountProducts && lastItem != null) {
+      tracking.reportViewPromotion({
+        promotionId: 'bundle_discount',
+        creativeName: 'BUNDLE_DISCOUNT_QUICK_LINKS',
+        productId: lastItem.product.id,
+        productName: lastItem.product.displayNameFull,
+        productVariant: lastItem.variant.typeOfContract,
+        priceAmount: lastItem.cost.net.amount,
+      })
+    }
+  }, [shouldShowBundleDiscountProducts, tracking, lastItem])
 
   return (
     <>
@@ -46,6 +81,28 @@ export function CartEntries({ shopSession }: Props) {
       <DiscountFieldContainer shopSession={shopSession} />
       <Divider />
       <TotalAmountContainer cart={shopSession.cart} />
+
+      {shouldShowBundleDiscountProducts && (
+        <div className={yStack({ gap: 'md' })}>
+          <BundleDiscountExtraProductLinks>
+            <div>
+              <Text>{t('BUNDLE_DISCOUNT_QUICK_LINKS_TITLE')}</Text>
+              <Text color="textSecondary">
+                {t('BUNDLE_DISCOUNT_QUICK_LINKS_SUBTITLE', {
+                  percentage: BUNDLE_DISCOUNT_PERCENTAGE,
+                })}{' '}
+                <Link
+                  href={BUNDLE_DISCOUNT_PROMO_PAGE_PATH}
+                  target="_blank"
+                  className={readMoreLink}
+                >
+                  {t('READ_MORE', { ns: 'common' })}
+                </Link>
+              </Text>
+            </div>
+          </BundleDiscountExtraProductLinks>
+        </div>
+      )}
     </>
   )
 }

--- a/apps/store/src/app/[locale]/new/checkout/CheckoutPage.css.ts
+++ b/apps/store/src/app/[locale]/new/checkout/CheckoutPage.css.ts
@@ -15,7 +15,7 @@ export const layout = style({
 
 export const content = style([
   yStack({
-    gap: 'md',
+    gap: 'lg',
   }),
   {
     gridColumn: '1 / -1',


### PR DESCRIPTION
## Describe your changes

* Display bundle offers in new checkout page.

<img width="819" alt="image" src="https://github.com/user-attachments/assets/02ceb106-2fc1-4b5e-9678-b39ab5ec0c11">


Logic for showing bundle offers were copied from `CartPage` meaning we have it twice. But when this get's released and `CartPage` deleted, we'll have a single copy.

## Justify why they are needed

Part of the merge between checkout and cart page.
