### PR TITLE
Stop escaping any text elements when rendering rich text

### DIFF
--- a/apps/store/src/blocks/RichTextBlock/richTextReactRenderer.tsx
+++ b/apps/store/src/blocks/RichTextBlock/richTextReactRenderer.tsx
@@ -85,9 +85,8 @@ const resolver = richTextResolver({
     },
     [BlockTypes.COMPONENT]: componentResolver,
   },
-  // No need to escape quote marks [\'\"], it breaks final result
-  // From safety perspective quotes should only be escaped in attribute values
-  textFn: (text: string) => text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+  // No need to escape anything, React does this already
+  textFn: (text: string) => text,
 })
 
 function componentResolver(node: StoryblokRichTextNode<ReactElement>) {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Escaping text manually lead to double-escaping. So, we're not explicitly using escape bypass and rely on React to do escaping

Screenshow showing that richtext stays XSS-safe even when we use `renderToString` with `dangerouslySetInnerHtml` (Content block)

![Screenshot 2024-10-03 at 11.17.40.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/01bbe4d6-93e7-4b74-b049-ba96983b4316.png)



<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Fixes remaining formatting issues

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
