### PR TITLE
Fix richText embedded styling and quote escaping

### DIFF
--- a/apps/store/src/blocks/RichTextBlock/richTextReactRenderer.tsx
+++ b/apps/store/src/blocks/RichTextBlock/richTextReactRenderer.tsx
@@ -55,6 +55,13 @@ const resolver = richTextResolver({
         return <Link key={node.attrs.uuid} {...linkProps} />
       }
     },
+    [MarkTypes.STYLED]: (node) => {
+      return (
+        <span key={node.text} className={node.attrs?.class}>
+          {node.text}
+        </span>
+      )
+    },
     [BlockTypes.IMAGE]: (node: StoryblokRichTextNode<ReactElement>) => {
       const attrs = node.attrs!
       const blok = {
@@ -67,6 +74,9 @@ const resolver = richTextResolver({
     },
     [BlockTypes.COMPONENT]: componentResolver,
   },
+  // No need to escape quote marks [\'\"], it breaks final result
+  // From safety perspective quotes should only be escaped in attribute values
+  textFn: (text: string) => text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
 })
 
 function componentResolver(node: StoryblokRichTextNode<ReactElement>) {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix regressions from rich text renderer upgrade
- Don't escape `'` and `"` characters in text. Also, explain why it's safe
- Convert styled text into child span with styles. Fixes things like preamble styles

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
