### PR TITLE
Wrap store pages into JotaiProvider to solve atom<->page sync problem. Remove previous solutions like dangerouslyForceHydrate

### DIFF
--- a/apps/store/src/app/[locale]/[[...slug]]/ProductCmsPage.tsx
+++ b/apps/store/src/app/[locale]/[[...slug]]/ProductCmsPage.tsx
@@ -1,4 +1,5 @@
 import { StoryblokStory } from '@storyblok/react/rsc'
+import { StorePageProviders } from '@/appComponents/providers/StorePageProviders'
 import { storyblokBridgeOptions } from '@/appComponents/storyblokBridgeOptions'
 import { BankIdDialog } from '@/components/BankIdDialog/BankIdDialog'
 import { PageBannerTriggers } from '@/components/Banner/PageBannerTriggers'
@@ -43,22 +44,24 @@ export const ProductCmsPage = async ({ locale, story }: ProductCmsPageProps) => 
   const initialSelectedTypeOfContract = initialSelectedVariant?.typeOfContract
 
   return (
-    <ProductDataProvider
-      productData={productData}
-      selectedTypeOfContract={initialSelectedTypeOfContract}
-    >
-      <ProductPageDataProvider
-        productPageData={getProductPageData(story, productData)}
-        priceTemplate={priceTemplate}
+    <StorePageProviders>
+      <ProductDataProvider
+        productData={productData}
+        selectedTypeOfContract={initialSelectedTypeOfContract}
       >
-        <ProductReviewsMetadataProvider productReviewsMetadata={productReviewsMetadata}>
-          <BankIdContextProvider>
-            <StoryblokStory story={story} bridgeOptions={storyblokBridgeOptions} />
-            <PageBannerTriggers blok={story.content} />
-            <BankIdDialog />
-          </BankIdContextProvider>
-        </ProductReviewsMetadataProvider>
-      </ProductPageDataProvider>
-    </ProductDataProvider>
+        <ProductPageDataProvider
+          productPageData={getProductPageData(story, productData)}
+          priceTemplate={priceTemplate}
+        >
+          <ProductReviewsMetadataProvider productReviewsMetadata={productReviewsMetadata}>
+            <BankIdContextProvider>
+              <StoryblokStory story={story} bridgeOptions={storyblokBridgeOptions} />
+              <PageBannerTriggers blok={story.content} />
+              <BankIdDialog />
+            </BankIdContextProvider>
+          </ProductReviewsMetadataProvider>
+        </ProductPageDataProvider>
+      </ProductDataProvider>
+    </StorePageProviders>
   )
 }

--- a/apps/store/src/app/[locale]/[[...slug]]/ProductCmsPageV2.tsx
+++ b/apps/store/src/app/[locale]/[[...slug]]/ProductCmsPageV2.tsx
@@ -1,4 +1,5 @@
 import { StoryblokStory } from '@storyblok/react/rsc'
+import { StorePageProviders } from '@/appComponents/providers/StorePageProviders'
 import { storyblokBridgeOptions } from '@/appComponents/storyblokBridgeOptions'
 import { DefaultDebugDialog } from '@/components/DebugDialog/DefaultDebugDialog'
 import { fetchProductData } from '@/components/ProductData/fetchProductData'
@@ -32,14 +33,16 @@ export const ProductCmsPageV2 = async ({ locale, story }: ProductCmsPageProps) =
   const initialSelectedTypeOfContract = initialSelectedVariant?.typeOfContract
 
   return (
-    <ProductDataProvider
-      productData={productData}
-      selectedTypeOfContract={initialSelectedTypeOfContract}
-    >
-      <ProductPageDataProviderV2 productPageData={getProductPageData(story, productData)}>
-        <StoryblokStory story={story} bridgeOptions={storyblokBridgeOptions} />
-        <DefaultDebugDialog />
-      </ProductPageDataProviderV2>
-    </ProductDataProvider>
+    <StorePageProviders>
+      <ProductDataProvider
+        productData={productData}
+        selectedTypeOfContract={initialSelectedTypeOfContract}
+      >
+        <ProductPageDataProviderV2 productPageData={getProductPageData(story, productData)}>
+          <StoryblokStory story={story} bridgeOptions={storyblokBridgeOptions} />
+          <DefaultDebugDialog />
+        </ProductPageDataProviderV2>
+      </ProductDataProvider>
+    </StorePageProviders>
   )
 }

--- a/apps/store/src/appComponents/providers/StorePageProviders.tsx
+++ b/apps/store/src/appComponents/providers/StorePageProviders.tsx
@@ -1,0 +1,10 @@
+import { Provider as JotaiProvider } from 'jotai'
+import { type ReactNode } from 'react'
+
+// TODO: Add more providers we want to keep outside of layout. For example, StoryblokProvider can be moved here
+export function StorePageProviders({ children }: { children: ReactNode }) {
+  // JotaiProvider ensures we don't carry over jotai atom values between navigations
+  // This prevents all sorts of bugs and allows us to treat readonly page-specific atoms as constant
+  // We have another `JotaiProvider` in root layout, but that one is retained during navigation
+  return <JotaiProvider>{children}</JotaiProvider>
+}

