### PR TITLE
Remove react-wrap-balancer and use native css rule instead

### DIFF
--- a/apps/store/src/appComponents/RootLayout/RootLayout.tsx
+++ b/apps/store/src/appComponents/RootLayout/RootLayout.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx'
 import { Suspense, type PropsWithChildren } from 'react'
-import { Provider as BalancerProvider } from 'react-wrap-balancer'
 import globalCss from 'ui/src/global.css'
 import { mainTheme } from 'ui'
 import { NavigationProgressIndicator } from '@/appComponents/RootLayout/NavigationProgressIndicator'
@@ -33,9 +32,7 @@ export function RootLayout({
         </Suspense>
         <NavigationProgressIndicator />
 
-        <ApolloProvider locale={locale}>
-          <BalancerProvider>{children}</BalancerProvider>
-        </ApolloProvider>
+        <ApolloProvider locale={locale}>{children}</ApolloProvider>
       </body>
     </html>
   )

--- a/apps/store/src/components/InsurableLimits/InsurableLimits.tsx
+++ b/apps/store/src/components/InsurableLimits/InsurableLimits.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled'
 import React from 'react'
-import Balancer from 'react-wrap-balancer'
 import { Badge, Text, theme } from 'ui'
 import * as GridLayout from '@/components/GridLayout/GridLayout'
 import { badge } from './InsurableLimits.css'
@@ -35,11 +34,9 @@ export const InsurableLimits = ({ items }: InsurableLimitsProps) => {
             {item.label}
           </Badge>
           <Text size="xl">{item.value}</Text>
-          <Balancer ratio={0.65}>
-            <Text size="xl" color="textSecondary">
-              {item.description}
-            </Text>
-          </Balancer>
+          <Text size="xl" color="textSecondary" balance={true}>
+            {item.description}
+          </Text>
         </GridLayout.Content>
       ))}
     </Grid>

--- a/apps/store/src/components/ProductItem/EditActionButton.tsx
+++ b/apps/store/src/components/ProductItem/EditActionButton.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled'
 import { useTranslation } from 'next-i18next'
-import Balancer from 'react-wrap-balancer'
 import { Button, Text } from 'ui'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
 import type { ProductOfferFragment } from '@/services/graphql/generated'
@@ -39,8 +38,8 @@ export const EditActionButton = ({ offer }: Props) => {
         }
       >
         <FullscreenDialog.Title asChild={true}>
-          <CappedText size={{ _: 'md', lg: 'xl' }} align="center">
-            <Balancer>{t('EDIT_CONFIRMATION_MODAL_PROMPT')}</Balancer>
+          <CappedText size={{ _: 'md', lg: 'xl' }} align="center" balance={true}>
+            {t('EDIT_CONFIRMATION_MODAL_PROMPT')}
           </CappedText>
         </FullscreenDialog.Title>
       </FullscreenDialog.Modal>

--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseFormErrorDialog.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseFormErrorDialog.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from 'next-i18next'
-import { Balancer } from 'react-wrap-balancer'
 import { Button, Text, theme, WarningTriangleIcon } from 'ui'
 import * as FullscreenDialog from '@/components/FullscreenDialog/FullscreenDialog'
 import * as GridLayout from '@/components/GridLayout/GridLayout'
