### PR TITLE
Seb lead debugger - import by ID

### DIFF
--- a/apps/store/src/app/debugger/seb-leads/CreateSebLeadsForm.tsx
+++ b/apps/store/src/app/debugger/seb-leads/CreateSebLeadsForm.tsx
@@ -1,14 +1,14 @@
 'use client'
 
 import { useFormState } from 'react-dom'
-import { Alert, yStack } from 'ui'
+import { yStack } from 'ui'
+import { FormResults } from '@/app/debugger/seb-leads/FormResults'
 import { SubmitButton } from '@/appComponents/SubmitButton'
-import { ErrorMessages } from '@/components/FormErrors/ErrorMessages'
 import { InputSelect } from '@/components/InputSelect/InputSelect'
 import { PersonalNumberField } from '@/components/PersonalNumberField/PersonalNumberField'
 import { TextField } from '@/components/TextField/TextField'
+import { SebDebuggerFormElement } from './constants'
 import { createSebLead } from './createSebLead'
-import { SEBFormElement } from './types'
 
 const PRODUCT_OPTIONS = [
   { name: 'SE_CAR (carInsurance)', value: 'carInsurance' },
@@ -36,55 +36,46 @@ export const SebLeadsDebuggerForm = () => {
     <form action={formAction} className={yStack({ gap: 'xs' })}>
       <PersonalNumberField
         label="SSN"
-        name={SEBFormElement.SSN}
+        name={SebDebuggerFormElement.SSN}
         required={true}
-        defaultValue={state?.fields?.[SEBFormElement.SSN]}
+        defaultValue={state?.fields?.[SebDebuggerFormElement.SSN]}
       />
       <TextField
-        name={SEBFormElement.FirstName}
-        type="text"
-        label={SEBFormElement.FirstName}
-        defaultValue={state?.fields?.[SEBFormElement.FirstName]}
+        name={SebDebuggerFormElement.FirstName}
+        label={SebDebuggerFormElement.FirstName}
+        defaultValue={state?.fields?.[SebDebuggerFormElement.FirstName]}
         required={true}
       />
       <TextField
-        type="text"
-        label={SEBFormElement.LastName}
-        name={SEBFormElement.LastName}
+        label={SebDebuggerFormElement.LastName}
+        name={SebDebuggerFormElement.LastName}
         required={true}
-        defaultValue={state?.fields?.[SEBFormElement.LastName]}
+        defaultValue={state?.fields?.[SebDebuggerFormElement.LastName]}
       />
       <TextField
-        type="text"
-        label={SEBFormElement.Email}
-        name={SEBFormElement.Email}
+        label={SebDebuggerFormElement.Email}
+        name={SebDebuggerFormElement.Email}
         required={true}
-        defaultValue={state?.fields?.[SEBFormElement.Email]}
+        defaultValue={state?.fields?.[SebDebuggerFormElement.Email]}
       />
       <TextField
-        type="text"
-        label={SEBFormElement.PhoneNumber}
-        name={SEBFormElement.PhoneNumber}
+        label={SebDebuggerFormElement.PhoneNumber}
+        name={SebDebuggerFormElement.PhoneNumber}
         required={true}
-        defaultValue={state?.fields?.[SEBFormElement.PhoneNumber]}
+        defaultValue={state?.fields?.[SebDebuggerFormElement.PhoneNumber]}
       />
       {/*
       TODO: select multiple values to be pushed to an array
           // multiple={true} looked bad
       */}
       <InputSelect
-        name={SEBFormElement.Product}
+        name={SebDebuggerFormElement.Product}
         required={true}
-        defaultValue={state?.fields?.[SEBFormElement.Product]}
+        defaultValue={state?.fields?.[SebDebuggerFormElement.Product]}
         options={PRODUCT_OPTIONS}
       />
       <SubmitButton>Create SEB lead</SubmitButton>
-      <ErrorMessages errors={state?.errors?.generic} />
-      {state?.messages?.map((message, index) => (
-        <Alert.Root key={index} variant={message.type}>
-          <Alert.Message>{message.content}</Alert.Message>
-        </Alert.Root>
-      ))}
+      <FormResults formState={state} />
     </form>
   )
 }

--- a/apps/store/src/app/debugger/seb-leads/FormResults.tsx
+++ b/apps/store/src/app/debugger/seb-leads/FormResults.tsx
@@ -1,0 +1,16 @@
+import { Alert } from 'ui'
+import { type FormStateWithErrors } from '@/app/types/formStateTypes'
+import { ErrorMessages } from '@/components/FormErrors/ErrorMessages'
+
+export function FormResults({ formState }: { formState: FormStateWithErrors }) {
+  return (
+    <>
+      <ErrorMessages errors={formState?.errors?.generic} />
+      {formState?.messages?.map((message, index) => (
+        <Alert.Root key={index} variant={message.type}>
+          <Alert.Message>{message.content}</Alert.Message>
+        </Alert.Root>
+      ))}
+    </>
+  )
+}

