### PR TITLE
Use LargeDialog to compare coverage on Price Calculator Page

### DIFF
--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/ProductTierSelectorV2/ProductTierSelectorV2.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/ProductTierSelectorV2/ProductTierSelectorV2.tsx
@@ -1,8 +1,8 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useTranslation } from 'next-i18next'
-import { useRef } from 'react'
 import { badgeFontColor } from 'ui/src/components/Badge/Badge.css'
+import * as Dialog from 'ui/src/components/Dialog/Dialog'
 import { sprinkles } from 'ui/src/theme/sprinkles.css'
 import {
   Badge,
@@ -16,10 +16,10 @@ import {
   xStack,
   yStack,
 } from 'ui'
-import { ComparisonTableModal } from '@/components/ProductPage/PurchaseForm/ComparisonTableModal'
 import type { ProductOfferFragment } from '@/services/graphql/generated'
 import { useFormatter } from '@/utils/useFormatter'
 import * as CardRadioGroup from '../CardRadioGroup/CardRadioGroup'
+import { TierComparisonDialogContent } from '../TierComparisonDialog/TierComparisonDialogContent'
 import { item } from './ProductTierSelectorV2.css'
 
 type Props = {
@@ -33,91 +33,84 @@ export function ProductTierSelectorV2({ offers, selectedOffer, onValueChange }: 
   const formatter = useFormatter()
   const { t } = useTranslation('purchase-form')
 
-  const tierDialogRef = useRef<{ open: () => void }>(null)
-
-  const openTierDialog = () => tierDialogRef.current?.open()
-
   return (
     <>
-      <CardRadioGroup.Root value={selectedOffer.id} onValueChange={onValueChange}>
-        {offers.map((offer, index) => (
-          <CardRadioGroup.Item
-            // NOTE: We want to avoid remounting selected deductible element when changing tiers
-            // to avoid extra animation, hence index key
-            key={index}
-            value={offer.id}
-            isSelected={selectedOffer.id === offer.id}
-            className={item}
-          >
-            <div className={yStack()}>
-              <div
-                className={xStack({
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  gap: 'md',
-                })}
-              >
-                <Heading as="h2" variant="standard.24">
-                  {offer.variant.displayNameSubtype || offer.variant.displayName}
-                </Heading>
-                {isDefaultTier(offer) && (
-                  <Badge
-                    size="small"
-                    color="pinkFill3"
-                    style={assignInlineVars({ [badgeFontColor]: tokens.colors.gray1000 })}
-                  >
-                    {t('DEFAULT_TIER_LABEL')}
-                  </Badge>
-                )}
-              </div>
-              <Heading as="h3" variant="standard.24" color="textSecondary">
-                {formatter.monthlyPrice(offer.cost.net)}
-              </Heading>
-            </div>
-            <Text color="textSecondary" className={sprinkles({ marginTop: 'md' })}>
-              {getVariantDescription(offer.variant.typeOfContract)}
-            </Text>
-            <AnimatePresence initial={false}>
-              {offer.id === selectedOffer.id && (
-                <motion.div
-                  transition={{
-                    duration: framerTransitions.defaultDuration,
-                    ...framerTransitions.easeInOutCubic,
-                  }}
-                  initial={{ height: 0, marginTop: 0, opacity: 0 }}
-                  animate={{ height: 'fit-content', marginTop: theme.space.md, opacity: 1 }}
-                  exit={{ height: 0, marginTop: 0, opacity: 0 }}
+      <Dialog.Root>
+        <CardRadioGroup.Root value={selectedOffer.id} onValueChange={onValueChange}>
+          {offers.map((offer, index) => (
+            <CardRadioGroup.Item
+              // NOTE: We want to avoid remounting selected deductible element when changing tiers
+              // to avoid extra animation, hence index key
+              key={index}
+              value={offer.id}
+              isSelected={selectedOffer.id === offer.id}
+              className={item}
+            >
+              <div className={yStack()}>
+                <div
+                  className={xStack({
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: 'md',
+                  })}
                 >
-                  <Button
-                    variant="secondary"
-                    fullWidth={true}
-                    size="medium"
-                    onClick={openTierDialog}
+                  <Heading as="h2" variant="standard.24">
+                    {offer.variant.displayNameSubtype || offer.variant.displayName}
+                  </Heading>
+                  {isDefaultTier(offer) && (
+                    <Badge
+                      size="small"
+                      color="pinkFill3"
+                      style={assignInlineVars({ [badgeFontColor]: tokens.colors.gray1000 })}
+                    >
+                      {t('DEFAULT_TIER_LABEL')}
+                    </Badge>
+                  )}
+                </div>
+                <Heading as="h3" variant="standard.24" color="textSecondary">
+                  {formatter.monthlyPrice(offer.cost.net)}
+                </Heading>
+              </div>
+              <Text color="textSecondary" className={sprinkles({ marginTop: 'md' })}>
+                {getVariantDescription(offer.variant.typeOfContract)}
+              </Text>
+              <AnimatePresence initial={false}>
+                {offer.id === selectedOffer.id && (
+                  <motion.div
+                    transition={{
+                      duration: framerTransitions.defaultDuration,
+                      ...framerTransitions.easeInOutCubic,
+                    }}
+                    initial={{ height: 0, marginTop: 0, opacity: 0 }}
+                    animate={{ height: 'fit-content', marginTop: theme.space.md, opacity: 1 }}
+                    exit={{ height: 0, marginTop: 0, opacity: 0 }}
                   >
-                    {t('COMPARE_TIERS_LABEL')}
-                  </Button>
-                </motion.div>
-              )}
-            </AnimatePresence>
-          </CardRadioGroup.Item>
-        ))}
-      </CardRadioGroup.Root>
+                    <Dialog.Trigger asChild>
+                      <Button variant="secondary" fullWidth={true} size="medium">
+                        {t('COMPARE_TIERS_LABEL')}
+                      </Button>
+                    </Dialog.Trigger>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </CardRadioGroup.Item>
+          ))}
+        </CardRadioGroup.Root>
 
-      <ComparisonTableModal
-        controlRef={tierDialogRef}
-        tiers={offers}
-        selectedTierId={selectedOffer.id}
-      >
-        <Button
-          variant="secondary"
-          size="small"
-          className={sprinkles({ alignSelf: 'center' })}
-          Icon={<PlusIcon />}
-          iconPosition="right"
-        >
-          {t('COMPARE_COVERAGE_BUTTON')}
-        </Button>
-      </ComparisonTableModal>
+        <Dialog.Trigger asChild>
+          <Button
+            variant="secondary"
+            size="small"
+            className={sprinkles({ alignSelf: 'center' })}
+            Icon={<PlusIcon />}
+            iconPosition="right"
+          >
+            {t('COMPARE_COVERAGE_BUTTON')}
+          </Button>
+        </Dialog.Trigger>
+
+        <TierComparisonDialogContent tiers={offers} selectedTierId={selectedOffer.id} />
+      </Dialog.Root>
     </>
   )
 }

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/TierComparisonDialog/TierComparisonDialogContent.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/TierComparisonDialog/TierComparisonDialogContent.tsx
@@ -1,0 +1,130 @@
+import { useTranslation } from 'next-i18next'
+import { useMemo } from 'react'
+import { LargeDialog } from 'ui/src/components/Dialog/LargeDialog'
+import {
+  type Body,
+  type Head,
+  type Table,
+  TableMarkers,
+} from '@/components/ComparisonTable/ComparisonTable.types'
+import { DesktopComparisonTable } from '@/components/ComparisonTable/DesktopComparisonTable'
+import { MobileComparisonTable } from '@/components/ComparisonTable/MobileComparisonTable'
+import type { ProductOfferFragment } from '@/services/graphql/generated'
+import { useResponsiveVariant } from '@/utils/useResponsiveVariant'
+
+type Props = {
+  tiers: Array<ProductOfferFragment>
+  selectedTierId: string
+}
+
+export function TierComparisonDialogContent({ tiers, selectedTierId }: Props) {
+  const { t } = useTranslation('purchase-form')
+  const variant = useResponsiveVariant('sm')
+  const { table, selectedTierDisplayName } = useTableData(tiers, selectedTierId)
+  return (
+    <LargeDialog.Content>
+      <LargeDialog.Header>{t('COMPARE_TIERS_LABEL')}</LargeDialog.Header>
+      <LargeDialog.ScrollableInnerContent>
+        {variant === 'mobile' && (
+          <MobileComparisonTable {...table} defaultSelectedColumn={selectedTierDisplayName} />
+        )}
+        {variant === 'desktop' && (
+          <DesktopComparisonTable {...table} selectedColumn={selectedTierDisplayName} />
+        )}
+      </LargeDialog.ScrollableInnerContent>
+    </LargeDialog.Content>
+  )
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// NOTE: Quick & dirty copy of old implementation below
+// Will be replaced by new terms-hub query that returns table data
+
+const removeDuplicatesByTitle = <T extends { title: string }>(arr: Array<T>): Array<T> => {
+  const seenTitles = new Set<string>()
+  return arr.filter((item) => {
+    if (!seenTitles.has(item.title)) {
+      seenTitles.add(item.title)
+      return true
+    }
+
+    return false
+  })
+}
+
+const getUniquePerils = (tiers: Array<ProductOfferFragment>) => {
+  const allPerils = tiers
+    .flatMap((item) => item.variant.perils)
+    .map(({ title, description }) => ({ title, description }))
+  return removeDuplicatesByTitle(allPerils)
+}
+
+const offerHasPeril = (offer: ProductOfferFragment, perilTitle: string) =>
+  offer.variant.perils.some((peril) => peril.title === perilTitle)
+
+// TODO: fetch from API
+const useGetVeryShortVariantDisplayName = () => {
+  const { t } = useTranslation('purchase-form')
+
+  return (typeOfContract: string) => {
+    switch (typeOfContract) {
+      case 'SE_CAR_FULL':
+        return t('COMPARISON_TABLE_COLUMN_SE_CAR_FULL')
+      case 'SE_CAR_HALF':
+        return t('COMPARISON_TABLE_COLUMN_SE_CAR_HALF')
+      case 'SE_CAR_TRAFFIC':
+        return t('COMPARISON_TABLE_COLUMN_SE_CAR_TRAFFIC')
+      case 'SE_DOG_BASIC':
+      case 'SE_CAT_BASIC':
+        return t('COMPARISON_TABLE_COLUMN_SE_DOG_BASIC')
+      case 'SE_DOG_STANDARD':
+      case 'SE_CAT_STANDARD':
+        return t('COMPARISON_TABLE_COLUMN_SE_DOG_STANDARD')
+      case 'SE_DOG_PREMIUM':
+      case 'SE_CAT_PREMIUM':
+        return t('COMPARISON_TABLE_COLUMN_SE_DOG_PREMIUM')
+    }
+  }
+}
+
+const useTableData = (tiers: Array<ProductOfferFragment>, selectedTierId: string) => {
+  const getVeryShortVariantDisplayName = useGetVeryShortVariantDisplayName()
+
+  const table = useMemo<Table>(() => {
+    const head: Head = [
+      TableMarkers.EmptyHeader,
+      ...tiers.map((tier) => {
+        const headerValue = getVeryShortVariantDisplayName(tier.variant.typeOfContract) ?? ''
+
+        if (!headerValue) {
+          console.warn(
+            `[ComparisonTableModal]: could not found tier display name to be used as table header for ${tier.variant.typeOfContract}. Using "" instead.`,
+          )
+        }
+
+        return headerValue
+      }),
+    ]
+    const body: Body = getUniquePerils(tiers).map((peril) => [
+      { title: peril.title, description: peril.description },
+      ...tiers.map((tier) =>
+        offerHasPeril(tier, peril.title) ? TableMarkers.Covered : TableMarkers.NotCovered,
+      ),
+    ])
+
+    return { head, body }
+  }, [tiers, getVeryShortVariantDisplayName])
+
+  const selectedTier = tiers.find((tier) => tier.id === selectedTierId)
+  const selectedTierDisplayName = selectedTier
+    ? getVeryShortVariantDisplayName(selectedTier.variant.typeOfContract)
+    : ''
+
+  if (!selectedTierDisplayName) {
+    console.warn(
+      `[ComparisonTableModal]: could not found tier display name to be used as active table header ${selectedTier?.variant.typeOfContract}. Using "" instead.`,
+    )
+  }
+
+  return { table, selectedTierDisplayName: selectedTierDisplayName || '' }
+}


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes

Use `LargeDialog` from previous PR to show tier comparison dialog instead of `FullscreenDialog`

Adjustments compared to Figma:
- Min vertical margin reduced from unknown value to 1rem, this matches min horizontal margin
- Close icon uses current `IconButton` styles, it's 28x28 compared to 24x24 in Figma
- Max width changed from 954px to 960px (40rem exactly)

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/GLY3tSM85RFBvAf6lFNA/0545b571-c55d-400c-aa2f-f1ac182f44a4.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/GLY3tSM85RFBvAf6lFNA/0545b571-c55d-400c-aa2f-f1ac182f44a4.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/GLY3tSM85RFBvAf6lFNA/0545b571-c55d-400c-aa2f-f1ac182f44a4.mov">Screen Recording 2024-10-23 at 13.04.39.mov</video>

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
