### PR TITLE
Explicitly specify gap in price calculator page styles

### DIFF
--- a/apps/store/src/features/priceCalculator/DeductibleSelectorV2.tsx
+++ b/apps/store/src/features/priceCalculator/DeductibleSelectorV2.tsx
@@ -54,7 +54,13 @@ export function DeductibleSelectorV2({ offers, selectedOffer, onValueChange }: P
             <div className={xStack({ gap: 'xs' })}>
               <CardRadioGroup.Indicator />
               <div className={yStack({ flexGrow: 1, gap: 'xs' })}>
-                <div className={xStack({ justifyContent: 'space-between', alignItems: 'center' })}>
+                <div
+                  className={xStack({
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: 'md',
+                  })}
+                >
                   <Heading as="h2" variant="standard.24">
                     {item.title}
                   </Heading>

--- a/apps/store/src/features/priceCalculator/OfferPresenterV2.tsx
+++ b/apps/store/src/features/priceCalculator/OfferPresenterV2.tsx
@@ -91,7 +91,7 @@ export const OfferPresenterV2 = memo(() => {
   return (
     <div className={yStack({ gap: 'md' })}>
       {tiers.length > 1 && (
-        <div className={yStack({ alignItems: 'stretch' })}>
+        <div className={yStack({ alignItems: 'stretch', gap: 'md' })}>
           <ProductTierSelectorV2
             offers={tiers}
             selectedOffer={selectedTier}
@@ -101,7 +101,7 @@ export const OfferPresenterV2 = memo(() => {
       )}
 
       {deductibles.length > 1 && (
-        <div className={yStack({ alignItems: 'stretch' })}>
+        <div className={yStack({ alignItems: 'stretch', gap: 'md' })}>
           <DeductibleSelectorV2
             offers={deductibles}
             selectedOffer={selectedOffer}

--- a/apps/store/src/features/priceCalculator/OfferPriceDetails.tsx
+++ b/apps/store/src/features/priceCalculator/OfferPriceDetails.tsx
@@ -71,7 +71,7 @@ export function OfferPriceDetails() {
 
     total = (
       <div>
-        <Text as="div" size="md" className={xStack({ justifyContent: 'flex-end' })}>
+        <Text as="div" size="md" className={xStack({ justifyContent: 'flex-end', gap: 'md' })}>
           {hasReducedPrice(selectedOffer) && (
             <Text as="span" size="md" color="textSecondary" strikethrough={true}>
               {formatter.monthlyPrice(selectedOffer.cost.gross)}
@@ -97,7 +97,7 @@ export function OfferPriceDetails() {
           <Separator />
         </>
       )}
-      <Text as="div" size="md" className={xStack({ alignItems: 'flex-start' })}>
+      <Text as="div" size="md" className={xStack({ alignItems: 'flex-start', gap: 'md' })}>
         {t('OFFER_SUMMARY_TOTAL_LABEL')}{' '}
         <div style={{ flexGrow: 1, textAlign: 'right' }}>{total}</div>
       </Text>

--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.tsx
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.tsx
@@ -30,7 +30,10 @@ export async function PriceCalculatorCmsPage({ locale, story }: Props) {
   }
   const { productName } = await getPriceTemplate(story.content.priceTemplate)
   return (
-    <div className={xStack()} style={{ backgroundColor: tokens.colors.backgroundStandard }}>
+    <div
+      className={xStack({ gap: 'md' })}
+      style={{ backgroundColor: tokens.colors.backgroundStandard }}
+    >
       <div
         style={{
           position: 'sticky',
@@ -38,7 +41,7 @@ export async function PriceCalculatorCmsPage({ locale, story }: Props) {
           width: '50%',
           height: `calc(100vh - ${HEADER_HEIGHT})`,
         }}
-        className={yStack({ justifyContent: 'center', alignItems: 'center' })}
+        className={yStack({ gap: 'md', justifyContent: 'center', alignItems: 'center' })}
       >
         <Suspense>
           <ProductHeroContainer locale={locale} productName={productName} />

--- a/apps/store/src/features/priceCalculator/ProductTierSelectorV2.tsx
+++ b/apps/store/src/features/priceCalculator/ProductTierSelectorV2.tsx
@@ -30,7 +30,13 @@ export function ProductTierSelectorV2({ offers, selectedOffer, onValueChange }: 
         {offers.map((offer) => (
           <CardRadioGroup.Item key={offer.id} value={offer.id} style={{ padding: tokens.space.lg }}>
             <div className={yStack()}>
-              <div className={xStack({ justifyContent: 'space-between', alignItems: 'center' })}>
+              <div
+                className={xStack({
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  gap: 'md',
+                })}
+              >
                 <Heading as="h2" variant="standard.24">
                   {offer.variant.displayNameSubtype || offer.variant.displayName}
                 </Heading>

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2.tsx
@@ -39,7 +39,10 @@ export function PurchaseFormV2() {
       return <InsuranceDataForm />
     case 'calculatingPrice':
       return (
-        <div className={yStack({ justifyContent: 'center' })} style={{ minHeight: '75vh' }}>
+        <div
+          className={yStack({ gap: 'md', justifyContent: 'center' })}
+          style={{ minHeight: '75vh' }}
+        >
           <PriceLoader />
         </div>
       )

--- a/apps/store/src/features/priceCalculator/SectionPreview.tsx
+++ b/apps/store/src/features/priceCalculator/SectionPreview.tsx
@@ -51,7 +51,7 @@ export function SectionPreview({ section }: { section: FormSection }) {
 
   return (
     <div
-      className={xStack({ padding: 'md', alignItems: 'center' })}
+      className={xStack({ padding: 'md', alignItems: 'center', gap: 'xs' })}
       style={{ backgroundColor: tokens.colors.backgroundStandard, borderRadius: tokens.radius.md }}
     >
       <div className={sprinkles({ flexGrow: 1, overflow: 'hidden' })}>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

We used to have default gap of 'md' in `xStack / yStack`. It became 'none' after recent refactoring, so I'm adding it explicitly to make price calculator page look like it's supposed to

Before

![Screenshot 2024-08-20 at 14.44.50.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/3fa0b0fc-e9ef-46cf-a5fe-3c6b9c81f158.png)

After

![Screenshot 2024-08-20 at 14.54.50.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/a574e9f0-883b-4a78-94cf-0b9d08600d8f.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
