### PR TITLE
Hide shopping cart menu item in mobile (PriceCalculatorPage only)

### DIFF
--- a/apps/store/src/blocks/HeaderBlock/HeaderBlock.tsx
+++ b/apps/store/src/blocks/HeaderBlock/HeaderBlock.tsx
@@ -2,7 +2,6 @@ import { storyblokEditable } from '@storyblok/react'
 import { useMemo } from 'react'
 import { Header } from '@/components/Header/Header'
 import { HeaderMenu } from '@/components/Header/HeaderMenu/HeaderMenu'
-import { ShoppingCartMenuItem } from '@/components/Header/ShoppingCartMenuItem/ShoppingCartMenuItem'
 import type { ExpectedBlockType, SbBaseBlockProps } from '@/services/storyblok/storyblok'
 import { checkBlockType } from '@/services/storyblok/Storyblok.helpers'
 import { type GeneralMenuBlockProps } from './GeneralMenuBlock'
@@ -33,8 +32,6 @@ export const HeaderBlock = ({ blok }: HeaderBlockProps) => {
       {blok.headerMenu.length > 0 && (
         <HeaderMenu defaultValue={productNavItem} items={blok.headerMenu} />
       )}
-
-      <ShoppingCartMenuItem />
     </Header>
   )
 }

--- a/apps/store/src/components/Header/HeaderMenu/HeaderMenu.css.ts
+++ b/apps/store/src/components/Header/HeaderMenu/HeaderMenu.css.ts
@@ -1,16 +1,33 @@
 import { createVar, style } from '@vanilla-extract/css'
-import { minWidth, tokens } from 'ui'
+import { minWidth, responsiveStyles, tokens, xStack } from 'ui'
 
 export const displaySubmenus = createVar()
 export const displayMobileMenu = createVar()
 
-export const headerMenu = style({
-  width: '100%',
-})
+export const headerMenu = style([
+  xStack({ alignItems: 'center' }),
+  {
+    width: '100%',
+  },
+])
 
 export const headerMenuMobile = style({
   display: displayMobileMenu,
+  lineHeight: 0,
 })
+
+export const backLink = style([
+  xStack({ gap: 'md', alignItems: 'center' }),
+  {
+    marginLeft: 'auto',
+
+    ...responsiveStyles({
+      lg: {
+        marginLeft: 'unset',
+      },
+    }),
+  },
+])
 
 export const backWrapper = style({
   backgroundColor: tokens.colors.buttonSecondary,

--- a/apps/store/src/components/Header/HeaderMenu/HeaderMenu.tsx
+++ b/apps/store/src/components/Header/HeaderMenu/HeaderMenu.tsx
@@ -4,15 +4,17 @@ import { assignInlineVars } from '@vanilla-extract/dynamic'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useState, useEffect, useMemo } from 'react'
-import { CrossIcon, Text, xStack } from 'ui'
+import { CrossIcon, Text } from 'ui'
 import { type HeaderMenuProps } from '@/blocks/HeaderBlock/HeaderBlock'
 import { NestedMenuBlock } from '@/blocks/HeaderBlock/NestedMenuBlock'
 import { useProductMetadata } from '@/components/LayoutWithMenu/productMetadataHooks'
 import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
 import { navigationPrimaryList, HeaderMenuDesktop } from '../Header.css'
 import { HeaderMenuMobile } from '../HeaderMenuMobile/HeaderMenuMobile'
+import { ShoppingCartMenuItem } from '../ShoppingCartMenuItem/ShoppingCartMenuItem'
 import {
   backButtonText,
+  backLink,
   backWrapper,
   displayMobileMenu,
   displaySubmenus,
@@ -45,7 +47,7 @@ export const HeaderMenu = ({ defaultValue, items }: HeaderMenuDesktopProps) => {
     return (
       <>
         {product && (
-          <Link href={product.pageLink} className={xStack({ gap: 'md', alignItems: 'center' })}>
+          <Link href={product.pageLink} className={backLink}>
             <div className={backWrapper}>
               <CrossIcon size="1.5rem" />
             </div>
@@ -65,6 +67,7 @@ export const HeaderMenu = ({ defaultValue, items }: HeaderMenuDesktopProps) => {
       className={headerMenu}
       style={assignInlineVars({
         [displaySubmenus]: product ? 'none' : 'block',
+        [displayMobileMenu]: product ? 'none' : 'block',
       })}
     >
       {/* 'Desktop' menu is always rendered for SEO reasons so navigation links becomes accessible */}
@@ -83,16 +86,13 @@ export const HeaderMenu = ({ defaultValue, items }: HeaderMenuDesktopProps) => {
       {variant === 'mobile' && (
         <>
           {priceCalculatorMenu}
-          <div
-            className={headerMenuMobile}
-            style={assignInlineVars({
-              [displayMobileMenu]: product ? 'none' : 'flex',
-            })}
-          >
+          <div className={headerMenuMobile}>
             <HeaderMenuMobile defaultValue={defaultValue}>{content}</HeaderMenuMobile>
           </div>
         </>
       )}
+
+      <ShoppingCartMenuItem />
     </div>
   )
 }

--- a/apps/store/src/components/Header/ShoppingCartMenuItem/ShoppingCartMenuItem.css.ts
+++ b/apps/store/src/components/Header/ShoppingCartMenuItem/ShoppingCartMenuItem.css.ts
@@ -1,10 +1,20 @@
 import { style } from '@vanilla-extract/css'
-import { tokens } from 'ui'
+import { responsiveStyles, tokens } from 'ui'
+import { displayMobileMenu } from '../HeaderMenu/HeaderMenu.css'
 
 export const wrapper = style({
+  // Hide shopping cart if mobile menu is hidden
+  display: displayMobileMenu,
   // Align to the right in the header
   marginLeft: 'auto',
   lineHeight: 0,
+
+  ...responsiveStyles({
+    lg: {
+      // Always visible in desktop
+      display: 'block',
+    },
+  }),
 })
 
 export const cartLink = style({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Make sure we hide shopping cart menu item in mobile view on PriceCalculatorPage

<img width="409" alt="Screenshot 2024-09-26 at 11 40 02" src="https://github.com/user-attachments/assets/f80f81e6-e938-4bd6-9884-8943b845b0fd">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
