### PR TITLE
fix(new-price-calculator): enable re-targeting links to new price calculator for pet insurances only

### DIFF
--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage/PriceCalculatorCmsPage.helpers.ts
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage/PriceCalculatorCmsPage.helpers.ts
@@ -1,0 +1,14 @@
+import type { TemplateV2 } from '@/services/PriceCalculator/PriceCalculator.types'
+
+export async function getPriceTemplate(templateName: string): Promise<TemplateV2> {
+  try {
+    const module_ = await import(`../priceTemplates/${templateName}`)
+    const template = module_.default
+    if (typeof template !== 'object' || template.name !== templateName) {
+      throw new Error('Template module does not export expected default value')
+    }
+    return template as TemplateV2
+  } catch (err) {
+    throw new Error(`Failed to find priceTemplate ${templateName}`, { cause: err })
+  }
+}

--- a/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage/PriceCalculatorCmsPage.tsx
+++ b/apps/store/src/features/priceCalculator/PriceCalculatorCmsPage/PriceCalculatorCmsPage.tsx
@@ -7,10 +7,10 @@ import { ProductPageDebugDialog } from '@/components/ProductPage/ProductPageDebu
 import { Skeleton } from '@/components/Skeleton/Skeleton'
 import { PriceCalculatorStoryProvider } from '@/features/priceCalculator/PriceCalculatorCmsPage/PriceCalculatorStoryProvider'
 import { setupApolloClient } from '@/services/apollo/app-router/rscClient'
-import { type TemplateV2 } from '@/services/PriceCalculator/PriceCalculator.types'
 import type { PriceCalculatorPageStory } from '@/services/storyblok/storyblok'
 import { Features } from '@/utils/Features'
 import { type RoutingLocale } from '@/utils/l10n/types'
+import { getPriceTemplate } from './PriceCalculatorCmsPage.helpers'
 import { PriceCalculatorCmsPageContent } from './PriceCalculatorCmsPageContent/PriceCalculatorCmsPageContent'
 import { PriceTemplateProvider } from './PriceTemplateProvider'
 
@@ -32,19 +32,6 @@ export function PriceCalculatorCmsPage({ locale, story }: Props) {
       </Suspense>
     </StorePageProviders>
   )
-}
-
-const getPriceTemplate = async (templateName: string): Promise<TemplateV2> => {
-  try {
-    const module_ = await import(`../priceTemplates/${templateName}`)
-    const template = module_.default
-    if (typeof template !== 'object' || template.name !== templateName) {
-      throw new Error('Template module does not export expected default value')
-    }
-    return template as TemplateV2
-  } catch (err) {
-    throw new Error(`Failed to find priceTemplate ${templateName}`, { cause: err })
-  }
 }
 
 const getProductData = async (locale: RoutingLocale, productName: string) => {

--- a/apps/store/src/graphql/PriceIntentFragment.graphql
+++ b/apps/store/src/graphql/PriceIntentFragment.graphql
@@ -15,6 +15,7 @@ fragment PriceIntent on PriceIntent {
     name
     displayNameShort
     pageLink
+    priceCalculatorPageLink
   }
   insurely {
     configName

--- a/apps/store/src/services/PriceCalculator/PriceCalculator.helpers.ts
+++ b/apps/store/src/services/PriceCalculator/PriceCalculator.helpers.ts
@@ -27,8 +27,8 @@ const TEMPLATES: Record<string, Template | undefined> = {
   SE_WIDGET_APARTMENT_NO_COMPARE,
 }
 
-export const getPriceTemplate = (id: string) => {
-  return TEMPLATES[id]
+export const getPriceTemplate = (productName: string) => {
+  return TEMPLATES[productName]
 }
 
 const convertTemplateIntoForm = (template: Template): Form => {


### PR DESCRIPTION
## Describe your changes

Subj.

## Justify why they are needed

While using re-targeting links one should be redirected to new price calculator if:

1. _New price calculator_ feature flag is enabled
2. It's a pet insurance. This condition is important; otherwise redirect wouldn't work for non pet insurances in prod.
