### PR TITLE
fix(cart-toast): send 'being_checkout' event

### DIFF
--- a/apps/store/src/components/CartNotification/CartToast.tsx
+++ b/apps/store/src/components/CartNotification/CartToast.tsx
@@ -15,6 +15,7 @@ import { BundleDiscountSummary } from '@/features/bundleDiscount/BundleDiscountS
 import type { CartFragment } from '@/services/graphql/generated'
 import { ExternalInsuranceCancellationOption } from '@/services/graphql/generated'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
+import { useTracking } from '@/services/Tracking/useTracking'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { useFormatter } from '@/utils/useFormatter'
@@ -39,10 +40,13 @@ export const CartToast = forwardRef<CartToastAttributes>((_, forwardedRef) => {
   const locale = useRoutingLocale()
   const { shopSession } = useShopSession()
   const { cart } = shopSession ?? {}
+  const tracking = useTracking()
+
   if (shopSession == null || cart == null) return null
 
   const handleClickLink = (type: 'Primary' | 'Secondary') => () => {
     datadogRum.addAction(`CartToast Link ${type}`)
+    tracking.reportBeginCheckout(cart)
   }
 
   let bundleDiscountHeader: ReactNode


### PR DESCRIPTION
## Describe your changes

Update Cart toast so we send 'begin_checkout' when "see your cart" button get's clicked

## Justify why they are needed

When _Checkout_ and _Cart_ page was merged and old _Cart_ we didn't cover where we should send 'begin_checkout' event:

* User add a quote to the cart
* Cart toast get's displayed
* User clicks on "see your cart"

That scenario was being covered before because cart toast would redirect _Cart_ page which then had buttons that send that event. Since _Cart_ page is now gone and Cart toast redirects directly to _Checkout_ page, we need to send that event in the context of Cart toast.