### PR TITLE
Send new internal events when price calculator is submitted

### DIFF
--- a/apps/store/src/appComponents/RootLayout/RootLayout.tsx
+++ b/apps/store/src/appComponents/RootLayout/RootLayout.tsx
@@ -8,6 +8,7 @@ import { contentFontClassName } from '@/utils/fonts'
 import { getLocaleOrFallback } from '@/utils/l10n/localeUtils'
 import type { RoutingLocale } from '@/utils/l10n/types'
 import { ApolloProvider } from '../providers/ApolloProvider'
+import { InternalReporterProvider } from '../providers/InternalReporterProvider'
 import { DebugError } from './DebugError'
 
 // Trick compiler into thinking we need global.css import for anything other than side effects
@@ -32,7 +33,9 @@ export function RootLayout({
         </Suspense>
         <NavigationProgressIndicator />
 
-        <ApolloProvider locale={locale}>{children}</ApolloProvider>
+        <ApolloProvider locale={locale}>
+          <InternalReporterProvider>{children}</InternalReporterProvider>
+        </ApolloProvider>
       </body>
     </html>
   )

--- a/apps/store/src/appComponents/providers/InternalReporterProvider.tsx
+++ b/apps/store/src/appComponents/providers/InternalReporterProvider.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { createContext, type ReactNode, useRef } from 'react'
+import { InternalEventReporter } from '@/services/Tracking/InternalEventReporter'
+
+export const InternalReporterContext = createContext<InternalEventReporter | null>(null)
+
+export function InternalReporterProvider({ children }: { children: ReactNode }) {
+  const reporterRef = useRef<InternalEventReporter>()
+  if (reporterRef.current == null) {
+    reporterRef.current = new InternalEventReporter()
+  }
+  return (
+    <InternalReporterContext.Provider value={reporterRef.current}>
+      {children}
+    </InternalReporterContext.Provider>
+  )
+}

--- a/apps/store/src/components/PriceCalculator/useHandleSubmitPriceCalculatorSection.ts
+++ b/apps/store/src/components/PriceCalculator/useHandleSubmitPriceCalculatorSection.ts
@@ -1,4 +1,6 @@
-import { startTransition, useCallback } from 'react'
+import { useApolloClient } from '@apollo/client'
+import { startTransition, useCallback, useContext } from 'react'
+import { InternalReporterContext } from '@/appComponents/providers/InternalReporterProvider'
 import { useUpdatePriceIntent } from '@/components/PriceCalculator/useUpdatePriceIntent'
 import { usePriceIntentId } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
 import type { JSONData } from '@/services/PriceCalculator/PriceCalculator.types'
@@ -14,6 +16,8 @@ export const useHandleSubmitPriceCalculatorSection = (params: Params) => {
   const shopSessionId = useShopSessionId()!
   const priceIntentId = usePriceIntentId()
   const updatePriceIntent = useUpdatePriceIntent({ onSuccess: params.onSuccess })
+  const apolloClient = useApolloClient()
+  const internalEventReporter = useContext(InternalReporterContext)
 
   // NOTE: We probably want to refactor this in the future
   // and stop editing priceIntent and customer data as a mix.
@@ -30,6 +34,7 @@ export const useHandleSubmitPriceCalculatorSection = (params: Params) => {
         return
       }
       startTransition(() => {
+        internalEventReporter?.flush(apolloClient, shopSessionId)
         updatePriceIntent({
           variables: {
             priceIntentId,
@@ -39,7 +44,7 @@ export const useHandleSubmitPriceCalculatorSection = (params: Params) => {
         })
       })
     },
-    [priceIntentId, shopSessionId, updatePriceIntent],
+    [apolloClient, internalEventReporter, priceIntentId, shopSessionId, updatePriceIntent],
   )
 
   return handleSubmitSection

--- a/apps/store/src/services/Tracking/InternalEventReporter.ts
+++ b/apps/store/src/services/Tracking/InternalEventReporter.ts
@@ -1,0 +1,53 @@
+import { type ApolloClient } from '@apollo/client'
+import { isBrowser } from '@/utils/env'
+import { SendEventBatchDocument } from '../graphql/generated'
+import { type TrackingEvent } from './TrackingEvent'
+
+export type InternalEvent = {
+  id: string
+  type: TrackingEvent
+  data: unknown
+  clientTimestamp: string
+}
+
+export class InternalEventReporter {
+  #queue: Array<InternalEvent> = []
+
+  enqueue(type: TrackingEvent, data: unknown) {
+    if (!isBrowser()) {
+      throw new Error('InternalEventReporter must be used client-side')
+    }
+    // Ignore few ancient browsers, universal support for randomUUID appeared in 2021
+    if (typeof crypto.randomUUID !== 'function') {
+      console.log('crypto.randomUUID not supported, skipping internal event reporting')
+    }
+    this.#queue.push({
+      id: crypto.randomUUID(),
+      type,
+      data,
+      clientTimestamp: new Date().toISOString(),
+    })
+  }
+
+  async flush(apolloClient: ApolloClient<unknown>, shopSessionId: string) {
+    if (!isBrowser()) {
+      throw new Error('InternalEventReporter must be used client-side')
+    }
+    if (this.#queue.length === 0) {
+      return
+    }
+    const inputList = this.#queue.map((item) => ({
+      ...item,
+      sessionId: shopSessionId,
+    }))
+    try {
+      await apolloClient.mutate({
+        mutation: SendEventBatchDocument,
+        variables: { inputList },
+      })
+      this.#queue = []
+    } catch (err) {
+      console.log('Failed to send internal events, keeping them in queue', err)
+    }
+  }
+}

