### PR TITLE
Update price calculator section preview design to match Figma

### DIFF
--- a/apps/store/src/features/priceCalculator/SectionPreview.css.ts
+++ b/apps/store/src/features/priceCalculator/SectionPreview.css.ts
@@ -1,0 +1,19 @@
+import { style } from '@vanilla-extract/css'
+import { tokens, xStack } from 'ui'
+
+export const sectionPreview = style([
+  xStack({
+    alignItems: 'center',
+    gap: 'xs',
+    paddingBlock: 'sm',
+    paddingInline: 'md',
+  }),
+  {
+    backgroundColor: tokens.colors.grayTranslucent100,
+    borderRadius: tokens.radius.md,
+  },
+])
+
+export const editButton = style({
+  backgroundColor: tokens.colors.white,
+})

--- a/apps/store/src/features/priceCalculator/SectionPreview.tsx
+++ b/apps/store/src/features/priceCalculator/SectionPreview.tsx
@@ -2,7 +2,7 @@ import { useSetAtom } from 'jotai'
 import { useTranslation } from 'next-i18next'
 import { startTransition, useMemo } from 'react'
 import { sprinkles } from 'ui/src/theme/sprinkles.css'
-import { Button, Text, tokens, xStack } from 'ui'
+import { Button, Text } from 'ui'
 import { SSN_SE_SECTION_ID } from '@/components/PriceCalculator/SsnSeSection'
 import { useTranslateFieldLabel } from '@/components/PriceCalculator/useTranslateFieldLabel'
 import { activeFormSectionIdAtom } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
@@ -12,6 +12,7 @@ import {
 } from '@/features/priceCalculator/priceCalculatorAtoms'
 import { type FormSection } from '@/services/PriceCalculator/PriceCalculator.types'
 import { useAutoFormat } from '@/utils/useFormatter'
+import { editButton, sectionPreview } from './SectionPreview.css'
 
 export function SectionPreview({ section }: { section: FormSection }) {
   const autoFormat = useAutoFormat()
@@ -50,22 +51,16 @@ export function SectionPreview({ section }: { section: FormSection }) {
   }
 
   return (
-    <div
-      className={xStack({ padding: 'md', alignItems: 'center', gap: 'xs' })}
-      style={{ backgroundColor: tokens.colors.backgroundStandard, borderRadius: tokens.radius.md }}
-    >
+    <div className={sectionPreview}>
       <div className={sprinkles({ flexGrow: 1, overflow: 'hidden' })}>
-        <Text color="textSecondary">{translateLabel(section.title)}</Text>
-        <Text size="xl" color="textSecondary" singleLine={true}>
+        <Text size="xs" color="textSecondary">
+          {translateLabel(section.title)}
+        </Text>
+        <Text size="md" singleLine={true}>
           {previewText}
         </Text>
       </div>
-      <Button
-        variant="secondary"
-        size="medium"
-        style={{ backgroundColor: tokens.colors.white }}
-        onClick={handleEdit}
-      >
+      <Button variant="secondary" size="small" onClick={handleEdit} className={editButton}>
         {t('PRICE_CALCULATOR_SECTION_EDIT_BUTTON')}
       </Button>
     </div>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Tweak styles for insurance form section preview to match Figma
- Get rid of inline styles used in first section

Before

![Screenshot 2024-08-23 at 10.37.17.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/44680c0f-a260-45fc-992a-7ef016008a45.png)

After

![Screenshot 2024-08-23 at 10.37.33.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/493149fe-406d-4377-98ba-8a35391f7038.png)


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [x] I have performed a self-review of my code
