### PR TITLE
Adjust layout price calculator

### DIFF
--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage/PriceCalculatorCmsPageContent/PriceCalculatorCmsPageContent.css.ts
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage/PriceCalculatorCmsPageContent/PriceCalculatorCmsPageContent.css.ts
@@ -3,9 +3,12 @@ import { responsiveStyles, tokens, yStack } from 'ui'
 import { HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header.css'
 import { HEADER_HEIGHT_MOBILE } from '@/components/Header/HeaderMenuMobile/HeaderMenuMobile.css'
 
+// Offset for fixed formFooter
+export const FORM_FOOTER = '7rem'
+
 export const pageGrid = style({
   display: 'grid',
-  gridTemplateRows: 'min-content 1fr',
+  gridTemplateRows: `min-content 1fr ${FORM_FOOTER}`,
   columnGap: tokens.space.md,
   maxWidth: tokens.width.layoutMax,
   minHeight: `calc(100vh - ${HEADER_HEIGHT_MOBILE})`,
@@ -15,6 +18,7 @@ export const pageGrid = style({
 
   ...responsiveStyles({
     lg: {
+      gridTemplateRows: 'auto',
       gridTemplateColumns: 'repeat(14, 1fr)',
       minHeight: `calc(100vh - ${HEADER_HEIGHT_DESKTOP})`,
       paddingInline: tokens.space.lg,

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/FormGridNew/FormGridNew.css.ts
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/FormGridNew/FormGridNew.css.ts
@@ -2,20 +2,10 @@ import { style, createVar } from '@vanilla-extract/css'
 import { responsiveStyles, tokens } from 'ui'
 import { CONTENT_MAX_WIDTH } from '../../PurchaseFormV2.css'
 
-// Offset for fixed formFooter
-const GRID_PADDING_BOTTOM = '7rem'
-
 export const grid = style({
   display: 'grid',
   gridTemplateColumns: 'repeat(6, 1fr)',
   gap: tokens.space.xxs,
-  paddingBottom: GRID_PADDING_BOTTOM,
-
-  ...responsiveStyles({
-    lg: {
-      paddingBottom: 0,
-    },
-  }),
 })
 
 export const columnSpan = createVar()

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.css.ts
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.css.ts
@@ -1,4 +1,4 @@
-import { style, styleVariants } from '@vanilla-extract/css'
+import { style } from '@vanilla-extract/css'
 import { responsiveStyles } from 'ui'
 import { HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header.css'
 
@@ -6,19 +6,14 @@ export const gdprLink = style({
   marginTop: '-1rem', // Offset from default gap of 2rem
 })
 
-export const formSection = styleVariants({
-  base: {
-    marginTop: '3.75rem',
-  },
-  ssn: {
-    ...responsiveStyles({
-      lg: {
-        position: 'absolute',
-        top: `50%`,
-        transform: `translateY(-50%)`,
-        // Visually center SSN form section
-        marginTop: `calc(-1 * (${HEADER_HEIGHT_DESKTOP} / 2))`,
-      },
-    }),
-  },
+export const ssnSectionWrapper = style({
+  marginTop: '3.75rem',
+  ...responsiveStyles({
+    lg: {
+      display: 'flex',
+      justifyContent: 'center',
+      // Visually center SSN form section
+      marginTop: `calc(-1 * (${HEADER_HEIGHT_DESKTOP} / 2))`,
+    },
+  }),
 })

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.tsx
@@ -21,7 +21,7 @@ import { priceCalculatorStepAtom } from '@/features/priceCalculator/priceCalcula
 import { EditSsnWarningContainer } from '@/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/EditSsnWarningContainer'
 import { FormGridNew } from '@/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/FormGridNew/FormGridNew'
 import {
-  formSection,
+  ssnSectionWrapper,
   gdprLink,
 } from '@/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.css'
 import { useConfirmPriceIntent } from '@/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/useConfirmPriceIntent'
@@ -81,18 +81,21 @@ export function InsuranceDataForm({ className }: { className?: string }) {
     return (
       <div
         key={section.id}
-        className={clsx(yStack({ gap: 'lg' }), formSection.base, isSsnSection && formSection.ssn)}
+        className={clsx(yStack({ gap: 'lg' }), isSsnSection && ssnSectionWrapper, className)}
       >
         {!isSsnSection && <SectionNavigation />}
-        <SectionHeadings section={section} />
-        {sectionBody}
+
+        <div className={yStack({ gap: 'lg' })}>
+          <SectionHeadings section={section} />
+          {sectionBody}
+        </div>
       </div>
     )
   })
 
   return (
     <>
-      <div className={clsx(yStack({ gap: 'xs' }), className)}>{sections}</div>
+      {sections}
       <EditSsnWarningContainer />
       <FetchInsuranceContainer />
     </>

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/OfferPresenterV2.css.ts
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/OfferPresenterV2.css.ts
@@ -1,0 +1,14 @@
+import { style } from '@vanilla-extract/css'
+import { responsiveStyles, tokens, yStack } from 'ui'
+
+export const offerPresenterWrapper = style([
+  yStack(),
+  {
+    gap: '5rem',
+    ...responsiveStyles({
+      lg: {
+        paddingBottom: tokens.space[9],
+      },
+    }),
+  },
+])

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/OfferPresenterV2.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/OfferPresenterV2.tsx
@@ -38,6 +38,7 @@ import {
 import { useTracking } from '@/services/Tracking/useTracking'
 import { useAddToCart } from '@/utils/useAddToCart'
 import { SectionTitle, SectionSubtitle } from '../SectionHeading'
+import { offerPresenterWrapper } from './OfferPresenterV2.css'
 import { OfferPriceDetails } from './OfferPriceDetails'
 
 export const OfferPresenterV2 = memo(() => {
@@ -94,7 +95,7 @@ export const OfferPresenterV2 = memo(() => {
   }, [tiers, selectedOffer])
 
   return (
-    <div className={yStack({ gap: 'xxxl' })}>
+    <div className={offerPresenterWrapper}>
       <Button
         className={sprinkles({ marginRight: 'auto' })}
         size="small"

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/PurchaseFormV2.css.ts
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/PurchaseFormV2.css.ts
@@ -10,6 +10,7 @@ export const centered = style({
     lg: {
       width: `max(${CONTENT_MAX_WIDTH}, 100%)`,
       maxWidth: 'unset',
+      height: '100%',
     },
   }),
 })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Adjust layout to new design. Went over all states and viewports. 
- Make sure layout takes into account the sticky footer in mobile
- Male sure there's no overflow scroll in desktop by removing rows on `pageGrid`
- Add gap between sections on offer presenter

<img width="1262" alt="Screenshot 2024-10-14 at 15 20 42" src="https://github.com/user-attachments/assets/648a3f06-2cad-4049-b03e-b6e0d5e17d0f">

<img width="399" alt="Screenshot 2024-10-14 at 15 21 06" src="https://github.com/user-attachments/assets/a379a262-e415-42aa-ba0f-7203a05f0cc9">


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Request from Niles and Peter

## Checklist before requesting a review


- [ ] I have performed a self-review of my code
