### PR TITLE
Create QuickPurchaseV2 component

### DIFF
--- a/apps/store/src/blocks/QuickPurchaseBlock.tsx
+++ b/apps/store/src/blocks/QuickPurchaseBlock.tsx
@@ -1,6 +1,8 @@
 'use client'
 import { QuickPurchase } from '@/components/QuickPurchase/QuickPurchase'
+import { QuickPurchaseV2 } from '@/components/QuickPurchaseV2/QuickPurchase'
 import type { SbBaseBlockProps } from '@/services/storyblok/storyblok'
+import { Features } from '@/utils/Features'
 
 type QuickPurchaseBlockProps = SbBaseBlockProps<{
   products: Array<string>
@@ -10,6 +12,18 @@ type QuickPurchaseBlockProps = SbBaseBlockProps<{
 }>
 
 export const QuickPurchaseBlock = ({ blok, nested }: QuickPurchaseBlockProps) => {
+  if (Features.enabled('PRICE_CALCULATOR_PAGE')) {
+    return (
+      <QuickPurchaseV2
+        products={blok.products}
+        showSsnField={blok.showSsnField}
+        campaignCode={blok.campaignCode}
+        attributedTo={blok.attributedTo}
+        nested={nested}
+      />
+    )
+  }
+
   return (
     <QuickPurchase
       products={blok.products}

--- a/apps/store/src/components/QuickPurchaseV2/QuickPurchase.css.ts
+++ b/apps/store/src/components/QuickPurchaseV2/QuickPurchase.css.ts
@@ -1,0 +1,10 @@
+import { style } from '@vanilla-extract/css'
+import { tokens } from 'ui'
+
+export const wrapper = style({
+  selectors: {
+    '&[data-nested="false"]': {
+      paddingInline: tokens.space.md,
+    },
+  },
+})

--- a/apps/store/src/components/QuickPurchaseV2/QuickPurchase.tsx
+++ b/apps/store/src/components/QuickPurchaseV2/QuickPurchase.tsx
@@ -1,0 +1,181 @@
+'use client'
+import { useApolloClient } from '@apollo/client'
+import { datadogLogs } from '@datadog/browser-logs'
+import { useRouter } from 'next/navigation'
+import { useTranslation } from 'next-i18next'
+import { type FormEventHandler, useMemo, useState } from 'react'
+import { useProductMetadata } from '@/components/LayoutWithMenu/productMetadataHooks'
+import type {
+  FormError,
+  ProductOption,
+} from '@/components/QuickPurchase/QuickPurchaseForm/QuickPurchaseForm'
+import {
+  PRODUCT_FIELDNAME,
+  QuickPurchaseForm,
+  SSN_FIELDNAME,
+} from '@/components/QuickPurchaseV2/QuickPurchaseForm/QuickPurchaseForm'
+import {
+  useRedeemCampaignMutation,
+  useShopSessionCustomerUpdateMutation,
+} from '@/services/graphql/generated'
+import { setupShopSessionServiceClientSide } from '@/services/shopSession/ShopSession.helpers'
+import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useCurrentCountry } from '@/utils/l10n/useCurrentCountry'
+import { wrapper } from './QuickPurchase.css'
+
+type QuickPurchaseProps = {
+  products: Array<string>
+  showSsnField: boolean
+  campaignCode?: string
+  attributedTo?: string
+  nested?: boolean
+}
+
+export const QuickPurchaseV2 = (props: QuickPurchaseProps) => {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<FormError>()
+
+  const router = useRouter()
+  const { t } = useTranslation()
+
+  const apolloClient = useApolloClient()
+  const { countryCode } = useCurrentCountry()
+  const { shopSession: currentShopSession } = useShopSession()
+  const productMetadata = useProductMetadata()
+
+  const [updateCustomer] = useShopSessionCustomerUpdateMutation()
+  const [redeemCampaign] = useRedeemCampaignMutation()
+
+  const productOptions = useMemo(() => {
+    const result: Array<
+      ProductOption & { pageLink: string; priceCalculatorPageLink?: string | null }
+    > = []
+    props.products.forEach((productName) => {
+      const matchedProduct = productMetadata?.find((product) => product.name === productName)
+      if (matchedProduct) {
+        result.push({
+          name: matchedProduct.displayNameShort,
+          value: matchedProduct.name,
+          img: {
+            src: matchedProduct.pillowImage.src,
+            alt: matchedProduct.pillowImage.alt ?? '',
+          },
+          pageLink: matchedProduct.pageLink,
+          priceCalculatorPageLink: matchedProduct.priceCalculatorPageLink,
+        })
+      }
+    })
+
+    return result
+  }, [props.products, productMetadata])
+
+  if (productOptions.length === 0) {
+    throw new Error('QuickPurchaseBlock | no product options found')
+  }
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault()
+
+    try {
+      setError({})
+      setIsSubmitting(true)
+
+      const formData = new FormData(event.currentTarget)
+      const ssn = formData.get(SSN_FIELDNAME)
+      const productName = formData.get(PRODUCT_FIELDNAME)
+
+      // This should never happen since QuickPurchaseForm controls are required
+      if (typeof ssn !== 'string' || typeof productName !== 'string') {
+        throw new Error('QuickPurchaseBlock | ssn and product are required')
+      }
+
+      let shopSession = currentShopSession
+      if (props.attributedTo) {
+        // Partner attribution can influence pricing, so we need to create a new shop session
+        datadogLogs.setGlobalContextProperty('attributedTo', props.attributedTo)
+        datadogLogs.logger.info(
+          `QuickPurchaseBlock | create shop session attributed to ${props.attributedTo}`,
+        )
+        const shopSessionService = setupShopSessionServiceClientSide(apolloClient)
+        shopSession = await shopSessionService.create({
+          countryCode,
+          attributedTo: props.attributedTo,
+        })
+        shopSessionService.saveId(shopSession.id)
+      }
+
+      if (!shopSession) {
+        setError((prevState) => ({ ...prevState, general: t('UNKNOWN_ERROR_MESSAGE') }))
+        throw new Error('QuickPurchaseBlock | shop session not found')
+      }
+
+      const priceCalculatorPageLink = productOptions.find(
+        (product) => product.value === productName,
+      )?.priceCalculatorPageLink
+      if (priceCalculatorPageLink == null) {
+        setError((prevState) => ({ ...prevState, general: t('UNKNOWN_ERROR_MESSAGE') }))
+        throw new Error(`QuickPurchaseBlock | PDP link for ${productName} not found`)
+      }
+
+      // Pre-fetches Price Calculator page - instant transitions
+      router.prefetch(priceCalculatorPageLink)
+
+      if (ssn && ssn !== shopSession.customer?.ssn) {
+        await updateCustomer({
+          variables: {
+            input: {
+              shopSessionId: shopSession.id,
+              ssn,
+            },
+          },
+          onError(error) {
+            const message = error.extraInfo?.userError?.message
+            // TODO: use useAppErrorHandleContext or not even throw an error here.
+            // It would be probably fine to redirect users even if we failed on updating
+            // their ssn.
+            setError((prevState) => {
+              if (message) {
+                return { ...prevState, ssn: message }
+              }
+              return { ...prevState, general: t('UNKNOWN_ERROR_MESSAGE') }
+            })
+            throw new Error(`QuickPurchaseBlock | failed to update customer: ${error.message}`)
+          },
+        })
+      }
+
+      if (props.campaignCode) {
+        redeemCampaign({
+          variables: {
+            shopSessionId: shopSession.id,
+            code: props.campaignCode,
+          },
+          onError(error) {
+            datadogLogs.logger.error(
+              `QuickPurchaseBlock | failed to redeem code ${props.campaignCode}: ${error.message}`,
+            )
+          },
+        })
+      }
+
+      const url = new URL(priceCalculatorPageLink, window.location.origin)
+
+      router.push(url.toString())
+    } catch (error) {
+      setIsSubmitting(false)
+      datadogLogs.logger.error((error as Error).message)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} data-nested={props.nested} className={wrapper}>
+      <QuickPurchaseForm
+        productOptions={productOptions}
+        submitting={isSubmitting}
+        showSsnField={props.showSsnField}
+        ssnDefaultValue={currentShopSession?.customer?.ssn ?? ''}
+        error={error}
+      />
+    </form>
+  )
+}

--- a/apps/store/src/components/QuickPurchaseV2/QuickPurchaseForm/ProductSelector.tsx
+++ b/apps/store/src/components/QuickPurchaseV2/QuickPurchaseForm/ProductSelector.tsx
@@ -1,0 +1,142 @@
+import styled from '@emotion/styled'
+import * as SelectPrimitive from '@radix-ui/react-select'
+import { useTranslation } from 'next-i18next'
+import { Fragment } from 'react'
+import { CheckIcon, ChevronIcon, theme } from 'ui'
+import { Pillow } from '@/components/Pillow/Pillow'
+
+export type ProductOption = {
+  name: string
+  value: string
+  img: {
+    src: string
+    alt?: string
+  }
+}
+
+type Props = {
+  productOptions: Array<ProductOption>
+} & Omit<SelectPrimitive.SelectProps, 'children'>
+
+export const ProductSelector = ({ productOptions, ...delegated }: Props) => {
+  const { t } = useTranslation('purchase-form')
+
+  return (
+    <SelectPrimitive.Root {...delegated}>
+      <SelectTrigger>
+        <SelectPrimitive.Value placeholder={t('FIELD_INSURANCE_SELECTOR_PLACEHOLDER')} />
+        <SelectPrimitive.Icon>
+          <StyledChevronIcon size="1rem" />
+        </SelectPrimitive.Icon>
+      </SelectTrigger>
+
+      <SelectPrimitive.Portal>
+        <SelectContent position="popper" sideOffset={4}>
+          <SelectPrimitive.Viewport>
+            {productOptions.map((option, index) => (
+              <Fragment key={option.value}>
+                {index !== 0 && <Separator />}
+                <SelectItem value={option.value}>
+                  <SelectPrimitive.ItemText asChild={true}>
+                    <ItemDisplay>
+                      <Pillow size="xxsmall" {...option.img} />
+                      <span>{option.name}</span>
+                    </ItemDisplay>
+                  </SelectPrimitive.ItemText>
+
+                  <SelectPrimitive.ItemIndicator>
+                    <StyledCheckIcon size="1rem" />
+                  </SelectPrimitive.ItemIndicator>
+                </SelectItem>
+              </Fragment>
+            ))}
+          </SelectPrimitive.Viewport>
+        </SelectContent>
+      </SelectPrimitive.Portal>
+    </SelectPrimitive.Root>
+  )
+}
+
+const SelectTrigger = styled(SelectPrimitive.Trigger)({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: theme.space.xs,
+  width: '100%',
+  height: '3rem',
+  borderRadius: theme.radius.sm,
+  paddingInline: theme.space.md,
+  backgroundColor: theme.colors.opaque1,
+  fontSize: theme.fontSizes.xl,
+  cursor: 'pointer',
+
+  '&[data-placeholder]': {
+    color: theme.colors.textSecondary,
+  },
+
+  '&:invalid, &:disabled': {
+    color: theme.colors.textSecondary,
+  },
+
+  '&:disabled': {
+    cursor: 'not-allowed',
+  },
+})
+
+const StyledChevronIcon = styled(ChevronIcon)({
+  transition: 'transform 200ms cubic-bezier(0.77, 0, 0.18, 1)',
+
+  [`${SelectTrigger}[data-state=open] &`]: {
+    transform: 'rotate(180deg)',
+  },
+})
+
+const SelectContent = styled(SelectPrimitive.Content)({
+  width: 'var(--radix-select-trigger-width)',
+  maxHeight: 'var(--radix-select-content-available-height)',
+  backgroundColor: theme.colors.opaque1,
+  borderRadius: theme.radius.sm,
+  // Cut out borders
+  overflow: 'hidden',
+})
+
+const SelectItem = styled(SelectPrimitive.Item)({
+  position: 'relative',
+  minHeight: '3rem',
+  paddingInline: theme.space.md,
+  paddingBlock: theme.space.xs,
+  fontSize: theme.fontSizes.xl,
+  isolation: 'isolate',
+
+  '&[data-highlighted]': {
+    backgroundColor: theme.colors.gray300,
+  },
+
+  '@media (hover: hover)': {
+    ':hover': {
+      cursor: 'pointer',
+      backgroundColor: theme.colors.gray300,
+    },
+  },
+})
+
+const Separator = styled(SelectPrimitive.Separator)({
+  height: 1,
+  backgroundColor: theme.colors.opaque2,
+  marginInline: theme.space.md,
+})
+
+const ItemDisplay = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.space.xs,
+})
+
+const StyledCheckIcon = styled(CheckIcon)({
+  position: 'absolute',
+  right: theme.space.md,
+  // Centers icon vertically
+  top: '50%',
+  transform: 'translateY(-50%)',
+  zIndex: 1,
+})