--- a/apps/store/src/app/debugger/seb-leads/ImportSebLeadForm.tsx
+++ b/apps/store/src/app/debugger/seb-leads/ImportSebLeadForm.tsx
@@ -1,0 +1,23 @@
+'use client'
+import { useFormState } from 'react-dom'
+import { yStack } from 'ui'
+import { SubmitButton } from '@/appComponents/SubmitButton'
+import { TextField } from '@/components/TextField/TextField'
+import { SebDebuggerFormElement } from './constants'
+import { FormResults } from './FormResults'
+import { importSebLead } from './importSebLead'
+
+export function ImportSebLeadForm() {
+  const [state, importLead] = useFormState(importSebLead, {})
+  return (
+    <form className={yStack({ gap: 'xs' })} action={importLead}>
+      <TextField
+        label="Insurely session ID (sebInsurelyId)"
+        name={SebDebuggerFormElement.SebInsurelyId}
+        required={true}
+      />
+      <SubmitButton>Import SEB lead</SubmitButton>
+      <FormResults formState={state} />
+    </form>
+  )
+}

--- a/apps/store/src/app/debugger/seb-leads/constants.ts
+++ b/apps/store/src/app/debugger/seb-leads/constants.ts
@@ -1,0 +1,9 @@
+export enum SebDebuggerFormElement {
+  FirstName = 'firstName',
+  LastName = 'lastName',
+  SSN = 'ssn',
+  PhoneNumber = 'phoneNumber',
+  Email = 'email',
+  Product = 'product',
+  SebInsurelyId = 'sebInsurelyId',
+}

--- a/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
+++ b/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
@@ -1,18 +1,18 @@
 'use server'
 
-import { SEBFormElement } from '@/app/debugger/seb-leads/types'
 import type { FormStateWithErrors } from '@/app/types/formStateTypes'
