### PR TITLE
RND-856 - fix(confirmation page): avoid crashing confirmation page if confimation story wasn't fetched

### DIFF
--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.tsx
@@ -25,10 +25,11 @@ export const ConfirmationPage = (props: ConfirmationPageProps) => {
             <GridLayout.Content width="1/3" align="center">
               <Space y={4}>
                 <Space y={{ base: 3, lg: 4.5 }}>
-                  <Heading as="h1" variant="standard.24" align="center">
-                    {props.story.content.title}
-                  </Heading>
-
+                  {props.story && (
+                    <Heading as="h1" variant="standard.24" align="center">
+                      {props.story.content.title}
+                    </Heading>
+                  )}
                   <ShopBreakdown>
                     {props.carTrialContract && (
                       <ProductItemContractContainerCar contract={props.carTrialContract} />
@@ -52,7 +53,8 @@ export const ConfirmationPage = (props: ConfirmationPageProps) => {
             </GridLayout.Content>
           </GridLayout.Root>
 
-          <StaticContent content={props.story.content} />
+          {/* Treating 'story' as optional here to provide a fallback confirmation page instead crashing the page */}
+          {props.story && <StaticContent content={props.story.content} />}
         </Space>
       </Wrapper>
     </SuccessAnimation>

--- a/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
+++ b/apps/store/src/components/ConfirmationPage/ConfirmationPage.types.ts
@@ -15,5 +15,5 @@ export type ConfirmationPageProps = {
     companyDisplayName: string
   }
   carTrialContract?: TrialContractFragment
-  story: ConfirmationStory
+  story?: ConfirmationStory
 }

--- a/apps/store/src/pages/[locale]/car-buyer/confirmation/[contractId].tsx
+++ b/apps/store/src/pages/[locale]/car-buyer/confirmation/[contractId].tsx
@@ -91,9 +91,11 @@ const fetchTrialExtensionData = async (
 const CarBuyerConfirmationPage: NextPageWithLayout<Props> = (props) => {
   return (
     <>
-      <Head>
-        <title>{props.story.content.seoTitle}</title>
-      </Head>
+      {props.story && (
+        <Head>
+          <title>{props.story.content.seoTitle}</title>
+        </Head>
+      )}
       <ConfirmationPage {...props} />
     </>
   )


### PR DESCRIPTION
# Describe your changes

Subj.

## Justify why they are needed

We might get some errors while fetching confirmation story in the context of confirmation page from time to time due to storyblok not being initialized correctly 🤷‍♂️. That makes the whole confirmation page to crash. Couldn't find the reason why that happens as this is not easy to reproduce. At least now we don't crash the whole page.
