### PR TITLE
Align Price Calculator layout page to the grid

### DIFF
--- a/apps/store/src/features/priceCalculator/InsuranceDataForm.css.ts
+++ b/apps/store/src/features/priceCalculator/InsuranceDataForm.css.ts
@@ -1,7 +1,6 @@
 import { style, styleVariants } from '@vanilla-extract/css'
 import { responsiveStyles } from 'ui'
 import { HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header.css'
-import { PRICE_CALCULATOR_SECTION_PADDING } from './PriceCalculatorCmsPageContent.css'
 
 export const gdprLink = style({
   marginTop: '-1rem', // Offset from default gap of 2rem
@@ -17,7 +16,6 @@ export const formSection = styleVariants({
         position: 'absolute',
         top: `50%`,
         transform: `translateY(-50%)`,
-        width: `min(23rem, calc(100% - 2 * ${PRICE_CALCULATOR_SECTION_PADDING}))`,
         // Visually center SSN form section
         marginTop: `calc(-1 * (${HEADER_HEIGHT_DESKTOP} / 2))`,
       },

--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPageContent.css.ts
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPageContent.css.ts
@@ -3,18 +3,21 @@ import { responsiveStyles, tokens, yStack } from 'ui'
 import { HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header.css'
 import { HEADER_HEIGHT_MOBILE } from '@/components/Header/HeaderMenuMobile/HeaderMenuMobile.css'
 
-export const PRICE_CALCULATOR_SECTION_PADDING = tokens.space.md
-
 export const pageGrid = style({
   display: 'grid',
   gridTemplateRows: 'min-content 1fr',
   columnGap: tokens.space.md,
-  backgroundColor: tokens.colors.backgroundStandard,
+  maxWidth: tokens.width.layoutMax,
   minHeight: `calc(100vh - ${HEADER_HEIGHT_MOBILE})`,
+  marginInline: 'auto',
+  paddingInline: tokens.space.md,
+  backgroundColor: tokens.colors.backgroundStandard,
+
   ...responsiveStyles({
     lg: {
-      gridTemplateColumns: '1fr 1fr',
+      gridTemplateColumns: 'repeat(14, 1fr)',
       minHeight: `calc(100vh - ${HEADER_HEIGHT_DESKTOP})`,
+      paddingInline: tokens.space.lg,
     },
   }),
 })
@@ -24,13 +27,13 @@ export const productHeroSection = style([
   {
     height: '13rem',
     alignSelf: 'start',
-    paddingInline: tokens.space.md,
+
     ...responsiveStyles({
       lg: {
         position: 'sticky',
         top: 0,
+        gridColumn: '1 / span 7',
         minHeight: `calc(100vh - ${HEADER_HEIGHT_DESKTOP})`,
-        paddingInline: tokens.space.lg,
       },
     }),
   },
@@ -38,7 +41,12 @@ export const productHeroSection = style([
 
 export const priceCalculatorSection = style({
   position: 'relative',
-  padding: PRICE_CALCULATOR_SECTION_PADDING,
+
+  ...responsiveStyles({
+    lg: {
+      gridColumn: '9 / span 4',
+    },
+  }),
 })
 
 export const productHero = style({

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2.css.ts
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2.css.ts
@@ -6,6 +6,12 @@ const CONTENT_MAX_WIDTH = '23rem'
 export const centered = style({
   maxWidth: CONTENT_MAX_WIDTH,
   marginInline: 'auto',
+  ...responsiveStyles({
+    lg: {
+      width: `max(${CONTENT_MAX_WIDTH}, 100%)`,
+      maxWidth: 'unset',
+    },
+  }),
 })
 
 export const priceLoaderWrapper = style([
@@ -24,7 +30,3 @@ export const purchaseSummaryWrapper = style([
   yStack({ alignItems: 'center', justifyContent: 'center' }),
   { height: '100%' },
 ])
-
-export const purchaseSummary = style({
-  width: `min(${CONTENT_MAX_WIDTH}, 100%)`,
-})

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2.tsx
@@ -23,7 +23,6 @@ import {
   priceLoaderWrapper,
   viewOffersWrapper,
   purchaseSummaryWrapper,
-  purchaseSummary,
 } from './PurchaseFormV2.css'
 import { PurchaseSummary } from './PurchaseSummary'
 
@@ -60,7 +59,7 @@ export function PurchaseFormV2() {
     case 'purchaseSummary':
       return (
         <div className={purchaseSummaryWrapper}>
-          <PurchaseSummary className={purchaseSummary} />
+          <PurchaseSummary className={centered} />
         </div>
       )
     default:

--- a/packages/ui/src/theme/theme.ts
+++ b/packages/ui/src/theme/theme.ts
@@ -20,6 +20,9 @@ export const theme = {
     focus: `0 0 0 2px ${colors.textPrimary}`,
     focusAlt: `0 0 0 2px ${colors.signalBlueElement}`,
   },
+  width: {
+    layoutMax: '90rem',
+  },
   components: {
     input: {
       background: {


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Align Price Calculator layout page to the 14-col grid to match Figma

![Screenshot 2024-10-03 at 15.54.41.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/nv8d5VeBPARA7ezh3Od3/ad8154db-2b47-4df1-b687-858cd578b5b6.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
