### PR TITLE
Stop wrapping widget server errors into 404

### DIFF
--- a/apps/store/src/pages/[locale]/widget/[[...slug]].tsx
+++ b/apps/store/src/pages/[locale]/widget/[[...slug]].tsx
@@ -66,8 +66,7 @@ export const getStaticProps: GetStaticProps<PageProps, StoryblokQueryParams> = a
       locale: context.locale,
     })
   } catch (error) {
-    console.warn(`Widget | Failed to fetch story for slug: ${slug}`)
-    console.warn(error)
+    console.warn(`Widget | Failed to fetch story for slug: ${slug}`, error)
     return { notFound: true }
   }
 

--- a/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
+++ b/apps/store/src/pages/[locale]/widget/run/[flow]/[shopSessionId]/[priceIntentId]/sign.tsx
@@ -83,62 +83,57 @@ export const getServerSideProps: GetServerSideProps<Props, Params> = async (cont
     res: context.res,
   })
 
-  try {
-    const [translations, shopSession, story, priceIntent] = await Promise.all([
-      serverSideTranslations(context.locale),
-      shopSessionService.fetchById(context.params.shopSessionId),
-      fetchFlowStory(context.params.flow, context.draftMode),
-      priceIntentService.get(context.params.priceIntentId),
-    ])
+  const [translations, shopSession, story, priceIntent] = await Promise.all([
+    serverSideTranslations(context.locale),
+    shopSessionService.fetchById(context.params.shopSessionId),
+    fetchFlowStory(context.params.flow, context.draftMode),
+    priceIntentService.get(context.params.priceIntentId),
+  ])
 
-    const customer = shopSession.customer
-    if (!customer) {
-      throw new Error(`Widget Sign | No customer in Shop Session: ${shopSession.id}`)
-    }
+  const customer = shopSession.customer
+  if (!customer) {
+    throw new Error(`Widget Sign | No customer in Shop Session: ${shopSession.id}`)
+  }
 
-    if (!customer.ssn) {
-      throw new Error(`Widget Sign | No SSN in Shop Session: ${shopSession.id}`)
-    }
+  if (!customer.ssn) {
+    throw new Error(`Widget Sign | No SSN in Shop Session: ${shopSession.id}`)
+  }
 
-    if (!priceIntent) {
-      throw new Error(`Widget Sign | No Price Intent: ${context.params.priceIntentId}`)
-    }
+  if (!priceIntent) {
+    throw new Error(`Widget Sign | No Price Intent: ${context.params.priceIntentId}`)
+  }
 
-    const partnerName = story.content.partner
-    const productName = priceIntent.product.name
+  const partnerName = story.content.partner
+  const productName = priceIntent.product.name
 
-    const productData = await fetchProductData({
-      apolloClient,
-      productName,
-      partnerName,
-    })
+  const productData = await fetchProductData({
+    apolloClient,
+    productName,
+    partnerName,
+  })
 
-    const initialSelectedTypeOfContract =
-      productData.variants.length > 1 ? productData.variants[0].typeOfContract : null
+  const initialSelectedTypeOfContract =
+    productData.variants.length > 1 ? productData.variants[0].typeOfContract : null
 
-    return {
-      props: {
-        ...translations,
-        ssn: customer.ssn,
-        shouldCollectEmail: getShouldCollectEmail(customer),
-        shouldCollectName: getShouldCollectName(customer),
-        shopSessionId: context.params.shopSessionId,
-        content: story.content.checkoutPageContent,
-        flow: context.params.flow,
-        partner: partnerName,
-        priceIntentId: priceIntent.id,
-        // TODO: check if we want to control this via CMS
-        ...hideChatOnPage(),
-        productName: priceIntent.product.name,
-        productData,
-        ...(initialSelectedTypeOfContract ? { initialSelectedTypeOfContract } : {}),
-        pageTitle: story.content.pageTitle ?? 'Hedvig',
-        showBackButton: story.content.showBackButton ?? false,
-      },
-    }
-  } catch (error) {
-    console.error('Widget Sign | Unable to render', error)
-    return { notFound: true }
+  return {
+    props: {
+      ...translations,
+      ssn: customer.ssn,
+      shouldCollectEmail: getShouldCollectEmail(customer),
+      shouldCollectName: getShouldCollectName(customer),
+      shopSessionId: context.params.shopSessionId,
+      content: story.content.checkoutPageContent,
+      flow: context.params.flow,
+      partner: partnerName,
+      priceIntentId: priceIntent.id,
+      // TODO: check if we want to control this via CMS
+      ...hideChatOnPage(),
+      productName: priceIntent.product.name,
+      productData,
+      ...(initialSelectedTypeOfContract ? { initialSelectedTypeOfContract } : {}),
+      pageTitle: story.content.pageTitle ?? 'Hedvig',
+      showBackButton: story.content.showBackButton ?? false,
+    },
   }
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

- Remove the code that converted server errors in widget flows into 404 pages

This is now regular HTTP 500 that gives more useful info in development and generic error page in production (screenshot below)

![Screenshot 2024-09-25 at 09.57.23.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/47bcb121-4e12-4994-9d76-5948c18da4a9.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Should make it easier to see backend errors in Datadog

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
