### PR TITLE
Place appErrorAtom explicitly into layout jotai store. Fixes error dialogs

### DIFF
--- a/apps/store/src/services/appErrors/appErrorAtom.ts
+++ b/apps/store/src/services/appErrors/appErrorAtom.ts
@@ -1,8 +1,9 @@
 import { atom, useSetAtom } from 'jotai'
+import { layoutJotaiStore } from '@/app/LayoutJotaiProvider'
 
 export const appErrorAtom = atom<Error | null>(null)
 
 export const useShowAppError = () => {
-  const showAppError = useSetAtom(appErrorAtom)
+  const showAppError = useSetAtom(appErrorAtom, { store: layoutJotaiStore })
   return showAppError
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Fix app error dialogs not appearing

Since app error atom is read from layout and written from pages, it needs explicit store assigned

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
