### PR TITLE
rename seb leads env vars

### DIFF
--- a/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
+++ b/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
@@ -79,8 +79,8 @@ type CreateSebLeadsResponse = {
 const createSebLeadStaging = async (
   params: CreateSebLeadsParams,
 ): Promise<CreateSebLeadsResponse> => {
-  const API_URL = getEnvOrThrow('SEB_LEADS_API_URL')
-  const API_KEY = getEnvOrThrow ('SEB_LEADS_API_KEY')
+  const API_URL = getEnvOrThrow('SEB_LEADS_INSURELY_API_URL')
+  const API_KEY = getEnvOrThrow ('SEB_LEADS_INSURELY_API_KEY')
 
   const url = new URL(API_URL)
   const headers = new Headers({

--- a/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
+++ b/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
@@ -79,6 +79,7 @@ type CreateSebLeadsResponse = {
 const createSebLeadStaging = async (
   params: CreateSebLeadsParams,
 ): Promise<CreateSebLeadsResponse> => {
+
   const API_URL = getEnvOrThrow('SEB_LEADS_INSURELY_API_URL')
   const API_KEY = getEnvOrThrow ('SEB_LEADS_INSURELY_API_KEY')
 

--- a/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
+++ b/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
@@ -79,7 +79,6 @@ type CreateSebLeadsResponse = {
 const createSebLeadStaging = async (
   params: CreateSebLeadsParams,
 ): Promise<CreateSebLeadsResponse> => {
-
   const API_URL = getEnvOrThrow('SEB_LEADS_INSURELY_API_URL')
   const API_KEY = getEnvOrThrow ('SEB_LEADS_INSURELY_API_KEY')
 


### PR DESCRIPTION
<!--
PR title: Update SEB Leads API environment variables
-->

## Describe your changes

- Updated the environment variable names for SEB Leads API in the `createSebLeadStaging` function:
  - Changed `SEB_LEADS_API_URL` to `SEB_LEADS_INSURELY_API_URL`
  - Changed `SEB_LEADS_API_KEY` to `SEB_LEADS_INSURELY_API_KEY`

## Justify why they are needed

When refactoring to use the function `getEnvOrThrow` I used the wrong name for the env variables 