### PR TITLE
GEN-2728 - refact(global-store): extract a jotai global store

### DIFF
--- a/apps/store/src/app/LayoutJotaiProvider.tsx
+++ b/apps/store/src/app/LayoutJotaiProvider.tsx
@@ -1,9 +1,8 @@
 'use client'
-import { createStore, Provider } from 'jotai'
+import { Provider } from 'jotai'
 import { type ReactNode } from 'react'
-
-export const layoutJotaiStore = createStore()
+import { globalStore } from 'globalStore'
 
 export function LayoutJotaiProvider({ children }: { children: ReactNode }) {
-  return <Provider store={layoutJotaiStore}>{children}</Provider>
+  return <Provider store={globalStore}>{children}</Provider>
 }

--- a/apps/store/src/components/Banner/PageBannerTriggers.tsx
+++ b/apps/store/src/components/Banner/PageBannerTriggers.tsx
@@ -1,12 +1,11 @@
 'use client'
 import { type StoryblokRichTextNode } from '@storyblok/richtext'
-import { useAtom } from 'jotai'
 import { useTranslation } from 'next-i18next'
 import { useEffect } from 'react'
 import type { ReusableBlockReferenceProps } from '@/blocks/ReusableBlockReference'
 import { renderRichTextToString } from '@/blocks/RichTextBlock/richTextReactRenderer'
 import type { BannerVariant } from '@/components/Banner/Banner.types'
-import { globalBannerAtom } from '@/components/GlobalBanner/globalBannerState'
+import { useGlobalBanner, useSetGlobalBanner } from '@/components/GlobalBanner/globalBannerState'
 import { hasBundleDiscount } from '@/features/bundleDiscount/bundleDiscount.utils'
 import { useShopSession } from '@/services/shopSession/ShopSessionContext'
 import type { ExpectedBlockType } from '@/services/storyblok/storyblok'
@@ -30,6 +29,19 @@ export function PageBannerTriggers({ blok }: Props) {
   return null
 }
 
