### PR TITLE
Conditionally show producthero and sticky header in mobile

### DIFF
--- a/apps/store/src/features/priceCalculator/ProductHeroV2/ProductHeroV2.css.ts
+++ b/apps/store/src/features/priceCalculator/ProductHeroV2/ProductHeroV2.css.ts
@@ -1,24 +1,39 @@
-import { style } from '@vanilla-extract/css'
+import { style, styleVariants } from '@vanilla-extract/css'
 import { badgeFontColor } from 'ui/src/components/Badge/Badge.css'
-import { responsiveStyles, tokens, yStack } from 'ui'
+import { pillowSize, responsiveStyles, tokens, yStack } from 'ui'
 import { HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header.css'
 
-export const productHeroWrapper = style([
-  yStack({ justifyContent: 'center', alignItems: 'center', gap: { _: 'xs', lg: 'md' } }),
-  {
-    height: '13rem',
-
+export const productHeroWrapper = styleVariants({
+  base: [
+    yStack({ justifyContent: 'center', alignItems: 'center', gap: 'md' }),
+    {
+      paddingBlock: tokens.space.xxl,
+      ...responsiveStyles({
+        lg: {
+          // Visually center Product Hero
+          marginTop: `calc(-1 * ${HEADER_HEIGHT_DESKTOP})`,
+        },
+      }),
+    },
+  ],
+  hidden: {
+    display: 'none',
     ...responsiveStyles({
       lg: {
-        // Visually center Product Hero
-        marginTop: `calc(-1 * ${HEADER_HEIGHT_DESKTOP})`,
+        display: 'flex',
       },
     }),
   },
-])
+})
 
 export const pillowWrapper = style({
   position: 'relative',
+})
+
+export const pillow = style({
+  vars: {
+    [pillowSize]: '10rem',
+  },
 })
 
 export const priceWrapper = style({ position: 'relative', height: tokens.space.lg })

--- a/apps/store/src/features/priceCalculator/ProductHeroV2/StickyProductHeader/StickyProductHeader.tsx
+++ b/apps/store/src/features/priceCalculator/ProductHeroV2/StickyProductHeader/StickyProductHeader.tsx
@@ -1,7 +1,9 @@
 import clsx from 'clsx'
+import { useAtomValue } from 'jotai'
 import { yStack, xStack } from 'ui'
-import { useIsPriceIntentStateReady } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
+import { priceCalculatorStepAtom } from '../../priceCalculatorAtoms'
 import { ProgressBar } from '../ProgressBar/ProgressBar'
+import { useCondensedProductHero } from '../useCondensedProductHero'
 import { stickyProductHeader, stickyProductHeaderContent } from './StickyProductHeader.css'
 
 type Props = {
@@ -10,7 +12,14 @@ type Props = {
 }
 
 export function StickyProductHeader({ children, hasScrolledPast }: Props) {
-  const isReady = useIsPriceIntentStateReady()
+  const step = useAtomValue(priceCalculatorStepAtom)
+  const isCondensedProductHero = useCondensedProductHero()
+  const showStickyHeader = isCondensedProductHero || hasScrolledPast
+
+  // Scroll to top when going to next step to avoid sticky header overlap
+  if (isCondensedProductHero || step === 'calculatingPrice') {
+    window.scrollTo({ top: 0, behavior: 'instant' })
+  }
 
   return (
     <div className={stickyProductHeader}>
@@ -22,7 +31,7 @@ export function StickyProductHeader({ children, hasScrolledPast }: Props) {
             paddingInline: 'md',
           }),
           stickyProductHeaderContent.base,
-          hasScrolledPast && stickyProductHeaderContent.visible,
+          showStickyHeader && stickyProductHeaderContent.visible,
         )}
       >
         <div
@@ -36,7 +45,7 @@ export function StickyProductHeader({ children, hasScrolledPast }: Props) {
           {children}
         </div>
 
-        {isReady && <ProgressBar />}
+        <ProgressBar />
       </div>
     </div>
   )

--- a/apps/store/src/features/priceCalculator/ProductHeroV2/useCondensedProductHero.ts
+++ b/apps/store/src/features/priceCalculator/ProductHeroV2/useCondensedProductHero.ts
@@ -1,0 +1,11 @@
+import { useAtomValue } from 'jotai'
+import { activeFormSectionIdAtom } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
+import { priceCalculatorStepAtom } from '../priceCalculatorAtoms'
+
+// The condensed state is used to show the sticky header and hides the large product pillow
+export const useCondensedProductHero = () => {
+  const step = useAtomValue(priceCalculatorStepAtom)
+  const activeSectionId = useAtomValue(activeFormSectionIdAtom)
+  const showCondensedProductHero = step === 'fillForm' && activeSectionId !== 'ssn-se'
+  return showCondensedProductHero
+}

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.css.ts
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.css.ts
@@ -7,7 +7,6 @@ export const gdprLink = style({
 })
 
 export const ssnSectionWrapper = style({
-  marginTop: '3.75rem',
   ...responsiveStyles({
     lg: {
       display: 'flex',

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.tsx
@@ -40,7 +40,7 @@ import type { PriceIntent } from '@/services/priceIntent/priceIntent.types'
 import { useRoutingLocale } from '@/utils/l10n/useRoutingLocale'
 import { PageLink } from '@/utils/PageLink'
 import { SectionTitle, SectionSubtitle } from '../SectionHeading'
-import { SectionNavigation } from './SectionNavigation'
+import { SectionNavigation } from './SectionNavigation/SectionNavigation'
 
 export function InsuranceDataForm({ className }: { className?: string }) {
   const locale = useRoutingLocale()

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/SectionNavigation/SectionNavigation.css.ts
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/SectionNavigation/SectionNavigation.css.ts
@@ -1,0 +1,17 @@
+import { style } from '@vanilla-extract/css'
+import { responsiveStyles, xStack } from 'ui'
+
+export const sectionNavigationWrapper = style([
+  xStack({
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 'xxl',
+  }),
+  {
+    ...responsiveStyles({
+      lg: {
+        marginTop: 0,
+      },
+    }),
+  },
+])

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/SectionNavigation/SectionNavigation.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/SectionNavigation/SectionNavigation.tsx
@@ -1,7 +1,7 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useTranslation } from 'next-i18next'
 import { startTransition } from 'react'
-import { xStack, Button, ChevronIcon, Text } from 'ui'
+import { Button, ChevronIcon, Text } from 'ui'
 import { SSN_SE_SECTION_ID } from '@/components/PriceCalculator/SsnSeSection'
 import {
   priceCalculatorFormAtom,
@@ -10,7 +10,8 @@ import {
 import {
   priceCalculatorShowEditSsnWarningAtom,
   priceCalculatorStepAtom,
-} from '../../priceCalculatorAtoms'
+} from '../../../priceCalculatorAtoms'
+import { sectionNavigationWrapper } from './SectionNavigation.css'
 
 export function SectionNavigation() {
   const { t } = useTranslation('purchase-form')
@@ -39,7 +40,7 @@ export function SectionNavigation() {
   }
 
   return (
-    <div className={xStack({ alignItems: 'center', justifyContent: 'space-between' })}>
+    <div className={sectionNavigationWrapper}>
       <Button
         size="small"
         variant="secondary"


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
For the price calculator steps where you fill in your details, the large product hero and pillow should be hidden and instead we show the sticky product header.

- Add a hook to check if product hero should be condensed
- Both `StickyProductHeader` and `ProductHeroPillow` needs to be wrapped with `isReady` state to make sure atoms are populated.
- Reset scrolls position to top between steps to always start at the top

https://github.com/user-attachments/assets/78f860d5-f838-44a3-93c6-35e7fb5d2654

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Match the intended design, details find in Figma file https://www.figma.com/design/p1TEzLLVqJB9gKDNTDVGU4/Hedvig.com?node-id=3388-61000&m=dev

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
