### PR TITLE
GEN-2432 - fix(useEditProductOffer): cover the scenario where there's no price intent for a product offer

### DIFF
--- a/apps/store/src/components/ProductItem/useEditProductOffer.ts
+++ b/apps/store/src/components/ProductItem/useEditProductOffer.ts
@@ -31,11 +31,9 @@ export const useEditProductOffer = () => {
         targetUrl = new URL(offer.product.priceCalculatorPageLink, window.location.origin)
       } else {
         targetUrl.searchParams.set(OPEN_PRICE_CALCULATOR_QUERY_PARAM, '1')
-        // NOTE: Temporary code path, no need to handle this after PriceCalculatorPage is used everywhere
-        if (offer.priceIntentId == null) {
-          throw new Error('Expected to have offer.priceIntentId')
+        if (offer.priceIntentId != null) {
+          targetUrl.searchParams.set(PRELOADED_PRICE_INTENT_QUERY_PARAM, offer.priceIntentId)
         }
-        targetUrl.searchParams.set(PRELOADED_PRICE_INTENT_QUERY_PARAM, offer.priceIntentId)
       }
       targetUrl.searchParams.set(CART_ENTRY_TO_REPLACE_QUERY_PARAM, offer.id)
       await push(targetUrl.toString())


### PR DESCRIPTION
## Describe your changes

Fix an issue with editing Accident Insurance added via accident x-sell card.

**Before**

https://github.com/user-attachments/assets/73dd29c5-a10e-4523-a1ee-502cae105720

**After**

https://github.com/user-attachments/assets/266ab156-d61c-487d-abad-01adf7207409
 
## Justify why they are needed

That happened because we used to throw an error in case you're trying to edit an offer which we couldn't retrieve the price intent. That piece of code was removed because that scenario is covered elsewhere.
