### PR TITLE
Forbid import loops with eslint import/no-cycle rule

### DIFF
--- a/apps/store/src/blocks/CardLinkBlock.tsx
+++ b/apps/store/src/blocks/CardLinkBlock.tsx
@@ -1,9 +1,9 @@
 'use client'
 import styled from '@emotion/styled'
 import { ArrowForwardIcon, theme, mq } from 'ui'
+import * as GridLayout from '@/components/GridLayout/GridLayout'
 import type { SbBaseBlockProps, LinkField } from '@/services/storyblok/storyblok'
 import { getLinkFieldURL } from '@/services/storyblok/Storyblok.helpers'
-import { Grid } from './CardLinkListBlock'
 
 type CardVariant = 'primary' | 'secondary'
 
@@ -25,6 +25,16 @@ export const CardLinkBlock = ({ blok }: CardLinkBlockProps) => {
     </Card>
   )
 }
+
+export const Grid = styled(GridLayout.Root)({
+  gap: theme.space.xs,
+  gridAutoRows: '9rem', // 144px
+
+  [mq.lg]: {
+    gap: theme.space.md,
+    gridAutoRows: '16rem', // 256px
+  },
+})
 
 const Card = styled.a({
   display: 'inline-flex',

--- a/apps/store/src/blocks/CardLinkListBlock.tsx
+++ b/apps/store/src/blocks/CardLinkListBlock.tsx
@@ -1,10 +1,9 @@
 'use client'
 import styled from '@emotion/styled'
-import { theme, mq } from 'ui'
-import * as GridLayout from '@/components/GridLayout/GridLayout'
+import { mq } from 'ui'
 import type { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import type { CardLinkBlockProps } from './CardLinkBlock'
-import { CardLinkBlock } from './CardLinkBlock'
+import { CardLinkBlock, Grid } from './CardLinkBlock'
 
 type CardLinkListBlockProps = SbBaseBlockProps<{
   cardLinks: ExpectedBlockType<CardLinkBlockProps>
@@ -21,16 +20,6 @@ export const CardLinkListBlock = ({ blok }: CardLinkListBlockProps) => {
     </Grid>
   )
 }
-
-export const Grid = styled(GridLayout.Root)({
-  gap: theme.space.xs,
-  gridAutoRows: '9rem', // 144px
-
-  [mq.lg]: {
-    gap: theme.space.md,
-    gridAutoRows: '16rem', // 256px
-  },
-})
 
 const Content = styled.div({
   gridColumn: '1 / span 12',

--- a/packages/eslint-config-custom/eslint-config-custom.cjs
+++ b/packages/eslint-config-custom/eslint-config-custom.cjs
@@ -47,6 +47,7 @@ module.exports = {
         pathGroupsExcludedImportTypes: ['internal'],
       },
     ],
+    'import/no-cycle': ['error', { maxDepth: 5 }],
     '@typescript-eslint/ban-ts-comment': ['error', { 'ts-expect-error': 'allow-with-description' }],
     '@typescript-eslint/no-unused-vars': 'error', // Also covers unused import
     '@typescript-eslint/consistent-type-imports': [

--- a/packages/ui/src/components/Badge/Badge.css.ts
+++ b/packages/ui/src/components/Badge/Badge.css.ts
@@ -1,6 +1,6 @@
 import { createVar } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
-import { tokens, minWidth } from 'ui'
+import { minWidth, tokens } from '../../theme'
 
 export const badgeBgColor = createVar('badgeBgColor')
 export const badgeFontColor = createVar('badgeFontColor')

--- a/packages/ui/src/theme/sprinkles.css.ts
+++ b/packages/ui/src/theme/sprinkles.css.ts
@@ -1,7 +1,7 @@
 import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles'
-import { tokens } from '../theme'
 import { createSubset } from '../utils/createSubset'
 import { mediaQueries } from './media'
+import { tokens } from './theme.css'
 import { fontSizes } from './typography'
 
 const textColors = {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Subj. Import loops can be confusing for build system, so why not prevent them

Made a few fixes to avoid existing loops
- ui: don't import from package root
- store: convert one circular dependency into unidirectional by moving one component around

No measurable difference in build speed right now

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