--- a/apps/store/src/services/Tracking/TrackingEvent.ts
+++ b/apps/store/src/services/Tracking/TrackingEvent.ts
@@ -1,0 +1,27 @@
+// Naming rules:
+// - snake_case for Analytics / ecommerce events (backward compatibility)
+// - camelCase for internal anayltics events
+export enum TrackingEvent {
+  AddToCart = 'add_to_cart',
+  Adtraction = 'adtraction',
+  BeginCheckout = 'begin_checkout',
+  ClickTermsAndConditions = 'clickTermsAndConditions',
+  DeleteFromCart = 'delete_from_cart',
+  DeviceInfo = 'deviceInfo',
+  ExpandPeril = 'expandPeril',
+  // Website-driven experiments, as configured in experiment.json
+  ExperimentImpression = 'experiment_impression',
+  OpenPriceCalculator = 'open_price_calculator',
+  OpenProductReviews = 'openProductReviews',
+  PageView = 'virtual_page_view',
+  Purchase = 'purchase',
+  SelectItem = 'select_item',
+  ViewCart = 'view_cart',
+  ViewItem = 'view_item',
+  ViewPromotion = 'view_promotion',
+  InsurelyPrompted = 'insurely_prompted',
+  InsurelyAccepted = 'insurely_accepted',
+  InsurelyCorrectlyFetched = 'insurely_correctly_fetched',
+  // Backend-driven experiments as defined in shopSession.experiments
+  ShopSessionExperiments = 'shop_session_experiments',
+}

--- a/apps/store/src/services/Tracking/useReportDeviceInfo.ts
+++ b/apps/store/src/services/Tracking/useReportDeviceInfo.ts
@@ -3,7 +3,8 @@ import { browserName, deviceType, osName } from 'react-device-detect'
 import { useSendEventBatchMutation } from '@/services/graphql/generated'
 import type { ShopSession } from '@/services/shopSession/ShopSession.types'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
-import { TrackingEvent } from '@/services/Tracking/Tracking'
+import { Features } from '@/utils/Features'
+import { TrackingEvent } from './TrackingEvent'
 import { useTracking } from './useTracking'
 
 export const useReportDeviceInfo = () => {
@@ -32,15 +33,17 @@ export const useReportDeviceInfo = () => {
           browserName,
         }
         tracking.reportDeviceInfo(data)
-
-        const deviceInfoEvent = {
-          type: TrackingEvent.DeviceInfo,
-          data,
-          id: crypto.randomUUID(),
-          sessionId: shopSession.id,
-          clientTimestamp: new Date().toISOString(),
+        // Old manual reporting, remove when BEHAVIOR_EVENTS becomes always on
+        if (!Features.enabled('BEHAVIOR_EVENTS')) {
+          const deviceInfoEvent = {
+            type: TrackingEvent.DeviceInfo,
+            data,
+            id: crypto.randomUUID(),
+            sessionId: shopSession.id,
+            clientTimestamp: new Date().toISOString(),
+          }
+          sendEventBatch({ variables: { inputList: [deviceInfoEvent] } })
         }
-        sendEventBatch({ variables: { inputList: [deviceInfoEvent] } })
       }),
     [tracking, onReady, sendEventBatch],
   )

--- a/apps/store/src/services/Tracking/useTracking.ts
+++ b/apps/store/src/services/Tracking/useTracking.ts
@@ -1,14 +1,17 @@
 import { useContext, useRef } from 'react'
+import { InternalReporterContext } from '@/appComponents/providers/InternalReporterProvider'
 import { Tracking } from './Tracking'
 import { TrackingContext } from './TrackingContext'
 
 export const useTracking = (): Tracking => {
   const data = useContext(TrackingContext)
+  const internalReporter = useContext(InternalReporterContext)
 
-  // Optimization: keep single instance then update context in-place
+  // Optimization: keep single instance then update in-place
   // Makes sure returned value is stable and callbacks depending on it are not recreated
   // every time something in the context changes
   const trackingRef = useRef(new Tracking())
   trackingRef.current.context = data
+  trackingRef.current.internalEventReporter = internalReporter
   return trackingRef.current
 }

--- a/apps/store/src/services/gtm.tsx
+++ b/apps/store/src/services/gtm.tsx
@@ -4,8 +4,8 @@
 
 import { datadogLogs } from '@datadog/browser-logs'
 import Script from 'next/script'
-import type { TrackingEvent } from '@/services/Tracking/Tracking'
 import type { CountryCode } from '@/utils/l10n/types'
+import { type TrackingEvent } from './Tracking/TrackingEvent'
 
 const GTM_ID = process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID
 const GTM_ENVIRONMENT = process.env.NEXT_PUBLIC_GTM_ENV

--- a/apps/store/src/utils/Features.ts
+++ b/apps/store/src/utils/Features.ts
@@ -7,6 +7,7 @@ export const Features = {
 }
 
 const config = {
+  BEHAVIOR_EVENTS: process.env.NEXT_PUBLIC_FEATURE_BEHAVIOR_EVENTS === 'true',
   // We're using it to disable cookie banner outside of production and staging
   COOKIE_BANNER: process.env.NEXT_PUBLIC_FEATURE_COOKIE_BANNER === 'true',
   // Keeping it around as a way to quickly disable Insurely if anything goes wrong


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Next step towards new behavior-driven pricing
- Add `InternalEventReporter` and use it behind `Tracking` facade for internal events
- Accumulate internal events in the queue and flush it when submitting any section of price calculator

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

The goal right now is to do early end-to-end integration. Flushing on price calculator section submit may not be early enough for latency purposes - we'll check this

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
