### PR TITLE
Fix PriceCalculator layout

### DIFF
--- a/apps/store/src/features/priceCalculator/InsuranceDataForm.css.ts
+++ b/apps/store/src/features/priceCalculator/InsuranceDataForm.css.ts
@@ -1,5 +1,26 @@
-import { style } from '@vanilla-extract/css'
+import { style, styleVariants } from '@vanilla-extract/css'
+import { responsiveStyles } from 'ui'
+import { HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header.css'
+import { PRICE_CALCULATOR_SECTION_PADDING } from './PriceCalculatorCmsPageContent.css'
 
 export const gdprLink = style({
   marginTop: '-1rem', // Offset from default gap of 2rem
+})
+
+export const formSection = styleVariants({
+  base: {
+    marginTop: '3.75rem',
+  },
+  ssn: {
+    ...responsiveStyles({
+      lg: {
+        position: 'absolute',
+        top: `50%`,
+        transform: `translateY(-50%)`,
+        width: `min(23rem, calc(100% - 2 * ${PRICE_CALCULATOR_SECTION_PADDING}))`,
+        // Visually center SSN form section
+        marginTop: `calc(-1 * (${HEADER_HEIGHT_DESKTOP} / 2))`,
+      },
+    }),
+  },
 })

--- a/apps/store/src/features/priceCalculator/InsuranceDataForm.tsx
+++ b/apps/store/src/features/priceCalculator/InsuranceDataForm.tsx
@@ -19,7 +19,7 @@ import { usePriceTemplate } from '@/components/ProductPage/PurchaseForm/priceTem
 import { TextLink } from '@/components/TextLink/TextLink'
 import { EditSsnWarningContainer } from '@/features/priceCalculator/EditSsnWarningContainer'
 import { FormGridNew } from '@/features/priceCalculator/FormGridNew'
-import { gdprLink } from '@/features/priceCalculator/InsuranceDataForm.css'
+import { formSection, gdprLink } from '@/features/priceCalculator/InsuranceDataForm.css'
 import { priceCalculatorStepAtom } from '@/features/priceCalculator/priceCalculatorAtoms'
 import { SectionPreview } from '@/features/priceCalculator/SectionPreview'
 import { useConfirmPriceIntent } from '@/features/priceCalculator/useConfirmPriceIntent'
@@ -37,7 +37,6 @@ import {
 import type { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
-import { PRICE_CALCULATOR_SECTION_PADDING } from './PriceCalculatorCmsPageContent.css'
 
 export function InsuranceDataForm({ className }: { className?: string }) {
   const locale = useRoutingLocale()
@@ -56,18 +55,10 @@ export function InsuranceDataForm({ className }: { className?: string }) {
     }
 
     let sectionBody: ReactNode
-    let sectionStyle = {}
-    if (section.id === SSN_SE_SECTION_ID) {
-      // There's no easy way to centralize only SSN section, so doing it with positioned layout here
-      sectionStyle = {
-        position: 'absolute',
-        top: '50%',
-        transform: 'translateY(-50%)',
-        width: `min(23rem, calc(100% - 2 * ${PRICE_CALCULATOR_SECTION_PADDING}))`,
-      }
+    const isSsnSection = section.id === SSN_SE_SECTION_ID
+    if (isSsnSection) {
       sectionBody = <SsnSeSection className={yStack({ gap: 'lg' })} />
     } else {
-      sectionStyle = { marginTop: '3.75rem' }
       const isLast = index === form.sections.length - 1
       sectionBody = (
         <>
@@ -86,7 +77,10 @@ export function InsuranceDataForm({ className }: { className?: string }) {
       )
     }
     return (
-      <div key={section.id} className={yStack({ gap: 'lg' })} style={sectionStyle}>
+      <div
+        key={section.id}
+        className={clsx(yStack({ gap: 'lg' }), formSection.base, isSsnSection && formSection.ssn)}
+      >
         <SectionTitle section={section} />
         {sectionBody}
       </div>

--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPageContent.css.ts
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPageContent.css.ts
@@ -8,7 +8,7 @@ export const PRICE_CALCULATOR_SECTION_PADDING = tokens.space.md
 export const pageGrid = style({
   display: 'grid',
   gridTemplateRows: 'min-content 1fr',
-  gap: tokens.space.md,
+  columnGap: tokens.space.md,
   backgroundColor: tokens.colors.backgroundStandard,
   minHeight: `calc(100vh - ${HEADER_HEIGHT_MOBILE})`,
   ...responsiveStyles({


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Adjust PriceCalculator layout 
Saw that you adjusted some layout @guilhermespopolin and I have an open PR https://github.com/HedvigInsurance/racoon/pull/4806 from earlier that caused a few conflicts so I closed that one and created a new one

- Make sure layout is visually centered in desktop
- Make sure view is not more than 100vh (should not scroll when content isn't taller than viewport)
- Adjust SSN section position in mobile
- Replace inline styles with classnames

### Before
https://github.com/user-attachments/assets/6f888b66-d5fc-45e4-851c-4b41b5d929b9

### After
https://github.com/user-attachments/assets/d352ecea-0f3c-4101-a9ab-72f9f3e2054f


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Fix layout

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
