### PR TITLE
Support entering widget flow with pre-create shopSession and priceIntent

### DIFF
--- a/apps/store/src/pages/[locale]/widget/flows/[...slug].tsx
+++ b/apps/store/src/pages/[locale]/widget/flows/[...slug].tsx
@@ -37,6 +37,23 @@ export const getServerSideProps: GetServerSideProps<any, Params> = async (contex
   resetAuthTokensIfPresent(context)
 
   const apolloClient = await initializeApolloServerSide({ ...context, locale: context.locale })
+
+  if (url.searchParams.has('shopSessionId') && url.searchParams.has('priceIntentId')) {
+    // Special case, redirect to prefilled price calculator
+    // Used in SEB leads flow
+    return {
+      redirect: {
+        destination: PageLink.widgetCalculatePrice({
+          locale: context.locale,
+          flow: flowMetadata.flow,
+          shopSessionId: url.searchParams.get('shopSessionId') as string,
+          priceIntentId: url.searchParams.get('priceIntentId') as string,
+        }).href,
+        permanent: false,
+      },
+    }
+  }
+
   const [shopSessionId, searchParams] = await createPartnerShopSession({
     apolloClient,
     countryCode: getCountryByLocale(context.locale).countryCode,


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Subj

SEB lead API pre-creates shopSession and priceIntent based on lead info and then uses new widget flow params to provide entry point for a user

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
