### PR TITLE
Add scroll to top when completing ssn step

### DIFF
--- a/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/SsnSeSectionV2.tsx
+++ b/apps/store/src/features/priceCalculator/PurchaseFormV2/InsuranceDataForm/SsnSeSectionV2.tsx
@@ -26,6 +26,8 @@ export const SsnSeSectionV2 = memo(({ className }: { className?: string }) => {
     awaitRefetchQueries: true,
     onCompleted() {
       setActiveSectionId(GOTO_NEXT_SECTION)
+      // Scroll to top when going to next step to avoid sticky header overlap
+      window.scrollTo({ top: 0, behavior: 'instant' })
     },
     onError(error) {
       datadogLogs.logger.debug(`Failed to update customer ssn: ${error.message}`, { error })


### PR DESCRIPTION
<!--
PR title: GRW-123 / Feature / Awesome new thing
-->

## Describe your changes
Make sure we scroll to top when completing SSN step

### Issue

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/nv8d5VeBPARA7ezh3Od3/d51b7020-9326-425a-8305-85ec4df0557d.MP4">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/nv8d5VeBPARA7ezh3Od3/d51b7020-9326-425a-8305-85ec4df0557d.MP4">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/nv8d5VeBPARA7ezh3Od3/d51b7020-9326-425a-8305-85ec4df0557d.MP4">ScreenRecording_10-24-2024 11-40-51_1.MP4</video>

<!--
What changes are made?
If there are many changes, a list might be a good format.
If it makes sense, add screenshots and/or screen recordings here.
-->

## Justify why they are needed
Information gets hidden 
## Checklist before requesting a review

- [ ] I have performed a self-review of my code
