### PR TITLE
fix(checkoutv2): make sure we redirect cart --> checkout

### DIFF
--- a/apps/store/next.config.mjs
+++ b/apps/store/next.config.mjs
@@ -136,12 +136,26 @@ const config = {
       console.log(`Loaded ${storyblokRedirects.length} redirects from storyblok`)
     }
 
+    const cartRedirects = [
+      {
+        source: '/se/cart',
+        destination: '/se/checkout',
+        permanent: true,
+      },
+      {
+        source: '/se-en/cart',
+        destination: '/se-en/checkout',
+        permanent: true,
+      },
+    ]
+
     return [
       ...noDkRedirects,
       ...oldSiteRedirects,
       ...getExperimentVariantRedirects(),
       ...memberAreaDefault,
       ...storyblokRedirects,
+      ...cartRedirects,
     ]
   },
 }


### PR DESCRIPTION
## Describe your changes

- Make sure we redirect cart --> checkout

## Justify why they are needed

So old links to cart page don't break.
