### PR TITLE
tech: [GEN-2609] Create grid CSS util

### DIFF
--- a/packages/ui/src/patterns/grid.ts
+++ b/packages/ui/src/patterns/grid.ts
@@ -1,0 +1,21 @@
+import clsx from 'clsx'
+import { sprinkles, type Sprinkles } from '../theme'
+
+type StackPatternParams = {
+  columns?: number | string
+  rows?: number | string
+  className?: string
+} & Omit<Sprinkles, 'display' | 'flexDirection' | 'flexGrow'>
+
+export const grid = ({ columns, rows, className, ...sprinklesProps }: StackPatternParams) => {
+  const classNames = clsx(className, sprinkles({ display: 'grid', ...sprinklesProps }))
+  const styleObject = {
+    ...(columns ? { gridTemplateColumns: `repeat(${columns}, 1fr)` } : {}),
+    ...(rows ? { gridTemplateRows: `repeat(${rows}, 1fr)` } : {}),
+  }
+
+  return {
+    className: classNames,
+    style: styleObject,
+  }
+}

--- a/packages/ui/src/patterns/index.ts
+++ b/packages/ui/src/patterns/index.ts
@@ -1,1 +1,2 @@
 export * from './stack'
+export * from './grid'


### PR DESCRIPTION
<!--
PR title: GEN-2609 / Tech / Create grid CSS util
-->

## Describe your changes
I wanted a `grid` utility similar to the `stack` one we have, but the problem with grid and vanilla-extract is that we can't have sprinkles with arbitrary values so we need to set `gridTemplateRows` and `gridTemplateColumns` some other way.

I tried different approaches and ended up with this one, it outputs the `className` and `style` attributes so we can spread them in the required element.

It also accepts `className` and merges it with internal classes through `clsx`

Usage:
```
<div {...grid({columns: 3, gap: 'md', className: 'customClassName', ...otherSprinklesCanGoHere})}
```
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Grid is a recurring pattern and I wanted to prevent creating `.css.ts` files to add just one property.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