--- a/apps/store/src/components/QuickPurchaseV2/QuickPurchaseForm/QuickPurchaseForm.css.ts
+++ b/apps/store/src/components/QuickPurchaseV2/QuickPurchaseForm/QuickPurchaseForm.css.ts
@@ -1,0 +1,15 @@
+import { style } from '@vanilla-extract/css'
+import { tokens } from 'ui'
+
+export const wrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: tokens.space.xxs,
+  maxWidth: '30rem',
+  marginInline: 'auto',
+  padding: '1rem',
+  border: `1px solid ${tokens.colors.borderTranslucent1}`,
+  borderRadius: tokens.radius.xl,
+  backgroundColor: tokens.colors.backgroundStandard,
+  boxShadow: tokens.shadow.card,
+})

--- a/apps/store/src/components/QuickPurchaseV2/QuickPurchaseForm/QuickPurchaseForm.tsx
+++ b/apps/store/src/components/QuickPurchaseV2/QuickPurchaseForm/QuickPurchaseForm.tsx
@@ -1,0 +1,79 @@
+import styled from '@emotion/styled'
+import { useTranslation } from 'next-i18next'
+import { Button, sprinkles } from 'ui'
+import { ProductSelector } from './ProductSelector'
+import { wrapper } from './QuickPurchaseForm.css'
+import { SsnField } from './SsnField'
+
+export const SSN_FIELDNAME = 'ssn'
+export const PRODUCT_FIELDNAME = 'product'
+
+export type ProductOption = {
+  name: string
+  value: string
+  img: {
+    src: string
+    alt?: string
+  }
+}
+
+export type FormError = {
+  general?: string
+  ssn?: string
+}
+
+type Props = {
+  productOptions: Array<ProductOption>
+  submitting?: boolean
+  showSsnField?: boolean
+  ssnDefaultValue?: string
+  error?: FormError
+}
+
+export const QuickPurchaseForm = ({
+  productOptions,
+  submitting = false,
+  ssnDefaultValue = '',
+  showSsnField = false,
+  error,
+}: Props) => {
+  const { t } = useTranslation('purchase-form')
+
+  return (
+    <div className={wrapper}>
+      {productOptions.length === 1 && (
+        <input type="hidden" name={PRODUCT_FIELDNAME} value={productOptions[0].value} />
+      )}
+      {productOptions.length > 1 && (
+        <ProductSelector
+          productOptions={productOptions}
+          name={PRODUCT_FIELDNAME}
+          disabled={submitting}
+          required={true}
+        />
+      )}
+      <SsnField
+        name={SSN_FIELDNAME}
+        defaultValue={ssnDefaultValue}
+        required={true}
+        disabled={submitting}
+        warning={!!error?.ssn}
+        message={error?.ssn}
+        hidden={!showSsnField}
+      />
+      <Button
+        type="submit"
+        loading={submitting}
+        fullWidth={true}
+        className={sprinkles({ mt: 'xxs' })}
+      >
+        {t('BUTTON_LABEL_GET_PRICE')}
+      </Button>
+      {error?.general && <GeneralErrorMessage>{error.general}</GeneralErrorMessage>}
+    </div>
+  )
+}
+
+const GeneralErrorMessage = styled.p({
+  textAlign: 'center',
+})

