### PR TITLE
Mark IconRoot as client component as assignInlineVars does not work on <svg> in RSC

### DIFF
--- a/packages/ui/src/icons/ArrowIcon.tsx
+++ b/packages/ui/src/icons/ArrowIcon.tsx
@@ -1,4 +1,3 @@
-'use client'
 import type { IconRootProps } from './Root'
 import { IconRoot } from './Root'
 

--- a/packages/ui/src/icons/Root.tsx
+++ b/packages/ui/src/icons/Root.tsx
@@ -1,3 +1,7 @@
+'use client'
+// NOTE: 'use client' prevents the following
+// "Warning: Only plain objects can be passed to Client Components from Server Components. Classes or other objects with methods are not supported"
+// We're passing down style object with assignInlineVars
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 import { clsx } from 'clsx'
 import { forwardRef, type ComponentProps } from 'react'


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Subj. We currently cannot use SVG icons as server components, but it's probably not a big deal

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
