### PR TITLE
feat(connect payment): load content from CMS

### DIFF
--- a/apps/store/src/app/[locale]/new/checkout/[shopSessionId]/payment/trustly/page.tsx
+++ b/apps/store/src/app/[locale]/new/checkout/[shopSessionId]/payment/trustly/page.tsx
@@ -54,9 +54,23 @@ export default async function Page({ params, searchParams }: Props) {
   )
 }
 
-const CONNECT_PAYMENT_SLUG = 'connect-payment'
 function fetchConnectPaymentStory(locale: RoutingLocale): Promise<ConnectPaymentStory> {
-  return getStoryBySlug<ConnectPaymentStory>(CONNECT_PAYMENT_SLUG, { locale })
+  return getStoryBySlug<ConnectPaymentStory>(getConnectPaymentSlug(locale), { locale })
+}
+
+// It's not pefect but we have fewer cases to handle today and that gives editor more
+// flexibility when it comes about organizing content in storyblok
+function getConnectPaymentSlug(locale: RoutingLocale): string {
+  const CONNECT_PAYMENT_SLUG = 'connect-payment'
+
+  switch (locale) {
+    case 'se':
+      return `hjalp/${CONNECT_PAYMENT_SLUG}`
+    case 'se-en':
+      return `help/${CONNECT_PAYMENT_SLUG}`
+    default:
+      return ''
+  }
 }
 
 export const dynamic = 'force-dynamic'


### PR DESCRIPTION
## Describe your changes

Update slug for getting Connect Payment CMS page to match changes on storyblok.

I understand both need to be in sync and that could be a pain but so far we have a couple of cases and I don't expect that changing so often. If that chagnes then we can think on an alternative way.

## Justify why they are needed

As part of new designs for checkout page, CMS content was added to connect payment page

<img width="1079" alt="image" src="https://github.com/user-attachments/assets/59d06b69-96b7-4c96-b92b-3189cc23e89e">

