### PR TITLE
Add close button to sticky header in ProductHeroV2

### DIFF
--- a/apps/store/src/features/priceCalculator/ProductHeroV2/ProductHeroV2.css.ts
+++ b/apps/store/src/features/priceCalculator/ProductHeroV2/ProductHeroV2.css.ts
@@ -1,6 +1,6 @@
 import { style, styleVariants } from '@vanilla-extract/css'
 import { badgeFontColor } from 'ui/src/components/Badge/Badge.css'
-import { pillowSize, responsiveStyles, tokens, yStack } from 'ui'
+import { pillowSize, responsiveStyles, sprinkles, tokens, yStack } from 'ui'
 import { HEADER_HEIGHT_DESKTOP } from '@/components/Header/Header.css'
 
 export const productHeroWrapper = styleVariants({
@@ -75,3 +75,11 @@ export const subTypeBadge = style({
     },
   }),
 })
+
+export const mobileCloseButton = style([
+  sprinkles({
+    marginBottom: 'auto',
+    marginLeft: 'auto',
+  }),
+  { width: tokens.space.xl, height: tokens.space.xl },
+])

--- a/apps/store/src/features/priceCalculator/ProductHeroV2/ProductHeroV2.tsx
+++ b/apps/store/src/features/priceCalculator/ProductHeroV2/ProductHeroV2.tsx
@@ -3,13 +3,15 @@ import clsx from 'clsx'
 import type { Variants } from 'framer-motion'
 import { AnimatePresence, motion } from 'framer-motion'
 import { type ReactNode } from 'react'
-import { Badge, framerTransitions, Heading, sprinkles, Text } from 'ui'
+import { Badge, CrossIcon, framerTransitions, Heading, sprinkles, Text } from 'ui'
+import { ButtonNextLink } from '@/components/ButtonNextLink'
 import { Pillow } from '@/components/Pillow/Pillow'
 import { useProductData } from '@/components/ProductData/ProductDataProvider'
 import { useIsPriceIntentStateReady } from '@/components/ProductPage/PurchaseForm/priceIntentAtoms'
 import { useSelectedOffer } from '@/components/ProductPage/PurchaseForm/useSelectedOffer'
 import { useFormatter } from '@/utils/useFormatter'
 import {
+  mobileCloseButton,
   pillow,
   pillowWrapper,
   priceLabel,
@@ -73,6 +75,13 @@ export function ProductHeroV2() {
             <>
               <Pillow size="small" {...productData.pillowImage} priority={true} />
               <div>{productHeading}</div>
+              <ButtonNextLink
+                className={mobileCloseButton}
+                href={productData.pageLink}
+                variant="secondary"
+                Icon={<CrossIcon size="1.5rem" />}
+                size="icon"
+              />
             </>
           }
         </StickyProductHeader>


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Add close button to sticky header in ProductHeroV2


<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/nv8d5VeBPARA7ezh3Od3/fe4b636b-951c-4b4d-839a-f29f353c37a6.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/nv8d5VeBPARA7ezh3Od3/fe4b636b-951c-4b4d-839a-f29f353c37a6.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/nv8d5VeBPARA7ezh3Od3/fe4b636b-951c-4b4d-839a-f29f353c37a6.mov">Screen Recording 2024-10-24 at 09.38.41.mov</video>

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Allow user to close down the price calculator in mobile
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
