### PR TITLE
Fix anchor rendering in rich text blocks

### DIFF
--- a/apps/store/src/blocks/RichTextBlock/richTextReactRenderer.tsx
+++ b/apps/store/src/blocks/RichTextBlock/richTextReactRenderer.tsx
@@ -35,7 +35,6 @@ const resolver = richTextResolver({
           "[RichTextBlock]: No 'href' provided to link. This is probably a configuration issue. Using '' as placeholder",
         )
       }
-
       const linkProps = {
         href: appendAnchor(href, node.attrs.anchor),
         children: node.text,
@@ -58,6 +57,18 @@ const resolver = richTextResolver({
     [MarkTypes.STYLED]: (node) => {
       return (
         <span key={node.text} className={node.attrs?.class}>
+          {node.text}
+        </span>
+      )
+    },
+    [MarkTypes.ANCHOR]: (node): ReactElement => {
+      const id = node.attrs?.id
+      if (id == null) {
+        // Should not happen, but let's play it safe
+        return null as unknown as ReactElement
+      }
+      return (
+        <span key={`anchor-${id}`} id={id}>
           {node.text}
         </span>
       )


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

Resolve rich text anchors into `<span id="$id"> </span>` as it was with previous library (https://github.com/claus/storyblok-rich-text-react-renderer/blob/62e45e9e865376a93989c81d3e24ce1f3f604346/src/index.js#L175)

Fixed delayed and incorrect scrolling to anchors. By default there we rendered as `<a href id="$id"> </a>` and I'm surprised this worked badly instead of not working at all 

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