--- a/apps/store/src/components/QuickPurchaseV2/QuickPurchaseForm/SsnField.tsx
+++ b/apps/store/src/components/QuickPurchaseV2/QuickPurchaseForm/SsnField.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'next-i18next'
+import { useCallback, useState } from 'react'
+import { ChangeSsnWarningDialog } from '@/components/ChangeSsnWarningDialog/ChangeSsnWarningDialog'
+import type { Props as PersonalNumberFieldProps } from '@/components/PersonalNumberField/PersonalNumberField'
+import { PersonalNumberField } from '@/components/PersonalNumberField/PersonalNumberField'
+
+type Props = Omit<PersonalNumberFieldProps, 'label'> & { label?: string }
+
+export const SsnField = (props: Props) => {
+  const [showChangeSsnDialog, setShowChangeSsnDialog] = useState(false)
+  const { t } = useTranslation('purchase-form')
+
+  const openChangeSsnDialog = useCallback(() => {
+    setShowChangeSsnDialog(true)
+  }, [setShowChangeSsnDialog])
+
+  const closeChangeSsnDialog = useCallback(() => {
+    setShowChangeSsnDialog(false)
+  }, [setShowChangeSsnDialog])
+
+  const label = t('FIELD_SSN_SE_LABEL')
+
+  if (props.defaultValue) {
+    return (
+      <>
+        <PersonalNumberField
+          {...props}
+          label={label}
+          name={props.name}
+          value={props.defaultValue}
+          readOnly={true}
+          onClear={openChangeSsnDialog}
+        />
+
+        <ChangeSsnWarningDialog
+          open={showChangeSsnDialog}
+          onAccept={closeChangeSsnDialog}
+          onDecline={closeChangeSsnDialog}
+        />
+      </>
+    )
+  }
+
+  return <PersonalNumberField label={label} {...props} />
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Create QuickPurchaseV2 component

Copied and modified the QuickPurchase component to use on the new ProductPage since the functionality is very similar. So using a feature flag we can change what QuickPurchase component that is rendered.

In the new version of the component it navigates to PriceCalculatorPage, the other logic is the same as the current implemented component.

If it turns out to have different use cases we can just create a new block for the component on ProductPage.

What should be modified is that we want to have an insurance pre-selected in the dropdown.

https://github.com/user-attachments/assets/cc47fe08-14ea-41e6-a224-1e9e68e35679

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Going from ProductPage to PriceCalculatorPage

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
