### PR TITLE
Simple navigation menu for debug tools

### DIFF
--- a/apps/store/src/app/debugger/DebuggerMenu.tsx
+++ b/apps/store/src/app/debugger/DebuggerMenu.tsx
@@ -1,33 +1,31 @@
 'use client'
-
-import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu'
-import { navigation, navigationItem, navigationPrimaryList } from '@/components/Header/Header.css'
-import { NavigationLink } from '@/components/Header/NavigationLink/NavigationLink'
+import { usePathname } from 'next/navigation'
+import { type ReactNode } from 'react'
+import { Text, yStack } from 'ui'
+import { ButtonNextLink } from '@/components/ButtonNextLink'
 
 export function DebuggerMenu() {
   return (
-    <NavigationMenuPrimitive.Root className={navigation}>
-      <NavigationMenuPrimitive.List className={navigationPrimaryList}>
-        <NavigationMenuPrimitive.Item className={navigationItem}>
-          <NavigationLink href="/debugger">Session debugger</NavigationLink>
-        </NavigationMenuPrimitive.Item>
+    <div className={yStack({ alignItems: 'stretch' })}>
+      <MenuItem href="/debugger/session">Session debugger</MenuItem>
+      <MenuItem href="/debugger/iframe">iframe debugger</MenuItem>
+      <MenuItem href="/debugger/car-trial">Car trial debugger</MenuItem>
+      <MenuItem href="/debugger/terms">Terms viewer</MenuItem>
+    </div>
+  )
+}
 
-        <NavigationMenuPrimitive.Item className={navigationItem}>
-          <NavigationLink href="/debugger/iframe">iframe debugger</NavigationLink>
-        </NavigationMenuPrimitive.Item>
-
-        <NavigationMenuPrimitive.Item className={navigationItem}>
-          <NavigationLink href="/debugger/trial">Trial debugger</NavigationLink>
-        </NavigationMenuPrimitive.Item>
-
-        <NavigationMenuPrimitive.Item className={navigationItem}>
-          <NavigationLink href="/debugger/car-trial">Car trial debugger</NavigationLink>
-        </NavigationMenuPrimitive.Item>
-
-        <NavigationMenuPrimitive.Item className={navigationItem}>
-          <NavigationLink href="/debugger/terms">Terms viewer</NavigationLink>
-        </NavigationMenuPrimitive.Item>
-      </NavigationMenuPrimitive.List>
-    </NavigationMenuPrimitive.Root>
+function MenuItem({ href, children }: { href: string; children: ReactNode }) {
+  const pathname = usePathname()
+  const isActive = pathname?.startsWith(href)
+  return (
+    <ButtonNextLink
+      variant={isActive ? 'secondary' : 'ghost'}
+      size="medium"
+      href={href}
+      style={{ borderRadius: 0 }}
+    >
+      <Text>{children}</Text>
+    </ButtonNextLink>
   )
 }

--- a/apps/store/src/app/debugger/layout.tsx
+++ b/apps/store/src/app/debugger/layout.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from 'react'
+import { Heading, xStack } from 'ui'
 import { DebuggerMenu } from '@/app/debugger/DebuggerMenu'
 import { RootLayout } from '@/appComponents/RootLayout/RootLayout'
 import { Header } from '@/components/Header/Header'
@@ -12,10 +13,14 @@ const Layout = ({ children }: Props) => {
   return (
     <RootLayout>
       <Header>
-        <DebuggerMenu />
+        <Heading as="h1" variant="standard.24" style={{ flexGrow: 1 }}>
+          Debug tools
+        </Heading>
       </Header>
-
-      <main className={contentWrapper}>{children}</main>
+      <div className={xStack({ gap: 'md' })}>
+        <DebuggerMenu />
+        <main className={contentWrapper}>{children}</main>
+      </div>
     </RootLayout>
   )
 }

--- a/apps/store/src/app/debugger/page.tsx
+++ b/apps/store/src/app/debugger/page.tsx
@@ -1,10 +1,8 @@
-import { CreateSessionForm } from './components/CreateSessionForm/CreateSessionForm'
+import { redirect } from 'next/navigation'
 
-const Page = () => {
-  return <CreateSessionForm />
+export default function DebuggerIndex() {
+  return redirect('/debugger/session')
 }
-
-export default Page
 
 export const metadata = {
   robots: 'noindex, nofollow',

--- a/apps/store/src/app/debugger/session/page.tsx
+++ b/apps/store/src/app/debugger/session/page.tsx
@@ -1,0 +1,11 @@
+import { CreateSessionForm } from '@/app/debugger/components/CreateSessionForm/CreateSessionForm'
+
+const Page = () => {
+  return <CreateSessionForm />
+}
+
+export default Page
+
+export const metadata = {
+  robots: 'noindex, nofollow',
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Replaced store menu based version of debug tools navigation with simple menu that behaves well on small screens

Original debugger menu (see https://dev.hedvigit.com/debugger) breaks on smaller widths because it assumes it's only used inside full store menu with mobile and desktop versions, etc. Using leaf components from it without full thing was never going to work well

Before

![Screenshot 2024-08-19 at 14.52.17.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/7b5fd2cb-4f16-4720-93ef-b3c327a3cdc9.png)

After

![Screenshot 2024-08-19 at 14.40.16.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/a90fa07f-9e88-46d6-a0f9-b69c369eb0a1.png)


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code

