### PR TITLE
Show priceIntent.notifications when presenting offer in price calculator

### DIFF
--- a/apps/store/src/components/Cancellation/CancellationForm.tsx
+++ b/apps/store/src/components/Cancellation/CancellationForm.tsx
@@ -50,11 +50,15 @@ export const CancellationForm = (props: Props) => {
     companyName: switcherCompanyName ?? 'Unknown',
   }
 
+  // TODO: Remove when all switchable products have priceIntent.notification. For now only car uses it
+  const shouldShowManualSwitchingNote =
+    props.offer.product.name !== 'SE_CAR' && switcherCompanyName != null
+
   switch (props.offer.cancellation.option) {
     case ExternalInsuranceCancellationOption.None:
       return (
         <>
-          {switcherCompanyName && (
+          {shouldShowManualSwitchingNote && (
             <InfoCard>{t('MANUAL_SWITCH_INFO', { COMPANY_NAME: switcherCompanyName })}</InfoCard>
           )}
 
@@ -69,9 +73,11 @@ export const CancellationForm = (props: Props) => {
     case ExternalInsuranceCancellationOption.Iex:
       return <IEXCancellation {...autoSwitchProps} {...startDateProps} />
 
+    // TODO: Remove when no longer supported for new purchases and old sessions have expired
     case ExternalInsuranceCancellationOption.Banksignering:
       return <BankSigneringCancellation {...autoSwitchProps} {...startDateProps} />
 
+    // TODO: Remove when no longer supported for new purchases and old sessions have expired
     case ExternalInsuranceCancellationOption.BanksigneringInvalidRenewalDate:
       if (startDateProps.startDate === undefined) {
         throw new Error('Cancellation | Missing start date')

--- a/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/OfferPresenter.tsx
@@ -8,6 +8,7 @@ import { memo, type MouseEventHandler, type ReactNode, type RefObject } from 're
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Space, Text, PlusIcon, theme } from 'ui'
 import { CancellationForm } from '@/components/Cancellation/CancellationForm'
+import { InfoCard } from '@/components/InfoCard/InfoCard'
 import { ScrollPast } from '@/components/ProductPage/ScrollPast/ScrollPast'
 import { ScrollToTopButton } from '@/components/ProductPage/ScrollToButton/ScrollToButton'
 import { useCartEntryToReplace } from '@/components/ProductPage/useCartEntryToReplace'
@@ -213,6 +214,10 @@ export const OfferPresenter = memo((props: Props) => {
                 defaultOpen={true}
               />
             )}
+
+            {priceIntent.notifications?.map((notification, index) => (
+              <InfoCard key={index}>{notification.message}</InfoCard>
+            ))}
 
             <CancellationForm productOfferIds={productOfferIds} offer={selectedOffer} />
 

--- a/apps/store/src/features/priceCalculator/OfferPresenterV2.tsx
+++ b/apps/store/src/features/priceCalculator/OfferPresenterV2.tsx
@@ -9,6 +9,7 @@ import { sprinkles } from 'ui/src/theme/sprinkles.css'
 import { Button, tokens, yStack } from 'ui'
 import { CancellationForm } from '@/components/Cancellation/CancellationForm'
 import Collapsible from '@/components/Collapsible/Collapsible'
+import { InfoCard } from '@/components/InfoCard/InfoCard'
 import { SSN_SE_SECTION_ID } from '@/components/PriceCalculator/SsnSeSection'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { useOfferDetails } from '@/components/ProductItem/useOfferDetails'
@@ -166,6 +167,10 @@ function OfferSummary() {
   return (
     <ProductCardSmall productData={productData} subtitle={selectedOffer.exposure.displayNameShort}>
       <OfferDetails />
+
+      {priceIntent.notifications?.map((notification, index) => (
+        <InfoCard key={index}>{notification.message}</InfoCard>
+      ))}
 
       <CancellationForm productOfferIds={productOfferIds} offer={selectedOffer} />
 

--- a/apps/store/src/graphql/PriceIntentFragment.graphql
+++ b/apps/store/src/graphql/PriceIntentFragment.graphql
@@ -23,4 +23,7 @@ fragment PriceIntent on PriceIntent {
   warning {
     ...PriceIntentWarning
   }
+  notifications {
+    message
+  }
 }

--- a/packages/ui/src/components/Alert/Alert.css.ts
+++ b/packages/ui/src/components/Alert/Alert.css.ts
@@ -60,6 +60,9 @@ export const iconStyles = style({
 
 export const bodyStyles = style({
   flex: 1,
+  // Prevent overflow when seeing untranslated key. Harmless otherwise
+  minWidth: 0,
+  overflowWrap: 'break-word',
 })
 
 export const messageStyles = style({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Show notification messages sent by storefront when presenting offers

![Screenshot 2024-08-27 at 14.15.16.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/56805015-049b-4296-88d0-63a97b3872bd.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

For now, this is needed to inform buyer about switching process for Car since we're removing BankSignering. In the future it will also cover "car not owned / decomissioned" notice and switching info for other products

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
