### PR TITLE
GEN-2651 - styles(price-calculator): conditionally render product hero

### DIFF
--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPageContent.tsx
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPageContent.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import { useAtomValue } from 'jotai'
 import { ProductHeroV2 } from '@/features/priceCalculator/ProductHeroV2'
 import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
 import { CartToast } from './CartToast'
+import { priceCalculatorStepAtom } from './priceCalculatorAtoms'
 import {
   pageGrid,
   priceCalculatorSection,
@@ -13,12 +15,17 @@ import { PurchaseFormV2 } from './PurchaseFormV2'
 
 export function PriceCalculatorCmsPageContent() {
   const variant = useResponsiveVariant('lg')
+  const step = useAtomValue(priceCalculatorStepAtom)
+
+  const showProductHero = variant === 'desktop' || step !== 'purchaseSummary'
 
   return (
     <div className={pageGrid}>
-      <section className={productHeroSection}>
-        <ProductHeroV2 className={productHero} />
-      </section>
+      {showProductHero && (
+        <section className={productHeroSection}>
+          <ProductHeroV2 className={productHero} />
+        </section>
+      )}
       <section className={priceCalculatorSection}>
         <PurchaseFormV2 />
       </section>


### PR DESCRIPTION
## Describe your changes

* Hides `ProductHero` if on mobile _and_ you've reached the end of the purchasing flow.


<img width="386" alt="image" src="https://github.com/user-attachments/assets/530d0896-12c1-4968-844d-8476a4a7b718">

## Justify why they are needed

Part of the design
