### PR TITLE
Add import and store SEB leads functionality to debugger

### DIFF
--- a/apps/store/src/app/debugger/seb-leads/ImportAndStoreLeadsForm.tsx
+++ b/apps/store/src/app/debugger/seb-leads/ImportAndStoreLeadsForm.tsx
@@ -9,11 +9,11 @@ import { FormResults } from './FormResults'
 
 export function ImportAndStoreLeadsForm() {
   const today = new Date().toISOString()
-  const lastWeek = new Date(new Date().setDate(new Date().getDate() - 1)).toISOString()
+  const yesterday = new Date(new Date().setDate(new Date().getDate() - 1)).toISOString()
 
   const [state, formAction] = useFormState(importAnsSendLeads, {
     fields: {
-      fromDate: lastWeek,
+      fromDate: yesterday,
       toDate: today,
     },
   })

--- a/apps/store/src/app/debugger/seb-leads/ImportAndStoreLeadsForm.tsx
+++ b/apps/store/src/app/debugger/seb-leads/ImportAndStoreLeadsForm.tsx
@@ -1,0 +1,38 @@
+'use client'
+import { useFormState } from 'react-dom'
+import { yStack } from 'ui'
+import { SebDebuggerFormElement } from '@/app/debugger/seb-leads/constants'
+import { importAnsSendLeads } from '@/app/debugger/seb-leads/importAndStoreLeads'
+import { SubmitButton } from '@/appComponents/SubmitButton'
+import { TextField } from '@/components/TextField/TextField'
+import { FormResults } from './FormResults'
+
+export function ImportAndStoreLeadsForm() {
+  const today = new Date().toISOString()
+  const lastWeek = new Date(new Date().setDate(new Date().getDate() - 1)).toISOString()
+
+  const [state, formAction] = useFormState(importAnsSendLeads, {
+    fields: {
+      fromDate: lastWeek,
+      toDate: today,
+    },
+  })
+  return (
+    <form className={yStack({ gap: 'xs' })} action={formAction}>
+      <TextField
+        label={SebDebuggerFormElement.FromDate}
+        name={SebDebuggerFormElement.FromDate}
+        defaultValue={state?.fields?.fromDate}
+        type={'date'}
+      />
+      <TextField
+        label={SebDebuggerFormElement.ToDate}
+        name={SebDebuggerFormElement.ToDate}
+        defaultValue={state?.fields?.toDate}
+        type={'date'}
+      />
+      <SubmitButton>Import all leads between from and to date </SubmitButton>
+      <FormResults formState={state} />
+    </form>
+  )
+}

--- a/apps/store/src/app/debugger/seb-leads/constants.ts
+++ b/apps/store/src/app/debugger/seb-leads/constants.ts
@@ -7,4 +7,6 @@ export enum SebDebuggerFormElement {
   Products = 'products',
   SebInsurelyId = 'sebInsurelyId',
   LeadId = 'leadId',
+  FromDate = 'fromDate',
+  ToDate = 'toDate',
 }

--- a/apps/store/src/app/debugger/seb-leads/importAndStoreLeads.ts
+++ b/apps/store/src/app/debugger/seb-leads/importAndStoreLeads.ts
@@ -1,0 +1,37 @@
+'use server'
+import { SebDebuggerFormElement } from '@/app/debugger/seb-leads/constants'
+import type { FormStateWithErrors } from '@/app/types/formStateTypes'
+import { storefrontLeadsApiRequest } from './storefrontLeadsApiRequest'
+
+export const importAnsSendLeads = async (
+  _: FormStateWithErrors,
+  formData: FormData,
+): Promise<FormStateWithErrors> => {
+  const fromDate = (formData.get(SebDebuggerFormElement.FromDate) as string) + 'T00:00:00Z'
+  const toDate = (formData.get(SebDebuggerFormElement.ToDate) as string) + 'T23:59:59Z'
+
+  try {
+    const result = await storefrontLeadsApiRequest(
+      `/debug/import-leads?from=${fromDate}&to=${toDate}`,
+      {
+        method: 'POST',
+      },
+    )
+
+    return {
+      messages: (result as { messages: Array<string> }).messages.map((message) => ({
+        type: 'success',
+        content: message,
+      })),
+    }
+  } catch (err) {
+    console.error('Error importing SEB leads sessions', err)
+    const errorMessage = err instanceof Error ? err.message : 'Unknown error'
+
+    return {
+      errors: {
+        generic: [errorMessage],
+      },
+    }
+  }
+}

--- a/apps/store/src/app/debugger/seb-leads/page.tsx
+++ b/apps/store/src/app/debugger/seb-leads/page.tsx
@@ -1,5 +1,6 @@
 import { Heading, sprinkles, Text, yStack } from 'ui'
 import {GenerateAndSendOfferButton} from "@/app/debugger/seb-leads/GenerateAndSendOfferButton";
+import {ImportAndStoreLeadsForm} from "@/app/debugger/seb-leads/ImportAndStoreLeadsForm";
 import * as GridLayout from '@/components/GridLayout/GridLayout'
 import { SebLeadsDebuggerForm } from './CreateSebLeadsForm'
 import { CreateWidgetSessionForm } from './CreateWidgetSessionForm'
@@ -27,6 +28,10 @@ function SebLeadsDebuggerPage() {
             Create widget session from existing leads And send offer to customer
           </Heading>
           <GenerateAndSendOfferButton />
+          <Heading as="h2" className={sprinkles({ marginTop: 'xl' })}>
+            Import and store SEB Leads
+          </Heading>
+          <ImportAndStoreLeadsForm />
         </div>
       </GridLayout.Content>
     </GridLayout.Root>


### PR DESCRIPTION
TLDR;
- Added debugger tool to simulate our own importing leads cron job, which ability to choose `lower/upper` date range

## Describe your changes

- Added a new `ImportAndStoreLeadsForm` component for importing SEB leads within a specified date range
- Created `importAnsSendLeads` server action to handle the form submission and API request
- Updated `constants.ts` to include new form elements for date range selection
- Integrated the new form into the SEB Leads Debugger page
