### PR TITLE
Make section buttons fixed in mobile

### DIFF
--- a/apps/store/src/components/PriceCalculator/SsnSeSection.tsx
+++ b/apps/store/src/components/PriceCalculator/SsnSeSection.tsx
@@ -10,6 +10,7 @@ import {
   GOTO_NEXT_SECTION,
   shopSessionCustomerAtom,
 } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
+import { formFooter } from '@/features/priceCalculator/FormGridNew.css'
 import { useShopSessionCustomerUpdateMutation } from '@/services/graphql/generated'
 import { useShopSessionId } from '@/services/shopSession/ShopSessionContext'
 import { useErrorMessage } from '@/utils/useErrorMessage'
@@ -60,9 +61,12 @@ export const SsnSeSection = memo(({ className }: { className?: string }) => {
         message={errorMessage}
         onValidValueEntered={handleValidValueEntered}
       />
-      <Button type="submit" loading={result.loading} fullWidth={true}>
-        {t('SUBMIT_LABEL_PROCEED')}
-      </Button>
+
+      <div className={formFooter}>
+        <Button type="submit" loading={result.loading} fullWidth={true}>
+          {t('SUBMIT_LABEL_PROCEED')}
+        </Button>
+      </div>
     </form>
   )
 })

--- a/apps/store/src/features/priceCalculator/FormGridNew.css.ts
+++ b/apps/store/src/features/priceCalculator/FormGridNew.css.ts
@@ -1,10 +1,21 @@
 import { style, createVar } from '@vanilla-extract/css'
-import { tokens } from 'ui'
+import { responsiveStyles, tokens } from 'ui'
+import { CONTENT_MAX_WIDTH } from './PurchaseFormV2.css'
+
+// Offset for fixed formFooter
+const GRID_PADDING_BOTTOM = '7rem'
 
 export const grid = style({
   display: 'grid',
   gridTemplateColumns: 'repeat(6, 1fr)',
   gap: tokens.space.xxs,
+  paddingBottom: GRID_PADDING_BOTTOM,
+
+  ...responsiveStyles({
+    lg: {
+      paddingBottom: 0,
+    },
+  }),
 })
 
 export const columnSpan = createVar()
@@ -14,6 +25,29 @@ export const gridItem = style({
 })
 
 export const submitButton = style({
-  gridColumn: 'span 6',
-  marginTop: tokens.space.xxl,
+  width: `min(100%, ${CONTENT_MAX_WIDTH})`,
+  marginInline: 'auto',
+})
+
+export const formFooter = style({
+  position: 'fixed',
+  left: 0,
+  right: 0,
+  bottom: 0,
+  display: 'flex',
+  width: '100vw',
+  paddingTop: tokens.space.md,
+  paddingBottom: tokens.space.xl,
+  paddingInline: tokens.space.md,
+  backdropFilter: 'blur(50px)',
+
+  ...responsiveStyles({
+    lg: {
+      position: 'unset',
+      gridColumn: 'span 6',
+      width: 'auto',
+      padding: 0,
+      backdropFilter: 'unset',
+    },
+  }),
 })

--- a/apps/store/src/features/priceCalculator/FormGridNew.tsx
+++ b/apps/store/src/features/priceCalculator/FormGridNew.tsx
@@ -6,7 +6,7 @@ import { useTranslateFieldLabel } from '@/components/PriceCalculator/useTranslat
 import { priceCalculatorLoadingAtom } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
 import { type InputField } from '@/services/PriceCalculator/Field.types'
 import type { Label, SectionItem } from '@/services/PriceCalculator/PriceCalculator.types'
-import { columnSpan, grid, gridItem, submitButton } from './FormGridNew.css'
+import { columnSpan, formFooter, grid, gridItem, submitButton } from './FormGridNew.css'
 
 type FormSectionProps = {
   items: Array<SectionItem>
@@ -35,9 +35,11 @@ export function FormGridNew({ items, autofocusFirst, submitLabel }: FormSectionP
         </div>
       ))}
 
-      <Button type="submit" loading={isLoading} fullWidth={true} className={submitButton}>
-        {translateLabel(submitLabel)}
-      </Button>
+      <div className={formFooter}>
+        <Button type="submit" loading={isLoading} fullWidth={true} className={submitButton}>
+          {translateLabel(submitLabel)}
+        </Button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->
## Describe your changes
Make section buttons fixed in mobile with a blurred background

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/nv8d5VeBPARA7ezh3Od3/19802524-0d03-41e9-b9e5-291f730c857a.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/nv8d5VeBPARA7ezh3Od3/19802524-0d03-41e9-b9e5-291f730c857a.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/nv8d5VeBPARA7ezh3Od3/19802524-0d03-41e9-b9e5-291f730c857a.mov">Screen Recording 2024-10-09 at 11.18.54.mov</video>


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
