### PR TITLE
Convert Pillow styles to vanilla-extract, allow to override size via CSS var

### DIFF
--- a/apps/store/src/components/Pillow/Pillow.css.ts
+++ b/apps/store/src/components/Pillow/Pillow.css.ts
@@ -1,0 +1,37 @@
+import { createVar } from '@vanilla-extract/css'
+import { responsiveVariants } from 'ui'
+
+export const pillowSize = createVar('pillowSize')
+
+export const pillowVariants = responsiveVariants({
+  base: {
+    width: pillowSize,
+    height: pillowSize,
+  },
+  variants: {
+    mini: {
+      vars: { [pillowSize]: '1.5rem' },
+    },
+    xxsmall: {
+      vars: { [pillowSize]: '1.75rem' },
+    },
+    xsmall: {
+      vars: { [pillowSize]: '2rem' },
+    },
+    small: {
+      vars: { [pillowSize]: '3rem' },
+    },
+    medium: {
+      vars: { [pillowSize]: '3.5rem' },
+    },
+    large: {
+      vars: { [pillowSize]: '5rem' },
+    },
+    xlarge: {
+      vars: { [pillowSize]: '6rem' },
+    },
+    xxlarge: {
+      vars: { [pillowSize]: '13rem' },
+    },
+  },
+})

--- a/apps/store/src/components/Pillow/Pillow.tsx
+++ b/apps/store/src/components/Pillow/Pillow.tsx
@@ -1,21 +1,23 @@
-import styled from '@emotion/styled'
+import clsx from 'clsx'
 import Image from 'next/image'
 import { memo } from 'react'
 import { getImgSrc } from '@/services/storyblok/Storyblok.helpers'
+import { pillowVariants } from './Pillow.css'
 
 type PillowProps = {
-  size?: 'mini' | 'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'
+  size: 'mini' | 'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'
   src?: string
   alt?: string | null
   priority?: boolean
   className?: string
 }
 
