### PR TITLE
Adjust PriceCalculator layout

### DIFF
--- a/apps/store/src/features/priceCalculator/InsuranceDataForm.css.ts
+++ b/apps/store/src/features/priceCalculator/InsuranceDataForm.css.ts
@@ -1,5 +1,0 @@
-import { style } from '@vanilla-extract/css'
-
-export const gdprLink = style({
-  marginTop: '-1rem', // Offset from default gap of 2rem
-})

--- a/apps/store/src/features/priceCalculator/InsuranceDataForm/InsuranceDataForm.css.ts
+++ b/apps/store/src/features/priceCalculator/InsuranceDataForm/InsuranceDataForm.css.ts
@@ -1,0 +1,25 @@
+import { style, styleVariants } from '@vanilla-extract/css'
+import { responsiveStyles } from 'ui'
+import { HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header.css'
+
+export const gdprLink = style({
+  marginTop: '-1rem', // Offset from default gap of 2rem
+})
+
+export const formSection = styleVariants({
+  base: {
+    marginTop: '3.75rem',
+  },
+  ssn: {
+    ...responsiveStyles({
+      lg: {
+        position: 'absolute',
+        top: `calc(50%)`,
+        transform: `translateY(-50%)`,
+        maxWidth: '23rem',
+        // Visually center form section
+        marginTop: `calc(-1 * (${HEADER_HEIGHT_DESKTOP} / 2))`,
+      },
+    }),
+  },
+})

--- a/apps/store/src/features/priceCalculator/InsuranceDataForm/InsuranceDataForm.tsx
+++ b/apps/store/src/features/priceCalculator/InsuranceDataForm/InsuranceDataForm.tsx
@@ -19,7 +19,10 @@ import { usePriceTemplate } from '@/components/ProductPage/PurchaseForm/priceTem
 import { TextLink } from '@/components/TextLink/TextLink'
 import { EditSsnWarningContainer } from '@/features/priceCalculator/EditSsnWarningContainer'
 import { FormGridNew } from '@/features/priceCalculator/FormGridNew'
-import { gdprLink } from '@/features/priceCalculator/InsuranceDataForm.css'
+import {
+  formSection,
+  gdprLink,
+} from '@/features/priceCalculator/InsuranceDataForm/InsuranceDataForm.css'
 import { priceCalculatorStepAtom } from '@/features/priceCalculator/priceCalculatorAtoms'
 import { SectionPreview } from '@/features/priceCalculator/SectionPreview'
 import { useConfirmPriceIntent } from '@/features/priceCalculator/useConfirmPriceIntent'
@@ -55,17 +58,10 @@ export function InsuranceDataForm() {
     }
 
     let sectionBody: ReactNode
-    let sectionStyle = {}
-    if (section.id === SSN_SE_SECTION_ID) {
-      sectionStyle = {
-        position: 'absolute',
-        top: '50%',
-        transform: 'translateY(-50%)',
-        maxWidth: '23rem',
-      }
+    const isSsnSection = section.id === SSN_SE_SECTION_ID
+    if (isSsnSection) {
       sectionBody = <SsnSeSection className={yStack({ gap: 'lg' })} />
     } else {
-      sectionStyle = { marginTop: '3.75rem' }
       const isLast = index === form.sections.length - 1
       sectionBody = (
         <>
@@ -84,7 +80,10 @@ export function InsuranceDataForm() {
       )
     }
     return (
-      <div key={section.id} className={yStack({ gap: 'lg' })} style={sectionStyle}>
+      <div
+        key={section.id}
+        className={clsx(yStack({ gap: 'lg' }), formSection.base, isSsnSection && formSection.ssn)}
+      >
         <SectionTitle section={section} />
         {sectionBody}
       </div>

--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.css.ts
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.css.ts
@@ -6,7 +6,7 @@ import { HEADER_HEIGHT_MOBILE } from '@/components/Header/HeaderMenuMobile/Heade
 export const pageGrid = style({
   display: 'grid',
   gridTemplateRows: 'min-content 1fr',
-  gap: tokens.space.md,
+  columnGap: tokens.space.md,
   backgroundColor: tokens.colors.backgroundStandard,
   minHeight: `calc(100vh - ${HEADER_HEIGHT_MOBILE})`,
   ...responsiveStyles({

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2.tsx
@@ -19,7 +19,7 @@ import {
   priceCalculatorStepAtom,
 } from '@/features/priceCalculator/priceCalculatorAtoms'
 import { BonusOfferPresenter } from './BonusOfferPresenter'
-import { InsuranceDataForm } from './InsuranceDataForm'
+import { InsuranceDataForm } from './InsuranceDataForm/InsuranceDataForm'
 
 export function PurchaseFormV2() {
   useSyncPriceIntentState()


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Adjust PriceCalculator layout 
- Make sure layout is visually centered in desktop and not expanding viewport height
- Adjust position in mobile
- Replace inline styles with classnames

### Before
<img width="390" alt="Screenshot 2024-09-30 at 14 50 09" src="https://github.com/user-attachments/assets/90e91969-0da1-4cdd-8f07-893f19e4b7e6">

<img width="1060" alt="Screenshot 2024-09-30 at 14 49 58" src="https://github.com/user-attachments/assets/7b059f92-127c-4eec-88aa-9f86b2922ed5">

### After
<img width="423" alt="Screenshot 2024-09-30 at 12 08 47" src="https://github.com/user-attachments/assets/3b561ce7-7d1a-42dd-88fb-1705846c9c64">

<img width="1065" alt="Screenshot 2024-09-30 at 14 58 47" src="https://github.com/user-attachments/assets/46fe9669-9d94-4654-a93c-e0bc9c572bd2">

<!--

What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Match design
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