+import { SebDebuggerFormElement } from './constants'
 
 export const createSebLead = async (
   _: FormStateWithErrors,
   formData: FormData,
 ): Promise<FormStateWithErrors> => {
-  const ssn = formData.get(SEBFormElement.SSN) as string
-  const firstName = formData.get(SEBFormElement.FirstName) as string
-  const lastName = formData.get(SEBFormElement.LastName) as string
-  const email = formData.get(SEBFormElement.Email) as string
-  const phoneNumber = formData.get(SEBFormElement.PhoneNumber) as string
-  const product = formData.get(SEBFormElement.Product) as string
+  const ssn = formData.get(SebDebuggerFormElement.SSN) as string
+  const firstName = formData.get(SebDebuggerFormElement.FirstName) as string
+  const lastName = formData.get(SebDebuggerFormElement.LastName) as string
+  const email = formData.get(SebDebuggerFormElement.Email) as string
+  const phoneNumber = formData.get(SebDebuggerFormElement.PhoneNumber) as string
+  const product = formData.get(SebDebuggerFormElement.Product) as string
 
   const parameters = {
     personalNumber: ssn,
@@ -37,7 +37,7 @@ export const createSebLead = async (
       messages: [{ type: 'success', content: message }],
     }
   } catch (error) {
-    console.error('Error creating car trial', error)
+    console.error('Error creating SEB lead', error)
     const errorMessage = error instanceof Error ? error.message : 'Unknown error'
 
     return {
@@ -67,11 +67,11 @@ type CreateSebLeadsResponse = {
 const createSebLeadStaging = async (
   params: CreateSebLeadsParams,
 ): Promise<CreateSebLeadsResponse> => {
-  const API_URL = process.env.SEB_LEADS_API_URL
+  const API_URL = process.env.SEB_LEADS_INSURELY_API_URL
   if (!API_URL) {
     throw new Error('SEB_LEADS_API_URL not configured')
   }
-  const API_KEY = process.env.SEB_LEADS_API_KEY
+  const API_KEY = process.env.SEB_LEADS_INSURELY_API_KEY
   if (!API_KEY) {
     throw new Error('SEB_LEADS_API_KEY not configured')
   }

--- a/apps/store/src/app/debugger/seb-leads/importSebLead.ts
+++ b/apps/store/src/app/debugger/seb-leads/importSebLead.ts
@@ -1,0 +1,54 @@
+'use server'
+import { SebDebuggerFormElement } from '@/app/debugger/seb-leads/constants'
+import type { FormStateWithErrors } from '@/app/types/formStateTypes'
+import { getFormValueOrThrow } from '@/utils/getFormValueOrTrrow'
+
+export const importSebLead = async (
+  _: FormStateWithErrors,
+  formData: FormData,
+): Promise<FormStateWithErrors> => {
+  try {
+    const headers = new Headers()
+    headers.set(
+      'Authorization',
+      'Basic ' +
+        Buffer.from(
+          `${getEnvOrThrow('SEB_LEADS_STOREFRONT_API_USERNAME')}:${getEnvOrThrow('SEB_LEADS_STOREFRONT_API_PASSWORD')}`,
+          'utf-8',
+        ).toString('base64'),
+    )
+    const sebInsurelyId = getFormValueOrThrow(formData, SebDebuggerFormElement.SebInsurelyId)
+    const response = await fetch(
+      `${getEnvOrThrow('SEB_LEADS_STOREFRONT_API_URL')}/leads/${sebInsurelyId}`,
+      { method: 'POST', headers },
+    )
+    const result = await response.json()
+    console.debug('API response', result)
+    if (!response.ok) {
+      throw new Error(`${result.status}: ${result.error ?? 'Unknown error'}`)
+    }
+    return {
+      messages: (result as { messages: Array<string> }).messages.map((message) => ({
+        type: 'success',
+        content: message,
+      })),
+    }
+  } catch (err) {
+    console.error('Error creating SEB lead', err)
+    const errorMessage = err instanceof Error ? err.message : 'Unknown error'
+
+    return {
+      errors: {
+        generic: [errorMessage],
+      },
+    }
+  }
+}
+
+const getEnvOrThrow = (name: string): string => {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`${name} not configured`)
+  }
+  return value
+}

--- a/apps/store/src/app/debugger/seb-leads/page.tsx
+++ b/apps/store/src/app/debugger/seb-leads/page.tsx
@@ -1,5 +1,6 @@
 import { Heading, sprinkles, Text, yStack } from 'ui'
 import { SebLeadsDebuggerForm } from '@/app/debugger/seb-leads/CreateSebLeadsForm'
+import { ImportSebLeadForm } from '@/app/debugger/seb-leads/ImportSebLeadForm'
 import * as GridLayout from '@/components/GridLayout/GridLayout'
 
 function SebLeadsDebuggerPage() {
@@ -9,11 +10,13 @@ function SebLeadsDebuggerPage() {
   return (
     <GridLayout.Root>
       <GridLayout.Content width="1/3" align="center">
-        <div className={yStack({ gap: 'xl' })}>
-          <Heading className={sprinkles({ marginTop: 'xl' })} as="h1" align="center" balance={true}>
-            Create SEB Leads
-          </Heading>
+        <div className={yStack({ gap: 'md' })}>
+          <Heading as="h2">Create SEB Lead</Heading>
           <SebLeadsDebuggerForm />
+          <Heading as="h2" className={sprinkles({ marginTop: 'xl' })}>
+            Import SEB Lead
+          </Heading>
+          <ImportSebLeadForm />
         </div>
       </GridLayout.Content>
     </GridLayout.Root>

--- a/apps/store/src/app/debugger/seb-leads/types.ts
+++ b/apps/store/src/app/debugger/seb-leads/types.ts
@@ -1,8 +1,0 @@
-export enum SEBFormElement {
-    FirstName = 'firstName',
-    LastName = 'lastName',
-    SSN = 'ssn',
-    PhoneNumber = 'phoneNumber',
-    Email = 'email',
-    Product = 'product',
-}

--- a/apps/store/src/app/debugger/trial/debuggerTrial.utils.ts
+++ b/apps/store/src/app/debugger/trial/debuggerTrial.utils.ts
@@ -90,6 +90,7 @@ export const getPartner = (formData: FormData): string => {
   return getOrThrow(formData, Field.partner)
 }
 
+// TODO: use getFormValueOrThrow
 const getOrThrow = (formData: FormData, field: string): string => {
   const value = formData.get(field)
   if (typeof value !== 'string') throw new Error(`Missing field ${field}`)

--- a/apps/store/src/utils/getFormValueOrTrrow.ts
+++ b/apps/store/src/utils/getFormValueOrTrrow.ts
@@ -1,0 +1,5 @@
+export const getFormValueOrThrow = (formData: FormData, field: string): string => {
+  const value = formData.get(field)
+  if (typeof value !== 'string') throw new Error(`Missing field ${field}`)
+  return value
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Manual import tool for SEB leads debugger

![Screenshot 2024-09-03 at 10.37.54.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/057ec39f-6118-4f0f-9aeb-414e8e8fedd5.png)

Imports single lead by external ID, returned by previous debugger step

Also, some refactorings
- Extract `getFormValueOrThrow(formData, name)` function
- Extract `<FormResults formState={formState} />` component for rendering errors and success messages

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [x] I have performed a self-review of my code