+export const useCampaignBanner = () => {
+  const { t } = useTranslation()
+  const { shopSession } = useShopSession()
+  const setGlobalBanner = useSetGlobalBanner()
+
+  const showCampaignBanner = !!shopSession?.cart.redeemedCampaign && !hasBundleDiscount(shopSession)
+  useEffect(() => {
+    if (showCampaignBanner) {
+      setGlobalBanner({ id: 'campaign', content: t('GLOBAL_BANNER_CAMPAIGN'), variant: 'campaign' })
+    }
+  }, [showCampaignBanner, setGlobalBanner, t])
+}
+
 type AnnouncementBlok = {
   id: string
   content: StoryblokRichTextNode
@@ -39,7 +51,7 @@ type AnnouncementBlok = {
 const usePageBanner = (blok?: AnnouncementBlok) => {
   const { t } = useTranslation()
   const { shopSession } = useShopSession()
-  const [globalBanner, setGlobalBanner] = useAtom(globalBannerAtom)
+  const [globalBanner, setGlobalBanner] = useGlobalBanner()
   const globalBannerId = globalBanner?.id
 
   const showCampaignBanner = !!shopSession?.cart.redeemedCampaign && !hasBundleDiscount(shopSession)

--- a/apps/store/src/components/GlobalBanner/GlobalBanner.tsx
+++ b/apps/store/src/components/GlobalBanner/GlobalBanner.tsx
@@ -1,15 +1,11 @@
 'use client'
-import { useAtomValue, useSetAtom } from 'jotai'
 import { Banner } from '@/components/Banner/Banner'
-import {
-  dismissedBannerIdAtom,
-  globalBannerAtom,
-} from '@/components/GlobalBanner/globalBannerState'
+import { useGlobalBannerValue, useDismissBanner } from '@/components/GlobalBanner/globalBannerState'
 import { useDebugShopSessionId } from '@/utils/useDebugShopSessionId'
 
 const GlobalBanner = () => {
-  const globalBanner = useAtomValue(globalBannerAtom)
-  const setDismissedBannerId = useSetAtom(dismissedBannerIdAtom)
+  const globalBanner = useGlobalBannerValue()
+  const dismissBanner = useDismissBanner()
 
   // Show standard banners if applicable
   useDebugShopSessionId()
@@ -17,7 +13,7 @@ const GlobalBanner = () => {
   if (globalBanner == null) return null
 
   return (
-    <Banner variant={globalBanner.variant} onClose={() => setDismissedBannerId(globalBanner.id)}>
+    <Banner variant={globalBanner.variant} onClose={() => dismissBanner(globalBanner.id)}>
       <span dangerouslySetInnerHTML={{ __html: globalBanner.content }} />
     </Banner>
   )

--- a/apps/store/src/components/GlobalBanner/globalBannerState.ts
+++ b/apps/store/src/components/GlobalBanner/globalBannerState.ts
@@ -1,6 +1,7 @@
-import { atom } from 'jotai'
+import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { atomWithStorage, createJSONStorage } from 'jotai/utils'
 import type { Banner } from '@/components/Banner/Banner.types'
+import { globalStore } from 'globalStore'
 
 type BannerWithId = Banner & { id: string }
 
@@ -12,7 +13,7 @@ type SetBannerOptions = {
 // Banner is identified by string id, so dismissing a banner does not prevent banner with different id from being shown
 //
 // We intentionally don't support banner stack or any other forms of multiple banners being tracked or displayed
-export const globalBannerAtom = atom(
+const globalBannerAtom = atom(
   (get) => {
     const currentBanner = get(currentBannerAtom)
     const dismissedBannerId = get(dismissedBannerIdAtom)
@@ -40,8 +41,22 @@ export const globalBannerAtom = atom(
 
 const currentBannerAtom = atom<BannerWithId | null>(null)
 
-export const dismissedBannerIdAtom = atomWithStorage<string | null>(
+const dismissedBannerIdAtom = atomWithStorage<string | null>(
   'dismissedGlobalBannerId',
   null,
   createJSONStorage(() => window.sessionStorage),
 )
+
+export function useGlobalBanner() {
+  return useAtom(globalBannerAtom, { store: globalStore })
+}
+export function useGlobalBannerValue() {
+  return useAtomValue(globalBannerAtom, { store: globalStore })
+}
+export function useSetGlobalBanner() {
+  return useSetAtom(globalBannerAtom, { store: globalStore })
+}
+
+export function useDismissBanner() {
+  return useSetAtom(dismissedBannerIdAtom, { store: globalStore })
+}

--- a/apps/store/src/components/LayoutWithMenu/productMetadataHooks.tsx
+++ b/apps/store/src/components/LayoutWithMenu/productMetadataHooks.tsx
@@ -1,16 +1,16 @@
 import { useAtomValue } from 'jotai'
 import { useHydrateAtoms } from 'jotai/utils'
-import { layoutJotaiStore } from '@/app/LayoutJotaiProvider'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
+import { globalStore } from 'globalStore'
 import { type GlobalProductMetadata } from './fetchProductMetadata'
 import { productsMetadataAtom } from './productMetadataAtom'
 
 export const useProductMetadata = () => {
   const locale = useRoutingLocale()
-  return useAtomValue(productsMetadataAtom(locale), { store: layoutJotaiStore })
+  return useAtomValue(productsMetadataAtom(locale), { store: globalStore })
 }
 
 export const useHydrateProductMetadata = (metadata: GlobalProductMetadata) => {
   const locale = useRoutingLocale()
-  useHydrateAtoms([[productsMetadataAtom(locale), metadata]], { store: layoutJotaiStore })
+  useHydrateAtoms([[productsMetadataAtom(locale), metadata]], { store: globalStore })
 }

--- a/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
+++ b/apps/store/src/features/carDealership/CarTrialExtensionBlock.tsx
@@ -4,12 +4,11 @@ import { type QueryHookOptions } from '@apollo/client'
 import { datadogLogs } from '@datadog/browser-logs'
 import { storyblokEditable } from '@storyblok/react'
 import { addDays } from 'date-fns'
-import { useSetAtom } from 'jotai'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { useCallback, useMemo } from 'react'
 import { Space } from 'ui'
-import { globalBannerAtom } from '@/components/GlobalBanner/globalBannerState'
+import { useSetGlobalBanner } from '@/components/GlobalBanner/globalBannerState'
 import * as GridLayout from '@/components/GridLayout/GridLayout'
 import { CarDealershipBanners } from '@/features/carDealership/carDearlership.constants'
 import { useCarTrialExtensionQuery } from '@/services/graphql/generated'
@@ -121,7 +120,7 @@ type AddNotificationBannerOptions = {
 }
 
 const useAddNotificationBanner = () => {
-  const setGlobalBanner = useSetAtom(globalBannerAtom)
+  const setGlobalBanner = useSetGlobalBanner()
   const { dateFull } = useFormatter()
   const { t } = useTranslation('carDealership')
 

--- a/apps/store/src/features/carDealership/PayForTrial.tsx
+++ b/apps/store/src/features/carDealership/PayForTrial.tsx
@@ -1,9 +1,8 @@
 import { datadogRum } from '@datadog/browser-rum'
-import { useSetAtom } from 'jotai'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { Space } from 'ui'
-import { dismissedBannerIdAtom } from '@/components/GlobalBanner/globalBannerState'
+import { useDismissBanner } from '@/components/GlobalBanner/globalBannerState'
 import { CarDealershipBanners } from '@/features/carDealership/carDearlership.constants'
 import { useBankIdContext } from '@/services/bankId/BankIdContext'
 import type { ProductOfferFragment } from '@/services/graphql/generated'
@@ -29,7 +28,7 @@ export const PayForTrial = ({ trialContract, shopSessionId, defaultOffer, ssn }:
   const { t } = useTranslation('carDealership')
   const formatter = useFormatter()
   const locale = useRoutingLocale()
-  const setDismissedBannerId = useSetAtom(dismissedBannerIdAtom)
+  const dismissBanner = useDismissBanner()
   const { startLogin } = useBankIdContext()
 
   const handleConfirmPay = () => {
@@ -47,7 +46,7 @@ export const PayForTrial = ({ trialContract, shopSessionId, defaultOffer, ssn }:
           locale,
           contractId: trialContract.id,
         }).pathname
-        setDismissedBannerId(CarDealershipBanners.ConnectPayment)
+        dismissBanner(CarDealershipBanners.ConnectPayment)
         await router.push(
           PageLink.checkoutPaymentTrustly({ locale, shopSessionId: shopSessionId, nextUrl }),
         )

--- a/apps/store/src/features/carDealership/TrialExtensionForm/useAcceptExtension.ts
+++ b/apps/store/src/features/carDealership/TrialExtensionForm/useAcceptExtension.ts
@@ -1,8 +1,7 @@
 import { datadogLogs } from '@datadog/browser-logs'
-import { useSetAtom } from 'jotai'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
-import { dismissedBannerIdAtom } from '@/components/GlobalBanner/globalBannerState'
+import { useDismissBanner } from '@/components/GlobalBanner/globalBannerState'
 import { CarDealershipBanners } from '@/features/carDealership/carDearlership.constants'
 import { useShowAppError } from '@/services/appErrors/appErrorAtom'
 import { BankIdState } from '@/services/bankId/bankId.types'
@@ -27,7 +26,7 @@ type Params = {
 export const useAcceptExtension = (params: Params) => {
   const { startCheckoutSign, currentOperation } = useBankIdContext()
   const router = useRouter()
-  const setDismissedBannerId = useSetAtom(dismissedBannerIdAtom)
+  const dismissBanner = useDismissBanner()
   const showError = useShowAppError()
   const [getCurrentMember] = useCurrentMemberLazyQuery()
   const locale = useRoutingLocale()
@@ -58,7 +57,7 @@ export const useAcceptExtension = (params: Params) => {
           return
         }
 
-        setDismissedBannerId(CarDealershipBanners.Extend)
+        dismissBanner(CarDealershipBanners.Extend)
 
         const nextUrl = PageLink.carDealershipConfirmation({
           locale,

--- a/apps/store/src/features/memberReviews/CompanyReviewsMetadataProvider.tsx
+++ b/apps/store/src/features/memberReviews/CompanyReviewsMetadataProvider.tsx
@@ -2,7 +2,7 @@
 import { atom, useAtomValue } from 'jotai'
 import { useHydrateAtoms } from 'jotai/utils'
 import { type PropsWithChildren } from 'react'
-import { layoutJotaiStore } from '@/app/LayoutJotaiProvider'
+import { globalStore } from 'globalStore'
 import type { ReviewsMetadata } from './memberReviews.types'
 
 const companyReviewsMetadataAtom = atom<ReviewsMetadata | null>(null)
@@ -11,7 +11,7 @@ type Props = PropsWithChildren<{ companyReviewsMetadata: ReviewsMetadata | null 
 
 export const CompanyReviewsMetadataProvider = ({ children, companyReviewsMetadata }: Props) => {
   useHydrateAtoms([[companyReviewsMetadataAtom, companyReviewsMetadata]], {
-    store: layoutJotaiStore,
+    store: globalStore,
   })
   return children
 }

--- a/apps/store/src/globalStore.ts
+++ b/apps/store/src/globalStore.ts
@@ -1,0 +1,3 @@
+import { createStore } from 'jotai'
+
+export const globalStore = createStore()

--- a/apps/store/src/pages/_app.tsx
+++ b/apps/store/src/pages/_app.tsx
@@ -36,6 +36,7 @@ import { useDebugTranslationKeys } from '@/utils/l10n/useDebugTranslationKeys'
 import { useForceHtmlLangAttribute } from '@/utils/l10n/useForceHtmlLangAttribute'
 import { useAllowActiveStylesInSafari } from '@/utils/useAllowActiveStylesInSafari'
 import { useReloadOnCountryChange } from '@/utils/useReloadOnCountryChange'
+import { globalStore } from 'globalStore'
 
 // GOTCHA: Here we need to trick compiler into thinking we need global.css import
 // for anything other than side effects
@@ -99,7 +100,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
       <OneTrustStyles />
       <PageTransitionProgressBar />
       <ApolloProvider client={apolloClient}>
-        <JotaiProvider>
+        <JotaiProvider store={globalStore}>
           <ShopSessionProvider shopSessionId={pageProps[SHOP_SESSION_PROP_NAME]}>
             <ShopSessionTrackingProvider>
               <BankIdContextProvider>

--- a/apps/store/src/services/appErrors/appErrorAtom.ts
+++ b/apps/store/src/services/appErrors/appErrorAtom.ts
@@ -1,9 +1,9 @@
 import { atom, useSetAtom } from 'jotai'
-import { layoutJotaiStore } from '@/app/LayoutJotaiProvider'
+import { globalStore } from 'globalStore'
 
 export const appErrorAtom = atom<Error | null>(null)
 
 export const useShowAppError = () => {
-  const showAppError = useSetAtom(appErrorAtom, { store: layoutJotaiStore })
+  const showAppError = useSetAtom(appErrorAtom, { store: globalStore })
   return showAppError
 }

--- a/apps/store/src/utils/useDebugShopSessionId.ts
+++ b/apps/store/src/utils/useDebugShopSessionId.ts
@@ -1,13 +1,12 @@
-import { useSetAtom } from 'jotai'
 import { useSearchParams } from 'next/navigation'
 import { useEffect } from 'react'
-import { globalBannerAtom } from '@/components/GlobalBanner/globalBannerState'
+import { useSetGlobalBanner } from '@/components/GlobalBanner/globalBannerState'
 import { getShopSessionId } from '@/services/shopSession/ShopSession.helpers'
 
 export const useDebugShopSessionId = () => {
   const searchParams = useSearchParams()
   const isDebug = searchParams?.has('debug', 'session')
-  const setGlobalBanner = useSetAtom(globalBannerAtom)
+  const setGlobalBanner = useSetGlobalBanner()
 
   useEffect(() => {
     if (!isDebug) return


### PR DESCRIPTION
## Describe your changes

* Extract a `globalStore` and update `globalBannerState` so it refers to that `globalStore`

## Justify why they are needed

GlobalBanner needs to populate jotai's global store, as other features in the app. Though it makes more sense to import that global store from the src folder instead of app router related files like LayoutJotaiProvider.