### PR TITLE
Center form sections visually

### DIFF
--- a/apps/store/src/components/Header/HeaderMenu/HeaderMenu.css.ts
+++ b/apps/store/src/components/Header/HeaderMenu/HeaderMenu.css.ts
@@ -1,5 +1,5 @@
 import { createVar, style } from '@vanilla-extract/css'
-import { minWidth, responsiveStyles, tokens, xStack } from 'ui'
+import { minWidth, responsiveStyles, sprinkles, tokens, xStack } from 'ui'
 
 export const displaySubmenus = createVar()
 export const displayMobileMenu = createVar()
@@ -29,15 +29,23 @@ export const backLink = style([
   },
 ])
 
-export const backWrapper = style({
-  backgroundColor: tokens.colors.buttonSecondary,
-  borderRadius: tokens.radius.xxs,
-  padding: tokens.space.xxs,
+export const backWrapper = style([
+  sprinkles({ display: 'flex', alignItems: 'center', justifyContent: 'center' }),
+  {
+    width: '2rem',
+    height: '2rem',
+    backgroundColor: tokens.colors.buttonSecondary,
+    borderRadius: tokens.radius.xxs,
 
-  ':hover': {
-    backgroundColor: tokens.colors.buttonSecondaryHover,
+    ':hover': {
+      backgroundColor: tokens.colors.buttonSecondaryHover,
+    },
+
+    ...responsiveStyles({
+      lg: { width: '2.5rem', height: '2.5rem' },
+    }),
   },
-})
+])
 
 export const backButtonText = style({
   display: 'none',

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.css.ts
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.css.ts
@@ -2,6 +2,8 @@ import { style } from '@vanilla-extract/css'
 import { responsiveStyles } from 'ui'
 import { HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header.css'
 
+const SECTION_NAVIGATION_OFFSET = '1.75rem'
+
 export const gdprLink = style({
   marginTop: '-1rem', // Offset from default gap of 2rem
 })
@@ -13,6 +15,17 @@ export const ssnSectionWrapper = style({
       justifyContent: 'center',
       // Visually center SSN form section
       marginTop: `calc(-1 * (${HEADER_HEIGHT_DESKTOP} / 2))`,
+    },
+  }),
+})
+
+export const formWrapper = style({
+  ...responsiveStyles({
+    lg: {
+      // Visually center form section with respect to header and section navigation
+      position: 'relative',
+      top: `calc(-1 * (${HEADER_HEIGHT_DESKTOP} / 2) - ${SECTION_NAVIGATION_OFFSET})`,
+      marginBlock: 'auto',
     },
   }),
 })

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.tsx
@@ -23,6 +23,7 @@ import { FormGridNew } from '@/features/priceCalculator/PurchaseFormV2/Insurance
 import {
   ssnSectionWrapper,
   gdprLink,
+  formWrapper,
 } from '@/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.css'
 import { useConfirmPriceIntent } from '@/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/useConfirmPriceIntent'
 import {
@@ -85,7 +86,7 @@ export function InsuranceDataForm({ className }: { className?: string }) {
       >
         {!isSsnSection && <SectionNavigation />}
 
-        <div className={yStack({ gap: 'lg' })}>
+        <div className={clsx(yStack({ gap: 'lg' }), formWrapper)}>
           <SectionHeadings section={section} />
           {sectionBody}
         </div>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Center form sections visually. We need to center it with a negative offset, same as we do for the product hero

### Before
<img width="1296" alt="Screenshot 2024-10-23 at 14 54 01" src="https://github.com/user-attachments/assets/bfb00c88-7fa4-4086-8dd9-4785579cae71">



### After
<img width="1294" alt="Screenshot 2024-10-23 at 14 53 51" src="https://github.com/user-attachments/assets/45218d5f-839d-4f43-8cb1-6a7676bb324a">


<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
