### PR TITLE
fix: v2 Make sure last section is always reachable in purchase form

### DIFF
--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/OfferPresenterV2.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/OfferPresenterV2.tsx
@@ -1,7 +1,7 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { datadogRum } from '@datadog/browser-rum'
 import { useInView } from 'framer-motion'
-import { useSetAtom, useStore } from 'jotai'
+import { useAtomValue, useSetAtom, useStore } from 'jotai'
 import { useTranslation } from 'next-i18next'
 import { memo, type MouseEventHandler, useEffect, useMemo, useRef, useState } from 'react'
 import { sprinkles } from 'ui/src/theme/sprinkles.css'
@@ -45,6 +45,8 @@ export const OfferPresenterV2 = memo(() => {
   const { t } = useTranslation('purchase-form')
   const priceIntent = usePriceIntent()
   const setStep = useSetAtom(priceCalculatorStepAtom)
+  const setActiveSectionId = useSetAtom(activeFormSectionIdAtom)
+  const form = useAtomValue(priceCalculatorFormAtom)
   const [selectedOffer, setSelectedOffer] = useSelectedOffer()
   if (selectedOffer == null) {
     throw new Error('selectedOffer must be defined')
@@ -67,6 +69,9 @@ export const OfferPresenterV2 = memo(() => {
 
   const handleEditInformation = () => {
     setStep('fillForm')
+    // Make sure to always go to the last section of the form when editing
+    const lastFormSectionId = form.sections[form.sections.length - 1].id
+    setActiveSectionId(lastFormSectionId)
   }
 
   const offerRef = useRef(null)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Make sure we set the last form section as active when clicking "Edit information". 


https://github.com/user-attachments/assets/dc344f1e-a15f-4226-a9f0-84d545e0f1c1

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Fix issue where last section of purchase form was not reachable.
If you get an offer, go back an edit step 2 of 3, click next section (which goes to offer presenter), then go back to edit you would end up on step 2 instead of step 3

More info in thread https://hedviginsurance.slack.com/archives/C041SD67G82/p1728990672902109

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
