### PR TITLE
fix: Make show details button into outline variant

### DIFF
--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/OfferPresenterV2.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/OfferPresenterV2.tsx
@@ -268,7 +268,7 @@ function OfferDetails() {
   return (
     <Collapsible.Root open={expanded} onOpenChange={setExpanded}>
       <Collapsible.Trigger asChild>
-        <Button variant="secondary-alt" size="medium" fullWidth={true}>
+        <Button variant="outline" size="medium" fullWidth={true}>
           {expanded ? t('HIDE_DETAILS_BUTTON_LABEL') : t('SHOW_DETAILS_BUTTON_LABEL')}
         </Button>
       </Collapsible.Trigger>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
See title


![Screenshot 2024-10-15 at 16.48.56.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/nv8d5VeBPARA7ezh3Od3/5f5d9b13-ef89-437f-a15f-0b49d2ff4d2d.png)

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Since it was white without border it wasn't clear it is a button

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
