### PR TITLE
Add layoutJotaiStore to explicitly pass atoms across layout / page boundary

### DIFF
--- a/apps/store/src/app/LayoutJotaiProvider.tsx
+++ b/apps/store/src/app/LayoutJotaiProvider.tsx
@@ -1,0 +1,9 @@
+'use client'
+import { createStore, Provider } from 'jotai'
+import { type ReactNode } from 'react'
+
+export const layoutJotaiStore = createStore()
+
+export function LayoutJotaiProvider({ children }: { children: ReactNode }) {
+  return <Provider store={layoutJotaiStore}>{children}</Provider>
+}

--- a/apps/store/src/app/layout.tsx
+++ b/apps/store/src/app/layout.tsx
@@ -1,9 +1,9 @@
-import { Provider as JotaiProvider } from 'jotai'
 import type { Metadata, Viewport } from 'next'
 import type { ReactNode } from 'react'
 import { theme } from 'ui'
 import { ORIGIN_URL } from 'utils/url'
 import { AppInitTriggers } from './AppInitTriggers'
+import { LayoutJotaiProvider } from './LayoutJotaiProvider'
 
 type Props = {
   children: ReactNode
@@ -12,7 +12,7 @@ type Props = {
 export default function RootAppLayout({ children }: Props) {
   return (
     <>
-      <JotaiProvider>{children}</JotaiProvider>
+      <LayoutJotaiProvider>{children}</LayoutJotaiProvider>
       <AppInitTriggers />
     </>
   )

--- a/apps/store/src/components/LayoutWithMenu/productMetadataHooks.tsx
+++ b/apps/store/src/components/LayoutWithMenu/productMetadataHooks.tsx
@@ -1,15 +1,16 @@
 import { useAtomValue } from 'jotai'
 import { useHydrateAtoms } from 'jotai/utils'
+import { layoutJotaiStore } from '@/app/LayoutJotaiProvider'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { type GlobalProductMetadata } from './fetchProductMetadata'
 import { productsMetadataAtom } from './productMetadataAtom'
 
 export const useProductMetadata = () => {
   const locale = useRoutingLocale()
-  return useAtomValue(productsMetadataAtom(locale))
+  return useAtomValue(productsMetadataAtom(locale), { store: layoutJotaiStore })
 }
 
 export const useHydrateProductMetadata = (metadata: GlobalProductMetadata) => {
   const locale = useRoutingLocale()
-  useHydrateAtoms([[productsMetadataAtom(locale), metadata]])
+  useHydrateAtoms([[productsMetadataAtom(locale), metadata]], { store: layoutJotaiStore })
 }

--- a/apps/store/src/features/memberReviews/CompanyReviewsMetadataProvider.tsx
+++ b/apps/store/src/features/memberReviews/CompanyReviewsMetadataProvider.tsx
@@ -2,6 +2,7 @@
 import { atom, useAtomValue } from 'jotai'
 import { useHydrateAtoms } from 'jotai/utils'
 import { type PropsWithChildren } from 'react'
+import { layoutJotaiStore } from '@/app/LayoutJotaiProvider'
 import type { ReviewsMetadata } from './memberReviews.types'
 
 const companyReviewsMetadataAtom = atom<ReviewsMetadata | null>(null)
@@ -9,7 +10,9 @@ const companyReviewsMetadataAtom = atom<ReviewsMetadata | null>(null)
 type Props = PropsWithChildren<{ companyReviewsMetadata: ReviewsMetadata | null }>
 
 export const CompanyReviewsMetadataProvider = ({ children, companyReviewsMetadata }: Props) => {
-  useHydrateAtoms([[companyReviewsMetadataAtom, companyReviewsMetadata]])
+  useHydrateAtoms([[companyReviewsMetadataAtom, companyReviewsMetadata]], {
+    store: layoutJotaiStore,
+  })
   return children
 }
 


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Explicitly specify `layoutJotaiStore` in cases where we publish atom values in layout and consume them in pages. This is unusual, most atoms are fully contained on one of the sides

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Solves the issue with missing values of `productMetadataAtom` in product pages

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