--- a/apps/store/src/components/ProductData/ProductDataProvider.tsx
+++ b/apps/store/src/components/ProductData/ProductDataProvider.tsx
@@ -27,7 +27,11 @@ type Props = {
 
 const ProductKeyContext = createContext<string | null>(null)
 
-// NOTE: No cleanup on atomFamilies here - we don't have that many products, so it's easier to retain all data
+// NOTE:
+// - Maybe this setup could be simplified to use plain atoms instead of `atomFamily`
+//   If you try to do this, test /debugger/terms/[productName] page - it shows multiple product variants
+//   and 2 languages at the same time. This might still work with plain atoms if properly surrounded by JotaiProvider wrappers
+// - No cleanup on atomFamilies here - we don't have that many products, so it's easier to retain all data
 export const ProductDataProvider = (props: Props) => {
   const locale = useRoutingLocale()
   // Custom key is only used in terms debugger page when we want to have several providers (one per variant)

--- a/apps/store/src/components/ProductPage/ProductPageDataProvider.tsx
+++ b/apps/store/src/components/ProductPage/ProductPageDataProvider.tsx
@@ -22,9 +22,7 @@ export function ProductPageDataProvider({ children, priceTemplate, productPageDa
 }
 
 export const useSyncProductPageData = (productPageData: ProductPageData) => {
-  useHydrateAtoms([[productPageDataAtom, productPageData]], {
-    dangerouslyForceHydrate: true,
-  })
+  useHydrateAtoms([[productPageDataAtom, productPageData]])
 }
 
 export const useProductPageData = () => {

--- a/apps/store/src/components/ProductPage/PurchaseForm/priceIntentAtoms.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/priceIntentAtoms.ts
@@ -227,11 +227,6 @@ export const useSyncPriceIntentState = ({
     }
   }, [entryToReplace, priceIntentId, productName, queryResult.data, syncSelectedOffer, store])
 
-  useEffect(() => {
-    // Cleanup key atom on navigation, prevents flash of previous content when navigating between price calculators
-    return () => store.set(currentPriceIntentIdAtom, null)
-  }, [store])
-
   const setIsLoading = useSetAtom(priceCalculatorLoadingAtom)
   useEffect(() => {
     setIsLoading(queryResult.loading || priceIntentId == null)

--- a/apps/store/src/components/ProductPage/PurchaseForm/priceTemplateAtom.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/priceTemplateAtom.ts
@@ -13,7 +13,5 @@ export const usePriceTemplate = () => {
 }
 
 export const useSyncPriceTemplate = (template: Template | TemplateV2) => {
-  useHydrateAtoms([[priceTemplateAtom, template]], {
-    dangerouslyForceHydrate: true,
-  })
+  useHydrateAtoms([[priceTemplateAtom, template]])
 }

--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.tsx
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation'
 import { type ReactNode, Suspense } from 'react'
+import { StorePageProviders } from '@/appComponents/providers/StorePageProviders'
 import { fetchProductData } from '@/components/ProductData/fetchProductData'
 import { ProductDataProvider } from '@/components/ProductData/ProductDataProvider'
 import { ProductPageDebugDialog } from '@/components/ProductPage/ProductPageDebugDialog'
@@ -31,20 +32,22 @@ export function PriceCalculatorCmsPage({ locale, story }: Props) {
     throw notFound()
   }
   return (
-    <div className={pageGrid}>
-      <Suspense fallback={<Skeleton style={{ height: '50vh' }} />}>
-        <PriceCalculatorProviders locale={locale} story={story}>
-          <section className={productHeroSection}>
-            <ProductHeroV2 className={productHero} />
-          </section>
-          <section className={priceCalculatorSection}>
-            <div className={purchaseFormWrapper}>
-              <PurchaseFormV2 />
-            </div>
-          </section>
-        </PriceCalculatorProviders>
-      </Suspense>
-    </div>
+    <StorePageProviders>
+      <div className={pageGrid}>
+        <Suspense fallback={<Skeleton style={{ height: '50vh' }} />}>
+          <PriceCalculatorProviders locale={locale} story={story}>
+            <section className={productHeroSection}>
+              <ProductHeroV2 className={productHero} />
+            </section>
+            <section className={priceCalculatorSection}>
+              <div className={purchaseFormWrapper}>
+                <PurchaseFormV2 />
+              </div>
+            </section>
+          </PriceCalculatorProviders>
+        </Suspense>
+      </div>
+    </StorePageProviders>
   )
 }
 

--- a/apps/store/src/features/priceCalculator/PriceCalculatorStoryProvider.tsx
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorStoryProvider.tsx
@@ -9,8 +9,6 @@ type Props = {
   children: ReactNode
 }
 export function PriceCalculatorStoryProvider({ story, children }: Props) {
-  useHydrateAtoms([[priceCalculatorDeductibleInfoAtom, story.content.deductibleInfo ?? null]], {
-    dangerouslyForceHydrate: true,
-  })
+  useHydrateAtoms([[priceCalculatorDeductibleInfoAtom, story.content.deductibleInfo ?? null]])
   return children
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

This is new, simpler solution to "how do we sync jotai atom values with current page?"

It wraps every page that needs page-specific atoms into `JotaiProvider`. When new page is rendered inside such provider, it gets brand new copies of every atom it uses

We still keep `JotaiProvider` at root of out app layout to handle truly global atoms such as cookie consent state and `availableProducts` metadata

Removed older solutions that are no longer needed
- cleanup effect for `currentPriceIntentIdAtom`
- `dangerouslyForceHydrate: true` on providers that injected page-specific initial data

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
