### PR TITLE
Add offset option to scrolled past hook

### DIFF
--- a/apps/store/src/components/ProductPage/ScrollPast/useHasScrolledPast.ts
+++ b/apps/store/src/components/ProductPage/ScrollPast/useHasScrolledPast.ts
@@ -1,18 +1,24 @@
 import { useScroll } from 'framer-motion'
 import { useState, useEffect } from 'react'
 
-export const useHasScrolledPast = ({ targetRef }: { targetRef: React.RefObject<HTMLElement> }) => {
+export const useHasScrolledPast = ({
+  targetRef,
+  offset = 0,
+}: {
+  targetRef: React.RefObject<HTMLElement>
+  offset?: number
+}) => {
   const { scrollY } = useScroll()
 
   const [hasScrolledPassed, setHasScrolledPassed] = useState(false)
   useEffect(() => {
     return scrollY.on('change', (latest) => {
       if (targetRef.current) {
-        const elementEnd = targetRef.current.offsetTop + targetRef.current.clientHeight
+        const elementEnd = targetRef.current.offsetTop + targetRef.current.clientHeight + offset
         setHasScrolledPassed(latest > elementEnd)
       }
     })
-  }, [scrollY, targetRef])
+  }, [scrollY, targetRef, offset])
 
   return hasScrolledPassed
 }

--- a/apps/store/src/features/priceCalculator/ProductHeroV2/ProductHeroV2.tsx
+++ b/apps/store/src/features/priceCalculator/ProductHeroV2/ProductHeroV2.tsx
@@ -31,7 +31,7 @@ export function ProductHeroV2({ className }: { className?: string }) {
   const productData = useProductData()
   const [selectedOffer] = useSelectedOffer()
   const subType = selectedOffer?.variant.displayNameSubtype
-  const hasScrolledPast = useHasScrolledPast({ targetRef: ref })
+  const hasScrolledPast = useHasScrolledPast({ targetRef: ref, offset: -100 })
   const formatter = useFormatter()
 
   const productHeading = (


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add offset option to scrolled past hook

It's common that you want to have some offset on when to trigger scrolled past state. In the Product Header instance we want the sticky header to appear before we have scrolled past the full hero. 


https://github.com/user-attachments/assets/262cd845-e1cb-482e-8069-c891565125cf

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Avoid sticky header disappearing when page is somewhat shorter
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
