### PR TITLE
Add LargeDialog component and story

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -63,6 +63,7 @@
     "@vanilla-extract/recipes": "0.5.5",
     "@vanilla-extract/sprinkles": "1.6.3",
     "clsx": "2.1.1",
+    "framer-motion": "11.1.7",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   }

--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -16,7 +16,7 @@ export default {
   },
 } as Meta<typeof Dialog>
 
-export const Default: StoryFn<typeof Dialog> = () => {
+export const Base: StoryFn<typeof Dialog> = () => {
   const [open, setOpen] = useState(false)
 
   return (

--- a/packages/ui/src/components/Dialog/LargeDialog.css.ts
+++ b/packages/ui/src/components/Dialog/LargeDialog.css.ts
@@ -1,0 +1,41 @@
+import { style } from '@vanilla-extract/css'
+import { minWidth, tokens } from '../../theme'
+
+export const closeButton = style({
+  position: 'absolute',
+  right: tokens.space.lg,
+  top: tokens.space.lg,
+})
+
+export const content = style({
+  display: 'flex',
+  width: '100%',
+})
+
+export const card = style({
+  position: 'relative',
+  marginBlock: 'auto',
+  marginInline: tokens.space.md,
+  width: '100%',
+  maxHeight: `calc(100vh - (${tokens.space.md}) * 2)`,
+  // If card has header inside, then other content should generally have its own wrapper with overflowY: 'auto'
+  // to make header and close button sticky. This is a fallback for dialogs which don't have a header
+  overflowY: 'auto',
+  padding: tokens.space.lg,
+
+  '@media': {
+    [minWidth.sm]: {
+      marginBlock: 'auto',
+      marginInline: 'auto',
+      maxWidth: 'min(60rem, 80%)',
+    },
+  },
+})
+
+export const heading = style({
+  marginRight: tokens.space.xl,
+})
+
+export const scrollableInnerContent = style({
+  overflowY: 'auto',
+})

--- a/packages/ui/src/components/Dialog/LargeDialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/LargeDialog.stories.tsx
@@ -1,0 +1,83 @@
+import { type Meta, type StoryFn } from '@storybook/react'
+import { yStack } from '../../patterns'
+import { Button } from '../Button/Button'
+import { Text } from '../Text/Text'
+import * as Dialog from './Dialog'
+import { LargeDialog } from './LargeDialog'
+
+export default {
+  title: 'Dialog',
+  parameters: {
+    backgrounds: {
+      default: 'gray100',
+    },
+    layout: 'centered',
+  },
+} as Meta<unknown>
+
+export const Large: StoryFn = () => {
+  return (
+    <div>
+      <Dialog.Root>
+        <div className={yStack({ gap: 'md' })}>
+          Button opens dialog. Inner content is scrollable when it does not fit
+          <Dialog.Trigger asChild>
+            <Button variant="secondary">Click me</Button>
+          </Dialog.Trigger>
+        </div>
+
+        <LargeDialog.Content>
+          <LargeDialog.Header>Hello, world!</LargeDialog.Header>
+          <LargeDialog.ScrollableInnerContent className={yStack({ gap: 'md' })}>
+            <Text>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam nec libero lacinia,
+              commodo odio eget, sodales leo. Integer vitae lectus nec lectus facilisis condimentum
+              vitae eu felis. Etiam eget orci consectetur, blandit sem sit amet, porta quam.
+              Pellentesque feugiat, ligula ac rutrum iaculis, purus nunc posuere quam, non luctus
+              lectus justo quis justo. Ut condimentum massa a fermentum gravida. In id tellus et
+              tellus sollicitudin iaculis. Maecenas ornare ex non elit porta interdum. Integer
+              sodales aliquam tellus ac lacinia. Praesent ornare lorem et ex malesuada pellentesque
+              in commodo sem. Etiam at libero ut purus molestie sagittis.
+            </Text>
+            <Text>
+              Pellentesque finibus vitae nisi et aliquam. Sed eros tellus, blandit eget dolor eget,
+              vestibulum aliquam libero. Etiam massa lorem, varius quis arcu in, blandit condimentum
+              leo. Proin consequat sodales lectus eu bibendum. Phasellus tempor pharetra dictum.
+              Aenean suscipit elit eu dapibus porttitor. Donec euismod sollicitudin fringilla. Proin
+              ac enim lobortis, mollis neque quis, posuere mauris. Donec sed tellus aliquam, dapibus
+              erat quis, imperdiet quam. In at sem quis dui finibus dapibus. Nam nisi enim, pulvinar
+              a nisi convallis, molestie tincidunt nulla. Vivamus accumsan posuere scelerisque.
+            </Text>
+            <Text>
+              Duis ac arcu quis lorem porta auctor. Mauris fermentum risus vitae volutpat convallis.
+              Proin tortor odio, auctor eget neque ac, semper elementum ligula. Sed fermentum
+              maximus orci et mattis. Quisque convallis quis nibh eget dignissim. Donec auctor erat
+              erat, tristique maximus dui ullamcorper eget. Nullam ultrices urna nec ultrices
+              tempor. Suspendisse potenti. Maecenas tincidunt tempus velit, in congue odio gravida
+              non. Proin at nulla non nisi scelerisque accumsan eu sed augue. Nunc at rutrum leo.
+              Curabitur eu egestas elit. Donec lobortis pretium risus, nec viverra nulla egestas
+              eget. Praesent ultricies facilisis malesuada.
+            </Text>
+            <Text>
+              In non dui molestie, blandit ex porta, condimentum metus. Integer elementum semper
+              finibus. Nulla egestas luctus neque. Praesent luctus eros sit amet lorem pellentesque
+              malesuada. Ut turpis quam, iaculis vel magna ac, consectetur porttitor eros. Praesent
+              ultrices, massa ac rutrum molestie, velit est varius nisl, sed venenatis arcu purus
+              eget dui. In dapibus mattis neque, et vehicula neque lobortis sed.
+            </Text>
+            <Text>
+              Ut sit amet massa sollicitudin, dictum est rutrum, commodo nibh. Morbi aliquet ornare
+              est, in tristique massa tristique quis. Donec quis sapien lorem. Sed vestibulum
+              vestibulum tellus. Nunc varius odio lectus, ut malesuada quam rhoncus ac. Orci varius
+              natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vel
+              neque sit amet urna faucibus dapibus. In at risus finibus, aliquet leo sit amet,
+              laoreet massa. Duis et elit eleifend, commodo magna id, pellentesque ligula. Phasellus
+              et commodo ligula. Donec porta, dui vel semper lacinia, arcu neque egestas nisl, at
+              sodales elit augue ut orci. Morbi vel nibh leo.
+            </Text>
+          </LargeDialog.ScrollableInnerContent>
+        </LargeDialog.Content>
+      </Dialog.Root>
+    </div>
+  )
+}

--- a/packages/ui/src/components/Dialog/LargeDialog.tsx
+++ b/packages/ui/src/components/Dialog/LargeDialog.tsx
@@ -1,0 +1,74 @@
+import { clsx } from 'clsx'
+import { motion } from 'framer-motion'
+import { type ComponentProps } from 'react'
+import { CrossIcon } from '../../icons'
+import { framerTransitions } from '../../theme'
+import { IconButton } from '../Button/IconButton'
+import { Card } from '../Card/Card'
+import { Heading } from '../Heading/Heading'
+import * as Dialog from './Dialog'
+import { card, closeButton, content, heading, scrollableInnerContent } from './LargeDialog.css'
+
+// Large modal, full-screen on mobile. Uses `Root` and `Trigger` from default `Dialog`
+function Content({
+  children,
+  centerContent = true,
+  className,
+  frostedOverlay = true,
+  ...forwardedProps
+}: ComponentProps<typeof Dialog.Content>) {
+  return (
+    <Dialog.Content
+      centerContent={centerContent}
+      className={clsx(content, className)}
+      frostedOverlay={frostedOverlay}
+      {...forwardedProps}
+    >
+      <MotionCard
+        className={card}
+        initial={{ opacity: 0, y: '2vh' }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{
+          ...framerTransitions.easeInOutCubic,
+          duration: framerTransitions.defaultDuration,
+        }}
+      >
+        <Dialog.Close asChild>
+          <IconButton variant="secondary" Icon={<CrossIcon />} className={closeButton} />
+        </Dialog.Close>
+        {children}
+      </MotionCard>
+    </Dialog.Content>
+  )
+}
+
+const MotionCard = motion(Card.Root)
+
+function Header({ children, className, ...forwardedProps }: ComponentProps<typeof Heading>) {
+  return (
+    <Dialog.Title asChild>
+      <Heading
+        as="h2"
+        variant="standard.24"
+        className={clsx(heading, className)}
+        {...forwardedProps}
+      >
+        {children}
+      </Heading>
+    </Dialog.Title>
+  )
+}
+
+function ScrollableInnerContent({ children, className, ...forwardedProps }: ComponentProps<'div'>) {
+  return (
+    <div className={clsx(scrollableInnerContent, className)} {...forwardedProps}>
+      {children}
+    </div>
+  )
+}
+
+export const LargeDialog = {
+  Content,
+  Header,
+  ScrollableInnerContent,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -25444,6 +25444,7 @@ __metadata:
     eslint-config-prettier: "npm:9.1.0"
     eslint-plugin-jest: "npm:28.8.3"
     eslint-plugin-testing-library: "npm:6.4.0"
+    framer-motion: "npm:11.1.7"
     jest: "npm:29.7.0"
     jest-environment-jsdom: "npm:29.7.0"
     react: "npm:18.3.1"


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Animated modal, full-screen on mobile, large and centered on desktop

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/GLY3tSM85RFBvAf6lFNA/b36a3a76-0742-48a9-9f7f-f96dd29cf667.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/GLY3tSM85RFBvAf6lFNA/b36a3a76-0742-48a9-9f7f-f96dd29cf667.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/b36a3a76-0742-48a9-9f7f-f96dd29cf667.mov">Screen Recording 2024-10-18 at 13.43.11.mov</video>

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

Better than current `FullscreenModal` for most use cases

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
