### PR TITLE
Add product subtype handling for condo insurance in SEB lead creation

### DIFF
--- a/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
+++ b/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
@@ -13,7 +13,17 @@ export const createSebLead = async (
   const lastName = formData.get(SebDebuggerFormElement.LastName) as string
   const email = formData.get(SebDebuggerFormElement.Email) as string
   const phoneNumber = formData.get(SebDebuggerFormElement.PhoneNumber) as string
-  const product = formData.get(SebDebuggerFormElement.Product) as string
+  let product = formData.get(SebDebuggerFormElement.Product) as string
+  let  maybeProductSubType = null
+
+  if (product === 'condoInsuranceBrf') {
+    product = 'condoInsurance'
+    maybeProductSubType = 'condoInsurance.condoInsuranceCondominium'
+  } else if (product === 'condoInsuranceRent') {
+    product = 'condoInsurance'
+    maybeProductSubType = 'condoInsurance.condoInsuranceRental'
+  }
+
 
   const parameters = {
     personalNumber: ssn,
@@ -23,6 +33,7 @@ export const createSebLead = async (
     contactEmail: email,
     metadata: {
       productType: product,
+      productSubType: maybeProductSubType
     },
   }
   let sebSessionId: string | null


### PR DESCRIPTION
### TL;DR

Enhanced product handling for SEB lead creation, specifically for condo insurance types.

### What changed?

- Modified the `createSebLead` function to handle specific condo insurance products.
- Introduced logic to differentiate between 'condoInsuranceBrf' and 'condoInsuranceRent' products.
- Added a new `productSubType` field to the metadata for more precise product categorization.

## Why make this change?
- After discussing with SEB/Insurly we figured out that we  are creating the leads incorrectly