### PR TITLE
GEN-2651 - feat(price-calculator): enable addition of multiple products in purchase summary

### DIFF
--- a/apps/store/public/locales/en/purchase-form.json
+++ b/apps/store/public/locales/en/purchase-form.json
@@ -1,5 +1,6 @@
 {
   "ADDED_TO_CART_LABEL": "Added to cart",
+  "ADD_ANOTHER_INSURANCE_LABEL": "Add another {{productName}}",
   "ADD_TO_CART_BUTTON_LABEL": "Add to cart",
   "AUTO_SWITCH_FIELD_LABEL": "Switch automatically",
   "AUTO_SWITCH_FIELD_MESSAGE": "We cancel your insurance at {{COMPANY}}. Hedvig is activated when it expires.",

--- a/apps/store/public/locales/sv-se/purchase-form.json
+++ b/apps/store/public/locales/sv-se/purchase-form.json
@@ -1,5 +1,6 @@
 {
   "ADDED_TO_CART_LABEL": "Tillag i varukorden",
+  "ADD_ANOTHER_INSURANCE_LABEL": "Lägg till en {{productName}}",
   "ADD_TO_CART_BUTTON_LABEL": "Lägg i varukorgen",
   "AUTO_SWITCH_FIELD_LABEL": "Byt automatiskt",
   "AUTO_SWITCH_FIELD_MESSAGE": "Vi avslutar din försäkring hos {{COMPANY}} åt dig. Hedvig aktiveras när den går ut.",

--- a/apps/store/src/components/ProductPage/PurchaseForm/priceIntentAtoms.ts
+++ b/apps/store/src/components/ProductPage/PurchaseForm/priceIntentAtoms.ts
@@ -1,8 +1,8 @@
 import { useApolloClient } from '@apollo/client'
 import { datadogLogs } from '@datadog/browser-logs'
-import { atom, useAtomValue, useSetAtom, useStore } from 'jotai'
+import { atom, useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import { atomFamily } from 'jotai/utils'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import {
   priceTemplateAtom,
@@ -17,7 +17,7 @@ import {
   usePriceIntentQuery,
 } from '@/services/graphql/generated'
 import { setupForm } from '@/services/PriceCalculator/PriceCalculator.helpers'
-import { type Form } from '@/services/PriceCalculator/PriceCalculator.types'
+import type { Form } from '@/services/PriceCalculator/PriceCalculator.types'
 import { priceIntentServiceInitClientSide } from '@/services/priceIntent/PriceIntentService'
 import { useShopSession, useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { getOffersByPrice } from '@/utils/getOffersByPrice'
@@ -133,9 +133,9 @@ export const useSyncPriceIntentState = ({
   const { shopSession } = useShopSession()
   const shopSessionId = shopSession?.id
   const apolloClient = useApolloClient()
+  const [priceIntentId, setPriceIntentId] = useAtom(currentPriceIntentIdAtom)
 
   const cart = shopSession?.cart
-  const [priceIntentId, setPriceIntentId] = useState<string | null>(null)
 
   useEffect(() => {
     if (shopSessionId == null || priceTemplate == null) {
@@ -143,7 +143,7 @@ export const useSyncPriceIntentState = ({
     }
     const service = priceIntentServiceInitClientSide(apolloClient)
     const createPriceIntent = () => {
-      service.getOrCreate({ productName, priceTemplate, shopSessionId }).then((priceIntent) => {
+      service.create({ productName, priceTemplate, shopSessionId }).then((priceIntent) => {
         setPriceIntentId(priceIntent.id)
       })
     }
@@ -205,6 +205,7 @@ export const useSyncPriceIntentState = ({
     priceTemplate,
     productName,
     shopSessionId,
+    setPriceIntentId,
   ])
 
   const queryResult = usePriceIntentQuery({
@@ -277,7 +278,8 @@ const compareOffer = (a: ComparableProductOffer, b: ComparableProductOffer) => {
 }
 
 export const useIsPriceIntentStateReady = (): boolean => {
-  return !!useAtomValue(currentPriceIntentIdAtom)
+  const priceIntentId = useAtomValue(currentPriceIntentIdAtom)
+  return !!useAtomValue(priceIntentAtomFamily(priceIntentId))
 }
 
 export const priceCalculatorLoadingAtom = atom(false)
@@ -292,16 +294,19 @@ export const usePriceIntentId = (): string => {
 
 export const useResetPriceIntent = () => {
   const shopSessionId = useShopSessionId()
+  // When we start using TemplateV2 exclusively, we can remove this
+  // and retrieve the name from the template directly
+  const productName = useProductData().name
   const apolloClient = useApolloClient()
-  const templateName = usePriceTemplate().name
-  const [, setSelectedOffer] = useSelectedOffer()
+  const priceTemplate = usePriceTemplate()
   const setCurrentPriceIntentId = useSetAtom(currentPriceIntentIdAtom)
+  const priceIntentService = priceIntentServiceInitClientSide(apolloClient)
 
   return useCallback(() => {
     if (shopSessionId == null) return
-    const service = priceIntentServiceInitClientSide(apolloClient)
-    service.clear(shopSessionId, templateName)
     setCurrentPriceIntentId(null)
-    setSelectedOffer(null)
-  }, [apolloClient, setCurrentPriceIntentId, setSelectedOffer, shopSessionId, templateName])
+    priceIntentService.create({ productName, priceTemplate, shopSessionId }).then((priceIntent) => {
+      setCurrentPriceIntentId(priceIntent.id)
+    })
+  }, [priceIntentService, setCurrentPriceIntentId, shopSessionId, priceTemplate, productName])
 }

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2.css.ts
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2.css.ts
@@ -1,7 +1,7 @@
 import { style } from '@vanilla-extract/css'
 import { yStack, responsiveStyles } from 'ui'
 
-const CONTENT_MAX_WIDTH = '23rem'
+export const CONTENT_MAX_WIDTH = '23rem'
 
 export const centered = style({
   maxWidth: CONTENT_MAX_WIDTH,

--- a/apps/store/src/features/priceCalculator/PurchaseSummary.css.ts
+++ b/apps/store/src/features/priceCalculator/PurchaseSummary.css.ts
@@ -1,0 +1,19 @@
+import { style } from '@vanilla-extract/css'
+import { yStack, responsiveStyles, tokens } from 'ui'
+import { CONTENT_MAX_WIDTH } from './PurchaseFormV2.css'
+
+export const actions = style([
+  yStack({ gap: 'xs' }),
+  {
+    position: 'fixed',
+    bottom: tokens.space.md,
+    width: `calc(100% - ${tokens.space.md} * 2)`,
+    maxWidth: CONTENT_MAX_WIDTH,
+    ...responsiveStyles({
+      lg: {
+        position: 'revert',
+        width: '100%',
+      },
+    }),
+  },
+])

--- a/apps/store/src/features/priceCalculator/PurchaseSummary.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseSummary.tsx
@@ -1,18 +1,31 @@
 import clsx from 'clsx'
 import { useTranslation } from 'next-i18next'
-import { Text, Card, Divider, yStack } from 'ui'
+import { useCallback } from 'react'
+import { Text, Card, Divider, Button, yStack } from 'ui'
 import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { TotalPrice } from '@/components/ProductCard/TotalPrice/TotalPrice'
+import { useResetPriceIntent } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
+import { usePriceTemplate } from '@/components/ProductPage/PurchaseForm/priceTemplateAtom'
 import { useSelectedOfferValueOrThrow } from '@/components/ProductPage/PurchaseForm/useSelectedOffer'
+import type { TemplateV2 } from '@/services/PriceCalculator/PriceCalculator.types'
 import { getOfferPrice } from '@/utils/getOfferPrice'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
+import { actions } from './PurchaseSummary.css'
 
 export function PurchaseSummary({ className }: { className?: string }) {
   const { t } = useTranslation('purchase-form')
   const locale = useRoutingLocale()
   const offer = useSelectedOfferValueOrThrow()
+  const priceTemplate = usePriceTemplate() as TemplateV2
+  const resetPriceIntent = useResetPriceIntent()
+
+  const handleAddMore = useCallback(() => {
+    resetPriceIntent()
+  }, [resetPriceIntent])
+
+  const showAddMoreButton = offer.product.multiple && priceTemplate.addMultiple
 
   return (
     <div className={clsx(yStack({ gap: 'xl' }), className)}>
@@ -32,7 +45,12 @@ export function PurchaseSummary({ className }: { className?: string }) {
         <TotalPrice label="Price" {...getOfferPrice(offer.cost)} />
       </Card.Root>
 
-      <div className={yStack({ gap: 'xs' })}>
+      <div className={actions}>
+        {showAddMoreButton && (
+          <Button onClick={handleAddMore} variant="secondary">
+            {t('ADD_ANOTHER_INSURANCE_LABEL', { productName: offer.product.displayNameShort })}
+          </Button>
+        )}
         <ButtonNextLink href={PageLink.checkout({ locale })} variant="primary">
           {t('GO_TO_CART_LABEL')}
         </ButtonNextLink>

--- a/apps/store/src/features/priceCalculator/priceTemplates/SE_PET_CAT_V2.ts
+++ b/apps/store/src/features/priceCalculator/priceTemplates/SE_PET_CAT_V2.ts
@@ -13,6 +13,7 @@ setI18nNamespace('purchase-form')
 const template: TemplateV2 = {
   name: 'SE_PET_CAT_V2',
   productName: 'SE_PET_CAT',
+  addMultiple: true,
   sections: [
     ssnSeSectionV2,
     {

--- a/apps/store/src/features/priceCalculator/priceTemplates/SE_PET_DOG_V2.ts
+++ b/apps/store/src/features/priceCalculator/priceTemplates/SE_PET_DOG_V2.ts
@@ -13,6 +13,7 @@ setI18nNamespace('purchase-form')
 const template: TemplateV2 = {
   name: 'SE_PET_DOG_V2',
   productName: 'SE_PET_DOG',
+  addMultiple: true,
   sections: [
     ssnSeSectionV2,
     {

--- a/apps/store/src/graphql/ProductOfferFragment.graphql
+++ b/apps/store/src/graphql/ProductOfferFragment.graphql
@@ -7,6 +7,7 @@ fragment ProductOffer on ProductOffer {
     priceCalculatorPageLink
     displayNameShort
     displayNameFull
+    multiple
     pillowImage {
       id
       alt

--- a/apps/store/src/services/PriceCalculator/PriceCalculator.types.ts
+++ b/apps/store/src/services/PriceCalculator/PriceCalculator.types.ts
@@ -31,6 +31,7 @@ export type Template = {
 
 export type TemplateV2 = Template & {
   productName: string
+  addMultiple?: boolean
 }
 
 export type TemplateSection = {


### PR DESCRIPTION
## Describe your changes

Enable the addition of multi products (E.g: Pet and Car).

https://github.com/user-attachments/assets/699e1535-50d4-42a1-ba0a-4739024b9ef6

We can now from storefront if a particular product is a multi-product or not via `Product.multiple` field. However we also want to control we user should be presented with "Add another" button on the FE side. For that I'm using the price template (`TemplateV2`) so at the end, before presenting that option we check: `Product.multiple && priceTemplate.addMutliple`.

This is a first attempt which requires a full page refresh for new price calculator. Will be investigating a better way to implement this that doesn't require a full page refresh. 

## Justify why they are needed

Make it easier to add multiple products when enabled.