@@ -39,11 +38,14 @@ export const PurchaseFormErrorDialog = (props: Props) => {
                   {t('GENERAL_ERROR_DIALOG_TITLE', { ns: 'common' })}
                 </SpaceFlex>
               </Text>
-              <Balancer ratio={0.5}>
-                <Text size={{ _: 'lg', lg: 'xl' }} align="center" color="textSecondary">
-                  {props.errorMessage ? props.errorMessage : t('GENERAL_ERROR_DIALOG_PROMPT')}
-                </Text>
-              </Balancer>
+              <Text
+                size={{ _: 'lg', lg: 'xl' }}
+                align="center"
+                color="textSecondary"
+                balance={true}
+              >
+                {props.errorMessage ? props.errorMessage : t('GENERAL_ERROR_DIALOG_PROMPT')}
+              </Text>
             </SpaceFlex>
           </GridLayout.Content>
         </GridLayout.Root>

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -5,7 +5,6 @@ import Head from 'next/head'
 import Router from 'next/router'
 import { appWithTranslation } from 'next-i18next'
 import { type ReactNode } from 'react'
-import { Provider as BalancerProvider } from 'react-wrap-balancer'
 import globalCss from 'ui/src/global.css'
 import { theme } from 'ui'
 import { AppErrorDialog } from '@/components/AppErrorDialog'
@@ -106,11 +105,9 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
           <ShopSessionProvider shopSessionId={pageProps[SHOP_SESSION_PROP_NAME]}>
             <ShopSessionTrackingProvider>
               <BankIdContextProvider>
-                <BalancerProvider>
-                  <AppErrorDialog />
-                  <GlobalBannerDynamic />
-                  {getLayout(<Component {...pageProps} className={contentFontClassName} />)}
-                </BalancerProvider>
+                <AppErrorDialog />
+                <GlobalBannerDynamic />
+                {getLayout(<Component {...pageProps} className={contentFontClassName} />)}
                 <BankIdDialogDynamic />
               </BankIdContextProvider>
             </ShopSessionTrackingProvider>

--- a/packages/ui/src/components/Heading/Heading.tsx
+++ b/packages/ui/src/components/Heading/Heading.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { clsx } from 'clsx'
-import Balancer from 'react-wrap-balancer'
 import type { UIColors, Level } from '../../theme'
 import { sprinkles } from '../../theme/sprinkles.css'
+import { balanceTextStyles } from '../Text/Text.css'
 import type { PolymorphicComponentsProps } from '../TypeUtils'
 import { responsiveVariantStyles } from './Heading.css'
 
@@ -48,11 +48,12 @@ export function Heading({
       className={clsx(
         responsiveVariantStyles(variant),
         sprinkles({ color, textAlign: align }),
+        balance && balanceTextStyles,
         className,
       )}
       {...rest}
     >
-      {balance ? <Balancer>{children}</Balancer> : children}
+      {children}
     </Component>
   )
 }

--- a/packages/ui/src/components/Text/Text.css.ts
+++ b/packages/ui/src/components/Text/Text.css.ts
@@ -21,3 +21,7 @@ export const textStrikethrough = style({
 export const textUppercase = style({
   textTransform: 'uppercase',
 })
+
+export const balanceTextStyles = style({
+  textWrap: 'balance',
+})

--- a/packages/ui/src/components/Text/Text.tsx
+++ b/packages/ui/src/components/Text/Text.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx'
 import type { ReactNode, CSSProperties } from 'react'
-import Balancer from 'react-wrap-balancer'
 import type { FontSizeProps } from '../../theme'
 import { type Sprinkles, sprinkles } from '../../theme/sprinkles.css'
 import {
+  balanceTextStyles,
   textBase,
   textFallbackColor,
   textSingleLine,
@@ -31,6 +31,7 @@ export type TextProps = {
 
 export const getTextStyles = ({
   align,
+  balance,
   color,
   singleLine,
   size = 'md',
@@ -46,6 +47,7 @@ export const getTextStyles = ({
     singleLine && textSingleLine,
     strikethrough && textStrikethrough,
     uppercase && textUppercase,
+    balance && balanceTextStyles,
     className,
   )
 }
@@ -73,11 +75,12 @@ export const Text = ({
         size,
         strikethrough,
         uppercase,
+        balance,
         className,
       })}
       {...rest}
     >
-      {!balance ? children : <Balancer>{children}</Balancer>}
+      {children}
     </Component>
   )
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Use native CSS text balancer instead of package. The one thing I though was nice with the package was that you could specify a ratio for how much to balance. But as the say in their docs:

> Note that if the native CSS balance ([text-wrap: balance](https://developer.chrome.com/blog/css-text-wrap-balance/)) is available, React Wrap Balancer will use it instead. And the `ratio` option will be ignored in that case. 

So we should just use native CSS rule instead

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Improve builds and bundle by using native css solution
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
