### PR TITLE
Fix issue with text-wrap balance being overriden by white space rule

### DIFF
--- a/packages/ui/src/components/Heading/Heading.css.ts
+++ b/packages/ui/src/components/Heading/Heading.css.ts
@@ -1,3 +1,4 @@
+import { style } from '@vanilla-extract/css'
 import { theme } from '../../theme'
 import { responsiveVariants } from '../../utils/responsiveVariants/responsiveVariants'
 
@@ -93,4 +94,9 @@ export const responsiveVariantStyles = responsiveVariants({
       lineHeight: 1.12,
     },
   },
+})
+
+export const balanceTextStyles = style({
+  whiteSpace: 'unset',
+  textWrap: 'balance',
 })

--- a/packages/ui/src/components/Heading/Heading.tsx
+++ b/packages/ui/src/components/Heading/Heading.tsx
@@ -3,9 +3,8 @@
 import { clsx } from 'clsx'
 import type { UIColors, Level } from '../../theme'
 import { sprinkles } from '../../theme/sprinkles.css'
-import { balanceTextStyles } from '../Text/Text.css'
 import type { PolymorphicComponentsProps } from '../TypeUtils'
-import { responsiveVariantStyles } from './Heading.css'
+import { balanceTextStyles, responsiveVariantStyles } from './Heading.css'
 
 type StandardHeadingSize = '18' | '20' | '24' | '32' | '40' | '48' | '56' | '72' | '96'
 type SerifHeadingSize = Exclude<StandardHeadingSize, '18'>

--- a/packages/ui/src/components/Text/Text.css.ts
+++ b/packages/ui/src/components/Text/Text.css.ts
@@ -23,5 +23,6 @@ export const textUppercase = style({
 })
 
 export const balanceTextStyles = style({
+  whiteSpace: 'unset',
   textWrap: 'balance',
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Make sure text-wrap balance rule isn't being overridden. 

- Unset white space rule we have for base styling as recommended [here](https://developer.chrome.com/docs/css-ui/css-text-wrap-balance#interactions_with_the_white-space_property)
- Create specific styling for Heading component since the CSS order caused the balance rule from Text component to be applied before base Heading styles
 
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Bug reported by Peter for Headings not having balance in prod due to CSS order

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
