### PR TITLE
fix(purchase-summary): centralize cta

### DIFF
--- a/apps/store/src/features/priceCalculator/PurchaseFormV2.css.ts
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2.css.ts
@@ -30,3 +30,13 @@ export const purchaseSummaryWrapper = style([
   yStack({ alignItems: 'center', justifyContent: 'center' }),
   { height: '100%' },
 ])
+
+export const purchaseSummary = style({
+  width: `min(100%, ${CONTENT_MAX_WIDTH})`,
+  marginInline: 'auto',
+  ...responsiveStyles({
+    lg: {
+      width: `max(100%, ${CONTENT_MAX_WIDTH})`,
+    },
+  }),
+})

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2.tsx
@@ -23,6 +23,7 @@ import {
   priceLoaderWrapper,
   viewOffersWrapper,
   purchaseSummaryWrapper,
+  purchaseSummary,
 } from './PurchaseFormV2.css'
 import { PurchaseSummary } from './PurchaseSummary'
 
@@ -59,7 +60,7 @@ export function PurchaseFormV2() {
     case 'purchaseSummary':
       return (
         <div className={purchaseSummaryWrapper}>
-          <PurchaseSummary className={centered} />
+          <PurchaseSummary className={purchaseSummary} />
         </div>
       )
     default:

--- a/apps/store/src/features/priceCalculator/PurchaseSummary.css.ts
+++ b/apps/store/src/features/priceCalculator/PurchaseSummary.css.ts
@@ -7,12 +7,12 @@ export const actions = style([
   {
     position: 'fixed',
     bottom: tokens.space.md,
-    width: `calc(100% - ${tokens.space.md} * 2)`,
-    maxWidth: CONTENT_MAX_WIDTH,
+    width: `min(100%, ${CONTENT_MAX_WIDTH})`,
+    marginInline: 'auto',
     ...responsiveStyles({
       lg: {
         position: 'revert',
-        width: '100%',
+        width: `max(100%, ${CONTENT_MAX_WIDTH})`,
       },
     }),
   },


### PR DESCRIPTION
## Describe your changes

Solves a UI bug where cta were not being centralize on _purchase summary_

**Before**

![Screenshot 2024-10-07 at 17.27.01.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/05a98a10-5ba2-4fcd-92e2-39ed3ed22110.png)

**After**

![Screenshot 2024-10-07 at 17.28.45.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ocPE5OGCo5Y6fhJekeDQ/44a785d3-4237-4155-bd9f-48b77bd93277.png)

