### PR TITLE
chore(widget): hide tiers under a featue flag

### DIFF
--- a/apps/store/src/utils/Features.ts
+++ b/apps/store/src/utils/Features.ts
@@ -14,6 +14,7 @@ const config = {
 
   PRICE_CALCULATOR_PAGE: process.env.NEXT_PUBLIC_FEATURE_PRICE_CALCULATOR_PAGE === 'true',
   PRODUCT_PAGE_V2: process.env.NEXT_PUBLIC_FEATURE_PRODUCT_PAGE_V2 === 'true',
+  WIDGET_FEATURE_HOME_TIERS: process.env.NEXT_PUBLIC_WIDGET_FEATURE_HOME_TIERS === 'true',
 } as const
 
 export type FeatureFlag = keyof typeof config


### PR DESCRIPTION
## Describe your changes

* Condition Home insurance tiers for widget flow to a feature flag.

## Justify why they are needed

Sonny wanted that for a couple of [reasons](https://hedviginsurance.slack.com/archives/C02JPS466NS/p1727773070196999)
