### PR TITLE
Fix scroll issue in mobile price calculator

### DIFF
--- a/apps/store/src/features/priceCalculator/ProductHeroV2/StickyProductHeader/StickyProductHeader.tsx
+++ b/apps/store/src/features/priceCalculator/ProductHeroV2/StickyProductHeader/StickyProductHeader.tsx
@@ -22,11 +22,6 @@ export function StickyProductHeader({ children }: Props) {
     setScrolledPast(latest > HERO_TRESHOLD)
   })
 
-  // Scroll to top when going to next step to avoid sticky header overlap
-  if (isCondensedProductHero) {
-    window.scrollTo({ top: 0, behavior: 'instant' })
-  }
-
   return (
     <div className={stickyProductHeader}>
       <div

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/InsuranceDataForm.tsx
@@ -142,6 +142,9 @@ function InsuranceDataSection({ section }: InsuranceDataSectionProps) {
       }
 
       setActiveSectionId(GOTO_NEXT_SECTION)
+
+      // Scroll to top when going to next step to avoid sticky header overlap
+      window.scrollTo({ top: 0, behavior: 'instant' })
     },
   })
 

--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/OfferPresenterV2.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/OfferPresenterV2/OfferPresenterV2.tsx
@@ -75,6 +75,8 @@ export const OfferPresenterV2 = memo(() => {
     // Make sure to always go to the last section of the form when editing
     const lastFormSectionId = form.sections[form.sections.length - 1].id
     setActiveSectionId(lastFormSectionId)
+    // Make sure the user is viewing the start of the form when editing
+    window.scrollTo({ top: 0, behavior: 'instant' })
   }
 
   const offerRef = useRef(null)


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Fix scroll issue in mobile price calculator
Only scroll to top once submitting a section or going back to edit
<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
The form scrolled to top unexpectedly when editing form
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
