### PR TITLE
Set product metadata cache TTL to 10m in production and 1m in preview

### DIFF
--- a/apps/store/src/components/LayoutWithMenu/fetchProductMetadata.ts
+++ b/apps/store/src/components/LayoutWithMenu/fetchProductMetadata.ts
@@ -1,4 +1,5 @@
 import type { ApolloClient } from '@apollo/client'
+import { productDataFetchOptions } from '@/services/apollo/productDataFetchOptions'
 import type { ProductMetadataQuery } from '@/services/graphql/generated'
 import { ProductMetadataDocument } from '@/services/graphql/generated'
 
@@ -11,6 +12,7 @@ type Params = {
 export const fetchGlobalProductMetadata = async ({ apolloClient }: Params) => {
   const { data } = await apolloClient.query<ProductMetadataQuery>({
     query: ProductMetadataDocument,
+    context: { fetchOptions: productDataFetchOptions },
   })
   return data.availableProducts
 }

--- a/apps/store/src/components/ProductData/fetchProductData.ts
+++ b/apps/store/src/components/ProductData/fetchProductData.ts
@@ -1,4 +1,5 @@
 import { type ApolloClient, type DefaultContext } from '@apollo/client'
+import { productDataFetchOptions } from '@/services/apollo/productDataFetchOptions'
 import {
   ProductDataDocument,
   type ProductDataQuery,
@@ -19,7 +20,7 @@ export const fetchProductData = async ({
   const { data } = await apolloClient.query<ProductDataQuery, ProductDataQueryVariables>({
     query: ProductDataDocument,
     variables,
-    context,
+    context: context ?? { fetchOptions: productDataFetchOptions },
   })
 
   if (!data.product) {

--- a/apps/store/src/services/apollo/productDataFetchOptions.ts
+++ b/apps/store/src/services/apollo/productDataFetchOptions.ts
@@ -1,0 +1,9 @@
+// Shorter validation window in preview environments to simplify testing terms changes
+// GOTCHA: storefront has its own caching for product metadata configured in storyblok, so you may see delays there
+export const productDataFetchOptions = {
+  next: {
+    revalidate: process.env.VERCEL_ENV === 'production' ? 10 * 60 : 60,
+    // Not used yet, but makes debugging with NEXT_PRIVATE_DEBUG_CACHE=1 easier
+    tags: ['productData'],
+  },
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Add caching for product data (availableProduct and productData queries). 10m TTL in production, 1m otherwise

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

This should simplify testing terms-hub changes on product pages. Sometimes debug tool is not enough

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
