### PR TITLE
feat: [GEN-2609] Day input disabled state

### DIFF
--- a/apps/store/src/components/InputDay/InputDay.css.ts
+++ b/apps/store/src/components/InputDay/InputDay.css.ts
@@ -29,12 +29,6 @@ export const trigger = style({
   ':disabled': {
     cursor: 'not-allowed',
   },
-
-  selectors: {
-    '&[data-loading=true]': {
-      cursor: 'wait',
-    },
-  },
 })
 
 export const label = style({

--- a/apps/store/src/components/InputDay/InputDay.css.ts
+++ b/apps/store/src/components/InputDay/InputDay.css.ts
@@ -25,6 +25,16 @@ export const trigger = style({
   ':focus-visible': {
     boxShadow: tokens.shadow.focus,
   },
+
+  ':disabled': {
+    cursor: 'not-allowed',
+  },
+
+  selectors: {
+    '&[data-loading=true]': {
+      cursor: 'wait',
+    },
+  },
 })
 
 export const label = style({

--- a/apps/store/src/components/InputDay/InputDay.tsx
+++ b/apps/store/src/components/InputDay/InputDay.tsx
@@ -49,6 +49,8 @@ export const InputDay = (props: InputDayProps) => {
   const autoIdentifier = useId()
   const inputId = props.id ?? autoIdentifier
 
+  const shouldBeDisabled = props.disabled || props.loading
+
   const { highlight, animationProps } = useHighlightAnimation<HTMLButtonElement>()
 
   const handleSelect: SelectSingleEventHandler = (day) => {
@@ -58,7 +60,7 @@ export const InputDay = (props: InputDayProps) => {
   }
 
   const handleOpenChange = (open: boolean) => {
-    if (open && (props.disabled || props.loading)) return
+    if (open && shouldBeDisabled) return
     startTransition(() => {
       setOpen(open)
     })
@@ -71,15 +73,21 @@ export const InputDay = (props: InputDayProps) => {
       <Popover.Trigger
         {...animationProps}
         className={clsx(trigger, props.className)}
-        disabled={props.disabled}
+        disabled={shouldBeDisabled}
+        data-loading={props.loading}
       >
         <div>
           <label htmlFor={inputId}>
-            <Text className={label} as="span" size="xs" color="textTranslucentSecondary">
+            <Text
+              className={label}
+              as="span"
+              size="xs"
+              color={shouldBeDisabled ? 'textTertiary' : 'textTranslucentSecondary'}
+            >
               {props.label}
             </Text>
           </label>
-          <Text size="xl" color={dateValue ? 'textPrimary' : 'textTertiary'}>
+          <Text size="xl" color={!dateValue || shouldBeDisabled ? 'textTertiary' : 'textPrimary'}>
             {dateValue ? formatter.fromNow(dateValue) : t('DATE_INPUT_EMPTY_LABEL')}
           </Text>
         </div>

--- a/apps/store/src/components/InputDay/InputStartDay.tsx
+++ b/apps/store/src/components/InputDay/InputStartDay.tsx
@@ -8,6 +8,7 @@ type Props = {
   date?: Date
   onChange?: (date: Date) => void
   loading?: boolean
+  disabled?: boolean
 }
 
 export const InputStartDay = (props: Props) => {
@@ -32,6 +33,7 @@ export const InputStartDay = (props: Props) => {
       toDate={toDate}
       onSelect={handleSelect}
       loading={props.loading}
+      disabled={props.disabled}
     />
   )
 }


### PR DESCRIPTION
<!--
PR title: GEN-2609 / Feature / Awesome new thing
-->

## Describe your changes
Adjust disabled styles for InputDay and a disable it when loading.

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/RV4Oucd6mLf2QBBMAjRa/71b3daea-24b9-4469-84d5-c99c127e0a65.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/RV4Oucd6mLf2QBBMAjRa/71b3daea-24b9-4469-84d5-c99c127e0a65.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/RV4Oucd6mLf2QBBMAjRa/71b3daea-24b9-4469-84d5-c99c127e0a65.mov">Screen Recording 2024-09-27 at 09.45.07.mov</video>

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Improved UX for disabled and loading day inputs

## Checklist before requesting a review

- [x] I have performed a self-review of my code
