### PR TITLE
GEN-2651 - refact(price-calculator-cms-page): mount CartToast only for desktop

### DIFF
--- a/apps/store/src/features/priceCalculator/InsuranceDataForm.tsx
+++ b/apps/store/src/features/priceCalculator/InsuranceDataForm.tsx
@@ -37,7 +37,7 @@ import {
 import type { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
-import { PRICE_CALCULATOR_SECTION_PADDING } from './PriceCalculatorCmsPage.css'
+import { PRICE_CALCULATOR_SECTION_PADDING } from './PriceCalculatorCmsPageContent.css'
 
 export function InsuranceDataForm({ className }: { className?: string }) {
   const locale = useRoutingLocale()

--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.tsx
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage.tsx
@@ -5,22 +5,14 @@ import { fetchProductData } from '@/components/ProductData/fetchProductData'
 import { ProductDataProvider } from '@/components/ProductData/ProductDataProvider'
 import { ProductPageDebugDialog } from '@/components/ProductPage/ProductPageDebugDialog'
 import { Skeleton } from '@/components/Skeleton/Skeleton'
-import {
-  pageGrid,
-  priceCalculatorSection,
-  productHero,
-  productHeroSection,
-} from '@/features/priceCalculator/PriceCalculatorCmsPage.css'
 import { PriceCalculatorStoryProvider } from '@/features/priceCalculator/PriceCalculatorStoryProvider'
-import { ProductHeroV2 } from '@/features/priceCalculator/ProductHeroV2'
 import { setupApolloClient } from '@/services/apollo/app-router/rscClient'
 import { type TemplateV2 } from '@/services/PriceCalculator/PriceCalculator.types'
 import type { PriceCalculatorPageStory } from '@/services/storyblok/storyblok'
 import { Features } from '@/utils/Features'
 import { type RoutingLocale } from '@/utils/l10n/types'
-import { CartToast } from './CartToast'
+import { PriceCalculatorCmsPageContent } from './PriceCalculatorCmsPageContent'
 import { PriceTemplateProvider } from './PriceTemplateProvider'
-import { PurchaseFormV2 } from './PurchaseFormV2'
 
 type Props = {
   locale: RoutingLocale
@@ -33,19 +25,11 @@ export function PriceCalculatorCmsPage({ locale, story }: Props) {
   }
   return (
     <StorePageProviders>
-      <div className={pageGrid}>
-        <Suspense fallback={<Skeleton style={{ height: '50vh' }} />}>
-          <PriceCalculatorProviders locale={locale} story={story}>
-            <section className={productHeroSection}>
-              <ProductHeroV2 className={productHero} />
-            </section>
-            <section className={priceCalculatorSection}>
-              <PurchaseFormV2 />
-            </section>
-          </PriceCalculatorProviders>
-        </Suspense>
-      </div>
-      <CartToast />
+      <Suspense fallback={<Skeleton style={{ height: '50vh' }} />}>
+        <PriceCalculatorProviders locale={locale} story={story}>
+          <PriceCalculatorCmsPageContent />
+        </PriceCalculatorProviders>
+      </Suspense>
     </StorePageProviders>
   )
 }

--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPageContent.css.ts
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPageContent.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { hoverStyles, responsiveStyles, tokens, xStack, yStack } from 'ui'
+import { responsiveStyles, tokens, yStack } from 'ui'
 import { HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header.css'
 import { HEADER_HEIGHT_MOBILE } from '@/components/Header/HeaderMenuMobile/HeaderMenuMobile.css'
 
@@ -52,25 +52,4 @@ export const productHero = style({
       marginTop: `calc(-1 * ${HEADER_HEIGHT_DESKTOP})`,
     },
   }),
-})
-
-export const backLink = style([
-  xStack({ gap: 'md', alignItems: 'center' }),
-  {
-    width: 'min-content',
-    height: 'min-content',
-    paddingRight: tokens.space.md,
-    borderRadius: tokens.radius.xxs,
-
-    ...hoverStyles({
-      backgroundColor: tokens.colors.grayTranslucent100,
-    }),
-  },
-])
-
-export const arrowBackWrapper = style({
-  transform: 'rotate(180deg)',
-  backgroundColor: tokens.colors.grayTranslucent100,
-  borderRadius: tokens.radius.xxs,
-  padding: tokens.space.xs,
 })

--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPageContent.tsx
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPageContent.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { ProductHeroV2 } from '@/features/priceCalculator/ProductHeroV2'
+import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
+import { CartToast } from './CartToast'
+import {
+  pageGrid,
+  priceCalculatorSection,
+  productHero,
+  productHeroSection,
+} from './PriceCalculatorCmsPageContent.css'
+import { PurchaseFormV2 } from './PurchaseFormV2'
+
+export function PriceCalculatorCmsPageContent() {
+  const variant = useResponsiveVariant('lg')
+
+  return (
+    <div className={pageGrid}>
+      <section className={productHeroSection}>
+        <ProductHeroV2 className={productHero} />
+      </section>
+      <section className={priceCalculatorSection}>
+        <PurchaseFormV2 />
+      </section>
+      {/* We don't mount CartToast on mobile as we hide ShoppingCartMenuItem at that level */}
+      {variant === 'desktop' && <CartToast />}
+    </div>
+  )
+}


### PR DESCRIPTION
## Describe your changes

* Added a inner client as part of `PriceCalculatorCmsPage`:  need to toggle on/off some things based on screen size and step you are in the `PriceCalculator`
* Don't mount _Price calculator's_ `CartToast` on mobile

## Justify why they are needed

`ShoppingCartMenuItem` get's visually hidden on mobile but it's still mounted. That causes the notification being shown which is not intended:

https://github.com/user-attachments/assets/72f39558-cb1a-4eed-ac9f-4dcd46d244a8

With that said, the solution is not render `CartToast` on mobile.

The addition of `PriceCalculatorCmsPage` might sound too much but I'm also using it for hiding `PurchaseHero` on mobile when finishing the purchase on the next PR.