### PR TITLE
changed endpoints path to reflect its debugging purpose

### DIFF
--- a/apps/store/src/app/debugger/seb-leads/createWidgetSession.ts
+++ b/apps/store/src/app/debugger/seb-leads/createWidgetSession.ts
@@ -10,7 +10,7 @@ export const createWidgetSession = async (
 ): Promise<FormStateWithErrors> => {
   try {
     const leadId = getFormValueOrThrow(formData, SebDebuggerFormElement.LeadId)
-    const result = await storefrontLeadsApiRequest(`/debugg/leads/${leadId}/widgetSession`, {
+    const result = await storefrontLeadsApiRequest(`/debug/leads/${leadId}/widgetSession`, {
       method: 'POST',
     })
     return {

--- a/apps/store/src/app/debugger/seb-leads/createWidgetSession.ts
+++ b/apps/store/src/app/debugger/seb-leads/createWidgetSession.ts
@@ -10,7 +10,7 @@ export const createWidgetSession = async (
 ): Promise<FormStateWithErrors> => {
   try {
     const leadId = getFormValueOrThrow(formData, SebDebuggerFormElement.LeadId)
-    const result = await storefrontLeadsApiRequest(`/leads/${leadId}/widgetSession`, {
+    const result = await storefrontLeadsApiRequest(`/debugg/leads/${leadId}/widgetSession`, {
       method: 'POST',
     })
     return {

--- a/apps/store/src/app/debugger/seb-leads/generateAndSendOffer.ts
+++ b/apps/store/src/app/debugger/seb-leads/generateAndSendOffer.ts
@@ -5,7 +5,7 @@ import { storefrontLeadsApiRequest } from './storefrontLeadsApiRequest'
 export const generateAndSendOffer = async (
 ): Promise<FormStateWithErrors> => {
   try {
-    const result = await storefrontLeadsApiRequest(`/debugg/generate-and-send-offer`, {
+    const result = await storefrontLeadsApiRequest(`/debug/generate-and-send-offer`, {
       method: 'POST',
     })
     return {

--- a/apps/store/src/app/debugger/seb-leads/generateAndSendOffer.ts
+++ b/apps/store/src/app/debugger/seb-leads/generateAndSendOffer.ts
@@ -5,7 +5,7 @@ import { storefrontLeadsApiRequest } from './storefrontLeadsApiRequest'
 export const generateAndSendOffer = async (
 ): Promise<FormStateWithErrors> => {
   try {
-    const result = await storefrontLeadsApiRequest(`/cron/generate-and-send-offer`, {
+    const result = await storefrontLeadsApiRequest(`/debugg/generate-and-send-offer`, {
       method: 'POST',
     })
     return {

--- a/apps/store/src/app/debugger/seb-leads/importSebLead.ts
+++ b/apps/store/src/app/debugger/seb-leads/importSebLead.ts
@@ -10,7 +10,7 @@ export const importSebLead = async (
 ): Promise<FormStateWithErrors> => {
   try {
     const sebInsurelyId = getFormValueOrThrow(formData, SebDebuggerFormElement.SebInsurelyId)
-    const result = await storefrontLeadsApiRequest(`/leads/${sebInsurelyId}`, { method: 'POST' })
+    const result = await storefrontLeadsApiRequest(`/debugg/leads/${sebInsurelyId}`, { method: 'POST' })
     return {
       messages: (result as { messages: Array<string> }).messages.map((message) => ({
         type: 'success',

--- a/apps/store/src/app/debugger/seb-leads/importSebLead.ts
+++ b/apps/store/src/app/debugger/seb-leads/importSebLead.ts
@@ -10,7 +10,7 @@ export const importSebLead = async (
 ): Promise<FormStateWithErrors> => {
   try {
     const sebInsurelyId = getFormValueOrThrow(formData, SebDebuggerFormElement.SebInsurelyId)
-    const result = await storefrontLeadsApiRequest(`/debugg/leads/${sebInsurelyId}`, { method: 'POST' })
+    const result = await storefrontLeadsApiRequest(`/debug/leads/${sebInsurelyId}`, { method: 'POST' })
     return {
       messages: (result as { messages: Array<string> }).messages.map((message) => ({
         type: 'success',


### PR DESCRIPTION
### TL;DR

Updated API endpoints for SEB leads debugger functionality.

### What changed?

Modified API endpoint paths in three files:
- `createWidgetSession.ts`: Changed to `/debug/leads/${leadId}/widgetSession`
- `generateAndSendOffer.ts`: Changed to `/debug/generate-and-send-offer`
- `importSebLead.ts`: Changed to `/debug/leads/${sebInsurelyId}`

### Why make this change?

This change adds a `/debug` prefix to the API endpoints used in the SEB leads debugger. This modification aims to clearly separate debugging-related API calls from production endpoints.
