### PR TITLE
Wrap member area menu on small screens

### DIFF
--- a/apps/store/src/features/memberArea/components/MemberAreaLayout.css.ts
+++ b/apps/store/src/features/memberArea/components/MemberAreaLayout.css.ts
@@ -8,7 +8,7 @@ export const layoutWrapper = style({
 
 export const main = style({
   display: 'grid',
-  gridTemplateRows: '60px 1fr',
+  gridTemplateRows: 'auto 1fr',
   width: '100%',
   marginInline: 'auto',
   paddingBottom: tokens.space.xxl,

--- a/apps/store/src/features/memberArea/components/Menu/Menu.css.ts
+++ b/apps/store/src/features/memberArea/components/Menu/Menu.css.ts
@@ -4,7 +4,6 @@ import { minWidth, tokens } from 'ui'
 export const navigation = style({
   paddingInline: tokens.space.md,
   paddingBottom: tokens.space.sm,
-  overflowX: 'auto',
 
   '@media': {
     [minWidth.lg]: {
@@ -29,7 +28,7 @@ export const navigationList = style({
   display: 'flex',
   alignItems: 'baseline',
   gap: tokens.space.xs,
-  width: 'fit-content',
+  flexWrap: 'wrap',
 
   '@media': {
     [minWidth.lg]: {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add wrapping to member area menu. This replaces horizontal scrolling with multiline layout, items are always visible. Does not affect wide variant where menu goes on the left

Before

![Screenshot 2024-08-19 at 10.55.17.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/f626da48-4f22-4e41-b735-711d32833d18.png)

![Screenshot 2024-08-19 at 10.54.58.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/782f8403-f1b8-4f28-8f75-39f34dcd9a3a.png)

After

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