-export const Pillow = memo(({ alt, src, priority, ...props }: PillowProps) => {
-  if (!src) return <FallbackPillow {...props} size={props.size} />
+export const Pillow = memo(({ alt, src, priority, className, size, ...props }: PillowProps) => {
+  if (!src) return <FallbackPillow {...props} size={size} />
   return (
-    <StyledImage
+    <Image
       {...props}
+      className={clsx(pillowVariants(size), className)}
       src={getImgSrc(src)}
       alt={alt ?? ''}
       width={208}
@@ -28,13 +30,11 @@ export const Pillow = memo(({ alt, src, priority, ...props }: PillowProps) => {
 })
 Pillow.displayName = 'Pillow'
 
-const StyledImage = styled(Image)<PillowProps>(({ size = 'medium' }) => getSize(size))
-
-const FallbackPillow = ({ size, ...props }: Pick<PillowProps, 'size'>) => {
+const FallbackPillow = ({ size, className, ...props }: PillowProps) => {
   return (
     <svg
       {...props}
-      {...getSize(size)}
+      className={clsx(pillowVariants(size), className)}
       viewBox="0 0 480 480"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
@@ -45,25 +45,4 @@ const FallbackPillow = ({ size, ...props }: Pick<PillowProps, 'size'>) => {
       />
     </svg>
   )
-}
-
-const getSize = (size: PillowProps['size']) => {
-  switch (size) {
-    case 'mini':
-      return { width: '1.5rem', height: '1.5rem' }
-    case 'xxsmall':
-      return { width: '1.75rem', height: '1.75rem' }
-    case 'xsmall':
-      return { width: '2rem', height: '2rem' }
-    case 'small':
-      return { width: '3rem', height: '3rem' }
-    case 'medium':
-      return { width: '3.5rem', height: '3.5rem' }
-    case 'large':
-      return { width: '5rem', height: '5rem' }
-    case 'xlarge':
-      return { width: '6rem', height: '6rem' }
-    case 'xxlarge':
-      return { width: '13rem', height: '13rem' }
-  }
 }

--- a/apps/store/src/components/ProductReviews/PillowHeader.tsx
+++ b/apps/store/src/components/ProductReviews/PillowHeader.tsx
@@ -11,7 +11,7 @@ type Props = {
   title: string
   score: number
   reviewsCount: number
-  pillow: Omit<ComponentProps<typeof Pillow>, 'className'>
+  pillow: Omit<ComponentProps<typeof Pillow>, 'className' | 'size'>
   className?: string
 }
 

--- a/apps/store/src/components/QuickAdd/QuickAddBundleView.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddBundleView.tsx
@@ -14,11 +14,13 @@ import {
   priceWrapper,
 } from './QuickAddBundleView.css'
 
+type PillowParams = Omit<ComponentProps<typeof Pillow>, 'size'>
+
 type Props = {
   title: string
   subtitle: string
-  primaryPillow: ComponentProps<typeof Pillow>
-  secondaryPillow?: ComponentProps<typeof Pillow>
+  primaryPillow: PillowParams
+  secondaryPillow?: PillowParams
   price: ComponentProps<typeof Price>
   // TODO: evaluate if 'href' this is actually is agood addition design wise
   // or at least came up with a better name for it

--- a/apps/store/src/components/QuickAdd/QuickAddEditableView.tsx
+++ b/apps/store/src/components/QuickAdd/QuickAddEditableView.tsx
@@ -53,7 +53,7 @@ type Props = {
   initialOffer: OfferRecommendationFragment
   title: string
   subtitle: string
-  pillow: ComponentProps<typeof Pillow>
+  pillow: Omit<ComponentProps<typeof Pillow>, 'size'>
   productPageLink: string
   badge?: string
   Body?: ReactNode

--- a/apps/store/src/components/RadioOptionList/RadioOptionList.tsx
+++ b/apps/store/src/components/RadioOptionList/RadioOptionList.tsx
@@ -15,7 +15,7 @@ export const Root = (props: RootProps) => {
 type ProductOptionProps = RadioGroup.RadioGroupItemProps & {
   title: string
   subtitle: string
-  pillow: ComponentProps<typeof Pillow>
+  pillow: Omit<ComponentProps<typeof Pillow>, 'size'>
 }
 
 export const ProductOption = (props: ProductOptionProps) => {

--- a/apps/store/src/components/SelectInsuranceGrid/ProductItem.tsx
+++ b/apps/store/src/components/SelectInsuranceGrid/ProductItem.tsx
@@ -38,7 +38,7 @@ const Item = styled.div({
 
 const Content = styled.div({ flex: 1, width: 0 })
 
-const Pillow = (props: ComponentProps<typeof BasePillow>) => {
+const Pillow = (props: Omit<ComponentProps<typeof BasePillow>, 'size'>) => {
   return <BasePillow size="small" {...props} />
 }
 

--- a/apps/store/src/features/retargeting/RetargetingPage.tsx
+++ b/apps/store/src/features/retargeting/RetargetingPage.tsx
@@ -6,7 +6,7 @@ import { Pillow } from '@/components/Pillow/Pillow'
 
 type Props = {
   pillows: Array<
-    ComponentProps<typeof Pillow> & {
+    Omit<ComponentProps<typeof Pillow>, 'size'> & {
       id: string
     }
   >
@@ -18,7 +18,7 @@ export const RetargetingPage = (props: Props) => {
       <Grid>
         {props.pillows.map((item, index) => (
           <PillowWrapper key={item.id} index={index}>
-            <Pillow {...item} priority={true} />
+            <Pillow size="small" {...item} priority={true} />
           </PillowWrapper>
         ))}
       </Grid>

--- a/packages/ui/src/theme/media.ts
+++ b/packages/ui/src/theme/media.ts
@@ -26,7 +26,14 @@ export const hoverStyles = (styles: CSSProperties) => {
   }
 }
 
-export const responsiveStyles = (breakpointStyles: PartialRecord<Level, CSSProperties>) => {
+// Copied from vanilla-extract since it does not export it
+type CSSPropertiesWithVars = CSSProperties & {
+  vars?: {
+    [key: string]: string
+  }
+}
+
+export const responsiveStyles = (breakpointStyles: PartialRecord<Level, CSSPropertiesWithVars>) => {
   return {
     '@media': Object.fromEntries(
       Object.entries(breakpointStyles).map(([key, styles]) => [minWidth[key as Level], styles]),


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Subj. Var-based size is needed for next PR where price calculator page has responsive pillow size

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [x] I have performed a self-review of my code
