### PR TITLE
Add ProductHero sticky header for mobile

### DIFF
--- a/apps/store/src/components/Header/HeaderMenu/HeaderMenu.css.ts
+++ b/apps/store/src/components/Header/HeaderMenu/HeaderMenu.css.ts
@@ -32,7 +32,7 @@ export const backLink = style([
 export const backWrapper = style({
   backgroundColor: tokens.colors.buttonSecondary,
   borderRadius: tokens.radius.xxs,
-  padding: tokens.space.xs,
+  padding: tokens.space.xxs,
 
   ':hover': {
     backgroundColor: tokens.colors.buttonSecondaryHover,

--- a/apps/store/src/components/ProductPage/ScrollPast/ScrollPast.tsx
+++ b/apps/store/src/components/ProductPage/ScrollPast/ScrollPast.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled'
-import { motion, useScroll } from 'framer-motion'
-import { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
 import { theme } from 'ui'
 import { zIndexes } from '@/utils/zIndex'
+import { useHasScrolledPast } from './useHasScrolledPast'
 
 export type ScrollPastProps = {
   targetRef: React.RefObject<HTMLElement>
@@ -11,17 +11,7 @@ export type ScrollPastProps = {
 }
 
 export const ScrollPast = ({ targetRef, children, className }: ScrollPastProps) => {
-  const { scrollY } = useScroll()
-
-  const [hasScrolledPassed, setHasScrolledPassed] = useState(false)
-  useEffect(() => {
-    return scrollY.on('change', (latest) => {
-      if (targetRef.current) {
-        const elementEnd = targetRef.current.offsetTop + targetRef.current.clientHeight
-        setHasScrolledPassed(latest > elementEnd)
-      }
-    })
-  }, [scrollY, targetRef])
+  const hasScrolledPast = useHasScrolledPast({ targetRef })
 
   return (
     <StyledWrapper
@@ -31,7 +21,7 @@ export const ScrollPast = ({ targetRef, children, className }: ScrollPastProps) 
         visible: { opacity: 1, display: 'block' },
       }}
       initial="hidden"
-      animate={hasScrolledPassed ? 'visible' : 'hidden'}
+      animate={hasScrolledPast ? 'visible' : 'hidden'}
     >
       {children}
     </StyledWrapper>

--- a/apps/store/src/components/ProductPage/ScrollPast/useHasScrolledPast.ts
+++ b/apps/store/src/components/ProductPage/ScrollPast/useHasScrolledPast.ts
@@ -1,0 +1,18 @@
+import { useScroll } from 'framer-motion'
+import { useState, useEffect } from 'react'
+
+export const useHasScrolledPast = ({ targetRef }: { targetRef: React.RefObject<HTMLElement> }) => {
+  const { scrollY } = useScroll()
+
+  const [hasScrolledPassed, setHasScrolledPassed] = useState(false)
+  useEffect(() => {
+    return scrollY.on('change', (latest) => {
+      if (targetRef.current) {
+        const elementEnd = targetRef.current.offsetTop + targetRef.current.clientHeight
+        setHasScrolledPassed(latest > elementEnd)
+      }
+    })
+  }, [scrollY, targetRef])
+
+  return hasScrolledPassed
+}

--- a/apps/store/src/features/priceCalculator/ProductHeroV2.css.ts
+++ b/apps/store/src/features/priceCalculator/ProductHeroV2.css.ts
@@ -1,18 +1,10 @@
-import { style } from '@vanilla-extract/css'
+import { style, styleVariants } from '@vanilla-extract/css'
 import { badgeFontColor } from 'ui/src/components/Badge/Badge.css'
-import { pillowSize, responsiveStyles, tokens } from 'ui'
+import { responsiveStyles, tokens } from 'ui'
+import { zIndexes } from '@/utils/zIndex'
 
 export const pillowWrapper = style({
   position: 'relative',
-})
-
-export const pillow = style({
-  vars: {
-    [pillowSize]: '4rem',
-  },
-  ...responsiveStyles({
-    lg: { vars: { [pillowSize]: '13rem' } },
-  }),
 })
 
 export const priceWrapper = style({ position: 'relative', height: tokens.space.lg })
@@ -35,6 +27,7 @@ export const subTypeBadge = style({
     [badgeFontColor]: tokens.colors.textNegative,
   },
   display: 'none',
+
   ...responsiveStyles({
     lg: {
       display: 'block',
@@ -45,4 +38,34 @@ export const subTypeBadge = style({
       backdropFilter: 'blur(50px)',
     },
   }),
+})
+
+export const stickyProductHeader = style({
+  insetInlineStart: 0,
+  position: 'fixed',
+  top: 0,
+  width: '100%',
+  zIndex: zIndexes.productHeader,
+  pointerEvents: 'none',
+
+  ...responsiveStyles({
+    lg: {
+      display: 'none',
+    },
+  }),
+})
+
+export const stickyProductHeaderContent = styleVariants({
+  base: {
+    position: 'sticky',
+    top: 0,
+    backgroundColor: tokens.colors.backgroundStandard,
+    transform: 'translateY(-100%)',
+    transition: 'transform .3s ease-in-out',
+    boxShadow: 'rgba(0, 0, 0, 0.06) 0px 2px 12px',
+  },
+  visible: {
+    pointerEvents: 'auto',
+    transform: 'translateY(0)',
+  },
 })

--- a/apps/store/src/utils/zIndex.tsx
+++ b/apps/store/src/utils/zIndex.tsx
@@ -1,4 +1,12 @@
-const zIndexOrder = ['body', 'tabs', 'scrollPast', 'header', 'contactUs', 'cookieBanner'] as const
+const zIndexOrder = [
+  'body',
+  'tabs',
+  'scrollPast',
+  'header',
+  'productHeader',
+  'contactUs',
+  'cookieBanner',
+] as const
 
 type ZIndexValues = (typeof zIndexOrder)[number]
 type ZIndexRecord = Record<ZIndexValues, number>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Refactor `ScrollPast` to export hook for reuse
- Animate a slide in for the sticky header with a CSS animation


https://github.com/user-attachments/assets/1a3a5e35-cba9-4fcf-b0a4-e11ddd940036



<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
When scrolling past the product hero in mobile, we want to show a fixed header with tier and price info

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
