### PR TITLE
Add animation to CardRadioGroup

### DIFF
--- a/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
+++ b/apps/store/src/components/ProductPage/PurchaseForm/PurchaseForm.tsx
@@ -187,7 +187,10 @@ const PurchaseFormInner = (props: PurchaseFormInnerProps) => {
     <motion.div
       initial={{ opacity: 0, y: '1vh' }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4, ...framerTransitions.easeInOutCubic }}
+      transition={{
+        duration: framerTransitions.defaultDuration,
+        ...framerTransitions.easeInOutCubic,
+      }}
     >
       <ProductHeroContainer size="small" compact={true}>
         {editingStateForm}

--- a/apps/store/src/features/priceCalculator/CardRadioGroup.css.ts
+++ b/apps/store/src/features/priceCalculator/CardRadioGroup.css.ts
@@ -7,7 +7,6 @@ export const item = style([
   yStack({ gap: 'sm' }),
   {
     borderRadius: tokens.radius.md,
-    backgroundColor: tokens.colors.opaque1,
     padding: tokens.space.md,
     cursor: 'pointer',
 
@@ -19,7 +18,6 @@ export const item = style([
 
     selectors: {
       '&[data-state=checked]': {
-        backgroundColor: tokens.colors.buttonPrimary,
         vars: {
           [tokens.colors.textPrimary]: tokens.colors.textNegative,
           [tokens.colors.textSecondary]: tokens.colors.gray500,

--- a/apps/store/src/features/priceCalculator/CardRadioGroup.tsx
+++ b/apps/store/src/features/priceCalculator/CardRadioGroup.tsx
@@ -5,7 +5,8 @@ import {
   type RadioGroupProps,
 } from '@radix-ui/react-radio-group'
 import { clsx } from 'clsx'
-import { yStack } from 'ui'
+import { motion } from 'framer-motion'
+import { framerTransitions, tokens, yStack } from 'ui'
 import { RadioIndicatorIcon } from '@/features/priceCalculator/RadioIndicatorIcon'
 import { item } from './CardRadioGroup.css'
 
@@ -17,10 +18,35 @@ export function Root({ children, className, ...forwardedProps }: RadioGroupProps
   )
 }
 
-export function Item({ children, className, value, ...forwardedProps }: RadioGroupItemProps) {
+export function Item({
+  children,
+  className,
+  value,
+  isSelected,
+  ...forwardedProps
+}: RadioGroupItemProps & { isSelected?: boolean }) {
+  const variants = {
+    selected: {
+      backgroundColor: tokens.colors.buttonPrimary,
+    },
+    unselected: {
+      backgroundColor: tokens.colors.opaque1,
+    },
+  }
   return (
     <RadioGroup.Item value={value} {...forwardedProps} asChild>
-      <div className={clsx(item, className)}>{children}</div>
+      <motion.div
+        className={clsx(item, className)}
+        variants={variants}
+        animate={isSelected ? 'selected' : 'unselected'}
+        transition={{
+          duration: framerTransitions.defaultDuration,
+          ...framerTransitions.easeInOutCubic,
+        }}
+        initial={false}
+      >
+        {children}
+      </motion.div>
     </RadioGroup.Item>
   )
 }

--- a/apps/store/src/features/priceCalculator/DeductibleSelectorV2.tsx
+++ b/apps/store/src/features/priceCalculator/DeductibleSelectorV2.tsx
@@ -49,8 +49,14 @@ export function DeductibleSelectorV2({ offers, selectedOffer, onValueChange }: P
   return (
     <>
       <CardRadioGroup.Root value={selectedOffer.id} onValueChange={onValueChange}>
-        {deductibleLevels.map((item) => (
-          <CardRadioGroup.Item key={item.id} value={item.id}>
+        {deductibleLevels.map((item, index) => (
+          <CardRadioGroup.Item
+            // NOTE: We want to avoid remounting selected deductible element when changing tiers
+            // to avoid extra animation, hence index key
+            key={index}
+            value={item.id}
+            isSelected={selectedOffer.id === item.id}
+          >
             <div className={xStack({ gap: 'xs' })}>
               <CardRadioGroup.Indicator />
               <div className={yStack({ flexGrow: 1, gap: 'xs' })}>

--- a/apps/store/src/features/priceCalculator/ProductTierSelectorV2.css.ts
+++ b/apps/store/src/features/priceCalculator/ProductTierSelectorV2.css.ts
@@ -1,0 +1,10 @@
+import { style } from '@vanilla-extract/css'
+import { sprinkles } from 'ui'
+
+export const item = style([
+  sprinkles({ padding: 'lg' }),
+  // We need zero gap to prevent AnimatePresence from causing height jump when element is added/removed
+  {
+    gap: 'unset',
+  },
+])

--- a/apps/store/src/features/priceCalculator/ProductTierSelectorV2.tsx
+++ b/apps/store/src/features/priceCalculator/ProductTierSelectorV2.tsx
@@ -1,13 +1,26 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic'
+import { AnimatePresence, motion } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
 import { useRef } from 'react'
 import { badgeFontColor } from 'ui/src/components/Badge/Badge.css'
 import { sprinkles } from 'ui/src/theme/sprinkles.css'
-import { Badge, Button, Heading, PlusIcon, Text, tokens, xStack, yStack } from 'ui'
+import {
+  Badge,
+  Button,
+  framerTransitions,
+  Heading,
+  PlusIcon,
+  Text,
+  theme,
+  tokens,
+  xStack,
+  yStack,
+} from 'ui'
 import { ComparisonTableModal } from '@/components/ProductPage/PurchaseForm/ComparisonTableModal'
 import type { ProductOfferFragment } from '@/services/graphql/generated'
 import { useFormatter } from '@/utils/useFormatter'
 import * as CardRadioGroup from './CardRadioGroup'
+import { item } from './ProductTierSelectorV2.css'
 
 type Props = {
   offers: Array<ProductOfferFragment>
@@ -27,8 +40,15 @@ export function ProductTierSelectorV2({ offers, selectedOffer, onValueChange }: 
   return (
     <>
       <CardRadioGroup.Root value={selectedOffer.id} onValueChange={onValueChange}>
-        {offers.map((offer) => (
-          <CardRadioGroup.Item key={offer.id} value={offer.id} style={{ padding: tokens.space.lg }}>
+        {offers.map((offer, index) => (
+          <CardRadioGroup.Item
+            // NOTE: We want to avoid remounting selected deductible element when changing tiers
+            // to avoid extra animation, hence index key
+            key={index}
+            value={offer.id}
+            isSelected={selectedOffer.id === offer.id}
+            className={item}
+          >
             <div className={yStack()}>
               <div
                 className={xStack({
@@ -57,11 +77,28 @@ export function ProductTierSelectorV2({ offers, selectedOffer, onValueChange }: 
             <Text color="textSecondary" className={sprinkles({ marginTop: 'md' })}>
               {getVariantDescription(offer.variant.typeOfContract)}
             </Text>
-            {offer.id === selectedOffer.id && (
-              <Button variant="secondary" fullWidth={true} size="medium" onClick={openTierDialog}>
-                {t('COMPARE_TIERS_LABEL')}
-              </Button>
-            )}
+            <AnimatePresence initial={false}>
+              {offer.id === selectedOffer.id && (
+                <motion.div
+                  transition={{
+                    duration: framerTransitions.defaultDuration,
+                    ...framerTransitions.easeInOutCubic,
+                  }}
+                  initial={{ height: 0, marginTop: 0, opacity: 0 }}
+                  animate={{ height: 'fit-content', marginTop: theme.space.md, opacity: 1 }}
+                  exit={{ height: 0, marginTop: 0, opacity: 0 }}
+                >
+                  <Button
+                    variant="secondary"
+                    fullWidth={true}
+                    size="medium"
+                    onClick={openTierDialog}
+                  >
+                    {t('COMPARE_TIERS_LABEL')}
+                  </Button>
+                </motion.div>
+              )}
+            </AnimatePresence>
           </CardRadioGroup.Item>
         ))}
       </CardRadioGroup.Root>

--- a/packages/ui/src/theme/transitions.ts
+++ b/packages/ui/src/theme/transitions.ts
@@ -12,4 +12,5 @@ export const framerTransitions = {
   easeInOutQuint: { ease: [0.86, 0, 0.07, 1] },
   easeInCubic: { ease: [0.55, 0.06, 0.68, 0.19] },
   easeOutCubic: { ease: [0.22, 0.61, 0.36, 1] },
+  defaultDuration: 0.4,
 } as const


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Animate product tier and deductible selectors
- background color
- height of "Compare coverage" button on selected tier

Mostly based on @gustaveen's work

**Upd**
- made it smooth without vertical jumps when tier change
- remove initial, on-render animations
- extracted constant for animation duration

New video:

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/GLY3tSM85RFBvAf6lFNA/97cef7bf-1f1c-4ddf-a766-04e60f083d32.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/GLY3tSM85RFBvAf6lFNA/97cef7bf-1f1c-4ddf-a766-04e60f083d32.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/97cef7bf-1f1c-4ddf-a766-04e60f083d32.mov">Screen Recording 2024-10-02 at 09.39.43.mov</video>

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
