### PR TITLE
chore(insurely): added cancel button

### DIFF
--- a/apps/store/src/components/PriceCalculator/FetchInsurance.css.ts
+++ b/apps/store/src/components/PriceCalculator/FetchInsurance.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { tokens } from 'ui'
+import { tokens, xStack } from 'ui'
 import {
   INSURELY_IFRAME_MAX_HEIGHT,
   INSURELY_IFRAME_MAX_WIDTH,
@@ -37,3 +37,8 @@ export const dialogIframeWindow = style({
   overflowY: 'auto',
   borderRadius: tokens.radius.xxs,
 })
+
+export const actions = style([
+  xStack({ justifyContent: 'center' }),
+  { marginBottom: tokens.space.xl },
+])

--- a/apps/store/src/components/PriceCalculator/FetchInsurance.tsx
+++ b/apps/store/src/components/PriceCalculator/FetchInsurance.tsx
@@ -2,7 +2,7 @@ import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
 import { useTranslation } from 'next-i18next'
 import { type ComponentProps, useCallback, useState, useMemo, type ReactNode } from 'react'
-import { Dialog, Text, visuallyHidden } from 'ui'
+import { Button, Dialog, Text, visuallyHidden } from 'ui'
 import { FetchInsurancePrompt } from '@/components/FetchInsurancePrompt/FetchInsurancePrompt'
 import type { ExternalInsurer } from '@/services/graphql/generated'
 import {
@@ -15,6 +15,7 @@ import {
   dialogIframeContent,
   dialogIframeWindow,
   dialogWindow,
+  actions,
 } from './FetchInsurance.css'
 import { FetchInsuranceSuccess } from './FetchInsuranceSuccess'
 import {
@@ -48,6 +49,7 @@ export const FetchInsurance = (props: Props) => {
   const [state, setState] = useFetchInsuranceState()
   const fetchInsuranceCompare = useFetchInsuranceCompare()
   const fetchInsuraceSuccess = useFetchInsuranceSuccess()
+  const [hasInsurelyLoaded, setHasInsurelyLoaded] = useState(false)
   const isOpen = ['PROMPT', 'COMPARE', 'SUCCESS'].includes(state)
 
   const dismiss = () => setState('DISMISSED')
@@ -123,6 +125,8 @@ export const FetchInsurance = (props: Props) => {
     }
   }, [updateDataCollectionId, props.priceIntentId, dataCollectionId, loggingContext])
 
+  const handleInsurelyLoaded = useCallback(() => setHasInsurelyLoaded(true), [])
+
   const { t } = useTranslation('purchase-form')
 
   let content: ReactNode = null
@@ -151,8 +155,16 @@ export const FetchInsurance = (props: Props) => {
             configName={props.insurely.configName}
             onCollection={handleInsurelyCollection}
             onClose={dismiss}
+            onLoaded={handleInsurelyLoaded}
             onCompleted={handleInsurelyCompleted}
           />
+          {hasInsurelyLoaded && (
+            <div className={actions}>
+              <Dialog.Close asChild>
+                <Button>{t('DIALOG_BUTTON_CANCEL', { ns: 'common' })}</Button>
+              </Dialog.Close>
+            </div>
+          )}
         </Dialog.Window>
       </Dialog.Content>
     )


### PR DESCRIPTION
## Describe your changes

Adds a "cancel" button for Insurely dialog

<img width="697" alt="image" src="https://github.com/user-attachments/assets/e6b10884-3213-4d34-bde4-405589b0eec7">

After they release the new header, we can go ahead and remove some code that relies on `APP_CLOSE`

## Justify why they are needed

_Insurely_ is deprecating `APP_CLOSE` event. More information on this [slack thread](https://hedviginsurance.slack.com/archives/C02JPS466NS/p1727243625825469)