### PR TITLE
Update product subtype initialization in SEB lead creation

### DIFF
--- a/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
+++ b/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
@@ -14,7 +14,7 @@ export const createSebLead = async (
   const email = formData.get(SebDebuggerFormElement.Email) as string
   const phoneNumber = formData.get(SebDebuggerFormElement.PhoneNumber) as string
   let product = formData.get(SebDebuggerFormElement.Product) as string
-  let  maybeProductSubType : string | undefined = undefined
+  let  maybeProductSubType: string | undefined
 
   if (product === 'condoInsuranceBrf') {
     product = 'condoInsurance'

--- a/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
+++ b/apps/store/src/app/debugger/seb-leads/createSebLead.tsx
@@ -14,7 +14,7 @@ export const createSebLead = async (
   const email = formData.get(SebDebuggerFormElement.Email) as string
   const phoneNumber = formData.get(SebDebuggerFormElement.PhoneNumber) as string
   let product = formData.get(SebDebuggerFormElement.Product) as string
-  let  maybeProductSubType = null
+  let  maybeProductSubType : string | undefined = undefined
 
   if (product === 'condoInsuranceBrf') {
     product = 'condoInsurance'


### PR DESCRIPTION
<!--
PR title: Update type definition in createSebLead function
-->

## Describe your changes

- Modified the type definition of `maybeProductSubType` variable in the `createSebLead` function
- Changed from `null` -> `string | undefined = undefined`

## Justify why they are needed

SEB api does not except null values for `productSubType` , so if not initialized do not include it.