### PR TITLE
Add single tiers support for PerilsTable

### DIFF
--- a/apps/store/src/components/Perils/PerilsTable/PerilsTable.tsx
+++ b/apps/store/src/components/Perils/PerilsTable/PerilsTable.tsx
@@ -1,8 +1,10 @@
 'use client'
 import { useMemo } from 'react'
+import { Heading, yStack } from 'ui'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import type { PerilFragment } from '@/services/graphql/generated'
 import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
+import { Perils } from '../Perils'
 import { PerilsTableDesktop } from './PerilsTableDesktop/PerilsTableDesktop'
 import { PerilsTabs } from './PerilsTabs'
 
@@ -40,10 +42,33 @@ export function PerilsTable({ heading, description }: PerilsTableProps) {
   return (
     <>
       {variant === 'mobile' && (
-        <div>
-          <PerilsTabs heading={heading} description={description} variantsPerils={variantsPerils} />
-        </div>
+        <>
+          {variantsPerils.length === 1 && (
+            <div className={yStack({ gap: 'lg' })}>
+              {heading && (
+                <Heading as="p" color="textPrimary" variant="standard.24" balance={true}>
+                  {heading}
+                </Heading>
+              )}
+              {description && (
+                <Heading as="p" color="textSecondary" variant="standard.24" balance={true}>
+                  {description}
+                </Heading>
+              )}
+              <Perils items={variantsPerils[0].perils} />
+            </div>
+          )}
+
+          {variantsPerils.length > 1 && (
+            <PerilsTabs
+              heading={heading}
+              description={description}
+              variantsPerils={variantsPerils}
+            />
+          )}
+        </>
       )}
+
       {variant === 'desktop' && (
         <PerilsTableDesktop
           heading={heading}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add support for single tier products like accident

In mobile we show Perils component and in desktop we show a table 



<img width="421" alt="Screenshot 2024-09-10 at 16 27 51" src="https://github.com/user-attachments/assets/e8703fff-8bd7-4fcb-9c0d-9be7456de286">
<img width="1165" alt="Screenshot 2024-09-10 at 16 28 29" src="https://github.com/user-attachments/assets/6b2246df-c407-4523-9fef-a1021bd26db4">
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Request from design (Nils)
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
