### PR TITLE
fix: Make sure last section is always reachable in purchase form

### DIFF
--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.tsx
@@ -136,7 +136,10 @@ function InsuranceDataSection({ section }: InsuranceDataSectionProps) {
         template: priceTemplate,
       })
       if (isFormReadyToConfirm({ form, priceIntent, customer })) {
+        const lastFormSectionId = form.sections[form.sections.length - 1].id
         setStep('calculatingPrice')
+        // Make sure the last section is active when confirming price intent
+        setActiveSectionId(lastFormSectionId)
         confirmPriceIntent()
         return
       }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Make sure we set the last form section as active when confirming a price intent. This makes it reachable when clicking "Edit information"


https://github.com/user-attachments/assets/dc344f1e-a15f-4226-a9f0-84d545e0f1c1

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Fix issue where last section of purchase form was not reachable.
If you get an offer, go back an edit step 2 of 3, click next section (which goes to offer presenter), then go back to edit you would end up on step 2 instead of step 3

More info in thread https://hedviginsurance.slack.com/archives/C041SD67G82/p1728990672902109

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
