### PR TITLE
Cache commonly used company/product review requests

### DIFF
--- a/apps/store/public/mockServiceWorker.js
+++ b/apps/store/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.4.3'
+const PACKAGE_VERSION = '2.4.4'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Use `unstable_cache` from `next/cache` to cache product and company review requests used in store layout

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Checkout page has longer response time according to site speed reports and one of root causes seems to be forced cache miss when fetching review metadata in store layout. Adding data cache remediates this

## Checklist before requesting a review

- [x] I have performed a self-review of my code
