### PR TITLE
GEN-2430 - fix(sync-price-intent): create new price intent when using priceIntentAtoms in the context of old price calculator

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -115,7 +115,10 @@ const PurchaseFormInner = (props: PurchaseFormInnerProps) => {
   const isLarge = useBreakpoint('lg')
 
   const preloadedPriceIntentId = usePreloadedPriceIntentId()
-  useSyncPriceIntentState(preloadedPriceIntentId)
+  useSyncPriceIntentState({
+    preloadedPriceIntentId,
+    replacePriceIntentWhenCurrentIsAddedToCart: true,
+  })
 
   const isPriceCalculatorExpanded = useIsPriceCalculatorExpanded()
   const [formState, setFormState] = usePurchaseFormState(

--- a/apps/store/src/features/widget/CalculatePricePage.tsx
+++ b/apps/store/src/features/widget/CalculatePricePage.tsx
@@ -131,7 +131,7 @@ export const CalculatePricePage = (props: Props) => {
   }
 
   useSyncPriceTemplate(props.priceTemplate)
-  useSyncPriceIntentState(priceIntentId)
+  useSyncPriceIntentState({ preloadedPriceIntentId: priceIntentId })
 
   const isReady = useIsPriceIntentStateReady()
   if (!isReady) {


### PR DESCRIPTION
## Describe your changes

Fixes an issue with `priceIntentAtoms` where a new price intent was being created whenever we have an offer for a product related with an existing price intent in the cart. We want that behaviour for old price calculator but not for the new one.
