### PR TITLE
Add display for single product option in QuickPurchase

### DIFF
--- a/apps/store/src/blocks/ProductPageBlockV2/ProductPageBlockV2.css.ts
+++ b/apps/store/src/blocks/ProductPageBlockV2/ProductPageBlockV2.css.ts
@@ -10,3 +10,7 @@ export const wrapper = style({
     },
   },
 })
+
+export const gridRoot = style({
+  rowGap: '5rem',
+})

--- a/apps/store/src/blocks/ProductPageBlockV2/ProductPageBlockV2.tsx
+++ b/apps/store/src/blocks/ProductPageBlockV2/ProductPageBlockV2.tsx
@@ -6,7 +6,7 @@ import * as GridLayout from '@/components/GridLayout/GridLayout'
 import { type PurchaseFormProps } from '@/components/ProductPage/PurchaseForm/PurchaseForm'
 import type { SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { Features } from '@/utils/Features'
-import { wrapper } from './ProductPageBlockV2.css'
+import { gridRoot, wrapper } from './ProductPageBlockV2.css'
 
 export type ProductPageBlockProps = SbBaseBlockProps<
   {
@@ -23,7 +23,7 @@ export const ProductPageBlockV2 = ({ blok }: ProductPageBlockProps) => {
 
   return (
     <main className={wrapper} {...storyblokEditable(blok)}>
-      <GridLayout.Root>
+      <GridLayout.Root className={gridRoot}>
         <GridLayout.Content width={{ lg: '1/2' }} align="left">
           {blok.topSectionFirstColumn.map((nestedBlock) => (
             <StoryblokComponent blok={nestedBlock} key={nestedBlock._uid} />

--- a/apps/store/src/blocks/QuickPurchaseBlock.tsx
+++ b/apps/store/src/blocks/QuickPurchaseBlock.tsx
@@ -6,6 +6,7 @@ import { Features } from '@/utils/Features'
 
 type QuickPurchaseBlockProps = SbBaseBlockProps<{
   products: Array<string>
+  productByline?: string
   preSelectFirstProduct?: boolean
   showSsnField: boolean
   campaignCode?: string
@@ -17,6 +18,7 @@ export const QuickPurchaseBlock = ({ blok, nested }: QuickPurchaseBlockProps) =>
     return (
       <QuickPurchaseV2
         products={blok.products}
+        productByline={blok.productByline}
         preSelectFirstProduct={blok.preSelectFirstProduct}
         showSsnField={blok.showSsnField}
         campaignCode={blok.campaignCode}

--- a/apps/store/src/components/Pillow/Pillow.tsx
+++ b/apps/store/src/components/Pillow/Pillow.tsx
@@ -1,11 +1,22 @@
 import clsx from 'clsx'
 import Image from 'next/image'
 import { memo } from 'react'
+import { type Level } from 'ui'
 import { getImgSrc } from '@/services/storyblok/Storyblok.helpers'
 import { pillowVariants } from './Pillow.css'
 
+type PillowSize =
+  | 'mini'
+  | 'xxsmall'
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge'
+  | 'xxlarge'
+
 type PillowProps = {
-  size: 'mini' | 'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'
+  size: PillowSize | Partial<Record<Level | '_', PillowSize>>
   src?: string
   alt?: string | null
   priority?: boolean

--- a/apps/store/src/components/QuickPurchaseV2/QuickPurchase.tsx
+++ b/apps/store/src/components/QuickPurchaseV2/QuickPurchase.tsx
@@ -25,6 +25,7 @@ import { wrapper } from './QuickPurchase.css'
 
 type QuickPurchaseProps = {
   products: Array<string>
+  productByline?: string
   preSelectFirstProduct?: boolean
   showSsnField: boolean
   campaignCode?: string
@@ -174,9 +175,9 @@ export const QuickPurchaseV2 = (props: QuickPurchaseProps) => {
         productOptions={productOptions}
         defaultValue={props.preSelectFirstProduct ? productOptions[0].value : undefined}
         submitting={isSubmitting}
-        showSsnField={props.showSsnField}
         ssnDefaultValue={currentShopSession?.customer?.ssn ?? ''}
         error={error}
+        {...props}
       />
     </form>
   )

--- a/apps/store/src/components/QuickPurchaseV2/QuickPurchaseForm/QuickPurchaseForm.css.ts
+++ b/apps/store/src/components/QuickPurchaseV2/QuickPurchaseForm/QuickPurchaseForm.css.ts
@@ -1,15 +1,38 @@
 import { style } from '@vanilla-extract/css'
-import { tokens } from 'ui'
+import { responsiveStyles, tokens, xStack, yStack } from 'ui'
 
-export const wrapper = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: tokens.space.xxs,
-  maxWidth: '30rem',
-  marginInline: 'auto',
-  padding: '1rem',
-  border: `1px solid ${tokens.colors.borderTranslucent1}`,
-  borderRadius: tokens.radius.xl,
-  backgroundColor: tokens.colors.backgroundStandard,
-  boxShadow: tokens.shadow.card,
-})
+export const wrapper = style([
+  yStack({
+    gap: 'xs',
+  }),
+  {
+    maxWidth: '30rem',
+    marginInline: 'auto',
+    padding: tokens.space.xs,
+    border: `1px solid ${tokens.colors.borderTranslucent1}`,
+    borderRadius: tokens.radius.xl,
+    backgroundColor: tokens.colors.backgroundStandard,
+    boxShadow: tokens.shadow.card,
+    ...responsiveStyles({
+      lg: {
+        padding: tokens.space.lg,
+      },
+    }),
+  },
+])
+
+export const productSingleOption = style([
+  xStack({
+    gap: 'xs',
+    alignItems: 'center',
+  }),
+  {
+    marginBottom: tokens.space.xs,
+    ...responsiveStyles({
+      lg: {
+        gap: tokens.space.sm,
+        marginBottom: tokens.space.xs,
+      },
+    }),
+  },
+])

--- a/apps/store/src/components/QuickPurchaseV2/QuickPurchaseForm/QuickPurchaseForm.tsx
+++ b/apps/store/src/components/QuickPurchaseV2/QuickPurchaseForm/QuickPurchaseForm.tsx
@@ -1,8 +1,8 @@
-import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import { Button, sprinkles } from 'ui'
+import { Button, sprinkles, Text } from 'ui'
+import { Pillow } from '@/components/Pillow/Pillow'
 import { ProductSelector } from './ProductSelector'
-import { wrapper } from './QuickPurchaseForm.css'
+import { productSingleOption, wrapper } from './QuickPurchaseForm.css'
 import { SsnField } from './SsnField'
 
 export const SSN_FIELDNAME = 'ssn'
@@ -24,6 +24,7 @@ export type FormError = {
 
 type Props = {
   productOptions: Array<ProductOption>
+  productByline?: string
   defaultValue?: ProductOption['value']
   submitting?: boolean
   showSsnField?: boolean
@@ -33,6 +34,7 @@ type Props = {
 
 export const QuickPurchaseForm = ({
   productOptions,
+  productByline,
   defaultValue,
   submitting = false,
   ssnDefaultValue = '',
@@ -44,8 +46,18 @@ export const QuickPurchaseForm = ({
   return (
     <div className={wrapper}>
       {productOptions.length === 1 && (
-        <input type="hidden" name={PRODUCT_FIELDNAME} value={productOptions[0].value} />
+        <>
+          <input type="hidden" name={PRODUCT_FIELDNAME} value={productOptions[0].value} />
+          <div className={productSingleOption}>
+            <Pillow size={{ _: 'xsmall', lg: 'small' }} {...productOptions[0].img} />
+            <div>
+              <Text>{productOptions[0].name}</Text>
+              {productByline && <Text color="textSecondary">{productByline}</Text>}
+            </div>
+          </div>
+        </>
       )}
+
       {productOptions.length > 1 && (
         <ProductSelector
           productOptions={productOptions}
@@ -55,6 +67,7 @@ export const QuickPurchaseForm = ({
           required={true}
         />
       )}
+
       <SsnField
         name={SSN_FIELDNAME}
         defaultValue={ssnDefaultValue}
@@ -64,19 +77,12 @@ export const QuickPurchaseForm = ({
         message={error?.ssn}
         hidden={!showSsnField}
       />
-      <Button
-        type="submit"
-        loading={submitting}
-        fullWidth={true}
-        className={sprinkles({ mt: 'xxs' })}
-      >
+
+      <Button type="submit" loading={submitting} fullWidth={true}>
         {t('BUTTON_LABEL_GET_PRICE')}
       </Button>
-      {error?.general && <GeneralErrorMessage>{error.general}</GeneralErrorMessage>}
+
+      {error?.general && <p className={sprinkles({ textAlign: 'center' })}>{error.general}</p>}
     </div>
   )
 }
-
-const GeneralErrorMessage = styled.p({
-  textAlign: 'center',
-})


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Updated design for showing a single Product in QuickPurchase component.
- Added a field for `productByline` in storyblok
- Update type for Pillow size so we can use the `responsiveVariants`

<img width="1345" alt="Screenshot 2024-08-22 at 17 47 45" src="https://github.com/user-attachments/assets/bc48e24d-0930-4c09-882c-340b9d402540">

[Figma](https://www.figma.com/design/p1TEzLLVqJB9gKDNTDVGU4/Hedvig.com?node-id=1141-15438&m=dev)
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Updated design 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
