### PR TITLE
Remove productDocuments placeholders from price calculator page, terms-hub returns proper documents now

### DIFF
--- a/apps/store/src/features/priceCalculator/OfferPresenterV2.tsx
+++ b/apps/store/src/features/priceCalculator/OfferPresenterV2.tsx
@@ -196,21 +196,10 @@ function OfferDetails() {
   const selectedOffer = useSelectedOfferValueOrThrow()
   const productDetails = useOfferDetails(selectedOffer)
 
-  // const productDocuments = selectedOffer.variant.documents.map((item) => ({
-  //   title: item.displayName,
-  //   url: item.url,
-  // }))
-  // TODO: Replace with commented code above when terms-hub starts returning something
-  const productDocuments = [
-    {
-      title: 'TODO: Terms and conditions',
-      url: 'about:blank',
-    },
-    {
-      title: 'TODO: One-pager',
-      url: 'about:blank',
-    },
-  ]
+  const productDocuments = selectedOffer.variant.documents.map((item) => ({
+    title: item.displayName,
+    url: item.url,
+  }))
 
   const store = useStore()
   const handleEditClick = () => {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

We used to show temporary static data instead of product documents in price calculator page. This workaround is no longer needed

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
