### PR TITLE
Hide progress bar for price calculation on view offers step

### DIFF
--- a/apps/store/src/features/priceCalculator/ProductHeroV2/ProgressBar/ProgressBar.tsx
+++ b/apps/store/src/features/priceCalculator/ProductHeroV2/ProgressBar/ProgressBar.tsx
@@ -14,6 +14,11 @@ export function ProgressBar() {
   const form = useAtomValue(priceCalculatorFormAtom)
   const progress = getPriceCalculatorProgress(step, activeSectionId, form.sections)
 
+  // Hide progress bar in viewOffers step
+  if (step === 'viewOffers') {
+    return null
+  }
+
   return (
     <div className={bar}>
       <motion.div
@@ -40,24 +45,15 @@ function getPriceCalculatorProgress(
           // Don't show any progress in first section
           break
         default: {
-          // +1 because we want to account for two additional steps:
-          // 'calculatingPrice' and 'viewOffers' but excluding 'ssn' step
-          const nrOfSteps = sections.length + 1
           const activeSectionIndex = sections.findIndex((section) => section.id === activeSectionId)
 
           if (activeSectionIndex !== -1) {
-            progress = `${(activeSectionIndex / nrOfSteps) * 100}%`
+            progress = `${(activeSectionIndex / sections.length) * 100}%`
           }
         }
       }
       break
     case 'calculatingPrice':
-      progress = '70%'
-      break
-    case 'viewOffers':
-      progress = '80%'
-      break
-    case 'purchaseSummary':
       progress = '100%'
       break
   }


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
- Hide progress bar for price calculation on view offers step
- Adjust calculation to match number of sections

### View offers (no progress bar)
<img width="436" alt="Screenshot 2024-10-21 at 14 10 48" src="https://github.com/user-attachments/assets/68968943-0ee1-443e-8b0c-59c24d481bdd">

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Hide progress bar for price calculation on view offers step since it only should indicate the progress of getting a price

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
